### PR TITLE
test(wire): fix outside-hours test to use fake timers instead of rely…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,150 +126,6 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(terser@5.46.2)(yaml@2.8.2)
 
-  contracts/lib/forge-std: {}
-
-  contracts/lib/openzeppelin-contracts:
-    devDependencies:
-      "@changesets/changelog-github":
-        specifier: ^0.6.0
-        version: 0.6.0
-      "@changesets/cli":
-        specifier: ^2.26.0
-        version: 2.31.0(@types/node@22.7.5)
-      "@changesets/pre":
-        specifier: ^2.0.0
-        version: 2.0.2
-      "@changesets/read":
-        specifier: ^0.6.0
-        version: 0.6.7
-      "@eslint/compat":
-        specifier: ^1.2.1
-        version: 1.4.1(eslint@9.39.3(jiti@2.6.1))
-      "@ethereumjs/mpt":
-        specifier: ^10.1.0
-        version: 10.1.1
-      "@noble/curves":
-        specifier: ^2.0.1
-        version: 2.2.0
-      "@nomicfoundation/hardhat-chai-matchers":
-        specifier: ^2.0.6
-        version: 2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(chai@4.5.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      "@nomicfoundation/hardhat-ethers":
-        specifier: ^3.0.9
-        version: 3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      "@nomicfoundation/hardhat-network-helpers":
-        specifier: ^1.0.13
-        version: 1.1.2(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      "@openzeppelin/docs-utils":
-        specifier: ^0.1.6
-        version: 0.1.6
-      "@openzeppelin/merkle-tree":
-        specifier: ^1.0.7
-        version: 1.0.8
-      "@openzeppelin/upgrade-safe-transpiler":
-        specifier: ^0.4.1
-        version: 0.4.1
-      "@openzeppelin/upgrades-core":
-        specifier: ^1.20.6
-        version: 1.44.2
-      chai:
-        specifier: ^4.2.0
-        version: 4.5.0
-      eslint:
-        specifier: ^9.0.0
-        version: 9.39.3(jiti@2.6.1)
-      eslint-config-prettier:
-        specifier: ^10.0.0
-        version: 10.1.8(eslint@9.39.3(jiti@2.6.1))
-      ethers:
-        specifier: ^6.16.0
-        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      glob:
-        specifier: ^13.0.0
-        version: 13.0.6
-      globals:
-        specifier: ^17.0.0
-        version: 17.6.0
-      graphlib:
-        specifier: ^2.1.8
-        version: 2.1.8
-      hardhat:
-        specifier: ^2.28.5
-        version: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      hardhat-exposed:
-        specifier: ^0.3.15
-        version: 0.3.19(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      hardhat-gas-reporter:
-        specifier: ^2.1.0
-        version: 2.3.0(bufferutil@4.1.0)(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      hardhat-ignore-warnings:
-        specifier: ^0.2.11
-        version: 0.2.12
-      hardhat-predeploy:
-        specifier: ^0.4.1
-        version: 0.4.1(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
-      interoperable-addresses:
-        specifier: ^0.1.3
-        version: 0.1.3
-      lint-staged:
-        specifier: ^16.0.0
-        version: 16.3.2
-      lodash.startcase:
-        specifier: ^4.4.0
-        version: 4.4.0
-      micromatch:
-        specifier: ^4.0.2
-        version: 4.0.8
-      p-limit:
-        specifier: ^7.0.0
-        version: 7.3.0
-      prettier:
-        specifier: ^3.0.0
-        version: 3.8.1
-      prettier-plugin-solidity:
-        specifier: ^2.0.0
-        version: 2.3.1(prettier@3.8.1)
-      rimraf:
-        specifier: ^6.0.0
-        version: 6.1.3
-      semver:
-        specifier: ^7.3.5
-        version: 7.7.4
-      solhint:
-        specifier: ^6.0.1
-        version: 6.2.1(typescript@5.9.3)
-      solhint-plugin-openzeppelin:
-        specifier: file:scripts/solhint-custom
-        version: file:contracts/lib/openzeppelin-contracts/scripts/solhint-custom
-      solidity-ast:
-        specifier: ^0.4.50
-        version: 0.4.62
-      solidity-coverage:
-        specifier: ^0.8.14
-        version: 0.8.17(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      solidity-docgen:
-        specifier: ^0.6.0-beta.29
-        version: 0.6.0-beta.36(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      undici:
-        specifier: ^7.4.0
-        version: 7.25.0
-      yargs:
-        specifier: ^18.0.0
-        version: 18.0.0
-
-  contracts/lib/openzeppelin-contracts/contracts: {}
-
-  contracts/lib/openzeppelin-contracts/lib/forge-std: {}
-
-  contracts/lib/openzeppelin-contracts/scripts/solhint-custom:
-    dependencies:
-      minimatch:
-        specifier: ^10.2.2
-        version: 10.2.4
-
 packages:
   "@adraffy/ens-normalize@1.10.1":
     resolution:
@@ -592,139 +448,6 @@ packages:
       hono:
         optional: true
 
-  "@bytecodealliance/preview2-shim@0.17.0":
-    resolution:
-      {
-        integrity: sha512-JorcEwe4ud0x5BS/Ar2aQWOQoFzjq/7jcnxYXCvSMh0oRm0dQXzOA+hqLDBnOMks1LLBA7dmiLLsEBl09Yd6iQ==,
-      }
-
-  "@bytecodealliance/preview2-shim@0.17.9":
-    resolution:
-      {
-        integrity: sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==,
-      }
-
-  "@changesets/apply-release-plan@7.1.1":
-    resolution:
-      {
-        integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==,
-      }
-
-  "@changesets/assemble-release-plan@6.0.10":
-    resolution:
-      {
-        integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==,
-      }
-
-  "@changesets/changelog-git@0.2.1":
-    resolution:
-      {
-        integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
-      }
-
-  "@changesets/changelog-github@0.6.0":
-    resolution:
-      {
-        integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==,
-      }
-
-  "@changesets/cli@2.31.0":
-    resolution:
-      {
-        integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==,
-      }
-    hasBin: true
-
-  "@changesets/config@3.1.4":
-    resolution:
-      {
-        integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==,
-      }
-
-  "@changesets/errors@0.2.0":
-    resolution:
-      {
-        integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==,
-      }
-
-  "@changesets/get-dependents-graph@2.1.4":
-    resolution:
-      {
-        integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==,
-      }
-
-  "@changesets/get-github-info@0.8.0":
-    resolution:
-      {
-        integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==,
-      }
-
-  "@changesets/get-release-plan@4.0.16":
-    resolution:
-      {
-        integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==,
-      }
-
-  "@changesets/get-version-range-type@0.4.0":
-    resolution:
-      {
-        integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==,
-      }
-
-  "@changesets/git@3.0.4":
-    resolution:
-      {
-        integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==,
-      }
-
-  "@changesets/logger@0.1.1":
-    resolution:
-      {
-        integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==,
-      }
-
-  "@changesets/parse@0.4.3":
-    resolution:
-      {
-        integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==,
-      }
-
-  "@changesets/pre@2.0.2":
-    resolution:
-      {
-        integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==,
-      }
-
-  "@changesets/read@0.6.7":
-    resolution:
-      {
-        integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==,
-      }
-
-  "@changesets/should-skip-package@0.1.2":
-    resolution:
-      {
-        integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==,
-      }
-
-  "@changesets/types@4.1.0":
-    resolution:
-      {
-        integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==,
-      }
-
-  "@changesets/types@6.1.0":
-    resolution:
-      {
-        integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==,
-      }
-
-  "@changesets/write@0.4.0":
-    resolution:
-      {
-        integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
-      }
-
   "@coinbase/cdp-sdk@1.45.0":
     resolution:
       {
@@ -748,13 +471,6 @@ packages:
       {
         integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==,
       }
-
-  "@colors/colors@1.5.0":
-    resolution:
-      {
-        integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==,
-      }
-    engines: { node: ">=0.1.90" }
 
   "@dotenvx/dotenvx@1.53.0":
     resolution:
@@ -1292,18 +1008,6 @@ packages:
       }
     engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  "@eslint/compat@1.4.1":
-    resolution:
-      {
-        integrity: sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.40 || 9
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-
   "@eslint/config-array@0.21.1":
     resolution:
       {
@@ -1359,35 +1063,12 @@ packages:
         integrity: sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==,
       }
 
-  "@ethereumjs/mpt@10.1.1":
-    resolution:
-      {
-        integrity: sha512-Kh1vNhUwSIyuehOJk9Hqxzgu8D5B2L3jidKVaH4VB/dSo/6mVA0IKQ312c0ophXY8uU4f8NOTW602FJe6Ezaag==,
-      }
-    engines: { node: ">=20" }
-
-  "@ethereumjs/rlp@10.1.1":
-    resolution:
-      {
-        integrity: sha512-jbnWTEwcpoY+gE0r+wxfDG9zgiu54DcTcwnc9sX3DsqKR4l5K7x2V8mQL3Et6hURa4DuT9g7z6ukwpBLFchszg==,
-      }
-    engines: { node: ">=20" }
-    hasBin: true
-
   "@ethereumjs/rlp@4.0.1":
     resolution:
       {
         integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==,
       }
     engines: { node: ">=14" }
-    hasBin: true
-
-  "@ethereumjs/rlp@5.0.2":
-    resolution:
-      {
-        integrity: sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==,
-      }
-    engines: { node: ">=18" }
     hasBin: true
 
   "@ethereumjs/tx@4.2.0":
@@ -1397,145 +1078,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@ethereumjs/util@10.1.1":
-    resolution:
-      {
-        integrity: sha512-r2EhaeEmLZXVs1dT2HJFQysAkr63ZWATu/9tgYSp1IlvjvwyC++DLg5kCDwMM49HBq3sOAhrPnXkoqf9DV2gbw==,
-      }
-    engines: { node: ">=20" }
-
   "@ethereumjs/util@8.1.0":
     resolution:
       {
         integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==,
-      }
-    engines: { node: ">=14" }
-
-  "@ethereumjs/util@9.1.0":
-    resolution:
-      {
-        integrity: sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==,
-      }
-    engines: { node: ">=18" }
-
-  "@ethersproject/abi@5.8.0":
-    resolution:
-      {
-        integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==,
-      }
-
-  "@ethersproject/abstract-provider@5.8.0":
-    resolution:
-      {
-        integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==,
-      }
-
-  "@ethersproject/abstract-signer@5.8.0":
-    resolution:
-      {
-        integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==,
-      }
-
-  "@ethersproject/address@5.8.0":
-    resolution:
-      {
-        integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==,
-      }
-
-  "@ethersproject/base64@5.8.0":
-    resolution:
-      {
-        integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==,
-      }
-
-  "@ethersproject/bignumber@5.8.0":
-    resolution:
-      {
-        integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==,
-      }
-
-  "@ethersproject/bytes@5.8.0":
-    resolution:
-      {
-        integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==,
-      }
-
-  "@ethersproject/constants@5.8.0":
-    resolution:
-      {
-        integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==,
-      }
-
-  "@ethersproject/hash@5.8.0":
-    resolution:
-      {
-        integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==,
-      }
-
-  "@ethersproject/keccak256@5.8.0":
-    resolution:
-      {
-        integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==,
-      }
-
-  "@ethersproject/logger@5.8.0":
-    resolution:
-      {
-        integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==,
-      }
-
-  "@ethersproject/networks@5.8.0":
-    resolution:
-      {
-        integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==,
-      }
-
-  "@ethersproject/properties@5.8.0":
-    resolution:
-      {
-        integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==,
-      }
-
-  "@ethersproject/rlp@5.8.0":
-    resolution:
-      {
-        integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==,
-      }
-
-  "@ethersproject/signing-key@5.8.0":
-    resolution:
-      {
-        integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==,
-      }
-
-  "@ethersproject/strings@5.8.0":
-    resolution:
-      {
-        integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==,
-      }
-
-  "@ethersproject/transactions@5.8.0":
-    resolution:
-      {
-        integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==,
-      }
-
-  "@ethersproject/units@5.8.0":
-    resolution:
-      {
-        integrity: sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==,
-      }
-
-  "@ethersproject/web@5.8.0":
-    resolution:
-      {
-        integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==,
-      }
-
-  "@fastify/busboy@2.1.1":
-    resolution:
-      {
-        integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==,
       }
     engines: { node: ">=14" }
 
@@ -1582,13 +1128,6 @@ packages:
       {
         integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
       }
-
-  "@frangio/servbot@0.3.0-1":
-    resolution:
-      {
-        integrity: sha512-eKXRqt8Zh3aqtVYoyayuLiktcW6vnYCuwlcqg91cv3HSdM5foTmIECJEJiwI+GBmSLY37mzczpt/ZfvYqzrQWQ==,
-      }
-    engines: { node: ">=12.x", pnpm: 10.x }
 
   "@gemini-wallet/core@0.3.2":
     resolution:
@@ -1681,13 +1220,6 @@ packages:
         integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
       }
     engines: { node: ">=12.22" }
-
-  "@humanwhocodes/momoa@2.0.4":
-    resolution:
-      {
-        integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==,
-      }
-    engines: { node: ">=10.10.0" }
 
   "@humanwhocodes/retry@0.4.3":
     resolution:
@@ -1939,18 +1471,6 @@ packages:
       "@types/node":
         optional: true
 
-  "@inquirer/external-editor@1.0.3":
-    resolution:
-      {
-        integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==,
-      }
-    engines: { node: ">=18" }
-    peerDependencies:
-      "@types/node": ">=18"
-    peerDependenciesMeta:
-      "@types/node":
-        optional: true
-
   "@inquirer/figures@1.0.15":
     resolution:
       {
@@ -1969,13 +1489,6 @@ packages:
     peerDependenciesMeta:
       "@types/node":
         optional: true
-
-  "@isaacs/cliui@8.0.2":
-    resolution:
-      {
-        integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
-      }
-    engines: { node: ">=12" }
 
   "@jridgewell/gen-mapping@0.3.13":
     resolution:
@@ -2034,18 +1547,6 @@ packages:
         integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==,
       }
 
-  "@manypkg/find-root@1.1.0":
-    resolution:
-      {
-        integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==,
-      }
-
-  "@manypkg/get-packages@1.1.3":
-    resolution:
-      {
-        integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==,
-      }
-
   "@marsidev/react-turnstile@1.4.2":
     resolution:
       {
@@ -2054,13 +1555,6 @@ packages:
     peerDependencies:
       react: ^17.0.2 || ^18.0.0 || ^19.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0
-
-  "@metamask/abi-utils@2.0.4":
-    resolution:
-      {
-        integrity: sha512-StnIgUB75x7a7AgUhiaUZDpCsqGp7VkNnZh2XivXkJ6mPkE83U8ARGQj5MbRis7VJY8BC5V1AbB1fjdh0hupPQ==,
-      }
-    engines: { node: ">=16.0.0" }
 
   "@metamask/eth-json-rpc-provider@1.0.1":
     resolution:
@@ -2363,13 +1857,6 @@ packages:
       }
     engines: { node: ^14.21.3 || >=16 }
 
-  "@noble/curves@1.9.0":
-    resolution:
-      {
-        integrity: sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==,
-      }
-    engines: { node: ^14.21.3 || >=16 }
-
   "@noble/curves@1.9.1":
     resolution:
       {
@@ -2390,19 +1877,6 @@ packages:
         integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==,
       }
     engines: { node: ^14.21.3 || >=16 }
-
-  "@noble/curves@2.2.0":
-    resolution:
-      {
-        integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==,
-      }
-    engines: { node: ">= 20.19.0" }
-
-  "@noble/hashes@1.2.0":
-    resolution:
-      {
-        integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==,
-      }
 
   "@noble/hashes@1.3.2":
     resolution:
@@ -2439,19 +1913,6 @@ packages:
       }
     engines: { node: ^14.21.3 || >=16 }
 
-  "@noble/hashes@2.2.0":
-    resolution:
-      {
-        integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==,
-      }
-    engines: { node: ">= 20.19.0" }
-
-  "@noble/secp256k1@1.7.1":
-    resolution:
-      {
-        integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==,
-      }
-
   "@nodelib/fs.scandir@2.1.5":
     resolution:
       {
@@ -2479,158 +1940,6 @@ packages:
         integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==,
       }
     engines: { node: ">=12.4.0" }
-
-  "@nomicfoundation/edr-darwin-arm64@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-Amh7mRoDzZyJJ4efqoePqdoZOzharmSOttZuJDlVE5yy07BoE8hL6ZRpa5fNYn0LCqn/KoWs8OHANWxhKDGhvQ==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr-darwin-x64@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-9wn489FIQm7m0UCD+HhktjWx6vskZzeZD9oDc2k9ZvbBzdXwPp5tiDqUBJ+eQpByAzCDfteAJwRn2lQCE0U+Iw==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-nlk5EejSzEUfEngv0Jkhqq3/wINIfF2ED9wAofc22w/V1DV99ASh9l3/e/MIHOQFecIZ9MDqt0Em9/oDyB1Uew==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-SJuPBp3Rc6vM92UtVTUxZQ/QlLhLfwTftt2XUiYohmGKB3RjGzpgduEFMCA0LEnucUckU6UHrJNFHiDm77C4PQ==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-NU+Qs3u7Qt6t3bJFdmmjd5CsvgI2bPPzO31KifM2Ez96/jsXYho5debtTQnimlb5NAqiHTSlxjh/F8ROcptmeQ==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-F78fZA2h6/ssiCSZOovlgIu0dUeI7ItKPsDDF3UUlIibef052GCXmliMinC90jVPbrjUADMd1BUwjfI0Z8OllQ==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-IfJZQJn7d/YyqhmguBIGoCKjE9dKjbu6V6iNEPApfwf5JyyjHYyyfkLU4rf7hygj57bfH4sl1jtQ6r8HnT62lw==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/edr@0.12.0-next.23":
-    resolution:
-      {
-        integrity: sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==,
-      }
-    engines: { node: ">= 20" }
-
-  "@nomicfoundation/hardhat-chai-matchers@2.1.2":
-    resolution:
-      {
-        integrity: sha512-NlUlde/ycXw2bLzA2gWjjbxQaD9xIRbAF30nsoEprAWzH8dXEI1ILZUKZMyux9n9iygEXTzN0SDVjE6zWDZi9g==,
-      }
-    peerDependencies:
-      "@nomicfoundation/hardhat-ethers": ^3.1.0
-      chai: ^4.2.0
-      ethers: ^6.14.0
-      hardhat: ^2.26.0
-
-  "@nomicfoundation/hardhat-ethers@3.1.3":
-    resolution:
-      {
-        integrity: sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==,
-      }
-    peerDependencies:
-      ethers: ^6.14.0
-      hardhat: ^2.28.0
-
-  "@nomicfoundation/hardhat-network-helpers@1.1.2":
-    resolution:
-      {
-        integrity: sha512-p7HaUVDbLj7ikFivQVNhnfMHUBgiHYMwQWvGn9AriieuopGOELIrwj2KjyM2a6z70zai5YKO264Vwz+3UFJZPQ==,
-      }
-    peerDependencies:
-      hardhat: ^2.26.0
-
-  "@nomicfoundation/slang@0.18.3":
-    resolution:
-      {
-        integrity: sha512-YqAWgckqbHM0/CZxi9Nlf4hjk9wUNLC9ngWCWBiqMxPIZmzsVKYuChdlrfeBPQyvQQBoOhbx+7C1005kLVQDZQ==,
-      }
-
-  "@nomicfoundation/slang@1.3.4":
-    resolution:
-      {
-        integrity: sha512-ghzrPSYH1sZO65id6+Bq2Ood87HT54QP3RGC8EkmpcrJ6tT9Ky0RtaJfrzV5G4jpDsnNua6+YEDpzOMori04hQ==,
-      }
-
-  "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2":
-    resolution:
-      {
-        integrity: sha512-JaqcWPDZENCvm++lFFGjrDd8mxtf+CtLd2MiXvMNTBD33dContTZ9TWETwNFwg7JTJT5Q9HEecH7FA+HTSsIUw==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer-darwin-x64@0.1.2":
-    resolution:
-      {
-        integrity: sha512-fZNmVztrSXC03e9RONBT+CiksSeYcxI1wlzqyr0L7hsQlK1fzV+f04g2JtQ1c/Fe74ZwdV6aQBdd6Uwl1052sw==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer-linux-arm64-gnu@0.1.2":
-    resolution:
-      {
-        integrity: sha512-3d54oc+9ZVBuB6nbp8wHylk4xh0N0Gc+bk+/uJae+rUgbOBwQSfuGIbAZt1wBXs5REkSmynEGcqx6DutoK0tPA==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer-linux-arm64-musl@0.1.2":
-    resolution:
-      {
-        integrity: sha512-iDJfR2qf55vgsg7BtJa7iPiFAsYf2d0Tv/0B+vhtnI16+wfQeTbP7teookbGvAo0eJo7aLLm0xfS/GTkvHIucA==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer-linux-x64-gnu@0.1.2":
-    resolution:
-      {
-        integrity: sha512-9dlHMAt5/2cpWyuJ9fQNOUXFB/vgSFORg1jpjX1Mh9hJ/MfZXlDdHQ+DpFCs32Zk5pxRBb07yGvSHk9/fezL+g==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer-linux-x64-musl@0.1.2":
-    resolution:
-      {
-        integrity: sha512-GzzVeeJob3lfrSlDKQw2bRJ8rBf6mEYaWY+gW0JnTDHINA0s2gPR4km5RLIj1xeZZOYz4zRw+AEeYgLRqB2NXg==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer-win32-x64-msvc@0.1.2":
-    resolution:
-      {
-        integrity: sha512-Fdjli4DCcFHb4Zgsz0uEJXZ2K7VEO+w5KVv7HmT7WO10iODdU9csC2az4jrhEsRtiR9Gfd74FlG0NYlw1BMdyA==,
-      }
-    engines: { node: ">= 12" }
-
-  "@nomicfoundation/solidity-analyzer@0.1.2":
-    resolution:
-      {
-        integrity: sha512-q4n32/FNKIhQ3zQGGw5CvPF6GTvDCpYwIf7bEY/dZTZbgfDsHyjJwURxUJf3VQuuJj+fDIFl4+KkBVbw4Ef6jA==,
-      }
-    engines: { node: ">= 12" }
 
   "@open-draft/deferred-promise@2.2.0":
     resolution:
@@ -2971,33 +2280,6 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.1.0
 
-  "@openzeppelin/docs-utils@0.1.6":
-    resolution:
-      {
-        integrity: sha512-cVLtDPrCdVgnLV9QRK9D1jrTB8ezQ8tCLTM4g6PHe9TIK3DbO6lSizLF98DhncK2bk6uodOLRT3LO1WtNzei1Q==,
-      }
-    hasBin: true
-
-  "@openzeppelin/merkle-tree@1.0.8":
-    resolution:
-      {
-        integrity: sha512-E2c9/Y3vjZXwVvPZKqCKUn7upnvam1P1ZhowJyZVQSkzZm5WhumtaRr+wkUXrZVfkIc7Gfrl7xzabElqDL09ow==,
-      }
-
-  "@openzeppelin/upgrade-safe-transpiler@0.4.1":
-    resolution:
-      {
-        integrity: sha512-IxNqDuHLBUp7WcTtrfNrl7ccHzaKLB0Pn9YLE6HyMdzppbBiKls47cHFIC/uLI91cvZP0cheIyvtA3g/3FEdOA==,
-      }
-    hasBin: true
-
-  "@openzeppelin/upgrades-core@1.44.2":
-    resolution:
-      {
-        integrity: sha512-m6iorjyhPK9ow5/trNs7qsBC/SOzJCO51pvvAF2W9nOiZ1t0RtCd+rlRmRmlWTv4M33V0wzIUeamJ2BPbzgUXA==,
-      }
-    hasBin: true
-
   "@paulmillr/qr@0.2.1":
     resolution:
       {
@@ -3010,34 +2292,6 @@ packages:
       {
         integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==,
       }
-
-  "@pkgjs/parseargs@0.11.0":
-    resolution:
-      {
-        integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
-      }
-    engines: { node: ">=14" }
-
-  "@pnpm/config.env-replace@1.1.0":
-    resolution:
-      {
-        integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==,
-      }
-    engines: { node: ">=12.22.0" }
-
-  "@pnpm/network.ca-file@1.0.2":
-    resolution:
-      {
-        integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==,
-      }
-    engines: { node: ">=12.22.0" }
-
-  "@pnpm/npm-conf@3.0.2":
-    resolution:
-      {
-        integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==,
-      }
-    engines: { node: ">=12" }
 
   "@prisma/instrumentation@7.2.0":
     resolution:
@@ -3608,12 +2862,6 @@ packages:
         integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==,
       }
 
-  "@scure/bip32@1.1.5":
-    resolution:
-      {
-        integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==,
-      }
-
   "@scure/bip32@1.4.0":
     resolution:
       {
@@ -3630,12 +2878,6 @@ packages:
     resolution:
       {
         integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==,
-      }
-
-  "@scure/bip39@1.1.1":
-    resolution:
-      {
-        integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==,
       }
 
   "@scure/bip39@1.3.0":
@@ -3797,27 +3039,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@sentry/core@5.30.0":
-    resolution:
-      {
-        integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==,
-      }
-    engines: { node: ">=6" }
-
-  "@sentry/hub@5.30.0":
-    resolution:
-      {
-        integrity: sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==,
-      }
-    engines: { node: ">=6" }
-
-  "@sentry/minimal@5.30.0":
-    resolution:
-      {
-        integrity: sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==,
-      }
-    engines: { node: ">=6" }
-
   "@sentry/nextjs@10.42.0":
     resolution:
       {
@@ -3864,13 +3085,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@sentry/node@5.30.0":
-    resolution:
-      {
-        integrity: sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==,
-      }
-    engines: { node: ">=6" }
-
   "@sentry/opentelemetry@10.42.0":
     resolution:
       {
@@ -3893,27 +3107,6 @@ packages:
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
 
-  "@sentry/tracing@5.30.0":
-    resolution:
-      {
-        integrity: sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==,
-      }
-    engines: { node: ">=6" }
-
-  "@sentry/types@5.30.0":
-    resolution:
-      {
-        integrity: sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==,
-      }
-    engines: { node: ">=6" }
-
-  "@sentry/utils@5.30.0":
-    resolution:
-      {
-        integrity: sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==,
-      }
-    engines: { node: ">=6" }
-
   "@sentry/vercel-edge@10.42.0":
     resolution:
       {
@@ -3935,13 +3128,6 @@ packages:
       {
         integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==,
       }
-
-  "@sindresorhus/is@5.6.0":
-    resolution:
-      {
-        integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==,
-      }
-    engines: { node: ">=14.16" }
 
   "@sindresorhus/merge-streams@4.0.0":
     resolution:
@@ -4515,12 +3701,6 @@ packages:
         integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==,
       }
 
-  "@solidity-parser/parser@0.20.2":
-    resolution:
-      {
-        integrity: sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA==,
-      }
-
   "@stablelib/base64@1.0.1":
     resolution:
       {
@@ -4538,13 +3718,6 @@ packages:
       {
         integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==,
       }
-
-  "@szmarczak/http-timer@5.0.1":
-    resolution:
-      {
-        integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==,
-      }
-    engines: { node: ">=14.16" }
 
   "@tailwindcss/node@4.2.1":
     resolution:
@@ -4720,18 +3893,6 @@ packages:
         integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
       }
 
-  "@types/bn.js@5.2.0":
-    resolution:
-      {
-        integrity: sha512-DLbJ1BPqxvQhIGbeu8VbUC1DiAiahHtAYvA0ZEAa4P31F7IaArc8z3C3BRQdWX4mtLQuABG4yzp76ZrS02Ui1Q==,
-      }
-
-  "@types/chai-as-promised@7.1.8":
-    resolution:
-      {
-        integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==,
-      }
-
   "@types/chai@5.2.3":
     resolution:
       {
@@ -4780,18 +3941,6 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
-  "@types/glob@7.2.0":
-    resolution:
-      {
-        integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==,
-      }
-
-  "@types/http-cache-semantics@4.2.0":
-    resolution:
-      {
-        integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==,
-      }
-
   "@types/json-schema@7.0.15":
     resolution:
       {
@@ -4809,13 +3958,6 @@ packages:
       {
         integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==,
       }
-
-  "@types/minimatch@6.0.0":
-    resolution:
-      {
-        integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==,
-      }
-    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   "@types/ms@2.1.0":
     resolution:
@@ -4853,12 +3995,6 @@ packages:
         integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==,
       }
 
-  "@types/pbkdf2@3.1.2":
-    resolution:
-      {
-        integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==,
-      }
-
   "@types/pg-pool@2.0.7":
     resolution:
       {
@@ -4883,12 +4019,6 @@ packages:
     resolution:
       {
         integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
-      }
-
-  "@types/secp256k1@4.0.7":
-    resolution:
-      {
-        integrity: sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==,
       }
 
   "@types/statuses@2.0.6":
@@ -5733,12 +4863,6 @@ packages:
         integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==,
       }
 
-  abbrev@1.0.9:
-    resolution:
-      {
-        integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==,
-      }
-
   abitype@1.0.6:
     resolution:
       {
@@ -5828,13 +4952,6 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
-  adm-zip@0.4.16:
-    resolution:
-      {
-        integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==,
-      }
-    engines: { node: ">=0.3.0" }
-
   aes-js@4.0.0-beta.5:
     resolution:
       {
@@ -5861,21 +4978,6 @@ packages:
         integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==,
       }
     engines: { node: ">= 8.0.0" }
-
-  aggregate-error@3.1.0:
-    resolution:
-      {
-        integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==,
-      }
-    engines: { node: ">=8" }
-
-  ajv-errors@3.0.0:
-    resolution:
-      {
-        integrity: sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==,
-      }
-    peerDependencies:
-      ajv: ^8.0.1
 
   ajv-formats@2.1.1:
     resolution:
@@ -5925,33 +5027,6 @@ packages:
         integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
-  amdefine@1.0.1:
-    resolution:
-      {
-        integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==,
-      }
-    engines: { node: ">=0.4.2" }
-
-  ansi-align@3.0.1:
-    resolution:
-      {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
-      }
-
-  ansi-colors@4.1.3:
-    resolution:
-      {
-        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
-      }
-    engines: { node: ">=6" }
-
-  ansi-escapes@4.3.2:
-    resolution:
-      {
-        integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==,
-      }
-    engines: { node: ">=8" }
-
   ansi-escapes@7.3.0:
     resolution:
       {
@@ -5972,13 +5047,6 @@ packages:
         integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
       }
     engines: { node: ">=12" }
-
-  ansi-styles@3.2.1:
-    resolution:
-      {
-        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
-      }
-    engines: { node: ">=4" }
 
   ansi-styles@4.3.0:
     resolution:
@@ -6008,12 +5076,6 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  argparse@1.0.10:
-    resolution:
-      {
-        integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
-      }
-
   argparse@2.0.1:
     resolution:
       {
@@ -6040,13 +5102,6 @@ packages:
         integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==,
       }
     engines: { node: ">= 0.4" }
-
-  array-union@2.1.0:
-    resolution:
-      {
-        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
-      }
-    engines: { node: ">=8" }
 
   array.prototype.findlast@1.2.5:
     resolution:
@@ -6090,24 +5145,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  assertion-error@1.1.0:
-    resolution:
-      {
-        integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==,
-      }
-
   assertion-error@2.0.1:
     resolution:
       {
         integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
       }
     engines: { node: ">=12" }
-
-  ast-parents@0.0.1:
-    resolution:
-      {
-        integrity: sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==,
-      }
 
   ast-types-flow@0.0.8:
     resolution:
@@ -6128,13 +5171,6 @@ packages:
         integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==,
       }
 
-  astral-regex@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
-      }
-    engines: { node: ">=8" }
-
   async-function@1.0.0:
     resolution:
       {
@@ -6146,12 +5182,6 @@ packages:
     resolution:
       {
         integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==,
-      }
-
-  async@1.5.2:
-    resolution:
-      {
-        integrity: sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==,
       }
 
   asynckit@0.4.0:
@@ -6255,57 +5285,16 @@ packages:
     engines: { node: ">=6.0.0" }
     hasBin: true
 
-  better-ajv-errors@2.0.3:
-    resolution:
-      {
-        integrity: sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==,
-      }
-    engines: { node: ">= 18.20.6" }
-    peerDependencies:
-      ajv: 4.11.8 - 8
-
-  better-path-resolve@1.0.0:
-    resolution:
-      {
-        integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==,
-      }
-    engines: { node: ">=4" }
-
   big.js@6.2.2:
     resolution:
       {
         integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==,
       }
 
-  bignumber.js@9.3.1:
-    resolution:
-      {
-        integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==,
-      }
-
-  binary-extensions@2.3.0:
-    resolution:
-      {
-        integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
-      }
-    engines: { node: ">=8" }
-
   blakejs@1.2.1:
     resolution:
       {
         integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==,
-      }
-
-  bn.js@4.11.6:
-    resolution:
-      {
-        integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==,
-      }
-
-  bn.js@4.12.3:
-    resolution:
-      {
-        integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==,
       }
 
   bn.js@5.2.3:
@@ -6333,23 +5322,10 @@ packages:
         integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
       }
 
-  boxen@5.1.2:
-    resolution:
-      {
-        integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==,
-      }
-    engines: { node: ">=10" }
-
   brace-expansion@1.1.12:
     resolution:
       {
         integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
-      }
-
-  brace-expansion@2.1.0:
-    resolution:
-      {
-        integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==,
       }
 
   brace-expansion@5.0.4:
@@ -6372,30 +5348,6 @@ packages:
         integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
       }
     engines: { node: ">=8" }
-
-  brorand@1.1.0:
-    resolution:
-      {
-        integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==,
-      }
-
-  brotli-wasm@2.0.1:
-    resolution:
-      {
-        integrity: sha512-+3USgYsC7bzb5yU0/p2HnnynZl0ak0E6uoIm4UW4Aby/8s8HFCq6NCfrrf1E9c3O8OCSzq3oYO1tUVqIi61Nww==,
-      }
-
-  browser-stdout@1.3.1:
-    resolution:
-      {
-        integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==,
-      }
-
-  browserify-aes@1.2.0:
-    resolution:
-      {
-        integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==,
-      }
 
   browserslist@4.28.1:
     resolution:
@@ -6431,22 +5383,10 @@ packages:
         integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==,
       }
 
-  bs58check@2.1.2:
-    resolution:
-      {
-        integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==,
-      }
-
   buffer-from@1.1.2:
     resolution:
       {
         integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==,
-      }
-
-  buffer-xor@1.0.3:
-    resolution:
-      {
-        integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==,
       }
 
   buffer@6.0.3:
@@ -6475,20 +5415,6 @@ packages:
         integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
       }
     engines: { node: ">= 0.8" }
-
-  cacheable-lookup@7.0.0:
-    resolution:
-      {
-        integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==,
-      }
-    engines: { node: ">=14.16" }
-
-  cacheable-request@10.2.14:
-    resolution:
-      {
-        integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==,
-      }
-    engines: { node: ">=14.16" }
 
   call-bind-apply-helpers@1.0.2:
     resolution:
@@ -6525,13 +5451,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  camelcase@6.3.0:
-    resolution:
-      {
-        integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==,
-      }
-    engines: { node: ">=10" }
-
   camelize@1.0.1:
     resolution:
       {
@@ -6557,48 +5476,12 @@ packages:
       }
     hasBin: true
 
-  cbor@10.0.12:
-    resolution:
-      {
-        integrity: sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==,
-      }
-    engines: { node: ">=20" }
-
-  chai-as-promised@7.1.2:
-    resolution:
-      {
-        integrity: sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==,
-      }
-    peerDependencies:
-      chai: ">= 2.1.2 < 6"
-
-  chai@4.5.0:
-    resolution:
-      {
-        integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==,
-      }
-    engines: { node: ">=4" }
-
   chai@6.2.2:
     resolution:
       {
         integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
       }
     engines: { node: ">=18" }
-
-  chalk@2.4.2:
-    resolution:
-      {
-        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
-      }
-    engines: { node: ">=4" }
-
-  chalk@3.0.0:
-    resolution:
-      {
-        integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==,
-      }
-    engines: { node: ">=8" }
 
   chalk@4.1.2:
     resolution:
@@ -6614,37 +5497,11 @@ packages:
       }
     engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
-  chardet@2.1.1:
-    resolution:
-      {
-        integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
-      }
-
   charenc@0.0.2:
     resolution:
       {
         integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==,
       }
-
-  check-error@1.0.3:
-    resolution:
-      {
-        integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==,
-      }
-
-  chokidar@3.6.0:
-    resolution:
-      {
-        integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
-      }
-    engines: { node: ">= 8.10.0" }
-
-  chokidar@4.0.3:
-    resolution:
-      {
-        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
-      }
-    engines: { node: ">= 14.16.0" }
 
   chokidar@5.0.0:
     resolution:
@@ -6660,19 +5517,6 @@ packages:
       }
     engines: { node: ">=6.0" }
 
-  ci-info@2.0.0:
-    resolution:
-      {
-        integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==,
-      }
-
-  cipher-base@1.0.7:
-    resolution:
-      {
-        integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==,
-      }
-    engines: { node: ">= 0.10" }
-
   cjs-module-lexer@2.2.0:
     resolution:
       {
@@ -6684,20 +5528,6 @@ packages:
       {
         integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==,
       }
-
-  clean-stack@2.2.0:
-    resolution:
-      {
-        integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==,
-      }
-    engines: { node: ">=6" }
-
-  cli-boxes@2.2.1:
-    resolution:
-      {
-        integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==,
-      }
-    engines: { node: ">=6" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -6712,13 +5542,6 @@ packages:
         integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==,
       }
     engines: { node: ">=6" }
-
-  cli-table3@0.6.5:
-    resolution:
-      {
-        integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==,
-      }
-    engines: { node: 10.* || >= 12.* }
 
   cli-truncate@5.2.0:
     resolution:
@@ -6746,25 +5569,12 @@ packages:
         integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==,
       }
 
-  cliui@7.0.4:
-    resolution:
-      {
-        integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==,
-      }
-
   cliui@8.0.1:
     resolution:
       {
         integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
       }
     engines: { node: ">=12" }
-
-  cliui@9.0.1:
-    resolution:
-      {
-        integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==,
-      }
-    engines: { node: ">=20" }
 
   clsx@1.2.1:
     resolution:
@@ -6786,24 +5596,12 @@ packages:
         integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==,
       }
 
-  color-convert@1.9.3:
-    resolution:
-      {
-        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
-      }
-
   color-convert@2.0.1:
     resolution:
       {
         integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
       }
     engines: { node: ">=7.0.0" }
-
-  color-name@1.1.3:
-    resolution:
-      {
-        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
-      }
 
   color-name@1.1.4:
     resolution:
@@ -6823,19 +5621,6 @@ packages:
         integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
       }
     engines: { node: ">= 0.8" }
-
-  command-exists@1.2.9:
-    resolution:
-      {
-        integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==,
-      }
-
-  commander@10.0.1:
-    resolution:
-      {
-        integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==,
-      }
-    engines: { node: ">=14" }
 
   commander@11.1.0:
     resolution:
@@ -6864,35 +5649,16 @@ packages:
         integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
       }
 
-  commander@8.3.0:
-    resolution:
-      {
-        integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==,
-      }
-    engines: { node: ">= 12" }
-
   commondir@1.0.1:
     resolution:
       {
         integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==,
       }
 
-  compare-versions@6.1.1:
-    resolution:
-      {
-        integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==,
-      }
-
   concat-map@0.0.1:
     resolution:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
-
-  config-chain@1.1.13:
-    resolution:
-      {
-        integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==,
       }
 
   content-disposition@1.0.1:
@@ -6958,13 +5724,6 @@ packages:
       }
     engines: { node: ">=6.6.0" }
 
-  cookie@0.4.2:
-    resolution:
-      {
-        integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==,
-      }
-    engines: { node: ">= 0.6" }
-
   cookie@0.7.2:
     resolution:
       {
@@ -6992,18 +5751,6 @@ packages:
       }
     engines: { node: ">= 0.10" }
 
-  cosmiconfig@8.3.6:
-    resolution:
-      {
-        integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==,
-      }
-    engines: { node: ">=14" }
-    peerDependencies:
-      typescript: ">=4.9.5"
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   cosmiconfig@9.0.1:
     resolution:
       {
@@ -7023,18 +5770,6 @@ packages:
       }
     engines: { node: ">=0.8" }
     hasBin: true
-
-  create-hash@1.2.0:
-    resolution:
-      {
-        integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==,
-      }
-
-  create-hmac@1.1.7:
-    resolution:
-      {
-        integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==,
-      }
 
   cross-fetch@3.2.0:
     resolution:
@@ -7128,12 +5863,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  dataloader@1.4.0:
-    resolution:
-      {
-        integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
-      }
-
   date-fns@2.30.0:
     resolution:
       {
@@ -7151,12 +5880,6 @@ packages:
     resolution:
       {
         integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==,
-      }
-
-  death@1.1.0:
-    resolution:
-      {
-        integrity: sha512-vsV6S4KVHvTGxbEcij7hkWRv0It+sGGWVOM67dQde/o5Xjnr+KmLjxWJii2uEObIrt1CcM9w0Yaovx+iOlIL+w==,
       }
 
   debug@3.2.7:
@@ -7201,26 +5924,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  decamelize@4.0.0:
-    resolution:
-      {
-        integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==,
-      }
-    engines: { node: ">=10" }
-
   decode-uri-component@0.2.2:
     resolution:
       {
         integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==,
       }
     engines: { node: ">=0.10" }
-
-  decompress-response@6.0.0:
-    resolution:
-      {
-        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
-      }
-    engines: { node: ">=10" }
 
   dedent@1.7.2:
     resolution:
@@ -7232,20 +5941,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-
-  deep-eql@4.1.4:
-    resolution:
-      {
-        integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==,
-      }
-    engines: { node: ">=6" }
-
-  deep-extend@0.6.0:
-    resolution:
-      {
-        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
-      }
-    engines: { node: ">=4.0.0" }
 
   deep-is@0.1.4:
     resolution:
@@ -7273,13 +5968,6 @@ packages:
         integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==,
       }
     engines: { node: ">=18" }
-
-  defer-to-connect@2.0.1:
-    resolution:
-      {
-        integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==,
-      }
-    engines: { node: ">=10" }
 
   define-data-property@1.1.4:
     resolution:
@@ -7349,26 +6037,12 @@ packages:
         integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==,
       }
 
-  detect-indent@6.1.0:
-    resolution:
-      {
-        integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==,
-      }
-    engines: { node: ">=8" }
-
   detect-libc@2.1.2:
     resolution:
       {
         integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
       }
     engines: { node: ">=8" }
-
-  diff@5.2.2:
-    resolution:
-      {
-        integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==,
-      }
-    engines: { node: ">=0.3.1" }
 
   diff@8.0.3:
     resolution:
@@ -7377,24 +6051,11 @@ packages:
       }
     engines: { node: ">=0.3.1" }
 
-  difflib@0.2.4:
-    resolution:
-      {
-        integrity: sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==,
-      }
-
   dijkstrajs@1.0.3:
     resolution:
       {
         integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==,
       }
-
-  dir-glob@3.0.1:
-    resolution:
-      {
-        integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
-      }
-    engines: { node: ">=8" }
 
   doctrine@2.1.0:
     resolution:
@@ -7417,13 +6078,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  dotenv@8.6.0:
-    resolution:
-      {
-        integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==,
-      }
-    engines: { node: ">=10" }
-
   dunder-proto@1.0.1:
     resolution:
       {
@@ -7435,12 +6089,6 @@ packages:
     resolution:
       {
         integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==,
-      }
-
-  eastasianwidth@0.2.0:
-    resolution:
-      {
-        integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
       }
 
   eciesjs@0.4.17:
@@ -7466,12 +6114,6 @@ packages:
     resolution:
       {
         integrity: sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==,
-      }
-
-  elliptic@6.6.1:
-    resolution:
-      {
-        integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==,
       }
 
   emoji-regex@10.6.0:
@@ -7537,13 +6179,6 @@ packages:
         integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==,
       }
     engines: { node: ">=10.13.0" }
-
-  enquirer@2.4.1:
-    resolution:
-      {
-        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
-      }
-    engines: { node: ">=8.6" }
 
   env-paths@2.2.1:
     resolution:
@@ -7686,27 +6321,12 @@ packages:
         integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
       }
 
-  escape-string-regexp@1.0.5:
-    resolution:
-      {
-        integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
-      }
-    engines: { node: ">=0.8.0" }
-
   escape-string-regexp@4.0.0:
     resolution:
       {
         integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
       }
     engines: { node: ">=10" }
-
-  escodegen@1.8.1:
-    resolution:
-      {
-        integrity: sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==,
-      }
-    engines: { node: ">=0.12.0" }
-    hasBin: true
 
   eslint-config-next@16.1.6:
     resolution:
@@ -7719,15 +6339,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  eslint-config-prettier@10.1.8:
-    resolution:
-      {
-        integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==,
-      }
-    hasBin: true
-    peerDependencies:
-      eslint: ">=7.0.0"
 
   eslint-import-resolver-node@0.3.9:
     resolution:
@@ -7870,14 +6481,6 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  esprima@2.7.3:
-    resolution:
-      {
-        integrity: sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==,
-      }
-    engines: { node: ">=0.10.0" }
-    hasBin: true
-
   esprima@4.0.1:
     resolution:
       {
@@ -7899,13 +6502,6 @@ packages:
         integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
       }
     engines: { node: ">=4.0" }
-
-  estraverse@1.9.3:
-    resolution:
-      {
-        integrity: sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA==,
-      }
-    engines: { node: ">=0.10.0" }
 
   estraverse@4.3.0:
     resolution:
@@ -7973,43 +6569,11 @@ packages:
         integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==,
       }
 
-  ethereum-bloom-filters@1.2.0:
-    resolution:
-      {
-        integrity: sha512-28hyiE7HVsWubqhpVLVmZXFd4ITeHi+BUu05o9isf0GUpMtzBUi+8/gFrGaGYzvGAJQmJ3JKj77Mk9G98T84rA==,
-      }
-
-  ethereum-cryptography@0.1.3:
-    resolution:
-      {
-        integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==,
-      }
-
-  ethereum-cryptography@1.2.0:
-    resolution:
-      {
-        integrity: sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==,
-      }
-
   ethereum-cryptography@2.2.1:
     resolution:
       {
         integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==,
       }
-
-  ethereum-cryptography@3.2.0:
-    resolution:
-      {
-        integrity: sha512-Urr5YVsalH+Jo0sYkTkv1MyI9bLYZwW8BENZCeE1QYaTHETEYx0Nv/SVsWkSqpYrzweg6d8KMY1wTjH/1m/BIg==,
-      }
-    engines: { node: ^14.21.3 || >=16, npm: ">=9" }
-
-  ethereumjs-util@7.1.5:
-    resolution:
-      {
-        integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==,
-      }
-    engines: { node: ">=10.0.0" }
 
   ethers@6.16.0:
     resolution:
@@ -8017,13 +6581,6 @@ packages:
         integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==,
       }
     engines: { node: ">=14.0.0" }
-
-  ethjs-unit@0.1.6:
-    resolution:
-      {
-        integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==,
-      }
-    engines: { node: ">=6.5.0", npm: ">=3" }
 
   event-target-shim@5.0.1:
     resolution:
@@ -8071,12 +6628,6 @@ packages:
       }
     engines: { node: ">=18.0.0" }
 
