### PR TITLE
feat(convex): #84 persist SIWA nonces in Convex

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,8 +8,10 @@
  * @module
  */
 
+import type * as crons from "../crons.js";
 import type * as deskManagers from "../deskManagers.js";
 import type * as me from "../me.js";
+import type * as siwaNonces from "../siwaNonces.js";
 import type * as traders from "../traders.js";
 import type * as wallet from "../wallet.js";
 
@@ -20,8 +22,10 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  crons: typeof crons;
   deskManagers: typeof deskManagers;
   me: typeof me;
+  siwaNonces: typeof siwaNonces;
   traders: typeof traders;
   wallet: typeof wallet;
 }>;

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -24,6 +24,8 @@ export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Doc<TableName extends TableNames> = DocumentByName<
   DataModel,
@@ -40,6 +42,8 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
 export type Id<TableName extends TableNames | SystemTableNames> =
   GenericId<TableName>;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,18 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+/**
+ * Purge expired SIWA nonces every hour.
+ * Nonces have a short TTL (default 5 min); this is a safety net for any
+ * that were issued but never consumed (e.g. abandoned auth flows).
+ */
+crons.hourly(
+  "purge expired siwa nonces",
+  { minuteUTC: 0 },
+  internal.siwaNonces.cleanup,
+  {}
+);
+
+export default crons;

--- a/convex/siwaNonces.ts
+++ b/convex/siwaNonces.ts
@@ -1,0 +1,97 @@
+import { internalMutation, internalQuery } from "./_generated/server";
+import { v } from "convex/values";
+
+/**
+ * SIWA nonce retention policy:
+ *   - Nonces are issued with a caller-supplied TTL (typically 5 minutes per SIWA spec).
+ *   - A Convex cron (convex/crons.ts) runs `cleanup` every hour to purge expired rows.
+ *   - `consume` deletes the row atomically; a second call returns null (idempotent).
+ */
+
+/** Internal: insert a new nonce row. Returns false if the nonce already exists (idempotent). */
+export const issue = internalMutation({
+  args: {
+    nonce: v.string(),
+    /** Unix timestamp (ms) when this nonce expires. */
+    expiresAt: v.number(),
+  },
+  handler: async (ctx, { nonce, expiresAt }) => {
+    // Idempotency: if the nonce is already stored just return true
+    const existing = await ctx.db
+      .query("siwaNonces")
+      .withIndex("byNonce", (q) => q.eq("nonce", nonce))
+      .unique();
+    if (existing) return false;
+
+    await ctx.db.insert("siwaNonces", {
+      nonce,
+      expiresAt,
+      createdAt: Date.now(),
+    });
+    return true;
+  },
+});
+
+/**
+ * Internal: read the nonce row without side-effects.
+ * Returns null if not found or already expired.
+ */
+export const find = internalQuery({
+  args: { nonce: v.string() },
+  handler: async (ctx, { nonce }) => {
+    const row = await ctx.db
+      .query("siwaNonces")
+      .withIndex("byNonce", (q) => q.eq("nonce", nonce))
+      .unique();
+    if (!row) return null;
+    if (row.expiresAt < Date.now()) return null;
+    return row;
+  },
+});
+
+/**
+ * Internal: atomically validate and delete a nonce.
+ *
+ * Returns:
+ *   "ok"               — nonce existed, was valid, and has been deleted
+ *   "expired"          — nonce existed but its TTL had passed (row deleted as a side-effect)
+ *   "notFound"         — nonce never existed or was already consumed
+ *
+ * This is idempotent: a second call on the same nonce always returns "notFound".
+ */
+export const consume = internalMutation({
+  args: { nonce: v.string() },
+  handler: async (ctx, { nonce }): Promise<"ok" | "expired" | "notFound"> => {
+    const row = await ctx.db
+      .query("siwaNonces")
+      .withIndex("byNonce", (q) => q.eq("nonce", nonce))
+      .unique();
+
+    if (!row) return "notFound";
+
+    // Always delete — whether valid or expired — so the row is consumed exactly once
+    await ctx.db.delete(row._id);
+
+    if (row.expiresAt < Date.now()) return "expired";
+    return "ok";
+  },
+});
+
+/**
+ * Internal: delete all rows whose expiresAt is in the past.
+ * Called by the hourly cron in convex/crons.ts.
+ * Safe to run concurrently; each row is deleted at most once.
+ */
+export const cleanup = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const expired = await ctx.db
+      .query("siwaNonces")
+      .withIndex("byExpiresAt", (q) => q.lt("expiresAt", now))
+      .collect();
+
+    await Promise.all(expired.map((row) => ctx.db.delete(row._id)));
+    return { deleted: expired.length };
+  },
+});

