### PR TITLE
feat(convex): #85 cron + scheduler + idempotent cycle skeleton

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,7 +8,11 @@
  * @module
  */
 
+import type * as agent_cycle from "../agent/cycle.js";
+import type * as agent_internal from "../agent/internal.js";
+import type * as agent_scheduler from "../agent/scheduler.js";
 import type * as agentActivityLog from "../agentActivityLog.js";
+import type * as crons from "../crons.js";
 import type * as dealApprovals from "../dealApprovals.js";
 import type * as dealOutcomes from "../dealOutcomes.js";
 import type * as deals from "../deals.js";
@@ -16,9 +20,6 @@ import type * as deskManagers from "../deskManagers.js";
 import type * as me from "../me.js";
 import type * as traders from "../traders.js";
 import type * as wallet from "../wallet.js";
-import type * as agent_cycle from "../agent/cycle.js";
-import type * as agent_internal from "../agent/internal.js";
-import type * as agent_scheduler from "../agent/scheduler.js";
 
 import type {
   ApiFromModules,
@@ -27,7 +28,11 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "agent/cycle": typeof agent_cycle;
+  "agent/internal": typeof agent_internal;
+  "agent/scheduler": typeof agent_scheduler;
   agentActivityLog: typeof agentActivityLog;
+  crons: typeof crons;
   dealApprovals: typeof dealApprovals;
   dealOutcomes: typeof dealOutcomes;
   deals: typeof deals;
@@ -35,9 +40,6 @@ declare const fullApi: ApiFromModules<{
   me: typeof me;
   traders: typeof traders;
   wallet: typeof wallet;
-  "agent/cycle": typeof agent_cycle;
-  "agent/internal": typeof agent_internal;
-  "agent/scheduler": typeof agent_scheduler;
 }>;
 
 /**

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,9 @@ import type * as deskManagers from "../deskManagers.js";
 import type * as me from "../me.js";
 import type * as traders from "../traders.js";
 import type * as wallet from "../wallet.js";
+import type * as agent_cycle from "../agent/cycle.js";
+import type * as agent_internal from "../agent/internal.js";
+import type * as agent_scheduler from "../agent/scheduler.js";
 
 import type {
   ApiFromModules,
@@ -24,6 +27,9 @@ declare const fullApi: ApiFromModules<{
   me: typeof me;
   traders: typeof traders;
   wallet: typeof wallet;
+  "agent/cycle": typeof agent_cycle;
+  "agent/internal": typeof agent_internal;
+  "agent/scheduler": typeof agent_scheduler;
 }>;
 
 /**

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -24,6 +24,8 @@ export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Doc<TableName extends TableNames> = DocumentByName<
   DataModel,
@@ -40,6 +42,8 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
   GenericId<TableName>;

--- a/convex/agent/cycle.ts
+++ b/convex/agent/cycle.ts
@@ -1,0 +1,115 @@
+"use node";
+
+import { internalAction } from "../_generated/server";
+import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import { CYCLE_LEASE_TTL_MS } from "./internal";
+
+/**
+ * Idempotent cycle action for a single trader agent.
+ *
+ * Idempotency strategy (lease-based CAS)
+ * ----------------------------------------
+ * 1. The scheduler reads cycleGeneration from listStaleTradersForCycle.
+ * 2. Before any work this action calls acquireCycleLease with:
+ *      expectedGeneration = trader.cycleGeneration ?? 0
+ *      leaseUntil = now + CYCLE_LEASE_TTL_MS
+ *    acquireCycleLease is an atomic Convex mutation: it only increments
+ *    cycleGeneration and stamps cycleLeaseUntil if currentGeneration === expectedGeneration
+ *    AND there is no active lease. If two concurrent invocations race, exactly
+ *    one wins the CAS; the other receives { acquired: false } and exits cleanly.
+ * 3. On success the action holds { acquired: true, generation: N }.
+ * 4. On completion it calls markCycleComplete({ generation: N }) which updates
+ *    lastCycleAt and clears the lease — but only if generation still equals N.
+ *    This prevents a stale cycle from clobbering a recovery cycle's state.
+ * 5. On crash / timeout the lease expires automatically after CYCLE_LEASE_TTL_MS
+ *    (90 s). The next scheduler tick sees no active lease and enqueues a fresh
+ *    cycle with an incremented generation.
+ *
+ * Overlapping ticks: if the cron fires while a cycle is in flight,
+ * listStaleTradersForCycle filters out traders with cycleLeaseUntil > now,
+ * so the scheduler never even enqueues a second cycle. Belt-and-suspenders:
+ * even if it did enqueue one (e.g. clock skew) the CAS would reject it.
+ *
+ * TODO (#86): wire in deal selection + outcome resolver
+ * TODO (#87): x402 deal-entry HTTP call
+ */
+export const cycle = internalAction({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const now = Date.now();
+
+    // ── 1. Load trader ────────────────────────────────────────────────────────
+    const trader = await ctx.runQuery(
+      internal.agent.internal.loadTraderForCycle,
+      { traderId }
+    );
+    if (!trader) {
+      console.warn(`[cycle] trader ${traderId} not found — skipping`);
+      return;
+    }
+
+    // Defensive guard: only run for active + ready traders
+    if (trader.status !== "active" || trader.walletStatus !== "ready") {
+      console.log(
+        `[cycle] trader ${traderId} not eligible (status=${trader.status}, wallet=${trader.walletStatus}) — skipping`
+      );
+      return;
+    }
+
+    // ── 2. Acquire lease (CAS) ────────────────────────────────────────────────
+    const expectedGeneration = trader.cycleGeneration ?? 0;
+    const leaseResult = await ctx.runMutation(
+      internal.agent.internal.acquireCycleLease,
+      {
+        traderId,
+        expectedGeneration,
+        leaseUntil: now + CYCLE_LEASE_TTL_MS,
+      }
+    );
+
+    if (!leaseResult.acquired) {
+      // Another cycle is in flight or just won the CAS race — exit cleanly.
+      console.log(
+        `[cycle] lease not acquired for ${traderId} (generation mismatch or active lease) — skipping`
+      );
+      return;
+    }
+
+    const { generation } = leaseResult;
+    console.log(
+      `[cycle] lease acquired for ${traderId} generation=${generation}`
+    );
+
+    try {
+      // ── 3. Core cycle work ──────────────────────────────────────────────────
+      // TODO (#86): load desk, pick deal, resolve outcome, apply PnL
+      // Placeholder: just log that the skeleton ran.
+      console.log(
+        `[cycle] running skeleton for trader ${traderId} (${trader.name})`
+      );
+
+      // ── 4. Mark complete (updates lastCycleAt, releases lease) ─────────────
+      await ctx.runMutation(internal.agent.internal.markCycleComplete, {
+        traderId,
+        generation,
+        lastCycleAt: Date.now(),
+      });
+
+      console.log(`[cycle] completed for ${traderId} generation=${generation}`);
+    } catch (err) {
+      // Release lease so the next tick can retry after TTL.
+      // markCycleComplete was not called, so lastCycleAt is unchanged; the
+      // scheduler will re-enqueue once the lease expires.
+      await ctx.runMutation(internal.agent.internal.releaseCycleLease, {
+        traderId,
+        generation,
+      });
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[cycle] error for ${traderId} generation=${generation}: ${message}`
+      );
+      throw err; // re-throw so Convex marks the action as failed
+    }
+  },
+});

--- a/convex/agent/internal.ts
+++ b/convex/agent/internal.ts
@@ -1,0 +1,158 @@
+import { internalMutation, internalQuery } from "../_generated/server";
+import { v } from "convex/values";
+
+/** Cycle lease TTL: 90 seconds. Longer than the cycle itself to avoid false-recovery. */
+export const CYCLE_LEASE_TTL_MS = 90_000;
+
+/** How stale lastCycleAt must be before the scheduler kicks a new cycle. */
+export const CYCLE_STALE_MS = 60_000; // 1 minute (Convex cron minimum)
+
+// ── Queries ───────────────────────────────────────────────────────────────────
+
+/**
+ * Load a trader document for use inside a cycle action.
+ * No auth check — internal only.
+ */
+export const loadTraderForCycle = internalQuery({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    return ctx.db.get(traderId);
+  },
+});
+
+/**
+ * List traders eligible for a new cycle:
+ *   - status === "active"
+ *   - walletStatus === "ready"
+ *   - lastCycleAt is either unset or older than CYCLE_STALE_MS
+ *   - cycleLeaseUntil is either unset or in the past (no active lease)
+ *
+ * Called by the scheduler action — no auth context required.
+ */
+export const listStaleTradersForCycle = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const staleThreshold = now - CYCLE_STALE_MS;
+
+    // Fetch active traders; Convex does not support multi-field inequality
+    // indexes so we filter in memory after the index scan.
+    const active = await ctx.db
+      .query("traders")
+      .withIndex("byStatus", (q) => q.eq("status", "active"))
+      .collect();
+
+    return active.filter((t) => {
+      if (t.walletStatus !== "ready") return false;
+      // Skip if a cycle lease is still valid (another cycle is in flight)
+      if (t.cycleLeaseUntil !== undefined && t.cycleLeaseUntil > now)
+        return false;
+      // Skip if recently cycled
+      if (t.lastCycleAt !== undefined && t.lastCycleAt > staleThreshold)
+        return false;
+      return true;
+    });
+  },
+});
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+/**
+ * Attempt to acquire a cycle lease via compare-and-set.
+ *
+ * Idempotency strategy
+ * ---------------------
+ * Each trader has two lease fields:
+ *   - cycleGeneration (monotonic counter): incremented on each new lease grant.
+ *   - cycleLeaseUntil (epoch ms): the lease expiry timestamp.
+ *
+ * Acquisition is a CAS transaction:
+ *   - The caller reads currentGeneration from listStaleTradersForCycle.
+ *   - It passes that value here as `expectedGeneration`.
+ *   - If the DB's generation still equals expectedGeneration AND either there
+ *     is no active lease or the lease has expired, we atomically increment
+ *     generation and stamp a new leaseUntil.
+ *   - Any other concurrent caller that observed the same generation will fail
+ *     the CAS check and receive { acquired: false }.
+ *
+ * Recovery: if a cycle crashes without releasing its lease, the next scheduler
+ * tick skips the trader (leaseUntil > now). After CYCLE_LEASE_TTL_MS the lease
+ * expires, listStaleTradersForCycle returns the trader again, and a new cycle
+ * acquires with a fresh generation — preventing double-execution.
+ */
+export const acquireCycleLease = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    expectedGeneration: v.number(),
+    leaseUntil: v.number(),
+  },
+  handler: async (ctx, { traderId, expectedGeneration, leaseUntil }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return { acquired: false, generation: expectedGeneration };
+
+    const currentGeneration = trader.cycleGeneration ?? 0;
+    const now = Date.now();
+
+    // CAS check: generation must match AND no active lease
+    const leaseActive =
+      trader.cycleLeaseUntil !== undefined && trader.cycleLeaseUntil > now;
+    if (currentGeneration !== expectedGeneration || leaseActive) {
+      return { acquired: false, generation: currentGeneration };
+    }
+
+    const newGeneration = currentGeneration + 1;
+    await ctx.db.patch(traderId, {
+      cycleGeneration: newGeneration,
+      cycleLeaseUntil: leaseUntil,
+      updatedAt: now,
+    });
+
+    return { acquired: true, generation: newGeneration };
+  },
+});
+
+/**
+ * Release the cycle lease for a trader.
+ * Only clears the lease if the generation matches (prevents a late release
+ * from clearing a lease owned by a recovery cycle).
+ */
+export const releaseCycleLease = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    generation: v.number(),
+  },
+  handler: async (ctx, { traderId, generation }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return;
+    if ((trader.cycleGeneration ?? 0) !== generation) return; // stale release
+
+    await ctx.db.patch(traderId, {
+      cycleLeaseUntil: undefined,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/**
+ * Record that a cycle completed successfully.
+ * Updates lastCycleAt and clears the lease atomically.
+ * Generation check prevents a stale completion from overwriting a newer cycle.
+ */
+export const markCycleComplete = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    generation: v.number(),
+    lastCycleAt: v.number(),
+  },
+  handler: async (ctx, { traderId, generation, lastCycleAt }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return;
+    if ((trader.cycleGeneration ?? 0) !== generation) return; // stale
+
+    await ctx.db.patch(traderId, {
+      lastCycleAt,
+      cycleLeaseUntil: undefined,
+      updatedAt: Date.now(),
+    });
+  },
+});

--- a/convex/agent/scheduler.ts
+++ b/convex/agent/scheduler.ts
@@ -1,0 +1,37 @@
+"use node";
+
+import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+/**
+ * Convex internal scheduler action — replaces the legacy Vercel Cron HTTP path.
+ *
+ * Triggered every 1 minute via convex/crons.ts (Convex minimum; PRD target is
+ * 30s but the platform constraint is 1m on most plans).
+ *
+ * For each eligible trader (active, wallet ready, no live lease, lastCycleAt
+ * stale) it enqueues an immediate cycle action via ctx.scheduler.runAfter.
+ * No HMAC, no HTTP self-call, no user auth context (internal-only action).
+ */
+export const scheduler = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const staleTraders = await ctx.runQuery(
+      internal.agent.internal.listStaleTradersForCycle,
+      {}
+    );
+
+    if (staleTraders.length === 0) return;
+
+    for (const trader of staleTraders) {
+      await ctx.scheduler.runAfter(0, internal.agent.cycle.cycle, {
+        traderId: trader._id,
+      });
+    }
+
+    console.log(
+      `[scheduler] enqueued ${staleTraders.length} cycle(s):`,
+      staleTraders.map((t) => t._id)
+    );
+  },
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,19 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+/**
+ * Agent scheduler cron — fires every 1 minute (Convex minimum; PRD target is
+ * 30 s but the platform constraint is 1 m on most plans).
+ *
+ * Calls internal.agent.scheduler which queries stale active traders and fans
+ * out one cycle action per trader via ctx.scheduler.runAfter(0, ...).
+ */
+crons.interval(
+  "agent-scheduler",
+  { minutes: 1 },
+  internal.agent.scheduler.scheduler
+);
+
+export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -27,6 +27,9 @@ export default defineSchema({
     personality: v.optional(v.string()),
     escrowBalanceUsdc: v.optional(v.number()),
     lastCycleAt: v.optional(v.number()),
+    // Cycle lease fields for idempotent, non-overlapping agent cycles (issue #85)
+    cycleLeaseUntil: v.optional(v.number()),
+    cycleGeneration: v.optional(v.number()),
     // CDP wallet pipeline
     walletStatus: v.union(
       v.literal("pending"),

--- a/src/app/api/agent/cycle/route.ts
+++ b/src/app/api/agent/cycle/route.ts
@@ -10,10 +10,26 @@ import { agentCycleLimit, checkRateLimit } from "@/lib/rate-limit";
 /**
  * POST /api/agent/cycle
  *
- * Runs one iteration of the autonomous trade loop for a trader.
- * Continuation is driven by Vercel Cron → POST /api/agent/scheduler (not self-POST + after()).
+ * LEGACY — guarded by LEGACY_AGENT_LOOP=1 env flag (issue #85).
+ * The Convex-native cycle action (convex/agent/cycle.ts) is now the canonical path.
+ * This HTTP route is kept to avoid breaking existing tooling until the full removal
+ * tracked in issue #91.
+ *
+ * To re-enable: set LEGACY_AGENT_LOOP=1 in your environment.
+ * Default: disabled (returns 503).
  */
 export async function POST(request: NextRequest) {
+  if (process.env.LEGACY_AGENT_LOOP !== "1") {
+    return NextResponse.json(
+      {
+        error:
+          "Legacy agent loop is disabled. Set LEGACY_AGENT_LOOP=1 to re-enable. " +
+          "The Convex-native cycle action (convex/agent/cycle.ts) is now active.",
+      },
+      { status: 503 }
+    );
+  }
+
   try {
     // Verify SIWA (Sign In With Agent) authentication
     const siwaMessageB64 = request.headers.get("x-siwa-message");

--- a/src/app/api/agent/scheduler/route.ts
+++ b/src/app/api/agent/scheduler/route.ts
@@ -7,10 +7,25 @@ import { AGENT_CRON_STALE_MS } from "@/lib/constants";
 /**
  * POST /api/agent/scheduler
  *
- * Vercel Cron: fans out signed agent cycles for active traders whose last cycle
- * started longer ago than AGENT_CRON_STALE_MS. Replaces fragile self-POST + after() chains.
+ * LEGACY — guarded by LEGACY_AGENT_LOOP=1 env flag (issue #85).
+ * The Convex cron + internal.agent.scheduler action is now the canonical path.
+ * This route is kept to avoid breaking existing Vercel Cron config until the
+ * full removal tracked in issue #91.
+ *
+ * To re-enable: set LEGACY_AGENT_LOOP=1 in your environment.
+ * Default: disabled (returns 503).
  */
 export async function POST(request: NextRequest) {
+  if (process.env.LEGACY_AGENT_LOOP !== "1") {
+    return NextResponse.json(
+      {
+        error:
+          "Legacy agent loop is disabled. Set LEGACY_AGENT_LOOP=1 to re-enable. " +
+          "The Convex-native cron (convex/crons.ts) is now the active scheduler.",
+      },
+      { status: 503 }
+    );
+  }
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret) {
     return NextResponse.json(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }


### PR DESCRIPTION
## Summary

- **`convex/crons.ts`** — registers a 1-minute interval cron (Convex minimum; PRD target 30 s, platform constraint 1 m) calling `internal.agent.scheduler`
- **`convex/agent/scheduler.ts`** — `internalAction` that queries stale active traders (no lease, lastCycleAt older than 60 s, walletStatus=ready, status=active) and fans out one `internal.agent.cycle` per trader via `ctx.scheduler.runAfter(0, ...)`; no HTTP, no HMAC, no `ctx.auth`
- **`convex/agent/cycle.ts`** — skeleton `internalAction` with full lease-based CAS idempotency; deal selection and outcome resolver wired in #86
- **`convex/agent/internal.ts`** — `loadTraderForCycle`, `listStaleTradersForCycle`, `acquireCycleLease`, `releaseCycleLease`, `markCycleComplete` helpers
- **`convex/schema.ts`** — additive: `cycleLeaseUntil?: number`, `cycleGeneration?: number` on `traders`
- **Legacy gates** — `POST /api/agent/scheduler` and `POST /api/agent/cycle` now return 503 unless `LEGACY_AGENT_LOOP=1` is set (default off); full removal tracked in #91

## Idempotency strategy

**Lease-based CAS with monotonic generation counter**

Each trader doc carries:
- `cycleGeneration: number` — monotonically incremented integer, owned by the holder of the current lease
- `cycleLeaseUntil: number` — epoch-ms expiry of the active lease

**Acquisition** (`acquireCycleLease`) is an atomic Convex mutation. The scheduler reads `cycleGeneration` from `listStaleTradersForCycle`; the cycle action passes it as `expectedGeneration`. The mutation only proceeds if:
1. `trader.cycleGeneration === expectedGeneration` (no other cycle acquired since the scheduler read)
2. `trader.cycleLeaseUntil` is either unset or in the past (no active lease)

On success, `cycleGeneration` is incremented and `cycleLeaseUntil` is stamped to `now + 90 s`.

**Overlapping ticks**: `listStaleTradersForCycle` filters out any trader with `cycleLeaseUntil > now`, so the scheduler never enqueues a second cycle while one is running. Belt-and-suspenders: even if a race delivers a duplicate, the CAS check rejects it.

**Crash recovery**: if a cycle crashes without releasing, the lease auto-expires after 90 s. The next scheduler tick sees no active lease and enqueues a fresh cycle with an incremented generation.

**Stale releases**: `releaseCycleLease` and `markCycleComplete` both check `trader.cycleGeneration === generation` before writing, so a late-running stale cycle cannot corrupt a newer cycle's state.

## Env flag guarding legacy code

`LEGACY_AGENT_LOOP=1` — default **off** (legacy routes return 503). Set to `"1"` to re-enable the old Vercel Cron + HMAC path during any rollback. Full removal in #91.

## Test plan

- [ ] `pnpm build` — TypeScript compiles cleanly (Supabase env errors are pre-existing and unrelated)
- [ ] `pnpm lint` — 0 new errors
- [ ] `npx convex dev --once` — schema migration applies without errors; agent/* modules are registered
- [ ] Convex dashboard shows `agent-scheduler` cron firing every minute
- [ ] With `LEGACY_AGENT_LOOP` unset, `POST /api/agent/scheduler` returns 503
- [ ] With `LEGACY_AGENT_LOOP=1`, legacy route works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)