-  evp_bytestokey@1.0.3:
-    resolution:
-      {
-        integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==,
-      }
-
   execa@5.1.1:
     resolution:
       {
@@ -8114,12 +6665,6 @@ packages:
       }
     engines: { node: ">= 18" }
 
-  extendable-error@0.1.7:
-    resolution:
-      {
-        integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==,
-      }
-
   extension-port-stream@3.0.0:
     resolution:
       {
@@ -8144,12 +6689,6 @@ packages:
     resolution:
       {
         integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
-      }
-
-  fast-diff@1.3.0:
-    resolution:
-      {
-        integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==,
       }
 
   fast-glob@3.3.1:
@@ -8308,13 +6847,6 @@ packages:
       }
     engines: { node: ">=16" }
 
-  flat@5.0.2:
-    resolution:
-      {
-        integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==,
-      }
-    hasBin: true
-
   flatted@3.3.4:
     resolution:
       {
@@ -8339,20 +6871,6 @@ packages:
         integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
       }
     engines: { node: ">= 0.4" }
-
-  foreground-child@3.3.1:
-    resolution:
-      {
-        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
-      }
-    engines: { node: ">=14" }
-
-  form-data-encoder@2.1.4:
-    resolution:
-      {
-        integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==,
-      }
-    engines: { node: ">= 14.17" }
 
   form-data@4.0.5:
     resolution:
@@ -8381,12 +6899,6 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  fp-ts@1.19.3:
-    resolution:
-      {
-        integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==,
-      }
-
   fresh@2.0.0:
     resolution:
       {
@@ -8400,26 +6912,6 @@ packages:
         integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==,
       }
     engines: { node: ">=14.14" }
-
-  fs-extra@7.0.1:
-    resolution:
-      {
-        integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==,
-      }
-    engines: { node: ">=6 <7 || >=8" }
-
-  fs-extra@8.1.0:
-    resolution:
-      {
-        integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
-      }
-    engines: { node: ">=6 <7 || >=8" }
-
-  fs.realpath@1.0.0:
-    resolution:
-      {
-        integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==,
-      }
 
   fsevents@2.3.3:
     resolution:
@@ -8488,12 +6980,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  get-func-name@2.0.2:
-    resolution:
-      {
-        integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==,
-      }
-
   get-intrinsic@1.3.0:
     resolution:
       {
@@ -8542,13 +7028,6 @@ packages:
         integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==,
       }
 
-  ghost-testrpc@0.0.2:
-    resolution:
-      {
-        integrity: sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==,
-      }
-    hasBin: true
-
   glob-parent@5.1.2:
     resolution:
       {
@@ -8569,56 +7048,12 @@ packages:
         integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==,
       }
 
-  glob@10.5.0:
-    resolution:
-      {
-        integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==,
-      }
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@13.0.6:
     resolution:
       {
         integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
       }
     engines: { node: 18 || 20 || >=22 }
-
-  glob@5.0.15:
-    resolution:
-      {
-        integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==,
-      }
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  glob@7.2.3:
-    resolution:
-      {
-        integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==,
-      }
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  glob@8.1.0:
-    resolution:
-      {
-        integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==,
-      }
-    engines: { node: ">=12" }
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  global-modules@2.0.0:
-    resolution:
-      {
-        integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==,
-      }
-    engines: { node: ">=6" }
-
-  global-prefix@3.0.0:
-    resolution:
-      {
-        integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==,
-      }
-    engines: { node: ">=6" }
 
   globals@14.0.0:
     resolution:
@@ -8634,33 +7069,12 @@ packages:
       }
     engines: { node: ">=18" }
 
-  globals@17.6.0:
-    resolution:
-      {
-        integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==,
-      }
-    engines: { node: ">=18" }
-
   globalthis@1.0.4:
     resolution:
       {
         integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
       }
     engines: { node: ">= 0.4" }
-
-  globby@10.0.2:
-    resolution:
-      {
-        integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==,
-      }
-    engines: { node: ">=8" }
-
-  globby@11.1.0:
-    resolution:
-      {
-        integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
-      }
-    engines: { node: ">=10" }
 
   gopd@1.2.0:
     resolution:
@@ -8669,29 +7083,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  got@12.6.1:
-    resolution:
-      {
-        integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==,
-      }
-    engines: { node: ">=14.16" }
-
-  graceful-fs@4.2.10:
-    resolution:
-      {
-        integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==,
-      }
-
   graceful-fs@4.2.11:
     resolution:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
-
-  graphlib@2.1.8:
-    resolution:
-      {
-        integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==,
       }
 
   graphql@16.13.1:
@@ -8707,80 +7102,12 @@ packages:
         integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==,
       }
 
-  handlebars@4.7.9:
-    resolution:
-      {
-        integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==,
-      }
-    engines: { node: ">=0.4.7" }
-    hasBin: true
-
-  hardhat-exposed@0.3.19:
-    resolution:
-      {
-        integrity: sha512-vVye5TurJu8dWeo4ma+EfLAOQaJyica4uncd0/BGPO2tmexuDwZUmE1vYx81PlP4Iak3wqkNTEPxWQaE2ZnKnw==,
-      }
-    peerDependencies:
-      hardhat: ^2.3.0
-
-  hardhat-gas-reporter@2.3.0:
-    resolution:
-      {
-        integrity: sha512-ySdA+044xMQv1BlJu5CYXToHzMexKFfIWxlQTBNNoerx1x96+d15IMdN01iQZ/TJ7NH2V5sU73bz77LoS/PEVw==,
-      }
-    peerDependencies:
-      hardhat: ^2.16.0
-
-  hardhat-ignore-warnings@0.2.12:
-    resolution:
-      {
-        integrity: sha512-SaxCLKzYBMk3Rd1275TnanUmmxwgU+bu4Ekf2MKcqXxxt6xTGcPTtTaM+USrLgmejZHC4Itg/PaWITlOp4RL3g==,
-      }
-
-  hardhat-predeploy@0.4.1:
-    resolution:
-      {
-        integrity: sha512-53Eoj5YECKNTkEezGByjKP5rVbYU0s1is8CtEbm0DPbqMgstNrPMQ0dfcDxA5Fu+hlZhc5w0T+RmJ/d/GAbB6g==,
-      }
-    peerDependencies:
-      "@nomicfoundation/hardhat-ethers": ^3.0.8
-      hardhat: ^2.26.0
-
-  hardhat@2.28.6:
-    resolution:
-      {
-        integrity: sha512-zQze7qe+8ltwHvhX5NQ8sN1N37WWZGw8L63y+2XcPxGwAjc/SMF829z3NS6o1krX0sryhAsVBK/xrwUqlsot4Q==,
-      }
-    hasBin: true
-    peerDependencies:
-      ts-node: "*"
-      typescript: "*"
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-      typescript:
-        optional: true
-
   has-bigints@1.1.0:
     resolution:
       {
         integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==,
       }
     engines: { node: ">= 0.4" }
-
-  has-flag@1.0.0:
-    resolution:
-      {
-        integrity: sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  has-flag@3.0.0:
-    resolution:
-      {
-        integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
-      }
-    engines: { node: ">=4" }
 
   has-flag@4.0.0:
     resolution:
@@ -8816,19 +7143,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  hash-base@3.1.2:
-    resolution:
-      {
-        integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==,
-      }
-    engines: { node: ">= 0.8" }
-
-  hash.js@1.1.7:
-    resolution:
-      {
-        integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==,
-      }
-
   hasown@2.0.2:
     resolution:
       {
@@ -8836,23 +7150,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  he@1.2.0:
-    resolution:
-      {
-        integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==,
-      }
-    hasBin: true
-
   headers-polyfill@4.0.3:
     resolution:
       {
         integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==,
-      }
-
-  heap@0.2.7:
-    resolution:
-      {
-        integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==,
       }
 
   help-me@5.0.0:
@@ -8873,12 +7174,6 @@ packages:
         integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==,
       }
 
-  hmac-drbg@1.0.1:
-    resolution:
-      {
-        integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==,
-      }
-
   hono@4.12.5:
     resolution:
       {
@@ -8892,25 +7187,12 @@ packages:
         integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
       }
 
-  http-cache-semantics@4.2.0:
-    resolution:
-      {
-        integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==,
-      }
-
   http-errors@2.0.1:
     resolution:
       {
         integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
       }
     engines: { node: ">= 0.8" }
-
-  http2-wrapper@2.2.1:
-    resolution:
-      {
-        integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==,
-      }
-    engines: { node: ">=10.19.0" }
 
   https-proxy-agent@5.0.1:
     resolution:
@@ -8925,13 +7207,6 @@ packages:
         integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==,
       }
     engines: { node: ">= 14" }
-
-  human-id@4.1.3:
-    resolution:
-      {
-        integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==,
-      }
-    hasBin: true
 
   human-signals@2.1.0:
     resolution:
@@ -8960,13 +7235,6 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
-
-  iconv-lite@0.4.24:
-    resolution:
-      {
-        integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==,
-      }
-    engines: { node: ">=0.10.0" }
 
   iconv-lite@0.7.2:
     resolution:
@@ -9007,12 +7275,6 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  immutable@4.3.8:
-    resolution:
-      {
-        integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==,
-      }
-
   import-fresh@3.3.1:
     resolution:
       {
@@ -9033,30 +7295,10 @@ packages:
       }
     engines: { node: ">=0.8.19" }
 
-  indent-string@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==,
-      }
-    engines: { node: ">=8" }
-
-  inflight@1.0.6:
-    resolution:
-      {
-        integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
-      }
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution:
       {
         integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
-
-  ini@1.3.8:
-    resolution:
-      {
-        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
       }
 
   internal-slot@1.1.0:
@@ -9065,25 +7307,6 @@ packages:
         integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
       }
     engines: { node: ">= 0.4" }
-
-  interoperable-addresses@0.1.3:
-    resolution:
-      {
-        integrity: sha512-0URwTYBZzjg+BsjEssrvxQPB2XHYVIXLcMjUR0Bd4IoINQHgmR5nbHAOSsCAAR32FsrN1VLZNaqPl8ijQzIMVQ==,
-      }
-
-  interpret@1.4.0:
-    resolution:
-      {
-        integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==,
-      }
-    engines: { node: ">= 0.10" }
-
-  io-ts@1.10.4:
-    resolution:
-      {
-        integrity: sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==,
-      }
 
   ip-address@10.1.0:
     resolution:
@@ -9138,13 +7361,6 @@ packages:
         integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==,
       }
     engines: { node: ">= 0.4" }
-
-  is-binary-path@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-      }
-    engines: { node: ">=8" }
 
   is-boolean-object@1.2.2:
     resolution:
@@ -9243,13 +7459,6 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  is-hex-prefixed@1.0.0:
-    resolution:
-      {
-        integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==,
-      }
-    engines: { node: ">=6.5.0", npm: ">=3" }
-
   is-in-ssh@1.0.0:
     resolution:
       {
@@ -9313,26 +7522,12 @@ packages:
       }
     engines: { node: ">=12" }
 
-  is-plain-obj@2.1.0:
-    resolution:
-      {
-        integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==,
-      }
-    engines: { node: ">=8" }
-
   is-plain-obj@4.1.0:
     resolution:
       {
         integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
       }
     engines: { node: ">=12" }
-
-  is-port-reachable@3.1.0:
-    resolution:
-      {
-        integrity: sha512-vjc0SSRNZ32s9SbZBzGaiP6YVB+xglLShhgZD/FHMZUXBvQWaV9CtzgeVhjccFJrI6RAMV+LX7NYxueW/A8W5A==,
-      }
-    engines: { node: ">=8" }
 
   is-promise@4.0.0:
     resolution:
@@ -9402,13 +7597,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  is-subdir@1.2.0:
-    resolution:
-      {
-        integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==,
-      }
-    engines: { node: ">=4" }
-
   is-symbol@1.1.1:
     resolution:
       {
@@ -9422,13 +7610,6 @@ packages:
         integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
       }
     engines: { node: ">= 0.4" }
-
-  is-unicode-supported@0.1.0:
-    resolution:
-      {
-        integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
-      }
-    engines: { node: ">=10" }
 
   is-unicode-supported@1.3.0:
     resolution:
@@ -9464,13 +7645,6 @@ packages:
         integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
       }
     engines: { node: ">= 0.4" }
-
-  is-windows@1.0.2:
-    resolution:
-      {
-        integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
-      }
-    engines: { node: ">=0.10.0" }
 
   is-wsl@3.1.1:
     resolution:
@@ -9556,12 +7730,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  jackspeak@3.4.3:
-    resolution:
-      {
-        integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
-      }
-
   jayson@4.3.0:
     resolution:
       {
@@ -9610,12 +7778,6 @@ packages:
       }
     engines: { node: ">=14" }
 
-  js-sha3@0.8.0:
-    resolution:
-      {
-        integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==,
-      }
-
   js-tokens@10.0.0:
     resolution:
       {
@@ -9627,13 +7789,6 @@ packages:
       {
         integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
       }
-
-  js-yaml@3.14.2:
-    resolution:
-      {
-        integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
-      }
-    hasBin: true
 
   js-yaml@4.1.1:
     resolution:
@@ -9699,13 +7854,6 @@ packages:
         integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
       }
 