--- a/src/lib/convex/server-client.ts
+++ b/src/lib/convex/server-client.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { ConvexHttpClient } from "convex/browser";
+
+/**
+ * Returns a server-side Convex HTTP client configured with the deploy key so
+ * that internal functions (internalMutation / internalQuery) can be called
+ * from Next.js API routes.
+ *
+ * `setAdminAuth` is an undocumented (but stable) method on ConvexHttpClient that
+ * accepts the Convex deploy key and grants access to internal functions.
+ *
+ * Required env vars:
+ *   NEXT_PUBLIC_CONVEX_URL   — deployment URL (shared with browser client)
+ *   CONVEX_DEPLOY_KEY        — secret deploy key (never exposed to the browser)
+ */
+export function createConvexAdminClient(): ConvexHttpClient {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!url) {
+    throw new Error(
+      "NEXT_PUBLIC_CONVEX_URL is not set. Add it to your .env.local file."
+    );
+  }
+
+  const deployKey = process.env.CONVEX_DEPLOY_KEY;
+  if (!deployKey) {
+    throw new Error(
+      "CONVEX_DEPLOY_KEY is not set. Add it to your .env.local file."
+    );
+  }
+
+  const client = new ConvexHttpClient(url);
+  // setAdminAuth exists at runtime but is not in the public TypeScript API;
+  // it is required to call internal Convex functions from outside Convex.
+  (client as unknown as { setAdminAuth(token: string): void }).setAdminAuth(
+    deployKey
+  );
+  return client;
+}

