### PR TITLE
feat(convex): #82 schema, desk/trader CRUD, CDP wallet pipeline

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,7 +8,10 @@
  * @module
  */
 
+import type * as deskManagers from "../deskManagers.js";
 import type * as me from "../me.js";
+import type * as traders from "../traders.js";
+import type * as wallet from "../wallet.js";
 
 import type {
   ApiFromModules,
@@ -17,7 +20,10 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  deskManagers: typeof deskManagers;
   me: typeof me;
+  traders: typeof traders;
+  wallet: typeof wallet;
 }>;
 
 /**

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -8,29 +8,27 @@
  * @module
  */
 
-import { AnyDataModel } from "convex/server";
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
 import type { GenericId } from "convex/values";
-
-/**
- * No `schema.ts` file found!
- *
- * This generated code has permissive types like `Doc = any` because
- * Convex doesn't know your schema. If you'd like more type safety, see
- * https://docs.convex.dev/using/schemas for instructions on how to add a
- * schema file.
- *
- * After you change a schema, rerun codegen with `npx convex dev`.
- */
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = string;
+export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
  */
-export type Doc = any;
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
 
 /**
  * An identifier for a document in Convex.
@@ -43,7 +41,7 @@ export type Doc = any;
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.
  */
-export type Id<TableName extends TableNames = TableNames> =
+export type Id<TableName extends TableNames | SystemTableNames> =
   GenericId<TableName>;
 
 /**
@@ -55,4 +53,4 @@ export type Id<TableName extends TableNames = TableNames> =
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = AnyDataModel;
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/convex/deskManagers.ts
+++ b/convex/deskManagers.ts
@@ -1,0 +1,55 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+/** Returns the deskManager row for the authenticated Privy subject, or null. */
+export const getMe = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    return (
+      (await ctx.db
+        .query("deskManagers")
+        .withIndex("bySubject", (q) => q.eq("subject", identity.subject))
+        .unique()) ?? null
+    );
+  },
+});
+
+/** Creates or updates the deskManager row keyed on Privy subject. */
+export const upsertMe = mutation({
+  args: {
+    walletAddress: v.optional(v.string()),
+    displayName: v.optional(v.string()),
+    settings: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("deskManagers")
+      .withIndex("bySubject", (q) => q.eq("subject", identity.subject))
+      .unique();
+
+    if (existing) {
+      const patch: Record<string, unknown> = { updatedAt: now };
+      if (args.walletAddress !== undefined)
+        patch.walletAddress = args.walletAddress;
+      if (args.displayName !== undefined) patch.displayName = args.displayName;
+      if (args.settings !== undefined) patch.settings = args.settings;
+      await ctx.db.patch(existing._id, patch);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("deskManagers", {
+      subject: identity.subject,
+      walletAddress: args.walletAddress,
+      displayName: args.displayName,
+      settings: args.settings ?? {},
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,0 +1,193 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  deskManagers: defineTable({
+    // Privy subject (e.g. "did:privy:xxx")
+    subject: v.string(),
+    walletAddress: v.optional(v.string()),
+    displayName: v.optional(v.string()),
+    settings: v.optional(v.any()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index("bySubject", ["subject"]),
+
+  traders: defineTable({
+    deskManagerId: v.id("deskManagers"),
+    // Privy subject for fast ownership queries without join
+    ownerSubject: v.string(),
+    name: v.string(),
+    // agent status
+    status: v.union(
+      v.literal("active"),
+      v.literal("paused"),
+      v.literal("wiped_out")
+    ),
+    mandate: v.optional(v.any()),
+    personality: v.optional(v.string()),
+    escrowBalanceUsdc: v.optional(v.number()),
+    lastCycleAt: v.optional(v.number()),
+    // CDP wallet pipeline
+    walletStatus: v.union(
+      v.literal("pending"),
+      v.literal("creating"),
+      v.literal("ready"),
+      v.literal("error")
+    ),
+    walletError: v.optional(v.string()),
+    // wallet metadata (set when walletStatus === "ready")
+    cdpWalletAddress: v.optional(v.string()),
+    cdpOwnerAddress: v.optional(v.string()),
+    cdpAccountName: v.optional(v.string()),
+    tokenId: v.optional(v.number()),
+    tbaAddress: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("byOwner", ["ownerSubject"])
+    .index("byDeskManager", ["deskManagerId"])
+    .index("byStatus", ["status"])
+    .index("byOwnerAndName", ["ownerSubject", "name"])
+    .index("byCreatedAt", ["createdAt"]),
+
+  deals: defineTable({
+    // nullable: on-chain synced deals use creatorAddress instead
+    creatorDeskManagerId: v.optional(v.id("deskManagers")),
+    creatorAddress: v.optional(v.string()),
+    creatorType: v.union(v.literal("desk_manager"), v.literal("agent")),
+    prompt: v.string(),
+    potUsdc: v.number(),
+    entryCostUsdc: v.number(),
+    maxExtractionPercentage: v.optional(v.number()),
+    feeUsdc: v.optional(v.number()),
+    status: v.union(
+      v.literal("open"),
+      v.literal("closed"),
+      v.literal("depleted")
+    ),
+    entryCount: v.optional(v.number()),
+    wipeoutCount: v.optional(v.number()),
+    onChainDealId: v.optional(v.number()),
+    onChainTxHash: v.optional(v.string()),
+    sourceHeadline: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("byStatus", ["status"])
+    .index("byCreator", ["creatorDeskManagerId"])
+    .index("byOnChainDealId", ["onChainDealId"])
+    .index("byCreatedAt", ["createdAt"]),
+
+  dealOutcomes: defineTable({
+    dealId: v.id("deals"),
+    // trader_id can reference either deskManagers or traders
+    traderId: v.string(),
+    narrative: v.optional(v.any()),
+    traderPnlUsdc: v.optional(v.number()),
+    potChangeUsdc: v.optional(v.number()),
+    rakeUsdc: v.optional(v.number()),
+    assetsGained: v.optional(v.any()),
+    assetsLost: v.optional(v.any()),
+    traderWipedOut: v.optional(v.boolean()),
+    wipeoutReason: v.optional(v.string()),
+    onChainTxHash: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index("byDeal", ["dealId"])
+    .index("byTrader", ["traderId"])
+    .index("byTraderAndDeal", ["traderId", "dealId"])
+    .index("byCreatedAt", ["createdAt"]),
+
+  dealApprovals: defineTable({
+    traderId: v.id("traders"),
+    dealId: v.id("deals"),
+    deskManagerId: v.id("deskManagers"),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("approved"),
+      v.literal("rejected"),
+      v.literal("expired"),
+      v.literal("consumed")
+    ),
+    entryCostUsdc: v.number(),
+    potUsdc: v.number(),
+    expiresAt: v.number(),
+    resolvedAt: v.optional(v.number()),
+    createdAt: v.number(),
+  })
+    .index("byTrader", ["traderId"])
+    .index("byDeskManager", ["deskManagerId"])
+    .index("byDeskManagerAndStatus", ["deskManagerId", "status"])
+    .index("byStatus", ["status"])
+    .index("byDeal", ["dealId"]),
+
+  agentActivityLog: defineTable({
+    traderId: v.id("traders"),
+    activityType: v.string(),
+    message: v.string(),
+    dealId: v.optional(v.id("deals")),
+    metadata: v.optional(v.any()),
+    createdAt: v.number(),
+  })
+    .index("byTrader", ["traderId"])
+    .index("byTraderAndCreatedAt", ["traderId", "createdAt"])
+    .index("byActivityType", ["activityType"]),
+
+  traderTransactions: defineTable({
+    traderId: v.id("traders"),
+    type: v.union(
+      v.literal("deposit"),
+      v.literal("withdrawal"),
+      v.literal("enter"),
+      v.literal("resolve")
+    ),
+    txHash: v.string(),
+    blockNumber: v.optional(v.number()),
+    amountUsdc: v.optional(v.number()),
+    dealId: v.optional(v.id("deals")),
+    onChainDealId: v.optional(v.number()),
+    pnlUsdc: v.optional(v.number()),
+    rakeUsdc: v.optional(v.number()),
+    createdAt: v.number(),
+  })
+    .index("byTrader", ["traderId"])
+    .index("byTraderAndCreatedAt", ["traderId", "createdAt"])
+    .index("byTxHash", ["txHash"]),
+
+  assets: defineTable({
+    traderId: v.id("traders"),
+    name: v.string(),
+    valueUsdc: v.optional(v.number()),
+    sourceDealId: v.optional(v.id("deals")),
+    sourceOutcomeId: v.optional(v.id("dealOutcomes")),
+    acquiredAt: v.number(),
+  })
+    .index("byTrader", ["traderId"])
+    .index("byDeal", ["sourceDealId"]),
+
+  marketNarratives: defineTable({
+    epoch: v.number(),
+    headlines: v.any(),
+    worldState: v.any(),
+    rawNarrative: v.string(),
+    eventsIngested: v.optional(v.any()),
+    createdAt: v.number(),
+  }).index("byEpoch", ["epoch"]),
+
+  systemPrompts: defineTable({
+    name: v.string(),
+    content: v.string(),
+    returnFormat: v.optional(v.string()),
+    isActive: v.boolean(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  }).index("byName", ["name"]),
+
+  siwaNonces: defineTable({
+    nonce: v.string(),
+    expiresAt: v.number(),
+    createdAt: v.number(),
+  })
+    .index("byNonce", ["nonce"])
+    .index("byExpiresAt", ["expiresAt"]),
+});

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -1,0 +1,152 @@
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+} from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+
+/** Public: list traders owned by the calling desk manager. */
+export const listByDesk = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return [];
+    return ctx.db
+      .query("traders")
+      .withIndex("byOwner", (q) => q.eq("ownerSubject", identity.subject))
+      .collect();
+  },
+});
+
+/** Public: get a trader by id, auth-checked (must be owner). */
+export const getById = query({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    const trader = await ctx.db.get(traderId);
+    if (!trader || trader.ownerSubject !== identity.subject) return null;
+    return trader;
+  },
+});
+
+/** Public: create a trader, schedule wallet creation. Idempotent on (ownerSubject, name). */
+export const create = mutation({
+  args: {
+    name: v.string(),
+    mandate: v.optional(v.any()),
+    personality: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+
+    // Resolve or create deskManager row
+    const existing = await ctx.db
+      .query("deskManagers")
+      .withIndex("bySubject", (q) => q.eq("subject", identity.subject))
+      .unique();
+    if (!existing)
+      throw new Error("Desk manager not found — call upsertMe first");
+
+    // Idempotency: check for existing trader with same owner+name
+    const dupe = await ctx.db
+      .query("traders")
+      .withIndex("byOwnerAndName", (q) =>
+        q.eq("ownerSubject", identity.subject).eq("name", args.name)
+      )
+      .unique();
+
+    if (dupe) {
+      // If wallet job is already in-flight or done, return existing trader
+      if (dupe.walletStatus !== "error") return dupe._id;
+      // Error state: allow retry — fall through to create new trader
+    }
+
+    const now = Date.now();
+    const traderId = await ctx.db.insert("traders", {
+      deskManagerId: existing._id,
+      ownerSubject: identity.subject,
+      name: args.name,
+      status: "active",
+      mandate: args.mandate ?? {},
+      personality: args.personality,
+      walletStatus: "pending",
+      escrowBalanceUsdc: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Schedule wallet creation as an internal action (no CDP inside mutations)
+    await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
+      traderId,
+    });
+
+    return traderId;
+  },
+});
+
+// ── Internal helpers (used by wallet action) ─────────────────────────────────
+
+/** Internal: load trader without auth (for wallet action). */
+export const loadInternal = internalQuery({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => ctx.db.get(traderId),
+});
+
+/** Internal: transition walletStatus pending|creating → creating. */
+export const markCreating = internalMutation({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return;
+    if (trader.walletStatus !== "pending") return; // already progressed
+    await ctx.db.patch(traderId, {
+      walletStatus: "creating",
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Internal: transition creating → ready with wallet metadata. */
+export const applyWalletReady = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    cdpWalletAddress: v.string(),
+    cdpOwnerAddress: v.string(),
+    cdpAccountName: v.string(),
+    tokenId: v.number(),
+  },
+  handler: async (ctx, { traderId, ...walletMeta }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return;
+    // CAS: only transition from pending or creating
+    if (trader.walletStatus === "ready") return;
+    await ctx.db.patch(traderId, {
+      walletStatus: "ready",
+      cdpWalletAddress: walletMeta.cdpWalletAddress,
+      cdpOwnerAddress: walletMeta.cdpOwnerAddress,
+      cdpAccountName: walletMeta.cdpAccountName,
+      tokenId: walletMeta.tokenId,
+      walletError: undefined,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Internal: transition pending|creating → error. */
+export const applyWalletError = internalMutation({
+  args: { traderId: v.id("traders"), error: v.string() },
+  handler: async (ctx, { traderId, error }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return;
+    if (trader.walletStatus === "ready") return; // don't clobber success
+    await ctx.db.patch(traderId, {
+      walletStatus: "error",
+      walletError: error,
+      updatedAt: Date.now(),
+    });
+  },
+});

--- a/convex/wallet.ts
+++ b/convex/wallet.ts
@@ -1,0 +1,209 @@
+"use node";
+
+import { internalAction } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+
+/**
+ * Required Convex env vars:
+ *   CDP_API_KEY_ID        — Coinbase CDP API key ID
+ *   CDP_API_KEY_SECRET    — Coinbase CDP API key secret (PEM)
+ *   CDP_WALLET_SECRET     — Coinbase CDP wallet encryption secret
+ *   IDENTITY_REGISTRY_ADDRESS — ERC-8004 identity registry contract address
+ *
+ * Set via: npx convex env set CDP_API_KEY_ID <value>
+ *          npx convex env set CDP_API_KEY_SECRET <value>
+ *          npx convex env set CDP_WALLET_SECRET <value>
+ *          npx convex env set IDENTITY_REGISTRY_ADDRESS <value>
+ */
+
+/**
+ * Creates a CDP smart account for a trader.
+ * Safe to retry: checks walletStatus before acting.
+ * Only transitions: pending|creating → ready|error.
+ */
+export const createForTrader = internalAction({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const trader = await ctx.runQuery(internal.traders.loadInternal, {
+      traderId,
+    });
+    if (!trader) return;
+    if (trader.walletStatus === "ready") return; // no-op
+
+    // CAS: mark creating so concurrent runs are idempotent
+    await ctx.runMutation(internal.traders.markCreating, { traderId });
+
+    try {
+      const { CdpClient } = await import("@coinbase/cdp-sdk");
+      const { encodeFunctionData } = await import("viem");
+      const { createPublicClient, http, decodeEventLog } = await import("viem");
+      const { baseSepolia } = await import("viem/chains");
+
+      const cdp = new CdpClient({
+        apiKeyId: process.env.CDP_API_KEY_ID,
+        apiKeySecret: process.env.CDP_API_KEY_SECRET,
+        walletSecret: process.env.CDP_WALLET_SECRET,
+      });
+
+      const identityRegistryAddress = (process.env.IDENTITY_REGISTRY_ADDRESS ??
+        "0x0000000000000000000000000000000000000000") as `0x${string}`;
+
+      const identityRegistryAbi = [
+        {
+          type: "function",
+          name: "register",
+          inputs: [{ name: "agentURI", type: "string" }],
+          outputs: [{ name: "tokenId", type: "uint256" }],
+          stateMutability: "nonpayable",
+        },
+        {
+          type: "event",
+          name: "Transfer",
+          inputs: [
+            { name: "from", type: "address", indexed: true },
+            { name: "to", type: "address", indexed: true },
+            { name: "tokenId", type: "uint256", indexed: true },
+          ],
+        },
+        {
+          type: "function",
+          name: "transferFrom",
+          inputs: [
+            { name: "from", type: "address" },
+            { name: "to", type: "address" },
+            { name: "tokenId", type: "uint256" },
+          ],
+          outputs: [],
+          stateMutability: "nonpayable",
+        },
+      ] as const;
+
+      const ts = Date.now();
+
+      // Step 1: Temporary mint accounts
+      const mintOwner = await cdp.evm.getOrCreateAccount({
+        name: `trader-mint-${ts}`,
+      });
+      const mintSmartAccount = await cdp.evm.getOrCreateSmartAccount({
+        name: `trader-sa-mint-${ts}`,
+        owner: mintOwner,
+      });
+
+      // Step 2: Mint ERC-8004 identity NFT
+      const agentURI = `data:application/json,${JSON.stringify({ name: trader.name })}`;
+      const mintData = encodeFunctionData({
+        abi: identityRegistryAbi,
+        functionName: "register",
+        args: [agentURI],
+      });
+
+      const { userOpHash: mintOpHash } =
+        await mintSmartAccount.sendUserOperation({
+          network: "base-sepolia",
+          calls: [
+            { to: identityRegistryAddress, value: BigInt(0), data: mintData },
+          ],
+        });
+      const mintReceipt = await mintSmartAccount.waitForUserOperation({
+        userOpHash: mintOpHash,
+      });
+      if (mintReceipt.status !== "complete") {
+        throw new Error(`Mint UserOp failed: ${mintReceipt.status}`);
+      }
+
+      // Parse Transfer event to get tokenId
+      const publicClient = createPublicClient({
+        chain: baseSepolia,
+        transport: http(),
+      });
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: mintReceipt.transactionHash as `0x${string}`,
+      });
+
+      let tokenId: number | undefined;
+      for (const log of receipt.logs) {
+        try {
+          const decoded = decodeEventLog({
+            abi: identityRegistryAbi,
+            data: log.data,
+            topics: log.topics,
+          });
+          if (decoded.eventName === "Transfer") {
+            tokenId = Number((decoded.args as { tokenId: bigint }).tokenId);
+            break;
+          }
+        } catch {
+          // not our event
+        }
+      }
+      if (tokenId === undefined) {
+        throw new Error("Failed to extract tokenId from mint transaction");
+      }
+
+      // Step 3: Create canonical accounts
+      const owner = await cdp.evm.getOrCreateAccount({
+        name: `trader-${tokenId}`,
+      });
+      const smartAccount = await cdp.evm.getOrCreateSmartAccount({
+        name: `trader-sa-${tokenId}`,
+        owner,
+      });
+
+      // Step 4: Transfer NFT from mint SA → canonical SA
+      const transferData = encodeFunctionData({
+        abi: identityRegistryAbi,
+        functionName: "transferFrom",
+        args: [mintSmartAccount.address, smartAccount.address, BigInt(tokenId)],
+      });
+
+      const MAX_RETRIES = 3;
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        try {
+          const { userOpHash: transferOpHash } =
+            await mintSmartAccount.sendUserOperation({
+              network: "base-sepolia",
+              calls: [
+                {
+                  to: identityRegistryAddress,
+                  value: BigInt(0),
+                  data: transferData,
+                },
+              ],
+            });
+          const transferReceipt = await mintSmartAccount.waitForUserOperation({
+            userOpHash: transferOpHash,
+          });
+          if (transferReceipt.status !== "complete") {
+            throw new Error(
+              `Transfer UserOp failed: ${transferReceipt.status}`
+            );
+          }
+          break;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (
+            !msg.includes("initialize smart wallet") ||
+            attempt === MAX_RETRIES - 1
+          )
+            throw err;
+          await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+        }
+      }
+
+      await ctx.runMutation(internal.traders.applyWalletReady, {
+        traderId,
+        cdpWalletAddress: smartAccount.address,
+        cdpOwnerAddress: owner.address,
+        cdpAccountName: `trader-sa-${tokenId}`,
+        tokenId,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await ctx.runMutation(internal.traders.applyWalletError, {
+        traderId,
+        error: message,
+      });
+    }
+  },
+});

--- a/convex/wallet.ts
+++ b/convex/wallet.ts
@@ -17,6 +17,17 @@ import { internal } from "./_generated/api";
  *          npx convex env set IDENTITY_REGISTRY_ADDRESS <value>
  */
 
+// If a `creating` job hasn't progressed in this long, treat it as crashed and allow a retry.
+const CREATING_LEASE_MS = 5 * 60 * 1000;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`Missing required Convex env var: ${name}`);
+  }
+  return value;
+}
+
 /**
  * Creates a CDP smart account for a trader.
  * Safe to retry: checks walletStatus before acting.
@@ -30,24 +41,36 @@ export const createForTrader = internalAction({
     });
     if (!trader) return;
     if (trader.walletStatus === "ready") return; // no-op
+    // Re-entry guard: another run is in flight and still within the lease window.
+    if (
+      trader.walletStatus === "creating" &&
+      Date.now() - trader.updatedAt < CREATING_LEASE_MS
+    ) {
+      return;
+    }
 
     // CAS: mark creating so concurrent runs are idempotent
     await ctx.runMutation(internal.traders.markCreating, { traderId });
 
     try {
+      // Validate env vars with clear errors instead of opaque SDK failures.
+      const cdpApiKeyId = requireEnv("CDP_API_KEY_ID");
+      const cdpApiKeySecret = requireEnv("CDP_API_KEY_SECRET");
+      const cdpWalletSecret = requireEnv("CDP_WALLET_SECRET");
+      const identityRegistryAddress = requireEnv(
+        "IDENTITY_REGISTRY_ADDRESS"
+      ) as `0x${string}`;
+
       const { CdpClient } = await import("@coinbase/cdp-sdk");
       const { encodeFunctionData } = await import("viem");
       const { createPublicClient, http, decodeEventLog } = await import("viem");
       const { baseSepolia } = await import("viem/chains");
 
       const cdp = new CdpClient({
-        apiKeyId: process.env.CDP_API_KEY_ID,
-        apiKeySecret: process.env.CDP_API_KEY_SECRET,
-        walletSecret: process.env.CDP_WALLET_SECRET,
+        apiKeyId: cdpApiKeyId,
+        apiKeySecret: cdpApiKeySecret,
+        walletSecret: cdpWalletSecret,
       });
-
-      const identityRegistryAddress = (process.env.IDENTITY_REGISTRY_ADDRESS ??
-        "0x0000000000000000000000000000000000000000") as `0x${string}`;
 
       const identityRegistryAbi = [
         {

--- a/src/app/traders/new/page.tsx
+++ b/src/app/traders/new/page.tsx
@@ -3,8 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useTraders } from "@/hooks/use-traders";
-import { useCreateTrader } from "@/hooks/use-create-trader";
+import {
+  useConvexTraders,
+  useConvexCreateTrader,
+} from "@/hooks/use-convex-traders";
 import { Nav } from "@/components/nav";
 import type { Mandate } from "@/lib/agent/evaluator";
 
@@ -56,16 +58,14 @@ const STEP_TITLES = [
 
 export default function NewTraderWizard() {
   const router = useRouter();
-  const { data: traders } = useTraders();
-  const {
-    createTrader,
-    isLoading: isCreating,
-    error: createError,
-  } = useCreateTrader();
+  const traders = useConvexTraders();
+  const createTrader = useConvexCreateTrader();
 
   const [step, setStep] = useState<number>(STEPS.NAME);
   const [name, setName] = useState("");
   const [mandate, setMandate] = useState<Mandate>({});
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | undefined>();
 
   const trimmedName = name.trim();
   const nameTaken =
@@ -97,11 +97,20 @@ export default function NewTraderWizard() {
     if (value !== null) finalMandate.approval_threshold_usdc = value;
     else delete finalMandate.approval_threshold_usdc;
 
+    setIsCreating(true);
+    setCreateError(undefined);
     try {
-      const trader = await createTrader(trimmedName, finalMandate);
-      router.push(`/traders/${trader.id}`);
-    } catch {
-      // error is surfaced via hook state
+      const traderId = await createTrader({
+        name: trimmedName,
+        mandate: finalMandate,
+      });
+      router.push(`/traders/${traderId}`);
+    } catch (err) {
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to create trader"
+      );
+    } finally {
+      setIsCreating(false);
     }
   }
 
@@ -208,7 +217,7 @@ export default function NewTraderWizard() {
               />
               {isCreating && (
                 <p className="mt-4 text-sm text-[var(--t-muted)]">
-                  Creating trader...
+                  Creating trader... wallet provisioning will complete shortly.
                 </p>
               )}
               {createError && (

--- a/src/app/traders/page.tsx
+++ b/src/app/traders/page.tsx
@@ -1,11 +1,26 @@
 "use client";
 
 import Link from "next/link";
-import { useTraders } from "@/hooks/use-traders";
+import { useConvexTraders } from "@/hooks/use-convex-traders";
 import { Nav } from "@/components/nav";
 
+const WALLET_STATUS_LABEL: Record<string, string> = {
+  pending: "[WALLET PENDING]",
+  creating: "[WALLET CREATING]",
+  ready: "",
+  error: "[WALLET ERROR]",
+};
+
+const WALLET_STATUS_COLOR: Record<string, string> = {
+  pending: "text-[var(--t-muted)]",
+  creating: "text-[var(--t-amber)]",
+  ready: "",
+  error: "text-[var(--t-red)]",
+};
+
 export default function TradersPage() {
-  const { data: traders, isLoading, error } = useTraders();
+  const traders = useConvexTraders();
+  const isLoading = traders === undefined;
 
   return (
     <div className="crt-scanlines min-h-screen bg-[var(--t-bg)] font-mono">
@@ -24,46 +39,58 @@ export default function TradersPage() {
       <div className="mx-auto w-full max-w-4xl px-4 py-4">
         {isLoading ? (
           <p className="text-[var(--t-muted)]">Loading traders...</p>
-        ) : error ? (
-          <p className="text-[var(--t-red)]">Failed to load traders.</p>
         ) : !traders || traders.length === 0 ? (
           <p className="text-[var(--t-muted)]">
-            No traders yet. Mint your first trader NFT to get started.
+            No traders yet. Create your first trader to get started.
           </p>
         ) : (
           <div className="flex flex-col gap-[1px] bg-[var(--t-border)]">
             {traders.map((trader) => (
               <Link
-                key={trader.id}
-                href={`/traders/${trader.id}`}
+                key={trader._id}
+                href={`/traders/${trader._id}`}
                 className="bg-[var(--t-bg)] p-5 transition-colors hover:bg-[var(--t-surface)]"
               >
                 <div className="mb-3 flex items-center justify-between">
                   <p className="text-lg font-medium text-[var(--t-text)]">
                     {trader.name}
                   </p>
-                  <span
-                    className={`text-[10px] font-bold uppercase ${
-                      trader.status === "active"
-                        ? "text-[var(--t-green)]"
-                        : trader.status === "paused"
-                          ? "text-[var(--t-amber)]"
-                          : "text-[var(--t-red)]"
-                    }`}
-                  >
-                    [
-                    {trader.status === "wiped_out"
-                      ? "WIPED"
-                      : trader.status.toUpperCase()}
-                    ]
-                  </span>
+                  <div className="flex items-center gap-2">
+                    {trader.walletStatus !== "ready" && (
+                      <span
+                        className={`text-[10px] font-bold uppercase ${WALLET_STATUS_COLOR[trader.walletStatus]}`}
+                      >
+                        {WALLET_STATUS_LABEL[trader.walletStatus]}
+                      </span>
+                    )}
+                    <span
+                      className={`text-[10px] font-bold uppercase ${
+                        trader.status === "active"
+                          ? "text-[var(--t-green)]"
+                          : trader.status === "paused"
+                            ? "text-[var(--t-amber)]"
+                            : "text-[var(--t-red)]"
+                      }`}
+                    >
+                      [
+                      {trader.status === "wiped_out"
+                        ? "WIPED"
+                        : trader.status.toUpperCase()}
+                      ]
+                    </span>
+                  </div>
                 </div>
                 <div className="flex flex-col gap-1 text-sm text-[var(--t-muted)]">
-                  <span>Token ID: #{trader.token_id}</span>
-                  {trader.tba_address && (
+                  {trader.tokenId && <span>Token ID: #{trader.tokenId}</span>}
+                  {trader.cdpWalletAddress && (
                     <span className="font-mono text-xs">
-                      Wallet: {trader.tba_address.slice(0, 6)}...
-                      {trader.tba_address.slice(-4)}
+                      Wallet: {trader.cdpWalletAddress.slice(0, 6)}...
+                      {trader.cdpWalletAddress.slice(-4)}
+                    </span>
+                  )}
+                  {trader.walletError && (
+                    <span className="text-xs text-[var(--t-red)]">
+                      {trader.walletError}
                     </span>
                   )}
                 </div>

--- a/src/components/providers/convex-provider.tsx
+++ b/src/components/providers/convex-provider.tsx
@@ -6,7 +6,7 @@ import { usePrivy } from "@privy-io/react-auth";
 
 const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL ?? "";
 
-const convex = new ConvexReactClient(convexUrl);
+const convex = convexUrl ? new ConvexReactClient(convexUrl) : null;
 
 function usePrivyAuth() {
   const { ready, authenticated, getAccessToken } = usePrivy();
@@ -29,7 +29,7 @@ export function ConvexClientProvider({
 }: {
   children: React.ReactNode;
 }) {
-  if (!convexUrl) return <>{children}</>;
+  if (!convex) return <>{children}</>;
   return (
     <ConvexProviderWithAuth client={convex} useAuth={usePrivyAuth}>
       {children}

--- a/src/hooks/use-convex-desk.ts
+++ b/src/hooks/use-convex-desk.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+/** Fetch the current user's deskManager row from Convex, or null. */
+export function useConvexDeskManager() {
+  return useQuery(api.deskManagers.getMe);
+}
+
+/** Upsert the current user's deskManager row. */
+export function useUpsertDeskManager() {
+  return useMutation(api.deskManagers.upsertMe);
+}

--- a/src/hooks/use-convex-traders.ts
+++ b/src/hooks/use-convex-traders.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+
+/** List traders for the authenticated desk manager. Reactive. */
+export function useConvexTraders() {
+  return useQuery(api.traders.listByDesk);
+}
+
+/** Get a single trader by id. Reactive. */
+export function useConvexTrader(traderId: Id<"traders"> | undefined) {
+  return useQuery(api.traders.getById, traderId ? { traderId } : "skip");
+}
+
+/** Create a trader (schedules CDP wallet pipeline). */
+export function useConvexCreateTrader() {
+  return useMutation(api.traders.create);
+}


### PR DESCRIPTION
## Summary

- Full Convex schema (`convex/schema.ts`) covering all 11 tables from the PRD with indexes matching current Supabase access patterns
- Desk manager CRUD (`convex/deskManagers.ts`): `getMe` query + `upsertMe` mutation keyed on Privy subject
- Trader CRUD (`convex/traders.ts`): `create` mutation (idempotent on owner+name, schedules wallet action), `listByDesk`/`getById` queries, internal CAS mutations for wallet state machine
- CDP wallet pipeline (`convex/wallet.ts`): `internalAction` in Node.js runtime — creates CDP smart account, mints ERC-8004 NFT, transfers to canonical account, writes wallet metadata back via compare-and-set mutations
- New Convex hooks: `use-convex-desk.ts`, `use-convex-traders.ts`
- `/traders` and `/traders/new` pages ported to Convex hooks with reactive wallet status display

## Required Convex env vars

Set these in the Convex dashboard or via CLI before running `npx convex dev`:

```bash
npx convex env set CDP_API_KEY_ID <value>
npx convex env set CDP_API_KEY_SECRET <value>
npx convex env set CDP_WALLET_SECRET <value>
npx convex env set IDENTITY_REGISTRY_ADDRESS <value>
```

## Migration decisions

- `traders.walletStatus` is a separate field from `traders.status` — status is the agent state (`active`/`paused`/`wiped_out`), walletStatus is the CDP provisioning state (`pending`/`creating`/`ready`/`error`)
- Timestamps stored as `number` (ms since epoch) — consistent with Convex conventions
- `dealOutcomes.traderId` is `v.string()` (not a typed `Id`) to match existing Postgres behavior where `trader_id` can reference either `desk_managers` or `traders`
- `traders.create` idempotency: same (ownerSubject, name) returns existing traderId unless walletStatus is `error`, in which case a new trader row is created (retry semantics)
- Supabase desk/trader API routes left in place alongside Convex paths — removal is #91

## Idempotency guarantees

- Two concurrent `traders.create` for same name: `byOwnerAndName` index + `unique()` returns existing row; second call returns existing traderId without scheduling another wallet job
- `wallet.createForTrader` retry on ready trader: early return on `walletStatus === "ready"`
- `markCreating` CAS: only transitions `pending → creating`
- `applyWalletReady` CAS: guards on `walletStatus === "ready"` before patch
- `applyWalletError` CAS: won't clobber a successful `ready` state

## Test plan

- [ ] Run `npx convex dev` to push schema and regenerate types
- [ ] Set env vars, create a trader via UI, verify `walletStatus` transitions `pending → creating → ready` in Convex dashboard
- [ ] Create duplicate trader (same name) — confirm single wallet created
- [ ] Trigger wallet error (bad env var), verify error shows in UI, fix env and retry
- [ ] `pnpm build` passes
- [ ] `pnpm lint` passes (0 errors)

Closes #82
Stacks on #81 / PR #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)