-  json-stream-stringify@3.1.6:
-    resolution:
-      {
-        integrity: sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==,
-      }
-    engines: { node: ">=7.10.1" }
-
   json-stringify-safe@5.0.1:
     resolution:
       {
@@ -9727,29 +7875,10 @@ packages:
     engines: { node: ">=6" }
     hasBin: true
 
-  jsonfile@4.0.0:
-    resolution:
-      {
-        integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
-      }
-
   jsonfile@6.2.0:
     resolution:
       {
         integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==,
-      }
-
-  jsonpointer@5.0.1:
-    resolution:
-      {
-        integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  jsonschema@1.5.0:
-    resolution:
-      {
-        integrity: sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==,
       }
 
   jsx-ast-utils@3.3.5:
@@ -9778,13 +7907,6 @@ packages:
         integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==,
       }
 
-  kind-of@6.0.3:
-    resolution:
-      {
-        integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
-      }
-    engines: { node: ">=0.10.0" }
-
   kleur@3.0.3:
     resolution:
       {
@@ -9811,27 +7933,6 @@ packages:
         integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==,
       }
     engines: { node: ">=0.10" }
-
-  latest-version@7.0.0:
-    resolution:
-      {
-        integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==,
-      }
-    engines: { node: ">=14.16" }
-
-  leven@3.1.0:
-    resolution:
-      {
-        integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
-      }
-    engines: { node: ">=6" }
-
-  levn@0.3.0:
-    resolution:
-      {
-        integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==,
-      }
-    engines: { node: ">= 0.8.0" }
 
   levn@0.4.1:
     resolution:
@@ -10012,29 +8113,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  lodash.isequal@4.5.0:
-    resolution:
-      {
-        integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==,
-      }
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
-
   lodash.merge@4.6.2:
     resolution:
       {
         integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
-      }
-
-  lodash.startcase@4.4.0:
-    resolution:
-      {
-        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
-      }
-
-  lodash.truncate@4.4.2:
-    resolution:
-      {
-        integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==,
       }
 
   lodash@4.17.23:
@@ -10042,13 +8124,6 @@ packages:
       {
         integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
       }
-
-  log-symbols@4.1.0:
-    resolution:
-      {
-        integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
-      }
-    engines: { node: ">=10" }
 
   log-symbols@6.0.0:
     resolution:
@@ -10071,32 +8146,6 @@ packages:
       }
     hasBin: true
 
-  loupe@2.3.7:
-    resolution:
-      {
-        integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==,
-      }
-
-  lowercase-keys@3.0.0:
-    resolution:
-      {
-        integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-  lru-cache@10.4.3:
-    resolution:
-      {
-        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
-      }
-
-  lru-cache@11.0.2:
-    resolution:
-      {
-        integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==,
-      }
-    engines: { node: 20 || >=22 }
-
   lru-cache@11.2.6:
     resolution:
       {
@@ -10108,12 +8157,6 @@ packages:
     resolution:
       {
         integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
-      }
-
-  lru_map@0.3.3:
-    resolution:
-      {
-        integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==,
       }
 
   lucide-react@0.554.0:
@@ -10151,24 +8194,12 @@ packages:
       }
     engines: { node: ">=10" }
 
-  markdown-table@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==,
-      }
-
   math-intrinsics@1.1.0:
     resolution:
       {
         integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
       }
     engines: { node: ">= 0.4" }
-
-  md5.js@1.3.5:
-    resolution:
-      {
-        integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==,
-      }
 
   md5@2.3.0:
     resolution:
@@ -10182,13 +8213,6 @@ packages:
         integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==,
       }
     engines: { node: ">= 0.8" }
-
-  memorystream@0.3.1:
-    resolution:
-      {
-        integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==,
-      }
-    engines: { node: ">= 0.10.0" }
 
   merge-descriptors@2.0.0:
     resolution:
@@ -10210,22 +8234,10 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  micro-eth-signer@0.14.0:
-    resolution:
-      {
-        integrity: sha512-5PLLzHiVYPWClEvZIXXFu5yutzpadb73rnQCpUqIHu3No3coFuWQNfE5tkBQJ7djuLYl6aRLaS0MgWJYGoqiBw==,
-      }
-
   micro-ftch@0.3.1:
     resolution:
       {
         integrity: sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==,
-      }
-
-  micro-packed@0.7.3:
-    resolution:
-      {
-        integrity: sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==,
       }
 
   micromatch@4.0.8:
@@ -10277,32 +8289,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  mimic-response@3.1.0:
-    resolution:
-      {
-        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
-      }
-    engines: { node: ">=10" }
-
-  mimic-response@4.0.0:
-    resolution:
-      {
-        integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-  minimalistic-assert@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==,
-      }
-
-  minimalistic-crypto-utils@1.0.1:
-    resolution:
-      {
-        integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==,
-      }
-
   minimatch@10.2.4:
     resolution:
       {
@@ -10322,20 +8308,6 @@ packages:
       {
         integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
       }
-
-  minimatch@5.1.9:
-    resolution:
-      {
-        integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==,
-      }
-    engines: { node: ">=10" }
-
-  minimatch@9.0.9:
-    resolution:
-      {
-        integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
 
   minimist@1.2.8:
     resolution:
@@ -10361,39 +8333,11 @@ packages:
       typescript:
         optional: true
 
-  mkdirp@0.5.6:
-    resolution:
-      {
-        integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==,
-      }
-    hasBin: true
-
-  mnemonist@0.38.5:
-    resolution:
-      {
-        integrity: sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==,
-      }
-
-  mocha@10.8.2:
-    resolution:
-      {
-        integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==,
-      }
-    engines: { node: ">= 14.0.0" }
-    hasBin: true
-
   module-details-from-path@1.0.4:
     resolution:
       {
         integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==,
       }
-
-  mri@1.2.0:
-    resolution:
-      {
-        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
-      }
-    engines: { node: ">=4" }
 
   ms@2.1.2:
     resolution:
@@ -10498,12 +8442,6 @@ packages:
         integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==,
       }
 
-  node-addon-api@5.1.0:
-    resolution:
-      {
-        integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==,
-      }
-
   node-domexception@1.0.0:
     resolution:
       {
@@ -10511,12 +8449,6 @@ packages:
       }
     engines: { node: ">=10.5.0" }
     deprecated: Use your platform's native DOMException instead
-
-  node-emoji@1.11.0:
-    resolution:
-      {
-        integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==,
-      }
 
   node-exports-info@1.6.0:
     resolution:
@@ -10557,13 +8489,6 @@ packages:
       }
     hasBin: true
 
-  node-interval-tree@2.1.2:
-    resolution:
-      {
-        integrity: sha512-bJ9zMDuNGzVQg1xv0bCPzyEDxHgbrx7/xGj6CDokvizZZmastPsOh0JJLuY8wA5q2SfX1TLNMk7XNV8WxbGxzA==,
-      }
-    engines: { node: ">= 14.0.0" }
-
   node-mock-http@1.0.4:
     resolution:
       {
@@ -10582,33 +8507,12 @@ packages:
         integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==,
       }
 
-  nofilter@3.1.0:
-    resolution:
-      {
-        integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==,
-      }
-    engines: { node: ">=12.19" }
-
-  nopt@3.0.6:
-    resolution:
-      {
-        integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==,
-      }
-    hasBin: true
-
   normalize-path@3.0.0:
     resolution:
       {
         integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
       }
     engines: { node: ">=0.10.0" }
-
-  normalize-url@8.1.1:
-    resolution:
-      {
-        integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==,
-      }
-    engines: { node: ">=14.16" }
 
   npm-run-path@4.0.1:
     resolution:
@@ -10623,13 +8527,6 @@ packages:
         integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==,
       }
     engines: { node: ">=18" }
-
-  number-to-bn@1.7.0:
-    resolution:
-      {
-        integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==,
-      }
-    engines: { node: ">=6.5.0", npm: ">=3" }
 
   obj-multiplex@1.0.0:
     resolution:
@@ -10699,12 +8596,6 @@ packages:
         integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==,
       }
     engines: { node: ">= 0.4" }
-
-  obliterator@2.0.5:
-    resolution:
-      {
-        integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==,
-      }
 
   obug@2.1.1:
     resolution:
@@ -10792,13 +8683,6 @@ packages:
         integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==,
       }
 
-  optionator@0.8.3:
-    resolution:
-      {
-        integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==,
-      }
-    engines: { node: ">= 0.8.0" }
-
   optionator@0.9.4:
     resolution:
       {
@@ -10812,25 +8696,6 @@ packages:
         integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==,
       }
     engines: { node: ">=18" }
-
-  ordinal@1.0.3:
-    resolution:
-      {
-        integrity: sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==,
-      }
-
-  os-tmpdir@1.0.2:
-    resolution:
-      {
-        integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  outdent@0.5.0:
-    resolution:
-      {
-        integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==,
-      }
 
   outvariant@1.4.3:
     resolution:
@@ -10911,20 +8776,6 @@ packages:
       typescript:
         optional: true
 
-  p-cancelable@3.0.0:
-    resolution:
-      {
-        integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==,
-      }
-    engines: { node: ">=12.20" }
-
-  p-filter@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==,
-      }
-    engines: { node: ">=8" }
-
   p-limit@2.3.0:
     resolution:
       {
@@ -10938,13 +8789,6 @@ packages:
         integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
       }
     engines: { node: ">=10" }
-
-  p-limit@7.3.0:
-    resolution:
-      {
-        integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
-      }
-    engines: { node: ">=20" }
 
   p-locate@4.1.0:
     resolution:
@@ -10960,45 +8804,12 @@ packages:
       }
     engines: { node: ">=10" }
 
-  p-map@2.1.0:
-    resolution:
-      {
-        integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==,
-      }
-    engines: { node: ">=6" }
-
-  p-map@4.0.0:
-    resolution:
-      {
-        integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==,
-      }
-    engines: { node: ">=10" }
-
   p-try@2.2.0:
     resolution:
       {
         integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
       }
     engines: { node: ">=6" }
-
-  package-json-from-dist@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
-      }
-
-  package-json@8.1.1:
-    resolution:
-      {
-        integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==,
-      }
-    engines: { node: ">=14.16" }
-
-  package-manager-detector@0.2.11:
-    resolution:
-      {
-        integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==,
-      }
 
   package-manager-detector@1.6.0:
     resolution:
@@ -11047,13 +8858,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  path-is-absolute@1.0.1:
-    resolution:
-      {
-        integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==,
-      }
-    engines: { node: ">=0.10.0" }
-
   path-key@3.1.1:
     resolution:
       {
@@ -11074,13 +8878,6 @@ packages:
         integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
       }
 
-  path-scurry@1.11.1:
-    resolution:
-      {
-        integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
-      }
-    engines: { node: ">=16 || 14 >=14.18" }
-
   path-scurry@2.0.2:
     resolution:
       {
@@ -11100,31 +8897,11 @@ packages:
         integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==,
       }
 
-  path-type@4.0.0:
-    resolution:
-      {
-        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
-      }
-    engines: { node: ">=8" }
-
   pathe@2.0.3:
     resolution:
       {
         integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
       }
-
-  pathval@1.1.1:
-    resolution:
-      {
-        integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==,
-      }
-
-  pbkdf2@3.1.5:
-    resolution:
-      {
-        integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==,
-      }
-    engines: { node: ">= 0.10" }
 
   pg-int8@1.0.1:
     resolution:
@@ -11172,13 +8949,6 @@ packages:
         integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==,
       }
     engines: { node: ">=4" }
-
-  pify@4.0.1:
-    resolution:
-      {
-        integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
-      }
-    engines: { node: ">=6" }
 
   pify@5.0.0:
     resolution:
@@ -11244,13 +9014,6 @@ packages:
         integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==,
       }
     engines: { node: ">=16.20.0" }
-
-  pluralize@8.0.0:
-    resolution:
-      {
-        integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==,
-      }
-    engines: { node: ">=4" }
 
   pngjs@5.0.0:
     resolution:
@@ -11395,36 +9158,12 @@ packages:
         integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==,
       }
 
-  prelude-ls@1.1.2:
-    resolution:
-      {
-        integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==,
-      }
-    engines: { node: ">= 0.8.0" }
-
   prelude-ls@1.2.1:
     resolution:
       {
         integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
       }
     engines: { node: ">= 0.8.0" }
-
-  prettier-plugin-solidity@2.3.1:
-    resolution:
-      {
-        integrity: sha512-71sZM5oqgq6pnTlf+RH23U6Ej710APfCiMWO2Z/pHNjrXyvn9Nr0vTS1AUVaSf4GRW0V6hj6Djt0MyWudJUJbQ==,
-      }
-    engines: { node: ">=20" }
-    peerDependencies:
-      prettier: ">=3.0.0"
-
-  prettier@2.8.8:
-    resolution:
-      {
-        integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
-      }
-    engines: { node: ">=10.13.0" }
-    hasBin: true
 
   prettier@3.8.1:
     resolution:
@@ -11484,18 +9223,6 @@ packages:
     resolution:
       {
         integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==,
-      }
-
-  proper-lockfile@4.1.2:
-    resolution:
-      {
-        integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==,
-      }
-
-  proto-list@1.2.4:
-    resolution:
-      {
-        integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==,
       }
 
   proxy-addr@2.0.7:
@@ -11559,12 +9286,6 @@ packages:
       }
     engines: { node: ">=0.6" }
 
-  quansync@0.2.11:
-    resolution:
-      {
-        integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
-      }
-
   query-string@7.1.3:
     resolution:
       {
@@ -11584,23 +9305,10 @@ packages:
         integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
       }
 
-  quick-lru@5.1.1:
-    resolution:
-      {
-        integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==,
-      }
-    engines: { node: ">=10" }
-
   radix3@1.1.2:
     resolution:
       {
         integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==,
-      }
-
-  randombytes@2.1.0:
-    resolution:
-      {
-        integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
       }
 
   range-parser@1.2.1:
@@ -11610,26 +9318,12 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  raw-body@2.5.3:
-    resolution:
-      {
-        integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==,
-      }
-    engines: { node: ">= 0.8" }
-
   raw-body@3.0.2:
     resolution:
       {
         integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==,
       }
     engines: { node: ">= 0.10" }
-
-  rc@1.2.8:
-    resolution:
-      {
-        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
-      }
-    hasBin: true
 
   react-device-detect@2.2.3:
     resolution:
@@ -11661,13 +9355,6 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  read-yaml-file@1.1.0:
-    resolution:
-      {
-        integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==,
-      }
-    engines: { node: ">=6" }
-
   readable-stream@2.3.8:
     resolution:
       {
@@ -11687,20 +9374,6 @@ packages:
         integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==,
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
-
-  readdirp@3.6.0:
-    resolution:
-      {
-        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-      }
-    engines: { node: ">=8.10.0" }
-
-  readdirp@4.1.2:
-    resolution:
-      {
-        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
-      }
-    engines: { node: ">= 14.18.0" }
 
   readdirp@5.0.0:
     resolution:
@@ -11730,20 +9403,6 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  rechoir@0.6.2:
-    resolution:
-      {
-        integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==,
-      }
-    engines: { node: ">= 0.10" }
-
-  recursive-readdir@2.2.3:
-    resolution:
-      {
-        integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==,
-      }
-    engines: { node: ">=6.0.0" }
-
   redaxios@0.5.1:
     resolution:
       {
@@ -11763,27 +9422,6 @@ packages:
         integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
       }
     engines: { node: ">= 0.4" }
-
-  registry-auth-token@5.1.1:
-    resolution:
-      {
-        integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==,
-      }
-    engines: { node: ">=14" }
-
-  registry-url@6.0.1:
-    resolution:
-      {
-        integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==,
-      }
-    engines: { node: ">=12" }
-
-  repeat-string@1.6.1:
-    resolution:
-      {
-        integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==,
-      }
-    engines: { node: ">=0.10" }
 
   require-directory@2.1.1:
     resolution:
@@ -11818,12 +9456,6 @@ packages:
         integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==,
       }
 