--- a/src/lib/siwa/__tests__/nonce-store.test.ts
+++ b/src/lib/siwa/__tests__/nonce-store.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for the Convex-backed SIWA nonce store.
+ *
+ * These tests exercise the read/write paths of `createConvexNonceStore` by
+ * mocking the Convex admin client so no real network call is made.
+ */
+
+// Mock the admin client module before importing nonce-store
+vi.mock("@/lib/convex/server-client", () => ({
+  createConvexAdminClient: vi.fn(),
+}));
+
+// Mock "server-only" to avoid Next.js server-only guard in tests
+vi.mock("server-only", () => ({}));
+
+import { createConvexAdminClient } from "@/lib/convex/server-client";
+import { createConvexNonceStore } from "@/lib/siwa/nonce-store";
+
+const mockMutation = vi.fn();
+const mockClient = { mutation: mockMutation };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (createConvexAdminClient as ReturnType<typeof vi.fn>).mockReturnValue(
+    mockClient
+  );
+});
+
+describe("createConvexNonceStore", () => {
+  describe("issue", () => {
+    it("returns true when Convex mutation inserts successfully", async () => {
+      mockMutation.mockResolvedValueOnce(true);
+      const store = createConvexNonceStore();
+      const result = await store.issue("abc123", 5 * 60 * 1000);
+      expect(result).toBe(true);
+      expect(mockMutation).toHaveBeenCalledOnce();
+    });
+
+    it("returns false when nonce already exists (Convex mutation returns false)", async () => {
+      mockMutation.mockResolvedValueOnce(false);
+      const store = createConvexNonceStore();
+      const result = await store.issue("abc123", 5 * 60 * 1000);
+      expect(result).toBe(false);
+    });
+
+    it("passes nonce and a future expiresAt to the mutation", async () => {
+      mockMutation.mockResolvedValueOnce(true);
+      const before = Date.now();
+      const store = createConvexNonceStore();
+      await store.issue("mynonce", 300_000);
+      const after = Date.now();
+
+      const [, args] = mockMutation.mock.calls[0];
+      expect(args.nonce).toBe("mynonce");
+      expect(args.expiresAt).toBeGreaterThanOrEqual(before + 300_000);
+      expect(args.expiresAt).toBeLessThanOrEqual(after + 300_000);
+    });
+  });
+
+  describe("consume", () => {
+    it('returns true when Convex mutation returns "ok"', async () => {
+      mockMutation.mockResolvedValueOnce("ok");
+      const store = createConvexNonceStore();
+      const result = await store.consume("abc123");
+      expect(result).toBe(true);
+    });
+
+    it('returns false when Convex mutation returns "expired"', async () => {
+      mockMutation.mockResolvedValueOnce("expired");
+      const store = createConvexNonceStore();
+      const result = await store.consume("abc123");
+      expect(result).toBe(false);
+    });
+
+    it('returns false when Convex mutation returns "notFound" (idempotent second call)', async () => {
+      mockMutation.mockResolvedValueOnce("notFound");
+      const store = createConvexNonceStore();
+      const result = await store.consume("already-consumed");
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/lib/siwa/nonce-store.ts
+++ b/src/lib/siwa/nonce-store.ts
@@ -1,48 +1,45 @@
 import "server-only";
 
 import type { SIWANonceStore } from "@buildersgarden/siwa/nonce-store";
-import { createServerClient } from "@/lib/supabase/client";
+import { createConvexAdminClient } from "@/lib/convex/server-client";
+import { internal } from "../../../convex/_generated/api";
 
 /**
- * Supabase-backed SIWA nonce store.
- * Works across serverless invocations (unlike the in-memory store).
+ * Convex-backed SIWA nonce store.
+ *
+ * Retention policy:
+ *   - Nonces are inserted with the TTL supplied by the SIWA library (default 5 min).
+ *   - `consume` deletes the row immediately on first use; subsequent calls return false.
+ *   - An hourly Convex cron (convex/crons.ts) purges any rows that were issued but
+ *     never consumed (e.g. abandoned auth flows).
  */
-export function createSupabaseNonceStore(): SIWANonceStore {
+export function createConvexNonceStore(): SIWANonceStore {
   return {
     async issue(nonce: string, ttlMs: number): Promise<boolean> {
-      const supabase = createServerClient();
-      const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+      const convex = createConvexAdminClient();
+      const expiresAt = Date.now() + ttlMs;
 
-      const { error } = await supabase
-        .from("siwa_nonces")
-        .insert({ nonce, expires_at: expiresAt });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const inserted = await (convex as any).mutation(
+        internal.siwaNonces.issue,
+        { nonce, expiresAt }
+      );
 
-      if (error) {
-        // Unique constraint violation → nonce already exists
-        if (error.code === "23505") return false;
-        console.error("[SIWA nonce] issue error:", error.message);
-        return false;
-      }
-      return true;
+      return inserted as boolean;
     },
 
     async consume(nonce: string): Promise<boolean> {
-      const supabase = createServerClient();
+      const convex = createConvexAdminClient();
 
-      // Atomically delete the nonce if it exists and hasn't expired
-      const { data, error } = await supabase
-        .from("siwa_nonces")
-        .delete()
-        .eq("nonce", nonce)
-        .gte("expires_at", new Date().toISOString())
-        .select("nonce");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (convex as any).mutation(
+        internal.siwaNonces.consume,
+        { nonce }
+      );
 
-      if (error) {
-        console.error("[SIWA nonce] consume error:", error.message);
-        return false;
-      }
-
-      return data !== null && data.length > 0;
+      // "ok" → nonce was valid and has been consumed
+      // "expired" | "notFound" → treat as invalid
+      return (result as string) === "ok";
     },
   };
 }

--- a/src/lib/siwa/verify.ts
+++ b/src/lib/siwa/verify.ts
@@ -7,10 +7,10 @@ import {
   IDENTITY_REGISTRY_ADDRESS,
   CONTRACTS_CHAIN_ID,
 } from "@/lib/contracts/escrow";
-import { createSupabaseNonceStore } from "@/lib/siwa/nonce-store";
+import { createConvexNonceStore } from "@/lib/siwa/nonce-store";
 import { createServerClient } from "@/lib/supabase/client";
 
-const nonceStore = createSupabaseNonceStore();
+const nonceStore = createConvexNonceStore();
 
 const domain =
   process.env.NEXT_PUBLIC_APP_URL?.replace(/^https?:\/\//, "") ??


### PR DESCRIPTION
## Summary

- Adds `convex/siwaNonces.ts` with four internal functions: `issue` (idempotent insert), `consume` (atomic read-delete returning `ok`/`expired`/`notFound`), `find` (non-destructive read), and `cleanup` (bulk purge expired rows)
- Adds `convex/crons.ts` with an hourly cron that calls `internal.siwaNonces.cleanup` as a safety net for abandoned auth flows
- Replaces Supabase-backed `createSupabaseNonceStore` in `src/lib/siwa/nonce-store.ts` with `createConvexNonceStore` backed by Convex internal mutations
- Adds `src/lib/convex/server-client.ts` — a server-only helper that builds a `ConvexHttpClient` authenticated with `CONVEX_DEPLOY_KEY` for calling internal functions from Next.js API routes
- Updates `src/lib/siwa/verify.ts` to use `createConvexNonceStore`
- Regenerates `convex/_generated` types after adding the `siwaNonces` module (verified with `npx convex dev --once` against the dev deployment)
- Adds 6 unit tests for nonce-store `issue`/`consume` paths; all pass

## Retention policy

Nonces are issued with the SIWA library's default TTL of **5 minutes**. `consume` deletes the row on first call (idempotent — second call returns `"notFound"`). An **hourly Convex cron** (`convex/crons.ts`) purges any rows that expired without being consumed (abandoned auth flows).

## New env var required

```
CONVEX_DEPLOY_KEY=<your-convex-deploy-key>
```

Add to `.env.local`. Never expose this to the browser.

## Test plan

- [x] `pnpm build` passes (TypeScript clean)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` — 6 new nonce-store unit tests pass; only pre-existing `chain-id.test.ts` failures remain (present on base branch)
- [x] `npx convex dev --once` succeeds — siwaNonces indexes visible in deployment
- [ ] Manual smoke: `POST /api/siwa/nonce` → confirm row appears in Convex dashboard; complete auth flow → confirm row disappears

Closes #84. Stacks on #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)