### PR TITLE
feat(wire): deal seed CTA hierarchy, premise prefill, and global crea…

### DIFF
--- a/src/app/wire/page.tsx
+++ b/src/app/wire/page.tsx
@@ -7,6 +7,7 @@ import { api } from "../../../convex/_generated/api";
 import { Nav } from "@/components/nav";
 import { WireFeed } from "@/components/wire/wire-feed";
 import { WireStatsBar } from "@/components/wire/wire-stats-bar";
+import { CreateDealDialog } from "@/components/wire/create-deal-dialog";
 import { DEAL_CREATION_FEE_PERCENTAGE } from "@/lib/constants";
 
 const HOW_DEALS_SECTIONS = [
@@ -35,6 +36,7 @@ export default function WirePage() {
   const drops = useQuery(api.marketNarratives.feedDrops, { limit: 20 });
   const isLoading = drops === undefined;
   const [howDealsOpen, setHowDealsOpen] = useState(false);
+  const [globalDealOpen, setGlobalDealOpen] = useState(false);
 
   const latestMood = drops?.[0]?.mood;
   const latestSecHeat = drops?.[0]?.secHeat;
@@ -60,6 +62,12 @@ export default function WirePage() {
                   HOW DEALS WORK
                 </button>
               </div>
+              <button
+                onClick={() => setGlobalDealOpen(true)}
+                className="cursor-pointer border border-[var(--t-accent)] bg-[var(--t-accent)] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[var(--t-bg)] transition-colors hover:bg-transparent hover:text-[var(--t-accent)]"
+              >
+                + CREATE DEAL
+              </button>
               {latestMood != null && (
                 <div className="flex items-center gap-3 text-xs">
                   <span className="text-[var(--t-muted)]">
@@ -131,6 +139,14 @@ export default function WirePage() {
               </Dialog.Popup>
             </Dialog.Portal>
           </Dialog.Root>
+
+          {globalDealOpen && (
+            <CreateDealDialog
+              headline={{ headline: "", body: "" }}
+              open={globalDealOpen}
+              onOpenChange={setGlobalDealOpen}
+            />
+          )}
 
           <div className="px-4 pb-4">
             {isLoading ? (

--- a/src/components/wire/create-deal-dialog.tsx
+++ b/src/components/wire/create-deal-dialog.tsx
@@ -2,15 +2,18 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
 import { Dialog } from "@base-ui/react/dialog";
 import { useSuggestPrompts } from "@/hooks/use-deals";
 import { useCreateDeal } from "@/hooks/use-create-deal";
+import { useUsdcBalance } from "@/hooks/use-usdc-balance";
 import {
   DEAL_CREATION_FEE_PERCENTAGE,
   MIN_POT_AMOUNT,
   MIN_ENTRY_COST,
 } from "@/lib/constants";
 import type { Id } from "../../../convex/_generated/dataModel";
+
 const STEP_LABELS: Record<string, string> = {
   approving: "APPROVING USDC SPEND...",
   creating: "CREATING DEAL ON-CHAIN...",
@@ -31,8 +34,6 @@ interface CreateDealDialogProps {
   headline: { headline: string; body: string };
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  authenticated: boolean;
-  balance: number | undefined;
   /** When provided, the dialog opens straight into "configure" with prefilled values. */
   dealSeed?: DealSeedPrefill;
 }
@@ -41,14 +42,21 @@ export function CreateDealDialog({
   headline,
   open,
   onOpenChange,
-  authenticated,
-  balance,
   dealSeed,
 }: CreateDealDialogProps) {
+  const { authenticated } = usePrivy();
+  const { balance } = useUsdcBalance();
+
+  // Open directly in configure when there's a seed or a source headline to prefill
+  const openInConfigure = !!(dealSeed || headline.headline);
+  const initialPrompt =
+    dealSeed?.prompt ??
+    [headline.headline, headline.body].filter(Boolean).join("\n\n");
+
   const [state, setState] = useState<DialogState>(
-    dealSeed ? "configure" : "suggestions"
+    openInConfigure ? "configure" : "suggestions"
   );
-  const [selectedPrompt, setSelectedPrompt] = useState(dealSeed?.prompt ?? "");
+  const [selectedPrompt, setSelectedPrompt] = useState(initialPrompt);
   const [potAmount, setPotAmount] = useState(
     dealSeed ? dealSeed.suggestedPotUsdc.toString() : MIN_POT_AMOUNT.toString()
   );
@@ -101,8 +109,7 @@ export function CreateDealDialog({
   };
 
   const handleBack = () => {
-    if (dealSeed) {
-      // Seed-driven flow has no suggestion step; close the dialog instead.
+    if (openInConfigure) {
       onOpenChange(false);
       return;
     }
@@ -128,16 +135,18 @@ export function CreateDealDialog({
           </div>
 
           {/* Source headline context */}
-          <div className="border-b border-[var(--t-border)] px-4 py-2">
-            <p className="text-xs font-bold text-[var(--t-text)]">
-              {headline.headline}
-            </p>
-            {headline.body && (
-              <p className="mt-1 text-[11px] leading-relaxed text-[var(--t-muted)]">
-                {headline.body}
+          {headline.headline && (
+            <div className="border-b border-[var(--t-border)] px-4 py-2">
+              <p className="text-xs font-bold text-[var(--t-text)]">
+                {headline.headline}
               </p>
-            )}
-          </div>
+              {headline.body && (
+                <p className="mt-1 text-[11px] leading-relaxed text-[var(--t-muted)]">
+                  {headline.body}
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Suggestions state */}
           {state === "suggestions" && (
@@ -146,7 +155,7 @@ export function CreateDealDialog({
                 <div className="px-4 py-6 text-center">
                   <p className="text-xs text-[var(--t-muted)]">
                     GENERATING DEAL IDEAS...
-                    <span className="cursor-blink">{"\u2588"}</span>
+                    <span className="cursor-blink">{"█"}</span>
                   </p>
                 </div>
               ) : suggestQuery.data ? (
@@ -276,7 +285,7 @@ export function CreateDealDialog({
                       {STEP_LABELS[step] ?? "PROCESSING..."}
                     </span>
                     <span className="cursor-blink text-[var(--t-green)]">
-                      {"\u2588"}
+                      {"█"}
                     </span>
                   </div>
                   <div className="mt-1 h-0.5 overflow-hidden bg-[var(--t-border)]">

--- a/src/components/wire/wire-drop.tsx
+++ b/src/components/wire/wire-drop.tsx
@@ -46,16 +46,9 @@ interface WireDispatchProps {
     dealSeed?: WireDealSeed;
   };
   headlineDeals?: Deal[];
-  authenticated: boolean;
-  balance: number | undefined;
 }
 
-export function WireDispatch({
-  dispatch,
-  headlineDeals,
-  authenticated,
-  balance,
-}: WireDispatchProps) {
+export function WireDispatch({ dispatch, headlineDeals }: WireDispatchProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const dealCount = headlineDeals?.length ?? 0;
@@ -88,9 +81,13 @@ export function WireDispatch({
       <div className="mt-2 flex items-center justify-between">
         <button
           onClick={() => setDialogOpen(true)}
-          className="flex items-center gap-1.5 border border-[var(--t-accent)] px-3 py-1 text-[11px] font-bold text-[var(--t-accent)] transition-colors hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+          className={
+            seed
+              ? "flex items-center gap-1.5 border border-[var(--t-accent)] px-3 py-1 text-[11px] font-bold text-[var(--t-accent)] transition-colors hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+              : "text-[10px] text-[var(--t-muted)] transition-colors hover:text-[var(--t-accent)]"
+          }
         >
-          {seed ? "$ CREATE DEAL FROM THIS" : "$ CREATE DEAL"}
+          {seed ? "$ CREATE DEAL FROM THIS" : "USE AS PREMISE →"}
         </button>
 
         {seed && (
@@ -120,8 +117,6 @@ export function WireDispatch({
           headline={{ headline: dispatch.headline, body: dispatch.body }}
           open={dialogOpen}
           onOpenChange={setDialogOpen}
-          authenticated={authenticated}
-          balance={balance}
           dealSeed={
             seed
               ? {
@@ -141,16 +136,9 @@ export function WireDispatch({
 interface WireDropBlockProps {
   drop: WireDrop;
   headlineDealsMap?: Record<string, Deal[]>;
-  authenticated: boolean;
-  balance: number | undefined;
 }
 
-export function WireDropBlock({
-  drop,
-  headlineDealsMap,
-  authenticated,
-  balance,
-}: WireDropBlockProps) {
+export function WireDropBlock({ drop, headlineDealsMap }: WireDropBlockProps) {
   const timeStr = useMemo(
     () =>
       new Date(drop.createdAt).toLocaleTimeString("en-US", {
@@ -207,8 +195,6 @@ export function WireDropBlock({
           <WireDispatch
             dispatch={{ ...dispatch, createdAt: drop.createdAt }}
             headlineDeals={headlineDealsMap?.[dispatch.headline]}
-            authenticated={authenticated}
-            balance={balance}
           />
         </div>
       ))}

--- a/src/components/wire/wire-feed.tsx
+++ b/src/components/wire/wire-feed.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
 import { useHeadlineDeals } from "@/hooks/use-deals";
-import { useUsdcBalance } from "@/hooks/use-usdc-balance";
 import { WireDropBlock, type WireDrop } from "./wire-drop";
 
 export type { WireDrop };
 
 export function WireFeed({ drops }: { drops: WireDrop[] }) {
   const { data: headlineDealsMap } = useHeadlineDeals();
-  const { authenticated } = usePrivy();
-  const { balance } = useUsdcBalance();
 
   return (
     <div className="divide-y divide-[var(--t-border)]">
@@ -19,8 +15,6 @@ export function WireFeed({ drops }: { drops: WireDrop[] }) {
           key={drop.epoch}
           drop={drop}
           headlineDealsMap={headlineDealsMap}
-          authenticated={authenticated}
-          balance={balance}
         />
       ))}
     </div>


### PR DESCRIPTION
…te deal (#110)

- Seed dispatches show strong bordered CTA with suggested pot/entry preview
- Non-seed dispatches show lighter "USE AS PREMISE →" action that prefills headline/body into configure mode
- Wire page sticky header gains a persistent "+ CREATE DEAL" global button
- CreateDealDialog derives configure/suggestions mode from headline presence, eliminating premisePrefill prop
- Moved usePrivy/useUsdcBalance into CreateDealDialog, removing authenticated/balance prop chain through WireFeed → WireDropBlock → WireDispatch