-  resolve-alpn@1.2.1:
-    resolution:
-      {
-        integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==,
-      }
-
   resolve-from@4.0.0:
     resolution:
       {
@@ -11831,29 +9463,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  resolve-from@5.0.0:
-    resolution:
-      {
-        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
-      }
-    engines: { node: ">=8" }
-
   resolve-pkg-maps@1.0.0:
     resolution:
       {
         integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
-      }
-
-  resolve@1.1.7:
-    resolution:
-      {
-        integrity: sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==,
-      }
-
-  resolve@1.17.0:
-    resolution:
-      {
-        integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==,
       }
 
   resolve@1.22.11:
@@ -11872,26 +9485,12 @@ packages:
     engines: { node: ">= 0.4" }
     hasBin: true
 
-  responselike@3.0.0:
-    resolution:
-      {
-        integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==,
-      }
-    engines: { node: ">=14.16" }
-
   restore-cursor@5.1.0:
     resolution:
       {
         integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
       }
     engines: { node: ">=18" }
-
-  retry@0.12.0:
-    resolution:
-      {
-        integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==,
-      }
-    engines: { node: ">= 4" }
 
   rettime@0.10.1:
     resolution:
@@ -11911,28 +9510,6 @@ packages:
       {
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
-
-  rimraf@6.1.3:
-    resolution:
-      {
-        integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==,
-      }
-    engines: { node: 20 || >=22 }
-    hasBin: true
-
-  ripemd160@2.0.3:
-    resolution:
-      {
-        integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==,
-      }
-    engines: { node: ">= 0.8" }
-
-  rlp@2.2.7:
-    resolution:
-      {
-        integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==,
-      }
-    hasBin: true
 
   rollup@4.59.0:
     resolution:
@@ -12014,13 +9591,6 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  sc-istanbul@0.4.6:
-    resolution:
-      {
-        integrity: sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==,
-      }
-    hasBin: true
-
   scheduler@0.27.0:
     resolution:
       {
@@ -12034,19 +9604,6 @@ packages:
       }
     engines: { node: ">= 10.13.0" }
 
-  scrypt-js@3.0.1:
-    resolution:
-      {
-        integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==,
-      }
-
-  secp256k1@4.0.4:
-    resolution:
-      {
-        integrity: sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==,
-      }
-    engines: { node: ">=18.0.0" }
-
   secure-json-parse@2.7.0:
     resolution:
       {
@@ -12058,13 +9615,6 @@ packages:
       {
         integrity: sha512-znUg8ae3cpuAaogiFBhP82gD2daVkSz4Qv/L7OWjB7wWvfbCdeqqQuJkm2/IvhKQPOV0T739YPR6rb7vs0uWaw==,
       }
-
-  semver@5.7.2:
-    resolution:
-      {
-        integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==,
-      }
-    hasBin: true
 
   semver@6.3.1:
     resolution:
@@ -12095,12 +9645,6 @@ packages:
         integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==,
       }
     engines: { node: ">= 18" }
-
-  serialize-javascript@6.0.2:
-    resolution:
-      {
-        integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==,
-      }
 
   serve-static@2.2.1:
     resolution:
@@ -12148,12 +9692,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  setimmediate@1.0.5:
-    resolution:
-      {
-        integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==,
-      }
-
   setprototypeof@1.2.0:
     resolution:
       {
@@ -12167,12 +9705,6 @@ packages:
       }
     engines: { node: ">= 0.10" }
     hasBin: true
-
-  sha1@1.1.1:
-    resolution:
-      {
-        integrity: sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==,
-      }
 
   shadcn@4.0.0:
     resolution:
@@ -12207,14 +9739,6 @@ packages:
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
     engines: { node: ">=8" }
-
-  shelljs@0.8.5:
-    resolution:
-      {
-        integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==,
-      }
-    engines: { node: ">=4" }
-    hasBin: true
 
   side-channel-list@1.0.0:
     resolution:
@@ -12269,20 +9793,6 @@ packages:
         integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
       }
 
-  slash@3.0.0:
-    resolution:
-      {
-        integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
-      }
-    engines: { node: ">=8" }
-
-  slice-ansi@4.0.0:
-    resolution:
-      {
-        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
-      }
-    engines: { node: ">=10" }
-
   slice-ansi@7.1.2:
     resolution:
       {
@@ -12317,149 +9827,6 @@ packages:
       }
     engines: { node: ">=10.0.0" }
 
-  solc@0.8.26:
-    resolution:
-      {
-        integrity: sha512-yiPQNVf5rBFHwN6SIf3TUUvVAFKcQqmSUFeq+fb6pNRCo0ZCgpYOZDi3BVoezCPIAcKrVYd/qXlBLUP9wVrZ9g==,
-      }
-    engines: { node: ">=10.0.0" }
-    hasBin: true
-
-  solhint-plugin-openzeppelin@file:contracts/lib/openzeppelin-contracts/scripts/solhint-custom:
-    resolution:
-      {
-        directory: contracts/lib/openzeppelin-contracts/scripts/solhint-custom,
-        type: directory,
-      }
-
-  solhint@6.2.1:
-    resolution:
-      {
-        integrity: sha512-+VHSa84CRjm2s+KZWYxIDnI+NokcLsZHOSpRtg5nBFmnVfh6RPmPaFd5TN922Cfrm2i85kNoQtLiapALe26b5w==,
-      }
-    engines: { node: ">=20" }
-    hasBin: true
-
-  solidity-ast@0.4.62:
-    resolution:
-      {
-        integrity: sha512-jSC7msQCkJXIzM8LlDjRZ5cif5w40g6THlXHFk3zchbL5dm3YLoBETvqPGo5KndYkftjhcs5kz1fnTu4d34lVQ==,
-      }
-
-  solidity-comments-darwin-arm64@0.0.2:
-    resolution:
-      {
-        integrity: sha512-HidWkVLSh7v+Vu0CA7oI21GWP/ZY7ro8g8OmIxE8oTqyMwgMbE8F1yc58Sj682Hj199HCZsjmtn1BE4PCbLiGA==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [arm64]
-    os: [darwin]
-
-  solidity-comments-darwin-x64@0.0.2:
-    resolution:
-      {
-        integrity: sha512-Zjs0Ruz6faBTPT6fBecUt6qh4CdloT8Bwoc0+qxRoTn9UhYscmbPQkUgQEbS0FQPysYqVzzxJB4h1Ofbf4wwtA==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [x64]
-    os: [darwin]
-
-  solidity-comments-freebsd-x64@0.0.2:
-    resolution:
-      {
-        integrity: sha512-8Qe4mpjuAxFSwZJVk7B8gAoLCdbtS412bQzBwk63L8dmlHogvE39iT70aAk3RHUddAppT5RMBunlPUCFYJ3ZTw==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [x64]
-    os: [freebsd]
-
-  solidity-comments-linux-arm64-gnu@0.0.2:
-    resolution:
-      {
-        integrity: sha512-spkb0MZZnmrP+Wtq4UxP+nyPAVRe82idOjqndolcNR0S9Xvu4ebwq+LvF4HiUgjTDmeiqYiFZQ8T9KGdLSIoIg==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [arm64]
-    os: [linux]
-
-  solidity-comments-linux-arm64-musl@0.0.2:
-    resolution:
-      {
-        integrity: sha512-guCDbHArcjE+JDXYkxx5RZzY1YF6OnAKCo+sTC5fstyW/KGKaQJNPyBNWuwYsQiaEHpvhW1ha537IvlGek8GqA==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [arm64]
-    os: [linux]
-
-  solidity-comments-linux-x64-gnu@0.0.2:
-    resolution:
-      {
-        integrity: sha512-zIqLehBK/g7tvrFmQljrfZXfkEeLt2v6wbe+uFu6kH/qAHZa7ybt8Vc0wYcmjo2U0PeBm15d79ee3AkwbIjFdQ==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [x64]
-    os: [linux]
-
-  solidity-comments-linux-x64-musl@0.0.2:
-    resolution:
-      {
-        integrity: sha512-R9FeDloVlFGTaVkOlELDVC7+1Tjx5WBPI5L8r0AGOPHK3+jOcRh6sKYpI+VskSPDc3vOO46INkpDgUXrKydlIw==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [x64]
-    os: [linux]
-
-  solidity-comments-win32-arm64-msvc@0.0.2:
-    resolution:
-      {
-        integrity: sha512-QnWJoCQcJj+rnutULOihN9bixOtYWDdF5Rfz9fpHejL1BtNjdLW1om55XNVHGAHPqBxV4aeQQ6OirKnp9zKsug==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [arm64]
-    os: [win32]
-
-  solidity-comments-win32-ia32-msvc@0.0.2:
-    resolution:
-      {
-        integrity: sha512-vUg4nADtm/NcOtlIymG23NWJUSuMsvX15nU7ynhGBsdKtt8xhdP3C/zA6vjDk8Jg+FXGQL6IHVQ++g/7rSQi0w==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [ia32]
-    os: [win32]
-
-  solidity-comments-win32-x64-msvc@0.0.2:
-    resolution:
-      {
-        integrity: sha512-36j+KUF4V/y0t3qatHm/LF5sCUCBx2UndxE1kq5bOzh/s+nQgatuyB+Pd5BfuPQHdWu2KaExYe20FlAa6NL7+Q==,
-      }
-    engines: { node: ">= 10" }
-    cpu: [x64]
-    os: [win32]
-
-  solidity-comments@0.0.2:
-    resolution:
-      {
-        integrity: sha512-G+aK6qtyUfkn1guS8uzqUeua1dURwPlcOjoTYW/TwmXAcE7z/1+oGCfZUdMSe4ZMKklNbVZNiG5ibnF8gkkFfw==,
-      }
-    engines: { node: ">= 12" }
-
-  solidity-coverage@0.8.17:
-    resolution:
-      {
-        integrity: sha512-5P8vnB6qVX9tt1MfuONtCTEaEGO/O4WuEidPHIAJjx4sktHHKhO3rFvnE0q8L30nWJPTrcqGQMT7jpE29B2qow==,
-      }
-    hasBin: true
-    peerDependencies:
-      hardhat: ^2.11.0
-
-  solidity-docgen@0.6.0-beta.36:
-    resolution:
-      {
-        integrity: sha512-f/I5G2iJgU1h0XrrjRD0hHMr7C10u276vYvm//rw1TzFcYQ4xTOyAoi9oNAHRU0JU4mY9eTuxdVc2zahdMuhaQ==,
-      }
-    peerDependencies:
-      hardhat: ^2.8.0
-
   sonic-boom@2.8.0:
     resolution:
       {
@@ -12491,25 +9858,12 @@ packages:
         integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==,
       }
 
-  source-map@0.2.0:
-    resolution:
-      {
-        integrity: sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==,
-      }
-    engines: { node: ">=0.8.0" }
-
   source-map@0.6.1:
     resolution:
       {
         integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
       }
     engines: { node: ">=0.10.0" }
-
-  spawndamnit@3.0.1:
-    resolution:
-      {
-        integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==,
-      }
 
   split-on-first@1.1.0:
     resolution:
@@ -12524,12 +9878,6 @@ packages:
         integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
       }
     engines: { node: ">= 10.x" }
-
-  sprintf-js@1.0.3:
-    resolution:
-      {
-        integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
-      }
 
   stable-hash@0.0.5:
     resolution:
@@ -12633,13 +9981,6 @@ packages:
         integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
       }
     engines: { node: ">=8" }
-
-  string-width@5.1.2:
-    resolution:
-      {
-        integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
-      }
-    engines: { node: ">=12" }
 
   string-width@7.2.0:
     resolution:
@@ -12750,20 +10091,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  strip-hex-prefix@1.0.0:
-    resolution:
-      {
-        integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==,
-      }
-    engines: { node: ">=6.5.0", npm: ">=3" }
-
-  strip-json-comments@2.0.1:
-    resolution:
-      {
-        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
-      }
-    engines: { node: ">=0.10.0" }
-
   strip-json-comments@3.1.1:
     resolution:
       {
@@ -12820,20 +10147,6 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
-  supports-color@3.2.3:
-    resolution:
-      {
-        integrity: sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==,
-      }
-    engines: { node: ">=0.8.0" }
-
-  supports-color@5.5.0:
-    resolution:
-      {
-        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
-      }
-    engines: { node: ">=4" }
-
   supports-color@7.2.0:
     resolution:
       {
@@ -12866,13 +10179,6 @@ packages:
       {
         integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==,
       }
-
-  table@6.9.0:
-    resolution:
-      {
-        integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==,
-      }
-    engines: { node: ">=10.0.0" }
 
   tagged-tag@1.0.0:
     resolution:
@@ -12907,13 +10213,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  term-size@2.2.1:
-    resolution:
-      {
-        integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
-      }
-    engines: { node: ">=8" }
-
   terser-webpack-plugin@5.5.0:
     resolution:
       {
@@ -12945,12 +10244,6 @@ packages:
     resolution:
       {
         integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==,
-      }
-
-  text-table@0.2.0:
-    resolution:
-      {
-        integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==,
       }
 
   thread-stream@0.15.2:
@@ -13023,13 +10316,6 @@ packages:
         integrity: sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==,
       }
     hasBin: true
-
-  tmp@0.0.33:
-    resolution:
-      {
-        integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==,
-      }
-    engines: { node: ">=0.6.0" }
 
   to-buffer@1.2.2:
     resolution:
@@ -13117,24 +10403,11 @@ packages:
         integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
       }
 
-  tsort@0.0.1:
-    resolution:
-      {
-        integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==,
-      }
-
   tw-animate-css@1.4.0:
     resolution:
       {
         integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==,
       }
-
-  type-check@0.3.2:
-    resolution:
-      {
-        integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==,
-      }
-    engines: { node: ">= 0.8.0" }
 
   type-check@0.4.0:
     resolution:
@@ -13142,27 +10415,6 @@ packages:
         integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
       }
     engines: { node: ">= 0.8.0" }
-
-  type-detect@4.1.0:
-    resolution:
-      {
-        integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==,
-      }
-    engines: { node: ">=4" }
-
-  type-fest@0.20.2:
-    resolution:
-      {
-        integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==,
-      }
-    engines: { node: ">=10" }
-
-  type-fest@0.21.3:
-    resolution:
-      {
-        integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==,
-      }
-    engines: { node: ">=10" }
 
   type-fest@0.7.1:
     resolution:
@@ -13220,12 +10472,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  typed-regex@0.0.8:
-    resolution:
-      {
-        integrity: sha512-1XkGm1T/rUngbFROIOw9wPnMAKeMsRoc+c9O6GwOHz6aH/FrJFtcyd2sHASbT0OXeGLot5N1shPNpwHGTv9RdQ==,
-      }
-
   typescript-eslint@8.56.1:
     resolution:
       {
@@ -13256,14 +10502,6 @@ packages:
       {
         integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
       }
-
-  uglify-js@3.19.3:
-    resolution:
-      {
-        integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==,
-      }
-    engines: { node: ">=0.8.0" }
-    hasBin: true
 
   uint8arrays@3.1.0:
     resolution:
@@ -13308,33 +10546,12 @@ packages:
         integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==,
       }
 
-  undici@5.29.0:
-    resolution:
-      {
-        integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==,
-      }
-    engines: { node: ">=14.0" }
-
-  undici@7.25.0:
-    resolution:
-      {
-        integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==,
-      }
-    engines: { node: ">=20.18.1" }
-
   unicorn-magic@0.3.0:
     resolution:
       {
         integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==,
       }
     engines: { node: ">=18" }
-
-  universalify@0.1.2:
-    resolution:
-      {
-        integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==,
-      }
-    engines: { node: ">= 4.0.0" }
 
   universalify@2.0.1:
     resolution:
@@ -13479,12 +10696,6 @@ packages:
         integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==,
       }
     engines: { node: ">=6.14.2" }
-
-  utf8@3.0.0:
-    resolution:
-      {
-        integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==,
-      }
 
   util-deprecate@1.0.2:
     resolution:
@@ -13728,13 +10939,6 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  web3-utils@1.10.4:
-    resolution:
-      {
-        integrity: sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==,
-      }
-    engines: { node: ">=8.0.0" }
-
   webextension-polyfill@0.10.0:
     resolution:
       {
@@ -13807,13 +11011,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  which@1.3.1:
-    resolution:
-      {
-        integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==,
-      }
-    hasBin: true
-
   which@2.0.2:
     resolution:
       {
@@ -13838,31 +11035,12 @@ packages:
     engines: { node: ">=8" }
     hasBin: true
 
-  widest-line@3.1.0:
-    resolution:
-      {
-        integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==,
-      }
-    engines: { node: ">=8" }
-
   word-wrap@1.2.5:
     resolution:
       {
         integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
       }
     engines: { node: ">=0.10.0" }
-
-  wordwrap@1.0.0:
-    resolution:
-      {
-        integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==,
-      }
-
-  workerpool@6.5.1:
-    resolution:
-      {
-        integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==,
-      }
 
   wrap-ansi@6.2.0:
     resolution:
@@ -13877,13 +11055,6 @@ packages:
         integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
       }
     engines: { node: ">=10" }
-
-  wrap-ansi@8.1.0:
-    resolution:
-      {
-        integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
-      }
-    engines: { node: ">=12" }
 
   wrap-ansi@9.0.2:
     resolution:
@@ -14034,33 +11205,12 @@ packages:
       }
     engines: { node: ">=6" }
 
-  yargs-parser@20.2.9:
-    resolution:
-      {
-        integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==,
-      }
-    engines: { node: ">=10" }
-
   yargs-parser@21.1.1:
     resolution:
       {
         integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
       }
     engines: { node: ">=12" }
-
-  yargs-parser@22.0.0:
-    resolution:
-      {
-        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
-      }
-    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
-
-  yargs-unparser@2.0.0:
-    resolution:
-      {
-        integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==,
-      }
-    engines: { node: ">=10" }
 
   yargs@15.4.1:
     resolution:
@@ -14069,13 +11219,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  yargs@16.2.0:
-    resolution:
-      {
-        integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==,
-      }
-    engines: { node: ">=10" }
-
   yargs@17.7.2:
     resolution:
       {
@@ -14083,26 +11226,12 @@ packages:
       }
     engines: { node: ">=12" }
 
-  yargs@18.0.0:
-    resolution:
-      {
-        integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==,
-      }
-    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
-
   yocto-queue@0.1.0:
     resolution:
       {
         integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
       }
     engines: { node: ">=10" }
-
-  yocto-queue@1.2.2:
-    resolution:
-      {
-        integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==,
-      }
-    engines: { node: ">=12.20" }
 
   yoctocolors-cjs@2.1.3:
     resolution:
@@ -14217,7 +11346,8 @@ packages:
         optional: true
 
 snapshots:
-  "@adraffy/ens-normalize@1.10.1": {}
+  "@adraffy/ens-normalize@1.10.1":
+    optional: true
 
   "@adraffy/ens-normalize@1.11.1": {}
 
@@ -14251,7 +11381,7 @@ snapshots:
       "@babel/types": 7.29.0
       "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14409,7 +11539,7 @@ snapshots:
       "@babel/parser": 7.29.0
       "@babel/template": 7.28.6
       "@babel/types": 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14501,168 +11631,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  "@bytecodealliance/preview2-shim@0.17.0": {}
-
-  "@bytecodealliance/preview2-shim@0.17.9": {}
-
-  "@changesets/apply-release-plan@7.1.1":
-    dependencies:
-      "@changesets/config": 3.1.4
-      "@changesets/get-version-range-type": 0.4.0
-      "@changesets/git": 3.0.4
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-      detect-indent: 6.1.0
-      fs-extra: 7.0.1
-      lodash.startcase: 4.4.0
-      outdent: 0.5.0
-      prettier: 2.8.8
-      resolve-from: 5.0.0
-      semver: 7.7.4
-
-  "@changesets/assemble-release-plan@6.0.10":
-    dependencies:
-      "@changesets/errors": 0.2.0
-      "@changesets/get-dependents-graph": 2.1.4
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-      semver: 7.7.4
-
-  "@changesets/changelog-git@0.2.1":
-    dependencies:
-      "@changesets/types": 6.1.0
-
-  "@changesets/changelog-github@0.6.0":
-    dependencies:
-      "@changesets/get-github-info": 0.8.0
-      "@changesets/types": 6.1.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
-
-  "@changesets/cli@2.31.0(@types/node@22.7.5)":
-    dependencies:
-      "@changesets/apply-release-plan": 7.1.1
-      "@changesets/assemble-release-plan": 6.0.10
-      "@changesets/changelog-git": 0.2.1
-      "@changesets/config": 3.1.4
-      "@changesets/errors": 0.2.0
-      "@changesets/get-dependents-graph": 2.1.4
-      "@changesets/get-release-plan": 4.0.16
-      "@changesets/git": 3.0.4
-      "@changesets/logger": 0.1.1
-      "@changesets/pre": 2.0.2
-      "@changesets/read": 0.6.7
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@changesets/write": 0.4.0
-      "@inquirer/external-editor": 1.0.3(@types/node@22.7.5)
-      "@manypkg/get-packages": 1.1.3
-      ansi-colors: 4.1.3
-      enquirer: 2.4.1
-      fs-extra: 7.0.1
-      mri: 1.2.0
-      package-manager-detector: 0.2.11
-      picocolors: 1.1.1
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      spawndamnit: 3.0.1
-      term-size: 2.2.1
-    transitivePeerDependencies:
-      - "@types/node"
-
-  "@changesets/config@3.1.4":
-    dependencies:
-      "@changesets/errors": 0.2.0
-      "@changesets/get-dependents-graph": 2.1.4
-      "@changesets/logger": 0.1.1
-      "@changesets/should-skip-package": 0.1.2
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-      fs-extra: 7.0.1
-      micromatch: 4.0.8
-
-  "@changesets/errors@0.2.0":
-    dependencies:
-      extendable-error: 0.1.7
-
-  "@changesets/get-dependents-graph@2.1.4":
-    dependencies:
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-      picocolors: 1.1.1
-      semver: 7.7.4
-
-  "@changesets/get-github-info@0.8.0":
-    dependencies:
-      dataloader: 1.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
-  "@changesets/get-release-plan@4.0.16":
-    dependencies:
-      "@changesets/assemble-release-plan": 6.0.10
-      "@changesets/config": 3.1.4
-      "@changesets/pre": 2.0.2
-      "@changesets/read": 0.6.7
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-
-  "@changesets/get-version-range-type@0.4.0": {}
-
-  "@changesets/git@3.0.4":
-    dependencies:
-      "@changesets/errors": 0.2.0
-      "@manypkg/get-packages": 1.1.3
-      is-subdir: 1.2.0
-      micromatch: 4.0.8
-      spawndamnit: 3.0.1
-
-  "@changesets/logger@0.1.1":
-    dependencies:
-      picocolors: 1.1.1
-
-  "@changesets/parse@0.4.3":
-    dependencies:
-      "@changesets/types": 6.1.0
-      js-yaml: 4.1.1
-
-  "@changesets/pre@2.0.2":
-    dependencies:
-      "@changesets/errors": 0.2.0
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-      fs-extra: 7.0.1
-
-  "@changesets/read@0.6.7":
-    dependencies:
-      "@changesets/git": 3.0.4
-      "@changesets/logger": 0.1.1
-      "@changesets/parse": 0.4.3
-      "@changesets/types": 6.1.0
-      fs-extra: 7.0.1
-      p-filter: 2.1.0
-      picocolors: 1.1.1
-
-  "@changesets/should-skip-package@0.1.2":
-    dependencies:
-      "@changesets/types": 6.1.0
-      "@manypkg/get-packages": 1.1.3
-
-  "@changesets/types@4.1.0": {}
-
-  "@changesets/types@6.1.0": {}
-
-  "@changesets/write@0.4.0":
-    dependencies:
-      "@changesets/types": 6.1.0
-      fs-extra: 7.0.1
-      human-id: 4.1.3
-      prettier: 2.8.8
-
   "@coinbase/cdp-sdk@1.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)":
     dependencies:
       "@solana-program/system": 0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
@@ -14745,9 +11713,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-    optional: true
-
-  "@colors/colors@1.5.0":
     optional: true
 
   "@dotenvx/dotenvx@1.53.0":
@@ -14953,16 +11918,10 @@ snapshots:
 
   "@eslint-community/regexpp@4.12.2": {}
 
-  "@eslint/compat@1.4.1(eslint@9.39.3(jiti@2.6.1))":
-    dependencies:
-      "@eslint/core": 0.17.0
-    optionalDependencies:
-      eslint: 9.39.3(jiti@2.6.1)
-
   "@eslint/config-array@0.21.1":
     dependencies:
       "@eslint/object-schema": 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -14978,7 +11937,7 @@ snapshots:
   "@eslint/eslintrc@3.3.4":
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -15003,21 +11962,7 @@ snapshots:
       "@ethereumjs/util": 8.1.0
       crc-32: 1.2.2
 
-  "@ethereumjs/mpt@10.1.1":
-    dependencies:
-      "@ethereumjs/rlp": 10.1.1
-      "@ethereumjs/util": 10.1.1
-      "@noble/hashes": 2.2.0
-      debug: 4.4.3(supports-color@8.1.1)
-      lru-cache: 11.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  "@ethereumjs/rlp@10.1.1": {}
-
   "@ethereumjs/rlp@4.0.1": {}
-
-  "@ethereumjs/rlp@5.0.2": {}
 
   "@ethereumjs/tx@4.2.0":
     dependencies:
@@ -15026,153 +11971,11 @@ snapshots:
       "@ethereumjs/util": 8.1.0
       ethereum-cryptography: 2.2.1
 
-  "@ethereumjs/util@10.1.1":
-    dependencies:
-      "@ethereumjs/rlp": 10.1.1
-      "@noble/curves": 2.2.0
-      "@noble/hashes": 2.2.0
-
   "@ethereumjs/util@8.1.0":
     dependencies:
       "@ethereumjs/rlp": 4.0.1
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
-
-  "@ethereumjs/util@9.1.0":
-    dependencies:
-      "@ethereumjs/rlp": 5.0.2
-      ethereum-cryptography: 2.2.1
-
-  "@ethersproject/abi@5.8.0":
-    dependencies:
-      "@ethersproject/address": 5.8.0
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/constants": 5.8.0
-      "@ethersproject/hash": 5.8.0
-      "@ethersproject/keccak256": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/properties": 5.8.0
-      "@ethersproject/strings": 5.8.0
-
-  "@ethersproject/abstract-provider@5.8.0":
-    dependencies:
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/networks": 5.8.0
-      "@ethersproject/properties": 5.8.0
-      "@ethersproject/transactions": 5.8.0
-      "@ethersproject/web": 5.8.0
-
-  "@ethersproject/abstract-signer@5.8.0":
-    dependencies:
-      "@ethersproject/abstract-provider": 5.8.0
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/properties": 5.8.0
-
-  "@ethersproject/address@5.8.0":
-    dependencies:
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/keccak256": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/rlp": 5.8.0
-
-  "@ethersproject/base64@5.8.0":
-    dependencies:
-      "@ethersproject/bytes": 5.8.0
-
-  "@ethersproject/bignumber@5.8.0":
-    dependencies:
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      bn.js: 5.2.3
-
-  "@ethersproject/bytes@5.8.0":
-    dependencies:
-      "@ethersproject/logger": 5.8.0
-
-  "@ethersproject/constants@5.8.0":
-    dependencies:
-      "@ethersproject/bignumber": 5.8.0
-
-  "@ethersproject/hash@5.8.0":
-    dependencies:
-      "@ethersproject/abstract-signer": 5.8.0
-      "@ethersproject/address": 5.8.0
-      "@ethersproject/base64": 5.8.0
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/keccak256": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/properties": 5.8.0
-      "@ethersproject/strings": 5.8.0
-
-  "@ethersproject/keccak256@5.8.0":
-    dependencies:
-      "@ethersproject/bytes": 5.8.0
-      js-sha3: 0.8.0
-
-  "@ethersproject/logger@5.8.0": {}
-
-  "@ethersproject/networks@5.8.0":
-    dependencies:
-      "@ethersproject/logger": 5.8.0
-
-  "@ethersproject/properties@5.8.0":
-    dependencies:
-      "@ethersproject/logger": 5.8.0
-
-  "@ethersproject/rlp@5.8.0":
-    dependencies:
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/logger": 5.8.0
-
-  "@ethersproject/signing-key@5.8.0":
-    dependencies:
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/properties": 5.8.0
-      bn.js: 5.2.3
-      elliptic: 6.6.1
-      hash.js: 1.1.7
-
-  "@ethersproject/strings@5.8.0":
-    dependencies:
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/constants": 5.8.0
-      "@ethersproject/logger": 5.8.0
-
-  "@ethersproject/transactions@5.8.0":
-    dependencies:
-      "@ethersproject/address": 5.8.0
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/constants": 5.8.0
-      "@ethersproject/keccak256": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/properties": 5.8.0
-      "@ethersproject/rlp": 5.8.0
-      "@ethersproject/signing-key": 5.8.0
-
-  "@ethersproject/units@5.8.0":
-    dependencies:
-      "@ethersproject/bignumber": 5.8.0
-      "@ethersproject/constants": 5.8.0
-      "@ethersproject/logger": 5.8.0
-
-  "@ethersproject/web@5.8.0":
-    dependencies:
-      "@ethersproject/base64": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/logger": 5.8.0
-      "@ethersproject/properties": 5.8.0
-      "@ethersproject/strings": 5.8.0
-
-  "@fastify/busboy@2.1.1": {}
 
   "@fastify/otel@0.16.0(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -15208,8 +12011,6 @@ snapshots:
       tabbable: 6.4.0
 
   "@floating-ui/utils@0.2.11": {}
-
-  "@frangio/servbot@0.3.0-1": {}
 
   "@gemini-wallet/core@0.3.2(viem@2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))":
     dependencies:
@@ -15264,8 +12065,6 @@ snapshots:
       "@humanwhocodes/retry": 0.4.3
 
   "@humanwhocodes/module-importer@1.0.1": {}
-
-  "@humanwhocodes/momoa@2.0.4": {}
 
   "@humanwhocodes/retry@0.4.3": {}
 
@@ -15388,27 +12187,11 @@ snapshots:
     optionalDependencies:
       "@types/node": 20.19.37
 
-  "@inquirer/external-editor@1.0.3(@types/node@22.7.5)":
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      "@types/node": 22.7.5
-
   "@inquirer/figures@1.0.15": {}
 
   "@inquirer/type@3.0.10(@types/node@20.19.37)":
     optionalDependencies:
       "@types/node": 20.19.37
-
-  "@isaacs/cliui@8.0.2":
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   "@jridgewell/gen-mapping@0.3.13":
     dependencies:
@@ -15445,33 +12228,10 @@ snapshots:
     dependencies:
       "@lit-labs/ssr-dom-shim": 1.5.1
 
-  "@manypkg/find-root@1.1.0":
-    dependencies:
-      "@babel/runtime": 7.28.6
-      "@types/node": 12.20.55
-      find-up: 4.1.0
-      fs-extra: 8.1.0
-
-  "@manypkg/get-packages@1.1.3":
-    dependencies:
-      "@babel/runtime": 7.28.6
-      "@changesets/types": 4.1.0
-      "@manypkg/find-root": 1.1.0
-      fs-extra: 8.1.0
-      globby: 11.1.0
-      read-yaml-file: 1.1.0
-
   "@marsidev/react-turnstile@1.4.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-
-  "@metamask/abi-utils@2.0.4":
-    dependencies:
-      "@metamask/superstruct": 3.2.1
-      "@metamask/utils": 9.3.0
-    transitivePeerDependencies:
-      - supports-color
 
   "@metamask/eth-json-rpc-provider@1.0.1":
     dependencies:
@@ -15612,7 +12372,7 @@ snapshots:
       "@scure/base": 1.2.6
       "@types/debug": 4.1.12
       "@types/lodash": 4.17.24
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       lodash: 4.17.23
       pony-cause: 2.1.11
       semver: 7.7.4
@@ -15624,7 +12384,7 @@ snapshots:
     dependencies:
       "@ethereumjs/tx": 4.2.0
       "@types/debug": 4.1.13
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       semver: 7.7.4
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -15637,7 +12397,7 @@ snapshots:
       "@noble/hashes": 1.8.0
       "@scure/base": 1.2.6
       "@types/debug": 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -15651,7 +12411,7 @@ snapshots:
       "@noble/hashes": 1.8.0
       "@scure/base": 1.2.6
       "@types/debug": 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -15735,6 +12495,7 @@ snapshots:
   "@noble/curves@1.2.0":
     dependencies:
       "@noble/hashes": 1.3.2
+    optional: true
 
   "@noble/curves@1.4.2":
     dependencies:
@@ -15748,10 +12509,6 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.7.1
 
-  "@noble/curves@1.9.0":
-    dependencies:
-      "@noble/hashes": 1.8.0
-
   "@noble/curves@1.9.1":
     dependencies:
       "@noble/hashes": 1.8.0
@@ -15764,13 +12521,8 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.8.0
 
-  "@noble/curves@2.2.0":
-    dependencies:
-      "@noble/hashes": 2.2.0
-
-  "@noble/hashes@1.2.0": {}
-
-  "@noble/hashes@1.3.2": {}
+  "@noble/hashes@1.3.2":
+    optional: true
 
   "@noble/hashes@1.4.0": {}
 
@@ -15779,10 +12531,6 @@ snapshots:
   "@noble/hashes@1.7.1": {}
 
   "@noble/hashes@1.8.0": {}
-
-  "@noble/hashes@2.2.0": {}
-
-  "@noble/secp256k1@1.7.1": {}
 
   "@nodelib/fs.scandir@2.1.5":
     dependencies:
@@ -15797,94 +12545,6 @@ snapshots:
       fastq: 1.20.1
 
   "@nolyfill/is-core-module@1.0.39": {}
-
-  "@nomicfoundation/edr-darwin-arm64@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr-darwin-x64@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr-linux-arm64-gnu@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr-linux-arm64-musl@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr-linux-x64-gnu@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr-linux-x64-musl@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr-win32-x64-msvc@0.12.0-next.23": {}
-
-  "@nomicfoundation/edr@0.12.0-next.23":
-    dependencies:
-      "@nomicfoundation/edr-darwin-arm64": 0.12.0-next.23
-      "@nomicfoundation/edr-darwin-x64": 0.12.0-next.23
-      "@nomicfoundation/edr-linux-arm64-gnu": 0.12.0-next.23
-      "@nomicfoundation/edr-linux-arm64-musl": 0.12.0-next.23
-      "@nomicfoundation/edr-linux-x64-gnu": 0.12.0-next.23
-      "@nomicfoundation/edr-linux-x64-musl": 0.12.0-next.23
-      "@nomicfoundation/edr-win32-x64-msvc": 0.12.0-next.23
-
-  "@nomicfoundation/hardhat-chai-matchers@2.1.2(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(chai@4.5.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))":
-    dependencies:
-      "@nomicfoundation/hardhat-ethers": 3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      "@types/chai-as-promised": 7.1.8
-      chai: 4.5.0
-      chai-as-promised: 7.1.2(chai@4.5.0)
-      deep-eql: 4.1.4
-      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      ordinal: 1.0.3
-
-  "@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))":
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      lodash.isequal: 4.5.0
-    transitivePeerDependencies:
-      - supports-color
-
-  "@nomicfoundation/hardhat-network-helpers@1.1.2(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))":
-    dependencies:
-      ethereumjs-util: 7.1.5
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-
-  "@nomicfoundation/slang@0.18.3":
-    dependencies:
-      "@bytecodealliance/preview2-shim": 0.17.0
-
-  "@nomicfoundation/slang@1.3.4":
-    dependencies:
-      "@bytecodealliance/preview2-shim": 0.17.9
-
-  "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer-darwin-x64@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer-linux-arm64-gnu@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer-linux-arm64-musl@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer-linux-x64-gnu@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer-linux-x64-musl@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer-win32-x64-msvc@0.1.2":
-    optional: true
-
-  "@nomicfoundation/solidity-analyzer@0.1.2":
-    optionalDependencies:
-      "@nomicfoundation/solidity-analyzer-darwin-arm64": 0.1.2
-      "@nomicfoundation/solidity-analyzer-darwin-x64": 0.1.2
-      "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": 0.1.2
-      "@nomicfoundation/solidity-analyzer-linux-arm64-musl": 0.1.2
-      "@nomicfoundation/solidity-analyzer-linux-x64-gnu": 0.1.2
-      "@nomicfoundation/solidity-analyzer-linux-x64-musl": 0.1.2
-      "@nomicfoundation/solidity-analyzer-win32-x64-msvc": 0.1.2
 
   "@open-draft/deferred-promise@2.2.0": {}
 
@@ -16163,71 +12823,11 @@ snapshots:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.0)
 
-  "@openzeppelin/docs-utils@0.1.6":
-    dependencies:
-      "@frangio/servbot": 0.3.0-1
-      chalk: 3.0.0
-      chokidar: 3.6.0
-      env-paths: 2.2.1
-      find-up: 4.1.0
-      is-port-reachable: 3.1.0
-      js-yaml: 3.14.2
-      lodash.startcase: 4.4.0
-      minimist: 1.2.8
-
-  "@openzeppelin/merkle-tree@1.0.8":
-    dependencies:
-      "@metamask/abi-utils": 2.0.4
-      ethereum-cryptography: 3.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  "@openzeppelin/upgrade-safe-transpiler@0.4.1":
-    dependencies:
-      ajv: 8.18.0
-      compare-versions: 6.1.1
-      ethereum-cryptography: 3.2.0
-      lodash: 4.17.23
-      minimatch: 10.2.4
-      minimist: 1.2.8
-      solidity-ast: 0.4.62
-
-  "@openzeppelin/upgrades-core@1.44.2":
-    dependencies:
-      "@nomicfoundation/slang": 0.18.3
-      bignumber.js: 9.3.1
-      cbor: 10.0.12
-      chalk: 4.1.2
-      compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
-      ethereumjs-util: 7.1.5
-      minimatch: 9.0.9
-      minimist: 1.2.8
-      proper-lockfile: 4.1.2
-      solidity-ast: 0.4.62
-    transitivePeerDependencies:
-      - supports-color
-
   "@paulmillr/qr@0.2.1": {}
 
   "@phosphor-icons/webcomponents@2.1.5":
     dependencies:
       lit: 3.3.0
-
-  "@pkgjs/parseargs@0.11.0":
-    optional: true
-
-  "@pnpm/config.env-replace@1.1.0": {}
-
-  "@pnpm/network.ca-file@1.0.2":
-    dependencies:
-      graceful-fs: 4.2.10
-
-  "@pnpm/npm-conf@3.0.2":
-    dependencies:
-      "@pnpm/config.env-replace": 1.1.0
-      "@pnpm/network.ca-file": 1.0.2
-      config-chain: 1.1.13
 
   "@prisma/instrumentation@7.2.0(@opentelemetry/api@1.9.0)":
     dependencies:
@@ -17139,12 +13739,6 @@ snapshots:
 
   "@scure/base@1.2.6": {}
 
-  "@scure/bip32@1.1.5":
-    dependencies:
-      "@noble/hashes": 1.2.0
-      "@noble/secp256k1": 1.7.1
-      "@scure/base": 1.1.9
-
   "@scure/bip32@1.4.0":
     dependencies:
       "@noble/curves": 1.4.2
@@ -17162,11 +13756,6 @@ snapshots:
       "@noble/curves": 1.9.7
       "@noble/hashes": 1.8.0
       "@scure/base": 1.2.6
-
-  "@scure/bip39@1.1.1":
-    dependencies:
-      "@noble/hashes": 1.2.0
-      "@scure/base": 1.1.9
 
   "@scure/bip39@1.3.0":
     dependencies:
@@ -17272,26 +13861,6 @@ snapshots:
 
   "@sentry/core@10.42.0": {}
 
-  "@sentry/core@5.30.0":
-    dependencies:
-      "@sentry/hub": 5.30.0
-      "@sentry/minimal": 5.30.0
-      "@sentry/types": 5.30.0
-      "@sentry/utils": 5.30.0
-      tslib: 1.14.1
-
-  "@sentry/hub@5.30.0":
-    dependencies:
-      "@sentry/types": 5.30.0
-      "@sentry/utils": 5.30.0
-      tslib: 1.14.1
-
-  "@sentry/minimal@5.30.0":
-    dependencies:
-      "@sentry/hub": 5.30.0
-      "@sentry/types": 5.30.0
-      tslib: 1.14.1
-
   "@sentry/nextjs@10.42.0(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.4)":
     dependencies:
       "@opentelemetry/api": 1.9.0
@@ -17371,20 +13940,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@sentry/node@5.30.0":
-    dependencies:
-      "@sentry/core": 5.30.0
-      "@sentry/hub": 5.30.0
-      "@sentry/tracing": 5.30.0
-      "@sentry/types": 5.30.0
-      "@sentry/utils": 5.30.0
-      cookie: 0.4.2
-      https-proxy-agent: 5.0.1
-      lru_map: 0.3.3
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - supports-color
-
   "@sentry/opentelemetry@10.42.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
       "@opentelemetry/api": 1.9.0
@@ -17399,21 +13954,6 @@ snapshots:
       "@sentry/browser": 10.42.0
       "@sentry/core": 10.42.0
       react: 19.2.3
-
-  "@sentry/tracing@5.30.0":
-    dependencies:
-      "@sentry/hub": 5.30.0
-      "@sentry/minimal": 5.30.0
-      "@sentry/types": 5.30.0
-      "@sentry/utils": 5.30.0
-      tslib: 1.14.1
-
-  "@sentry/types@5.30.0": {}
-
-  "@sentry/utils@5.30.0":
-    dependencies:
-      "@sentry/types": 5.30.0
-      tslib: 1.14.1
 
   "@sentry/vercel-edge@10.42.0":
     dependencies:
@@ -17431,8 +13971,6 @@ snapshots:
       - supports-color
 
   "@simplewebauthn/browser@13.2.2": {}
-
-  "@sindresorhus/is@5.6.0": {}
 
   "@sindresorhus/merge-streams@4.0.0": {}
 
@@ -17932,8 +14470,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  "@solidity-parser/parser@0.20.2": {}
-
   "@stablelib/base64@1.0.1": {}
 
   "@standard-schema/spec@1.1.0": {}
@@ -17941,10 +14477,6 @@ snapshots:
   "@swc/helpers@0.5.15":
     dependencies:
       tslib: 2.8.1
-
-  "@szmarczak/http-timer@5.0.1":
-    dependencies:
-      defer-to-connect: 2.0.1
 
   "@tailwindcss/node@4.2.1":
     dependencies:
@@ -18041,14 +14573,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@types/bn.js@5.2.0":
-    dependencies:
-      "@types/node": 20.19.37
-
-  "@types/chai-as-promised@7.1.8":
-    dependencies:
-      "@types/chai": 5.2.3
-
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
@@ -18080,22 +14604,11 @@ snapshots:
 
   "@types/estree@1.0.8": {}
 
-  "@types/glob@7.2.0":
-    dependencies:
-      "@types/minimatch": 6.0.0
-      "@types/node": 20.19.37
-
-  "@types/http-cache-semantics@4.2.0": {}
-
   "@types/json-schema@7.0.15": {}
 
   "@types/json5@0.0.29": {}
 
   "@types/lodash@4.17.24": {}
-
-  "@types/minimatch@6.0.0":
-    dependencies:
-      minimatch: 10.2.5
 
   "@types/ms@2.1.0": {}
 
@@ -18116,10 +14629,7 @@ snapshots:
   "@types/node@22.7.5":
     dependencies:
       undici-types: 6.19.8
-
-  "@types/pbkdf2@3.1.2":
-    dependencies:
-      "@types/node": 20.19.37
+    optional: true
 
   "@types/pg-pool@2.0.7":
     dependencies:
@@ -18138,10 +14648,6 @@ snapshots:
   "@types/react@19.2.14":
     dependencies:
       csstype: 3.2.3
-
-  "@types/secp256k1@4.0.7":
-    dependencies:
-      "@types/node": 20.19.37
 
   "@types/statuses@2.0.6": {}
 
@@ -18187,7 +14693,7 @@ snapshots:
       "@typescript-eslint/types": 8.56.1
       "@typescript-eslint/typescript-estree": 8.56.1(typescript@5.9.3)
       "@typescript-eslint/visitor-keys": 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18197,7 +14703,7 @@ snapshots:
     dependencies:
       "@typescript-eslint/tsconfig-utils": 8.56.1(typescript@5.9.3)
       "@typescript-eslint/types": 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -18216,7 +14722,7 @@ snapshots:
       "@typescript-eslint/types": 8.56.1
       "@typescript-eslint/typescript-estree": 8.56.1(typescript@5.9.3)
       "@typescript-eslint/utils": 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -18231,7 +14737,7 @@ snapshots:
       "@typescript-eslint/tsconfig-utils": 8.56.1(typescript@5.9.3)
       "@typescript-eslint/types": 8.56.1
       "@typescript-eslint/visitor-keys": 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -19556,8 +16062,6 @@ snapshots:
 
   "@xtuc/long@4.2.2": {}
 
-  abbrev@1.0.9: {}
-
   abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -19611,13 +16115,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.4.16: {}
-
-  aes-js@4.0.0-beta.5: {}
+  aes-js@4.0.0-beta.5:
+    optional: true
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19626,15 +16129,6 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-
-  ajv-errors@3.0.0(ajv@8.18.0):
-    dependencies:
-      ajv: 8.18.0
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -19670,19 +16164,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  amdefine@1.0.1:
-    optional: true
-
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
-
-  ansi-colors@4.1.3: {}
-
-  ansi-escapes@4.3.2:
-    dependencies:
-      type-fest: 0.21.3
-
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -19690,10 +16171,6 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
-
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -19707,10 +16184,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -19731,8 +16204,6 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
-
-  array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -19785,11 +16256,7 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
-  assertion-error@1.1.0: {}
-
   assertion-error@2.0.1: {}
-
-  ast-parents@0.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -19803,15 +16270,11 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  astral-regex@2.0.0: {}
-
   async-function@1.0.0: {}
 
   async-mutex@0.2.6:
     dependencies:
       tslib: 2.8.1
-
-  async@1.5.2: {}
 
   asynckit@0.4.0: {}
 
@@ -19830,7 +16293,7 @@ snapshots:
 
   axios@1.13.6:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.15.11
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -19856,30 +16319,9 @@ snapshots:
 
   baseline-browser-mapping@2.10.27: {}
 
-  better-ajv-errors@2.0.3(ajv@8.18.0):
-    dependencies:
-      "@babel/code-frame": 7.29.0
-      "@humanwhocodes/momoa": 2.0.4
-      ajv: 8.18.0
-      chalk: 4.1.2
-      jsonpointer: 5.0.1
-      leven: 3.1.0
-
-  better-path-resolve@1.0.0:
-    dependencies:
-      is-windows: 1.0.2
-
   big.js@6.2.2: {}
 
-  bignumber.js@9.3.1: {}
-
-  binary-extensions@2.3.0: {}
-
   blakejs@1.2.1: {}
-
-  bn.js@4.11.6: {}
-
-  bn.js@4.12.3: {}
 
   bn.js@5.2.3: {}
 
@@ -19887,7 +16329,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -19905,25 +16347,10 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  boxen@5.1.2:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 6.3.0
-      chalk: 4.1.2
-      cli-boxes: 2.2.1
-      string-width: 4.2.3
-      type-fest: 0.20.2
-      widest-line: 3.1.0
-      wrap-ansi: 7.0.0
-
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
     dependencies:
@@ -19936,21 +16363,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  brorand@1.1.0: {}
-
-  brotli-wasm@2.0.1: {}
-
-  browser-stdout@1.3.1: {}
-
-  browserify-aes@1.2.0:
-    dependencies:
-      buffer-xor: 1.0.3
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      evp_bytestokey: 1.0.3
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
 
   browserslist@4.28.1:
     dependencies:
@@ -19980,15 +16392,7 @@ snapshots:
     dependencies:
       base-x: 5.0.1
 
-  bs58check@2.1.2:
-    dependencies:
-      bs58: 4.0.1
-      create-hash: 1.2.0
-      safe-buffer: 5.2.1
-
   buffer-from@1.1.2: {}
-
-  buffer-xor@1.0.3: {}
 
   buffer@6.0.3:
     dependencies:
@@ -20004,18 +16408,6 @@ snapshots:
       run-applescript: 7.1.0
 
   bytes@3.1.2: {}
-
-  cacheable-lookup@7.0.0: {}
-
-  cacheable-request@10.2.14:
-    dependencies:
-      "@types/http-cache-semantics": 4.2.0
-      get-stream: 6.0.1
-      http-cache-semantics: 4.2.0
-      keyv: 4.5.4
-      mimic-response: 4.0.0
-      normalize-url: 8.1.1
-      responselike: 3.0.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -20038,8 +16430,6 @@ snapshots:
 
   camelcase@5.3.1: {}
 
-  camelcase@6.3.0: {}
-
   camelize@1.0.1: {}
 
   caniuse-lite@1.0.30001777: {}
@@ -20048,37 +16438,7 @@ snapshots:
 
   canonicalize@2.1.0: {}
 
-  cbor@10.0.12:
-    dependencies:
-      nofilter: 3.1.0
-
-  chai-as-promised@7.1.2(chai@4.5.0):
-    dependencies:
-      chai: 4.5.0
-      check-error: 1.0.3
-
-  chai@4.5.0:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.4
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.1.0
-
   chai@6.2.2: {}
-
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
-  chalk@3.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   chalk@4.1.2:
     dependencies:
@@ -20087,29 +16447,7 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  chardet@2.1.1: {}
-
   charenc@0.0.2: {}
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
 
   chokidar@5.0.0:
     dependencies:
@@ -20117,35 +16455,17 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  ci-info@2.0.0: {}
-
-  cipher-base@1.0.7:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
   cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
-  clean-stack@2.2.0: {}
-
-  cli-boxes@2.2.1: {}
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
-
-  cli-table3@0.6.5:
-    dependencies:
-      string-width: 4.2.3
-    optionalDependencies:
-      "@colors/colors": 1.5.0
 
   cli-truncate@5.2.0:
     dependencies:
@@ -20162,23 +16482,11 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
-  cliui@7.0.4:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
 
   clsx@1.2.1: {}
 
@@ -20186,15 +16494,9 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -20204,10 +16506,6 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  command-exists@1.2.9: {}
-
-  commander@10.0.1: {}
-
   commander@11.1.0: {}
 
   commander@14.0.2: {}
@@ -20216,18 +16514,9 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commander@8.3.0: {}
-
   commondir@1.0.1: {}
 
-  compare-versions@6.1.1: {}
-
   concat-map@0.0.1: {}
-
-  config-chain@1.1.13:
-    dependencies:
-      ini: 1.3.8
-      proto-list: 1.2.4
 
   content-disposition@1.0.1: {}
 
@@ -20254,8 +16543,6 @@ snapshots:
 
   cookie-signature@1.2.2: {}
 
-  cookie@0.4.2: {}
-
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
@@ -20267,15 +16554,6 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
-    dependencies:
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-    optionalDependencies:
-      typescript: 5.9.3
-
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -20286,23 +16564,6 @@ snapshots:
       typescript: 5.9.3
 
   crc-32@1.2.2: {}
-
-  create-hash@1.2.0:
-    dependencies:
-      cipher-base: 1.0.7
-      inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.3
-      sha.js: 2.4.12
-
-  create-hmac@1.1.7:
-    dependencies:
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      inherits: 2.0.4
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
 
   cross-fetch@3.2.0:
     dependencies:
@@ -20362,8 +16623,6 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  dataloader@1.4.0: {}
-
   date-fns@2.30.0:
     dependencies:
       "@babel/runtime": 7.28.6
@@ -20371,8 +16630,6 @@ snapshots:
   dateformat@4.6.3: {}
 
   dayjs@1.11.13: {}
-
-  death@1.1.0: {}
 
   debug@3.2.7:
     dependencies:
@@ -20382,29 +16639,15 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.4.3(supports-color@8.1.1):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 8.1.1
 
   decamelize@1.2.0: {}
 
-  decamelize@4.0.0: {}
-
   decode-uri-component@0.2.2: {}
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   dedent@1.7.2: {}
-
-  deep-eql@4.1.4:
-    dependencies:
-      type-detect: 4.1.0
-
-  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -20416,8 +16659,6 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
-
-  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -20449,23 +16690,11 @@ snapshots:
 
   detect-browser@5.3.0: {}
 
-  detect-indent@6.1.0: {}
-
   detect-libc@2.1.2: {}
-
-  diff@5.2.2: {}
 
   diff@8.0.3: {}
 
-  difflib@0.2.4:
-    dependencies:
-      heap: 0.2.7
-
   dijkstrajs@1.0.3: {}
-
-  dir-glob@3.0.1:
-    dependencies:
-      path-type: 4.0.0
 
   doctrine@2.1.0:
     dependencies:
@@ -20474,8 +16703,6 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.3.1: {}
-
-  dotenv@8.6.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -20490,8 +16717,6 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
-  eastasianwidth@0.2.0: {}
-
   eciesjs@0.4.17:
     dependencies:
       "@ecies/ciphers": 0.2.5(@noble/ciphers@1.3.0)
@@ -20504,16 +16729,6 @@ snapshots:
   electron-to-chromium@1.5.307: {}
 
   electron-to-chromium@1.5.351: {}
-
-  elliptic@6.6.1:
-    dependencies:
-      bn.js: 4.12.3
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@10.6.0: {}
 
@@ -20532,7 +16747,7 @@ snapshots:
   engine.io-client@6.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       "@socket.io/component-emitter": 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       engine.io-parser: 5.2.3
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       xmlhttprequest-ssl: 2.1.2
@@ -20552,11 +16767,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-
-  enquirer@2.4.1:
-    dependencies:
-      ansi-colors: 4.1.3
-      strip-ansi: 6.0.1
 
   env-paths@2.2.1: {}
 
@@ -20743,18 +16953,7 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@1.0.5: {}
-
   escape-string-regexp@4.0.0: {}
-
-  escodegen@1.8.1:
-    dependencies:
-      esprima: 2.7.3
-      estraverse: 1.9.3
-      esutils: 2.0.3
-      optionator: 0.8.3
-    optionalDependencies:
-      source-map: 0.2.0
 
   eslint-config-next@16.1.6(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -20776,10 +16975,6 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.39.3(jiti@2.6.1)):
-    dependencies:
-      eslint: 9.39.3(jiti@2.6.1)
-
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -20791,7 +16986,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       "@nolyfill/is-core-module": 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       eslint: 9.39.3(jiti@2.6.1)
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
@@ -20928,7 +17123,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -20958,8 +17153,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
-  esprima@2.7.3: {}
-
   esprima@4.0.1: {}
 
   esquery@1.7.0:
@@ -20969,8 +17162,6 @@ snapshots:
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
-
-  estraverse@1.9.3: {}
 
   estraverse@4.3.0: {}
 
@@ -21013,70 +17204,12 @@ snapshots:
     dependencies:
       fast-safe-stringify: 2.1.1
 
-  ethereum-bloom-filters@1.2.0:
-    dependencies:
-      "@noble/hashes": 1.8.0
-
-  ethereum-cryptography@0.1.3:
-    dependencies:
-      "@types/pbkdf2": 3.1.2
-      "@types/secp256k1": 4.0.7
-      blakejs: 1.2.1
-      browserify-aes: 1.2.0
-      bs58check: 2.1.2
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      hash.js: 1.1.7
-      keccak: 3.0.4
-      pbkdf2: 3.1.5
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-      scrypt-js: 3.0.1
-      secp256k1: 4.0.4
-      setimmediate: 1.0.5
-
-  ethereum-cryptography@1.2.0:
-    dependencies:
-      "@noble/hashes": 1.2.0
-      "@noble/secp256k1": 1.7.1
-      "@scure/bip32": 1.1.5
-      "@scure/bip39": 1.1.1
-
   ethereum-cryptography@2.2.1:
     dependencies:
       "@noble/curves": 1.4.2
       "@noble/hashes": 1.4.0
       "@scure/bip32": 1.4.0
       "@scure/bip39": 1.3.0
-
-  ethereum-cryptography@3.2.0:
-    dependencies:
-      "@noble/ciphers": 1.3.0
-      "@noble/curves": 1.9.0
-      "@noble/hashes": 1.8.0
-      "@scure/bip32": 1.7.0
-      "@scure/bip39": 1.6.0
-
-  ethereumjs-util@7.1.5:
-    dependencies:
-      "@types/bn.js": 5.2.0
-      bn.js: 5.2.3
-      create-hash: 1.2.0
-      ethereum-cryptography: 0.1.3
-      rlp: 2.2.7
-
-  ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    dependencies:
-      "@adraffy/ens-normalize": 1.10.1
-      "@noble/curves": 1.2.0
-      "@noble/hashes": 1.3.2
-      "@types/node": 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -21091,11 +17224,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
     optional: true
-
-  ethjs-unit@0.1.6:
-    dependencies:
-      bn.js: 4.11.6
-      number-to-bn: 1.7.0
 
   event-target-shim@5.0.1: {}
 
@@ -21112,11 +17240,6 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
-
-  evp_bytestokey@1.0.3:
-    dependencies:
-      md5.js: 1.3.5
-      safe-buffer: 5.2.1
 
   execa@5.1.1:
     dependencies:
@@ -21160,7 +17283,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -21185,8 +17308,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extendable-error@0.1.7: {}
-
   extension-port-stream@3.0.0:
     dependencies:
       readable-stream: 4.7.0
@@ -21197,8 +17318,6 @@ snapshots:
   fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-diff@1.3.0: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -21265,7 +17384,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -21289,24 +17408,13 @@ snapshots:
       flatted: 3.3.4
       keyv: 4.5.4
 
-  flat@5.0.2: {}
-
   flatted@3.3.4: {}
 
-  follow-redirects@1.15.11(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+  follow-redirects@1.15.11: {}
 
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
-  form-data-encoder@2.1.4: {}
 
   form-data@4.0.5:
     dependencies:
@@ -21324,8 +17432,6 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  fp-ts@1.19.3: {}
-
   fresh@2.0.0: {}
 
   fs-extra@11.3.4:
@@ -21333,20 +17439,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
-
-  fs-extra@7.0.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
-  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -21375,8 +17467,6 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
-
-  get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -21415,11 +17505,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  ghost-testrpc@0.0.2:
-    dependencies:
-      chalk: 2.4.2
-      node-emoji: 1.11.0
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -21430,110 +17515,24 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  glob@5.0.15:
-    dependencies:
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
-  glob@8.1.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
-
-  global-modules@2.0.0:
-    dependencies:
-      global-prefix: 3.0.0
-
-  global-prefix@3.0.0:
-    dependencies:
-      ini: 1.3.8
-      kind-of: 6.0.3
-      which: 1.3.1
-
   globals@14.0.0: {}
 
   globals@16.4.0: {}
-
-  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globby@10.0.2:
-    dependencies:
-      "@types/glob": 7.2.0
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      glob: 7.2.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
-
-  globby@11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
-
   gopd@1.2.0: {}
 
-  got@12.6.1:
-    dependencies:
-      "@sindresorhus/is": 5.6.0
-      "@szmarczak/http-timer": 5.0.1
-      cacheable-lookup: 7.0.0
-      cacheable-request: 10.2.14
-      decompress-response: 6.0.0
-      form-data-encoder: 2.1.4
-      get-stream: 6.0.1
-      http2-wrapper: 2.2.1
-      lowercase-keys: 3.0.0
-      p-cancelable: 3.0.0
-      responselike: 3.0.0
-
-  graceful-fs@4.2.10: {}
-
   graceful-fs@4.2.11: {}
-
-  graphlib@2.1.8:
-    dependencies:
-      lodash: 4.17.23
 
   graphql@16.13.1: {}
 
@@ -21549,110 +17548,7 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
-  handlebars@4.7.9:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
-  hardhat-exposed@0.3.19(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)):
-    dependencies:
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      micromatch: 4.0.8
-      solidity-ast: 0.4.62
-
-  hardhat-gas-reporter@2.3.0(bufferutil@4.1.0)(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
-    dependencies:
-      "@ethersproject/abi": 5.8.0
-      "@ethersproject/bytes": 5.8.0
-      "@ethersproject/units": 5.8.0
-      "@solidity-parser/parser": 0.20.2
-      axios: 1.13.6
-      brotli-wasm: 2.0.1
-      chalk: 4.1.2
-      cli-table3: 0.6.5
-      ethereum-cryptography: 2.2.1
-      glob: 10.5.0
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      jsonschema: 1.5.0
-      lodash: 4.17.23
-      markdown-table: 2.0.0
-      sha1: 1.1.1
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - typescript
-      - utf-8-validate
-      - zod
-
-  hardhat-ignore-warnings@0.2.12:
-    dependencies:
-      minimatch: 5.1.9
-      node-interval-tree: 2.1.2
-      solidity-comments: 0.0.2
-
-  hardhat-predeploy@0.4.1(@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)):
-    dependencies:
-      "@nomicfoundation/hardhat-ethers": 3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-
-  hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10):
-    dependencies:
-      "@ethereumjs/util": 9.1.0
-      "@ethersproject/abi": 5.8.0
-      "@nomicfoundation/edr": 0.12.0-next.23
-      "@nomicfoundation/solidity-analyzer": 0.1.2
-      "@sentry/node": 5.30.0
-      adm-zip: 0.4.16
-      aggregate-error: 3.1.0
-      ansi-escapes: 4.3.2
-      boxen: 5.1.2
-      chokidar: 4.0.3
-      ci-info: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      enquirer: 2.4.1
-      env-paths: 2.2.1
-      ethereum-cryptography: 1.2.0
-      find-up: 5.0.0
-      fp-ts: 1.19.3
-      fs-extra: 7.0.1
-      immutable: 4.3.8
-      io-ts: 1.10.4
-      json-stream-stringify: 3.1.6
-      keccak: 3.0.4
-      lodash: 4.17.23
-      micro-eth-signer: 0.14.0
-      mnemonist: 0.38.5
-      mocha: 10.8.2
-      p-map: 4.0.0
-      picocolors: 1.1.1
-      raw-body: 2.5.3
-      resolve: 1.17.0
-      semver: 6.3.1
-      solc: 0.8.26(debug@4.4.3)
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.15
-      tsort: 0.0.1
-      undici: 5.29.0
-      uuid: 8.3.2
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   has-bigints@1.1.0: {}
-
-  has-flag@1.0.0: {}
-
-  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -21670,27 +17566,11 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hash-base@3.1.2:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
-  hash.js@1.1.7:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
-  he@1.2.0: {}
-
   headers-polyfill@4.0.3: {}
-
-  heap@0.2.7: {}
 
   help-me@5.0.0: {}
 
@@ -21700,17 +17580,9 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hmac-drbg@1.0.1:
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-
   hono@4.12.5: {}
 
   html-escaper@2.0.2: {}
-
-  http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -21720,26 +17592,19 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http2-wrapper@2.2.1:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
-
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  human-id@4.1.3: {}
 
   human-signals@2.1.0: {}
 
@@ -21750,10 +17615,6 @@ snapshots:
       ms: 2.1.3
 
   husky@9.1.7: {}
-
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -21769,8 +17630,6 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immutable@4.3.8: {}
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -21785,34 +17644,13 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  indent-string@4.0.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
   inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
-
-  interoperable-addresses@0.1.3:
-    dependencies:
-      "@scure/base": 1.2.6
-      ethereum-cryptography: 3.2.0
-      typed-regex: 0.0.8
-
-  interpret@1.4.0: {}
-
-  io-ts@1.10.4:
-    dependencies:
-      fp-ts: 1.19.3
 
   ip-address@10.1.0: {}
 
@@ -21844,10 +17682,6 @@ snapshots:
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
 
   is-boolean-object@1.2.2:
     dependencies:
@@ -21903,8 +17737,6 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-hex-prefixed@1.0.0: {}
-
   is-in-ssh@1.0.0: {}
 
   is-inside-container@1.0.0:
@@ -21928,11 +17760,7 @@ snapshots:
 
   is-obj@3.0.0: {}
 
-  is-plain-obj@2.1.0: {}
-
   is-plain-obj@4.1.0: {}
-
-  is-port-reachable@3.1.0: {}
 
   is-promise@4.0.0: {}
 
@@ -21966,10 +17794,6 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
-  is-subdir@1.2.0:
-    dependencies:
-      better-path-resolve: 1.0.0
-
   is-symbol@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -21979,8 +17803,6 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
-
-  is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@1.3.0: {}
 
@@ -21996,8 +17818,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-
-  is-windows@1.0.2: {}
 
   is-wsl@3.1.1:
     dependencies:
@@ -22045,12 +17865,6 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
-  jackspeak@3.4.3:
-    dependencies:
-      "@isaacs/cliui": 8.0.2
-    optionalDependencies:
-      "@pkgjs/parseargs": 0.11.0
-
   jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       "@types/connect": 3.4.38
@@ -22085,16 +17899,9 @@ snapshots:
 
   js-cookie@3.0.5: {}
 
-  js-sha3@0.8.0: {}
-
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -22121,8 +17928,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stream-stringify@3.1.6: {}
-
   json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
@@ -22131,19 +17936,11 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsonpointer@5.0.1: {}
-
-  jsonschema@1.5.0: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -22164,8 +17961,6 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  kind-of@6.0.3: {}
-
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -22175,17 +17970,6 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
-
-  latest-version@7.0.0:
-    dependencies:
-      package-json: 8.1.1
-
-  leven@3.1.0: {}
-
-  levn@0.3.0:
-    dependencies:
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
 
   levn@0.4.1:
     dependencies:
@@ -22289,20 +18073,9 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.isequal@4.5.0: {}
-
   lodash.merge@4.6.2: {}
 
-  lodash.startcase@4.4.0: {}
-
-  lodash.truncate@4.4.2: {}
-
   lodash@4.17.23: {}
-
-  log-symbols@4.1.0:
-    dependencies:
-      chalk: 4.1.2
-      is-unicode-supported: 0.1.0
 
   log-symbols@6.0.0:
     dependencies:
@@ -22321,23 +18094,11 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
-
-  lowercase-keys@3.0.0: {}
-
-  lru-cache@10.4.3: {}
-
-  lru-cache@11.0.2: {}
-
   lru-cache@11.2.6: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru_map@0.3.3: {}
 
   lucide-react@0.554.0(react@19.2.3):
     dependencies:
@@ -22361,17 +18122,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  markdown-table@2.0.0:
-    dependencies:
-      repeat-string: 1.6.1
-
   math-intrinsics@1.1.0: {}
-
-  md5.js@1.3.5:
-    dependencies:
-      hash-base: 3.1.2
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
 
   md5@2.3.0:
     dependencies:
@@ -22381,25 +18132,13 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  memorystream@0.3.1: {}
-
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
-  micro-eth-signer@0.14.0:
-    dependencies:
-      "@noble/curves": 1.8.1
-      "@noble/hashes": 1.7.1
-      micro-packed: 0.7.3
-
   micro-ftch@0.3.1: {}
-
-  micro-packed@0.7.3:
-    dependencies:
-      "@scure/base": 1.2.6
 
   micromatch@4.0.8:
     dependencies:
@@ -22422,14 +18161,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
-
-  mimic-response@4.0.0: {}
-
-  minimalistic-assert@1.0.1: {}
-
-  minimalistic-crypto-utils@1.0.1: {}
-
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -22442,14 +18173,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.1.0
-
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.0
-
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -22458,40 +18181,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-
-  mnemonist@0.38.5:
-    dependencies:
-      obliterator: 2.0.5
-
-  mocha@10.8.2:
-    dependencies:
-      ansi-colors: 4.1.3
-      browser-stdout: 1.3.1
-      chokidar: 3.6.0
-      debug: 4.4.3(supports-color@8.1.1)
-      diff: 5.2.2
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 8.1.0
-      he: 1.2.0
-      js-yaml: 4.1.1
-      log-symbols: 4.1.0
-      minimatch: 5.1.9
-      ms: 2.1.3
-      serialize-javascript: 6.0.2
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      workerpool: 6.5.1
-      yargs: 16.2.0
-      yargs-parser: 20.2.9
-      yargs-unparser: 2.0.0
-
   module-details-from-path@1.0.4: {}
-
-  mri@1.2.0: {}
 
   ms@2.1.2: {}
 
@@ -22563,13 +18253,7 @@ snapshots:
 
   node-addon-api@2.0.2: {}
 
-  node-addon-api@5.1.0: {}
-
   node-domexception@1.0.0: {}
-
-  node-emoji@1.11.0:
-    dependencies:
-      lodash: 4.17.23
 
   node-exports-info@1.6.0:
     dependencies:
@@ -22592,25 +18276,13 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-interval-tree@2.1.2:
-    dependencies:
-      shallowequal: 1.1.0
-
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.36: {}
 
   node-releases@2.0.38: {}
 
-  nofilter@3.1.0: {}
-
-  nopt@3.0.6:
-    dependencies:
-      abbrev: 1.0.9
-
   normalize-path@3.0.0: {}
-
-  normalize-url@8.1.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -22620,11 +18292,6 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
-
-  number-to-bn@1.7.0:
-    dependencies:
-      bn.js: 4.11.6
-      strip-hex-prefix: 1.0.0
 
   obj-multiplex@1.0.0:
     dependencies:
@@ -22676,8 +18343,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  obliterator@2.0.5: {}
-
   obug@2.1.1: {}
 
   ofetch@1.5.1:
@@ -22726,15 +18391,6 @@ snapshots:
 
   openapi-typescript-helpers@0.0.15: {}
 
-  optionator@0.8.3:
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.3.0
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-      word-wrap: 1.2.5
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -22755,12 +18411,6 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.2.0
-
-  ordinal@1.0.3: {}
-
-  os-tmpdir@1.0.2: {}
-
-  outdent@0.5.0: {}
 
   outvariant@1.4.3: {}
 
@@ -22902,12 +18552,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  p-cancelable@3.0.0: {}
-
-  p-filter@2.1.0:
-    dependencies:
-      p-map: 2.1.0
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -22915,10 +18559,6 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-
-  p-limit@7.3.0:
-    dependencies:
-      yocto-queue: 1.2.2
 
   p-locate@4.1.0:
     dependencies:
@@ -22928,26 +18568,7 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p-map@2.1.0: {}
-
-  p-map@4.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-
   p-try@2.2.0: {}
-
-  package-json-from-dist@1.0.1: {}
-
-  package-json@8.1.1:
-    dependencies:
-      got: 12.6.1
-      registry-auth-token: 5.1.1
-      registry-url: 6.0.1
-      semver: 7.7.4
-
-  package-manager-detector@0.2.11:
-    dependencies:
-      quansync: 0.2.11
 
   package-manager-detector@1.6.0: {}
 
@@ -22970,18 +18591,11 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-is-absolute@1.0.1: {}
-
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -22992,20 +18606,7 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
-  path-type@4.0.0: {}
-
   pathe@2.0.3: {}
-
-  pathval@1.1.1: {}
-
-  pbkdf2@3.1.5:
-    dependencies:
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-      to-buffer: 1.2.2
 
   pg-int8@1.0.1: {}
 
@@ -23026,8 +18627,6 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@3.0.0: {}
-
-  pify@4.0.1: {}
 
   pify@5.0.0: {}
 
@@ -23095,8 +18694,6 @@ snapshots:
       thread-stream: 0.15.2
 
   pkce-challenge@5.0.1: {}
-
-  pluralize@8.0.0: {}
 
   pngjs@5.0.0: {}
 
@@ -23188,18 +18785,7 @@ snapshots:
 
   preact@10.29.1: {}
 
-  prelude-ls@1.1.2: {}
-
   prelude-ls@1.2.1: {}
-
-  prettier-plugin-solidity@2.3.1(prettier@3.8.1):
-    dependencies:
-      "@nomicfoundation/slang": 1.3.4
-      "@solidity-parser/parser": 0.20.2
-      prettier: 3.8.1
-      semver: 7.7.4
-
-  prettier@2.8.8: {}
 
   prettier@3.8.1: {}
 
@@ -23227,14 +18813,6 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-
-  proper-lockfile@4.1.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      retry: 0.12.0
-      signal-exit: 3.0.7
-
-  proto-list@1.2.4: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -23271,8 +18849,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  quansync@0.2.11: {}
-
   query-string@7.1.3:
     dependencies:
       decode-uri-component: 0.2.2
@@ -23284,22 +18860,9 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
-  quick-lru@5.1.1: {}
-
   radix3@1.1.2: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.1: {}
-
-  raw-body@2.5.3:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -23307,13 +18870,6 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-device-detect@2.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -23329,13 +18885,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.3: {}
-
-  read-yaml-file@1.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 3.14.2
-      pify: 4.0.1
-      strip-bom: 3.0.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -23361,12 +18910,6 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
-
-  readdirp@4.1.2: {}
-
   readdirp@5.0.0: {}
 
   real-require@0.1.0: {}
@@ -23380,14 +18923,6 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
-
-  rechoir@0.6.2:
-    dependencies:
-      resolve: 1.22.11
-
-  recursive-readdir@2.2.3:
-    dependencies:
-      minimatch: 3.1.5
 
   redaxios@0.5.1: {}
 
@@ -23411,23 +18946,13 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  registry-auth-token@5.1.1:
-    dependencies:
-      "@pnpm/npm-conf": 3.0.2
-
-  registry-url@6.0.1:
-    dependencies:
-      rc: 1.2.8
-
-  repeat-string@1.6.1: {}
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -23436,19 +18961,9 @@ snapshots:
 
   reselect@5.1.1: {}
 
-  resolve-alpn@1.2.1: {}
-
   resolve-from@4.0.0: {}
 
-  resolve-from@5.0.0: {}
-
   resolve-pkg-maps@1.0.0: {}
-
-  resolve@1.1.7: {}
-
-  resolve@1.17.0:
-    dependencies:
-      path-parse: 1.0.7
 
   resolve@1.22.11:
     dependencies:
@@ -23465,36 +18980,16 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  responselike@3.0.0:
-    dependencies:
-      lowercase-keys: 3.0.0
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
-
-  retry@0.12.0: {}
 
   rettime@0.10.1: {}
 
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@6.1.3:
-    dependencies:
-      glob: 13.0.6
-      package-json-from-dist: 1.0.1
-
-  ripemd160@2.0.3:
-    dependencies:
-      hash-base: 3.1.2
-      inherits: 2.0.4
-
-  rlp@2.2.7:
-    dependencies:
-      bn.js: 5.2.3
 
   rollup@4.59.0:
     dependencies:
@@ -23529,7 +19024,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -23583,23 +19078,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sc-istanbul@0.4.6:
-    dependencies:
-      abbrev: 1.0.9
-      async: 1.5.2
-      escodegen: 1.8.1
-      esprima: 2.7.3
-      glob: 5.0.15
-      handlebars: 4.7.9
-      js-yaml: 3.14.2
-      mkdirp: 0.5.6
-      nopt: 3.0.6
-      once: 1.4.0
-      resolve: 1.1.7
-      supports-color: 3.2.3
-      which: 1.3.1
-      wordwrap: 1.0.0
-
   scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
@@ -23609,19 +19087,9 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
-  scrypt-js@3.0.1: {}
-
-  secp256k1@4.0.4:
-    dependencies:
-      elliptic: 6.6.1
-      node-addon-api: 5.1.0
-      node-gyp-build: 4.8.4
-
   secure-json-parse@2.7.0: {}
 
   secure-password-utilities@0.2.1: {}
-
-  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -23631,7 +19099,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -23644,10 +19112,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
 
   serve-static@2.2.1:
     dependencies:
@@ -23686,8 +19150,6 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  setimmediate@1.0.5: {}
-
   setprototypeof@1.2.0: {}
 
   sha.js@2.4.12:
@@ -23695,11 +19157,6 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
-
-  sha1@1.1.1:
-    dependencies:
-      charenc: 0.0.2
-      crypt: 0.0.2
 
   shadcn@4.0.0(@types/node@20.19.37)(typescript@5.9.3):
     dependencies:
@@ -23785,12 +19242,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shelljs@0.8.5:
-    dependencies:
-      glob: 7.2.3
-      interpret: 1.4.0
-      rechoir: 0.6.2
-
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -23827,14 +19278,6 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  slash@3.0.0: {}
-
-  slice-ansi@4.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -23850,7 +19293,7 @@ snapshots:
   socket.io-client@4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       "@socket.io/component-emitter": 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       engine.io-client: 6.6.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       socket.io-parser: 4.2.5
     transitivePeerDependencies:
@@ -23861,124 +19304,9 @@ snapshots:
   socket.io-parser@4.2.5:
     dependencies:
       "@socket.io/component-emitter": 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  solc@0.8.26(debug@4.4.3):
-    dependencies:
-      command-exists: 1.2.9
-      commander: 8.3.0
-      follow-redirects: 1.15.11(debug@4.4.3)
-      js-sha3: 0.8.0
-      memorystream: 0.3.1
-      semver: 5.7.2
-      tmp: 0.0.33
-    transitivePeerDependencies:
-      - debug
-
-  solhint-plugin-openzeppelin@file:contracts/lib/openzeppelin-contracts/scripts/solhint-custom:
-    dependencies:
-      minimatch: 10.2.5
-
-  solhint@6.2.1(typescript@5.9.3):
-    dependencies:
-      "@solidity-parser/parser": 0.20.2
-      ajv: 8.18.0
-      ajv-errors: 3.0.0(ajv@8.18.0)
-      ast-parents: 0.0.1
-      better-ajv-errors: 2.0.3(ajv@8.18.0)
-      chalk: 4.1.2
-      commander: 10.0.1
-      cosmiconfig: 8.3.6(typescript@5.9.3)
-      fast-diff: 1.3.0
-      glob: 13.0.6
-      ignore: 5.3.2
-      js-yaml: 4.1.1
-      latest-version: 7.0.0
-      lodash: 4.17.23
-      pluralize: 8.0.0
-      semver: 7.7.4
-      table: 6.9.0
-      text-table: 0.2.0
-    optionalDependencies:
-      prettier: 3.8.1
-    transitivePeerDependencies:
-      - typescript
-
-  solidity-ast@0.4.62: {}
-
-  solidity-comments-darwin-arm64@0.0.2:
-    optional: true
-
-  solidity-comments-darwin-x64@0.0.2:
-    optional: true
-
-  solidity-comments-freebsd-x64@0.0.2:
-    optional: true
-
-  solidity-comments-linux-arm64-gnu@0.0.2:
-    optional: true
-
-  solidity-comments-linux-arm64-musl@0.0.2:
-    optional: true
-
-  solidity-comments-linux-x64-gnu@0.0.2:
-    optional: true
-
-  solidity-comments-linux-x64-musl@0.0.2:
-    optional: true
-
-  solidity-comments-win32-arm64-msvc@0.0.2:
-    optional: true
-
-  solidity-comments-win32-ia32-msvc@0.0.2:
-    optional: true
-
-  solidity-comments-win32-x64-msvc@0.0.2:
-    optional: true
-
-  solidity-comments@0.0.2:
-    optionalDependencies:
-      solidity-comments-darwin-arm64: 0.0.2
-      solidity-comments-darwin-x64: 0.0.2
-      solidity-comments-freebsd-x64: 0.0.2
-      solidity-comments-linux-arm64-gnu: 0.0.2
-      solidity-comments-linux-arm64-musl: 0.0.2
-      solidity-comments-linux-x64-gnu: 0.0.2
-      solidity-comments-linux-x64-musl: 0.0.2
-      solidity-comments-win32-arm64-msvc: 0.0.2
-      solidity-comments-win32-ia32-msvc: 0.0.2
-      solidity-comments-win32-x64-msvc: 0.0.2
-
-  solidity-coverage@0.8.17(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)):
-    dependencies:
-      "@ethersproject/abi": 5.8.0
-      "@solidity-parser/parser": 0.20.2
-      chalk: 2.4.2
-      death: 1.1.0
-      difflib: 0.2.4
-      fs-extra: 8.1.0
-      ghost-testrpc: 0.0.2
-      global-modules: 2.0.0
-      globby: 10.0.2
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      jsonschema: 1.5.0
-      lodash: 4.17.23
-      mocha: 10.8.2
-      node-emoji: 1.11.0
-      pify: 4.0.1
-      recursive-readdir: 2.2.3
-      sc-istanbul: 0.4.6
-      semver: 7.7.4
-      shelljs: 0.8.5
-      web3-utils: 1.10.4
-
-  solidity-docgen@0.6.0-beta.36(hardhat@2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)):
-    dependencies:
-      handlebars: 4.7.9
-      hardhat: 2.28.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      solidity-ast: 0.4.62
 
   sonic-boom@2.8.0:
     dependencies:
@@ -23999,23 +19327,11 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
-  source-map@0.2.0:
-    dependencies:
-      amdefine: 1.0.1
-    optional: true
-
   source-map@0.6.1: {}
-
-  spawndamnit@3.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
 
   split-on-first@1.1.0: {}
 
   split2@4.2.0: {}
-
-  sprintf-js@1.0.3: {}
 
   stable-hash@0.0.5: {}
 
@@ -24062,12 +19378,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -24158,12 +19468,6 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  strip-hex-prefix@1.0.0:
-    dependencies:
-      is-hex-prefixed: 1.0.0
-
-  strip-json-comments@2.0.1: {}
-
   strip-json-comments@3.1.1: {}
 
   styled-components@6.3.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
@@ -24194,14 +19498,6 @@ snapshots:
 
   superstruct@2.0.2: {}
 
-  supports-color@3.2.3:
-    dependencies:
-      has-flag: 1.0.0
-
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -24219,14 +19515,6 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  table@6.9.0:
-    dependencies:
-      ajv: 8.18.0
-      lodash.truncate: 4.4.2
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -24236,8 +19524,6 @@ snapshots:
   tapable@2.3.0: {}
 
   tapable@2.3.3: {}
-
-  term-size@2.2.1: {}
 
   terser-webpack-plugin@5.5.0(webpack@5.105.4):
     dependencies:
@@ -24255,8 +19541,6 @@ snapshots:
       source-map-support: 0.5.21
 
   text-encoding-utf-8@1.0.2: {}
-
-  text-table@0.2.0: {}
 
   thread-stream@0.15.2:
     dependencies:
@@ -24288,10 +19572,6 @@ snapshots:
   tldts@7.0.25:
     dependencies:
       tldts-core: 7.0.25
-
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
 
   to-buffer@1.2.2:
     dependencies:
@@ -24337,27 +19617,16 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tslib@2.7.0: {}
+  tslib@2.7.0:
+    optional: true
 
   tslib@2.8.1: {}
 
-  tsort@0.0.1: {}
-
   tw-animate-css@1.4.0: {}
-
-  type-check@0.3.2:
-    dependencies:
-      prelude-ls: 1.1.2
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-detect@4.1.0: {}
-
-  type-fest@0.20.2: {}
-
-  type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
 
@@ -24406,8 +19675,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typed-regex@0.0.8: {}
-
   typescript-eslint@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       "@typescript-eslint/eslint-plugin": 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
@@ -24424,9 +19691,6 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   ufo@1.6.3: {}
-
-  uglify-js@3.19.3:
-    optional: true
 
   uint8arrays@3.1.0:
     dependencies:
@@ -24445,21 +19709,14 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.19.8:
+    optional: true
 
   undici-types@6.21.0: {}
 
   undici-types@7.22.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      "@fastify/busboy": 2.1.1
-
-  undici@7.25.0: {}
-
   unicorn-magic@0.3.0: {}
-
-  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 
@@ -24542,8 +19799,6 @@ snapshots:
       node-gyp-build: 4.8.4
     optional: true
 
-  utf8@3.0.0: {}
-
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -24609,23 +19864,6 @@ snapshots:
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       ox: 0.9.1(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
-    dependencies:
-      "@noble/curves": 1.9.1
-      "@noble/hashes": 1.8.0
-      "@scure/bip32": 1.7.0
-      "@scure/bip39": 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.14.0(typescript@5.9.3)(zod@4.3.6)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -24813,17 +20051,6 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web3-utils@1.10.4:
-    dependencies:
-      "@ethereumjs/util": 8.1.0
-      bn.js: 5.2.3
-      ethereum-bloom-filters: 1.2.0
-      ethereum-cryptography: 2.2.1
-      ethjs-unit: 0.1.6
-      number-to-bn: 1.7.0
-      randombytes: 2.1.0
-      utf8: 3.0.0
-
   webextension-polyfill@0.10.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -24910,10 +20137,6 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
 
-  which@1.3.1:
-    dependencies:
-      isexe: 2.0.0
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -24927,15 +20150,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  widest-line@3.1.0:
-    dependencies:
-      string-width: 4.2.3
-
   word-wrap@1.2.5: {}
-
-  wordwrap@1.0.0: {}
-
-  workerpool@6.5.1: {}
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -24949,12 +20164,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
-
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -24963,20 +20172,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
-
-  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
 
   ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
@@ -24988,11 +20187,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
-
-  ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
 
   ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
@@ -25079,18 +20273,7 @@ snapshots:
       camelcase: 5.3.1
       decamelize: 1.2.0
 
-  yargs-parser@20.2.9: {}
-
   yargs-parser@21.1.1: {}
-
-  yargs-parser@22.0.0: {}
-
-  yargs-unparser@2.0.0:
-    dependencies:
-      camelcase: 6.3.0
-      decamelize: 4.0.0
-      flat: 5.0.2
-      is-plain-obj: 2.1.0
 
   yargs@15.4.1:
     dependencies:
@@ -25106,16 +20289,6 @@ snapshots:
       y18n: 4.0.3
       yargs-parser: 18.1.3
 
-  yargs@16.2.0:
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
-
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -25126,18 +20299,7 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
-
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}
 

--- a/tests/convex/wire-generator.test.ts
+++ b/tests/convex/wire-generator.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../../convex/schema";
 import { api, internal } from "../../convex/_generated/api";
@@ -185,21 +185,30 @@ describe("wire/generator: writes a marketNarratives row on success", () => {
 
 describe("wire/generator: no-op outside trading hours (via generateNextEpoch)", () => {
   it("generateNextEpoch skips without writing when called on a weekend", async () => {
-    const t = convexTest(schema, modules);
-    await seedSeasonAndDrops(t);
+    // Pin clock to Saturday 2026-05-09 14:00 UTC — guaranteed outside ET trading hours
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-09T14:00:00.000Z"));
 
-    // We can't control Date.now() in convex-test actions, but we can verify
-    // the idempotency path: if the test is run on a weekend / off-hours, the
-    // action returns skipped. On weekdays during market hours it may proceed.
-    // This test verifies that the action handler exists and returns a valid shape.
-    const result = await t.action(
-      internal.wire.generator.generateNextEpoch,
-      {}
-    );
+    try {
+      const t = convexTest(schema, modules);
+      await seedSeasonAndDrops(t);
 
-    // Result must be either a skipped object or an inserted object — never undefined
-    expect(result).toBeDefined();
-    expect(typeof result).toBe("object");
+      const result = await t.action(
+        internal.wire.generator.generateNextEpoch,
+        {}
+      );
+
+      expect(result).toMatchObject({ skipped: "outside-market-hours" });
+
+      // No rows written
+      const rows = await t.run(async (ctx) =>
+        ctx.db.query("marketNarratives").collect()
+      );
+      const generatedRows = rows.filter((r) => r.epochSlot !== 0);
+      expect(generatedRows.length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
…ing on runtime day

The `generateNextEpoch` no-op test was calling the action without a stub, which would attempt a real OpenAI call whenever run during market hours. Pin `Date.now()` to a Saturday with `vi.useFakeTimers()` inside the test, restoring real timers via `finally` to avoid leaking into sibling tests.