### PR TITLE
feat(wire): operator narrative tools (#112)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL=   # Base Sepolia JSON-RPC endpoint (e.g. Alche
 OPERATOR_PRIVATE_KEY=        # Private key for enterDeal / resolveEntry on MarginCallEscrow
 OPERATOR_SECRET=             # Shared secret for admin endpoints (e.g. resolve-pending)
 
+# Operator console — set via: npx convex env set OPERATOR_SUBJECTS "did:privy:xxx,did:privy:yyy"
+# Comma-separated Privy subject IDs. Controls access to /admin/wire and gated Convex actions.
+OPERATOR_SUBJECTS=           # (Convex env var — set in Convex dashboard or CLI, not .env.local)
+
 # Upstash Redis (rate limiting) — optional for local dev (uses in-memory fallback)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -41,6 +41,9 @@ import type * as wire_epochAssembler from "../wire/epochAssembler.js";
 import type * as wire_epochValidator from "../wire/epochValidator.js";
 import type * as wire_generator from "../wire/generator.js";
 import type * as wire_internal from "../wire/internal.js";
+import type * as wire_operatorActions from "../wire/operatorActions.js";
+import type * as wire_operatorMutations from "../wire/operatorMutations.js";
+import type * as wire_operatorQueries from "../wire/operatorQueries.js";
 import type * as wire_persist from "../wire/persist.js";
 import type * as wire_tradingHours from "../wire/tradingHours.js";
 
@@ -84,6 +87,9 @@ declare const fullApi: ApiFromModules<{
   "wire/epochValidator": typeof wire_epochValidator;
   "wire/generator": typeof wire_generator;
   "wire/internal": typeof wire_internal;
+  "wire/operatorActions": typeof wire_operatorActions;
+  "wire/operatorMutations": typeof wire_operatorMutations;
+  "wire/operatorQueries": typeof wire_operatorQueries;
   "wire/persist": typeof wire_persist;
   "wire/tradingHours": typeof wire_tradingHours;
 }>;

--- a/convex/agent/scheduler.ts
+++ b/convex/agent/scheduler.ts
@@ -31,7 +31,7 @@ export const scheduler = internalAction({
 
     console.log(
       `[scheduler] enqueued ${staleTraders.length} cycle(s):`,
-      staleTraders.map((t) => t._id)
+      staleTraders.map((t: { _id: string }) => t._id)
     );
   },
 });

--- a/convex/wire/_operatorUtils.ts
+++ b/convex/wire/_operatorUtils.ts
@@ -1,0 +1,14 @@
+const OPERATOR_SUBJECTS = (process.env.OPERATOR_SUBJECTS ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export function isOperatorSubject(subject: string): boolean {
+  return OPERATOR_SUBJECTS.length > 0 && OPERATOR_SUBJECTS.includes(subject);
+}
+
+export function assertOperatorSubject(subject: string): void {
+  if (!isOperatorSubject(subject)) {
+    throw new Error("Unauthorized: not an operator subject");
+  }
+}

--- a/convex/wire/generator.ts
+++ b/convex/wire/generator.ts
@@ -8,7 +8,7 @@ import { isMarketOpen, currentEpochSlot, dayPosture } from "./tradingHours";
 import { assembleUserMessage } from "./epochAssembler";
 import { validateEpoch } from "./epochValidator";
 import type { NarrativeEpoch } from "./_schemas";
-import type { Id } from "../_generated/dataModel";
+import type { Id, Doc } from "../_generated/dataModel";
 
 const FALLBACK_NARRATIVE_GENERATION_SYSTEM = `You are the Wire narrative engine for a 1980s Wall Street trading game.
 You produce hourly Wire Drop dispatches that serialize an ongoing financial thriller.
@@ -48,14 +48,23 @@ async function runGenerator(
 
   // Load all context in parallel
   const [seasonData, recentDrops, recentGameEvents, recentSeedCadence] =
-    await Promise.all([
+    (await Promise.all([
       ctx.runQuery(internal.wire.internal.loadActiveSeason, {}),
       ctx.runQuery(internal.wire.internal.listRecentDrops, { limit: 10 }),
       ctx.runQuery(internal.wire.internal.listRecentGameEvents, {
         since: sinceMs,
       }),
       ctx.runQuery(internal.wire.internal.listRecentSeedCadence, { limit: 6 }),
-    ]);
+    ])) as [
+      {
+        season: Doc<"narrativeSeasons">;
+        entities: Doc<"narrativeEntities">[];
+        arcs: Doc<"narrativeArcs">[];
+      } | null,
+      Doc<"marketNarratives">[],
+      import("./epochAssembler").GameEventCtx[],
+      { epochSlot: number | null; hadSeed: boolean }[],
+    ];
 
   if (!seasonData) {
     console.warn("[wire/generator] no active season found — skipping");

--- a/convex/wire/operatorActions.ts
+++ b/convex/wire/operatorActions.ts
@@ -1,0 +1,62 @@
+"use node";
+
+import { action } from "../_generated/server";
+import { internal, api } from "../_generated/api";
+import { assertOperatorSubject } from "./_operatorUtils";
+
+type GenerateResult =
+  | { skipped: "outside-market-hours" | "duplicate-slot" }
+  | { skipped: "validation-failed"; error: string }
+  | { inserted: boolean; dropId: string; epoch?: number };
+
+type ResetResult = {
+  cleared: {
+    deletedNarratives: number;
+    deletedSeeds: number;
+    deletedSeedLinks: number;
+  };
+  imported: {
+    seasonId: string;
+    entitiesUpserted: number;
+    arcsUpserted: number;
+    dropInserted: boolean;
+  };
+};
+
+export const forceGenerateDrop = action({
+  args: {},
+  handler: async (ctx): Promise<GenerateResult> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    assertOperatorSubject(identity.subject);
+
+    return ctx.runAction(internal.wire.generator.devForceEpoch, {
+      ignoreSlot: true,
+    }) as Promise<GenerateResult>;
+  },
+});
+
+export const resetNarrativeState = action({
+  args: {},
+  handler: async (ctx): Promise<ResetResult> => {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("Reset is not available in production");
+    }
+
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    assertOperatorSubject(identity.subject);
+
+    const cleared = (await ctx.runMutation(
+      internal.wire.operatorMutations.clearNarrativeState,
+      {}
+    )) as ResetResult["cleared"];
+
+    const imported = (await ctx.runMutation(
+      api.seasons.importSeason,
+      {}
+    )) as ResetResult["imported"];
+
+    return { cleared, imported };
+  },
+});

--- a/convex/wire/operatorMutations.ts
+++ b/convex/wire/operatorMutations.ts
@@ -1,0 +1,29 @@
+import { internalMutation } from "../_generated/server";
+
+/**
+ * Dev-only: delete all Wire narrative state (marketNarratives, wireDealSeeds,
+ * wireDealSeedLinks). Arc tension resets happen via the subsequent importSeason call.
+ * Bounded to 500 rows per table — safe for development volumes.
+ */
+export const clearNarrativeState = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const [seedLinks, seeds, narratives] = await Promise.all([
+      ctx.db.query("wireDealSeedLinks").take(500),
+      ctx.db.query("wireDealSeeds").take(500),
+      ctx.db.query("marketNarratives").take(500),
+    ]);
+
+    await Promise.all([
+      ...seedLinks.map((r) => ctx.db.delete(r._id)),
+      ...seeds.map((r) => ctx.db.delete(r._id)),
+      ...narratives.map((r) => ctx.db.delete(r._id)),
+    ]);
+
+    return {
+      deletedNarratives: narratives.length,
+      deletedSeeds: seeds.length,
+      deletedSeedLinks: seedLinks.length,
+    };
+  },
+});

--- a/convex/wire/operatorQueries.ts
+++ b/convex/wire/operatorQueries.ts
@@ -1,0 +1,98 @@
+import { query } from "../_generated/server";
+import { isOperatorSubject } from "./_operatorUtils";
+import type { Id } from "../_generated/dataModel";
+
+export const getOperatorContext = query({
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    const isOperator = identity != null && isOperatorSubject(identity.subject);
+    const isDevEnv = process.env.NODE_ENV !== "production";
+
+    if (!isOperator) {
+      return {
+        isOperator: false,
+        isDevEnv,
+        season: null,
+        arcs: [],
+        recentDropCount: 0,
+        lastDrop: null,
+      };
+    }
+
+    const season = await ctx.db
+      .query("narrativeSeasons")
+      .withIndex("byIsActive", (q) => q.eq("isActive", true))
+      .first();
+
+    if (!season) {
+      return {
+        isOperator: true,
+        isDevEnv,
+        season: null,
+        arcs: [],
+        recentDropCount: 0,
+        lastDrop: null,
+      };
+    }
+
+    const [arcs, lastDrop] = await Promise.all([
+      ctx.db
+        .query("narrativeArcs")
+        .withIndex("bySeasonAndStatus", (q) =>
+          q.eq("seasonId", season._id).eq("status", "active")
+        )
+        .take(50),
+      ctx.db
+        .query("marketNarratives")
+        .withIndex("byEpoch")
+        .order("desc")
+        .first(),
+    ]);
+
+    // Collect all unique entity IDs across all arcs, fetch once, reassemble
+    const allEntityIds = [
+      ...new Set(
+        arcs.flatMap((arc) => arc.entityRefs as Id<"narrativeEntities">[])
+      ),
+    ];
+    const entityResults = await Promise.all(
+      allEntityIds.map((id) => ctx.db.get(id))
+    );
+    const entityMap = new Map(
+      entityResults
+        .filter(Boolean)
+        .map((e) => [
+          e!._id as string,
+          { slug: e!.slug, displayName: e!.displayName },
+        ])
+    );
+
+    const arcsWithEntities = arcs.map((arc) => ({
+      _id: arc._id,
+      slug: arc.slug,
+      title: arc.title,
+      summary: arc.summary,
+      tensionScore: arc.tensionScore,
+      lastTouchedAt: arc.lastTouchedAt,
+      entities: arc.entityRefs
+        .map((id) => entityMap.get(id as string))
+        .filter(Boolean) as { slug: string; displayName: string }[],
+    }));
+
+    return {
+      isOperator: true,
+      isDevEnv,
+      season: { title: season.title, seasonKey: season.seasonKey },
+      arcs: arcsWithEntities.sort((a, b) => b.tensionScore - a.tensionScore),
+      recentDropCount: lastDrop?.epoch ?? 0,
+      lastDrop: lastDrop
+        ? {
+            epoch: lastDrop.epoch,
+            dropTitle: lastDrop.dropTitle ?? null,
+            createdAt: lastDrop.createdAt,
+          }
+        : null,
+    };
+  },
+});

--- a/src/app/admin/wire/page.tsx
+++ b/src/app/admin/wire/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const WireAdminClient = dynamic(() => import("./wire-admin-client"), {
+  ssr: false,
+});
+
+export default function WireAdminPage() {
+  return <WireAdminClient />;
+}

--- a/src/app/admin/wire/wire-admin-client.tsx
+++ b/src/app/admin/wire/wire-admin-client.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useAction } from "convex/react";
+import { api } from "../../../../convex/_generated/api";
+import { Nav } from "@/components/nav";
+
+function tensionColor(score: number): string {
+  if (score >= 8) return "text-[var(--t-red)]";
+  if (score >= 5) return "text-[var(--t-amber)]";
+  return "text-[var(--t-green)]";
+}
+
+function relativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export default function WireAdminClient() {
+  const ctx = useQuery(api.wire.operatorQueries.getOperatorContext);
+
+  const forceGenerate = useAction(api.wire.operatorActions.forceGenerateDrop);
+  const resetState = useAction(api.wire.operatorActions.resetNarrativeState);
+
+  const [generateStatus, setGenerateStatus] = useState<string | null>(null);
+  const [generatePending, setGeneratePending] = useState(false);
+  const [resetStatus, setResetStatus] = useState<string | null>(null);
+  const [resetPending, setResetPending] = useState(false);
+  const [resetConfirm, setResetConfirm] = useState(false);
+
+  if (ctx === undefined) {
+    return (
+      <div className="crt-scanlines min-h-screen bg-[var(--t-bg)] font-mono">
+        <Nav />
+        <div className="flex items-center justify-center pt-24">
+          <p className="text-sm text-[var(--t-muted)]">
+            LOADING<span className="cursor-blink">{"█"}</span>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!ctx.isOperator) {
+    return (
+      <div className="crt-scanlines min-h-screen bg-[var(--t-bg)] font-mono">
+        <Nav />
+        <div className="flex items-center justify-center pt-24">
+          <div className="border border-[var(--t-red)] px-8 py-6 text-center">
+            <p className="text-sm uppercase tracking-widest text-[var(--t-red)]">
+              ACCESS DENIED
+            </p>
+            <p className="mt-2 text-xs text-[var(--t-muted)]">
+              Operator subjects only.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  async function handleForceGenerate() {
+    setGeneratePending(true);
+    setGenerateStatus(null);
+    try {
+      const result = await forceGenerate({});
+      if ("skipped" in result) {
+        setGenerateStatus(`SKIPPED — ${result.skipped}`);
+      } else {
+        setGenerateStatus(
+          `OK — epoch ${result.epoch ?? "?"} · drop ${result.dropId.slice(-6)}`
+        );
+      }
+    } catch (err) {
+      setGenerateStatus(
+        `ERROR — ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      setGeneratePending(false);
+    }
+  }
+
+  async function handleReset() {
+    if (!resetConfirm) {
+      setResetConfirm(true);
+      return;
+    }
+    setResetPending(true);
+    setResetStatus(null);
+    setResetConfirm(false);
+    try {
+      const result = await resetState({});
+      const c = result.cleared;
+      setResetStatus(
+        `OK — deleted ${c.deletedNarratives} drops · ${c.deletedSeeds} seeds · ${c.deletedSeedLinks} links · season re-imported`
+      );
+    } catch (err) {
+      setResetStatus(
+        `ERROR — ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      setResetPending(false);
+    }
+  }
+
+  return (
+    <div className="crt-scanlines min-h-screen bg-[var(--t-bg)] font-mono">
+      <Nav />
+
+      <div className="mx-auto w-full max-w-4xl px-4">
+        <div className="border-x border-[var(--t-border)]">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-[var(--t-border)] px-4 py-2">
+            <div className="flex items-center gap-3">
+              <span className="text-xs uppercase tracking-widest text-[var(--t-accent)]">
+                OPS CONSOLE
+              </span>
+              {ctx.season && (
+                <span className="text-xs text-[var(--t-muted)]">
+                  {ctx.season.title}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-4 text-xs text-[var(--t-muted)]">
+              <span>
+                DROPS{" "}
+                <span className="text-[var(--t-text)]">
+                  {ctx.recentDropCount}
+                </span>
+              </span>
+              {ctx.lastDrop && (
+                <span>
+                  LAST{" "}
+                  <span className="text-[var(--t-text)]">
+                    {relativeTime(ctx.lastDrop.createdAt)}
+                  </span>
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="divide-y divide-[var(--t-border)]">
+            {/* Force Generate */}
+            <section className="px-4 py-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-[10px] uppercase tracking-widest text-[var(--t-muted)]">
+                  WIRE GENERATOR
+                </span>
+              </div>
+              <div className="flex items-center gap-4">
+                <button
+                  onClick={handleForceGenerate}
+                  disabled={generatePending}
+                  className="cursor-pointer border border-[var(--t-accent)] bg-[var(--t-accent)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest text-[var(--t-bg)] transition-colors hover:bg-transparent hover:text-[var(--t-accent)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {generatePending ? "GENERATING..." : "FORCE GENERATE DROP"}
+                </button>
+                {generateStatus && (
+                  <span
+                    className={`text-xs ${
+                      generateStatus.startsWith("ERROR")
+                        ? "text-[var(--t-red)]"
+                        : generateStatus.startsWith("SKIPPED")
+                          ? "text-[var(--t-amber)]"
+                          : "text-[var(--t-green)]"
+                    }`}
+                  >
+                    {generateStatus}
+                  </span>
+                )}
+              </div>
+              <p className="mt-2 text-[10px] text-[var(--t-muted)]">
+                Bypasses market-hours gate. Writes a distinct row
+                (ignoreSlot=true).
+              </p>
+            </section>
+
+            {/* Arc Inspector */}
+            <section className="px-4 py-4">
+              <div className="mb-3">
+                <span className="text-[10px] uppercase tracking-widest text-[var(--t-muted)]">
+                  ACTIVE ARCS ({ctx.arcs.length})
+                </span>
+              </div>
+
+              {ctx.arcs.length === 0 ? (
+                <p className="text-xs text-[var(--t-muted)]">
+                  No active arcs — import a season first.
+                </p>
+              ) : (
+                <div className="divide-y divide-[var(--t-border)]">
+                  {ctx.arcs.map((arc) => (
+                    <div key={arc._id} className="py-3">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-[var(--t-text)]">
+                              {arc.title}
+                            </span>
+                            <span className="text-[10px] text-[var(--t-muted)]">
+                              [{arc.slug}]
+                            </span>
+                          </div>
+                          <p className="mt-0.5 text-[10px] leading-relaxed text-[var(--t-muted)]">
+                            {arc.summary}
+                          </p>
+                          {arc.entities.length > 0 && (
+                            <div className="mt-1 flex flex-wrap gap-1.5">
+                              {arc.entities.map((e) => (
+                                <span
+                                  key={e.slug}
+                                  className="border border-[var(--t-border)] px-1 py-0.5 text-[9px] uppercase tracking-wider text-[var(--t-muted)]"
+                                >
+                                  {e.displayName}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        <div className="shrink-0 text-right">
+                          <div
+                            className={`text-sm font-bold tabular-nums ${tensionColor(arc.tensionScore)}`}
+                          >
+                            {arc.tensionScore}/10
+                          </div>
+                          <div className="mt-0.5 text-[9px] text-[var(--t-muted)]">
+                            {relativeTime(arc.lastTouchedAt)}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* Dev Reset */}
+            {ctx.isDevEnv && (
+              <section className="px-4 py-4">
+                <div className="mb-3">
+                  <span className="text-[10px] uppercase tracking-widest text-[var(--t-muted)]">
+                    DEV RESET
+                  </span>
+                </div>
+                <div className="border border-[var(--t-red)]/30 p-3">
+                  <p className="mb-3 text-[10px] leading-relaxed text-[var(--t-muted)]">
+                    Deletes all Wire Drops, Deal Seeds, and Seed Links, then
+                    re-imports the active season (resets arc tensions to seed
+                    values).{" "}
+                    <span className="text-[var(--t-red)]">
+                      Irreversible in dev.
+                    </span>
+                  </p>
+                  <div className="flex items-center gap-4">
+                    <button
+                      onClick={handleReset}
+                      disabled={resetPending}
+                      className={`cursor-pointer border px-3 py-1.5 text-[10px] font-bold uppercase tracking-widest transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                        resetConfirm
+                          ? "border-[var(--t-red)] bg-[var(--t-red)] text-[var(--t-bg)] hover:bg-transparent hover:text-[var(--t-red)]"
+                          : "border-[var(--t-red)]/50 text-[var(--t-red)] hover:border-[var(--t-red)] hover:bg-[var(--t-red)]/10"
+                      }`}
+                    >
+                      {resetPending
+                        ? "RESETTING..."
+                        : resetConfirm
+                          ? "CONFIRM RESET"
+                          : "RESET NARRATIVE STATE"}
+                    </button>
+                    {resetConfirm && !resetPending && (
+                      <button
+                        onClick={() => setResetConfirm(false)}
+                        className="cursor-pointer text-[10px] uppercase tracking-wider text-[var(--t-muted)] hover:text-[var(--t-text)]"
+                      >
+                        CANCEL
+                      </button>
+                    )}
+                    {resetStatus && (
+                      <span
+                        className={`text-xs ${
+                          resetStatus.startsWith("ERROR")
+                            ? "text-[var(--t-red)]"
+                            : "text-[var(--t-green)]"
+                        }`}
+                      >
+                        {resetStatus}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </section>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/prompt/suggest/route.ts
+++ b/src/app/api/prompt/suggest/route.ts
@@ -8,9 +8,8 @@ import {
 } from "@/lib/rate-limit";
 import { verifyPrivyToken } from "@/lib/privy/server";
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-
 export async function POST(request: NextRequest) {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   try {
     // Require auth to protect OpenAI spend
     await verifyPrivyToken(request);


### PR DESCRIPTION
## Summary

- Adds `/admin/wire` operator console (terminal-style, gated to `OPERATOR_SUBJECTS` Convex env var)
- Force-generate Wire Drop action bypassing market-hours gate (`ignoreSlot=true`)
- Arc inspector showing active arcs with tension scores, last-touched timestamps, and linked entities
- Dev-only reset action: clears all Wire Drops/Seeds/SeedLinks, re-imports active season seed (resets arc tensions)

## Setup

Set operator subjects in Convex:
```
npx convex env set OPERATOR_SUBJECTS "did:privy:xxx,did:privy:yyy"
```

Then visit `/admin/wire`.

## Test plan

- [ ] Unauthenticated or non-operator subject → "ACCESS DENIED"
- [ ] FORCE GENERATE DROP fires, shows epoch/dropId on success
- [ ] Arc inspector lists active arcs with tension color coding (green/amber/red) and linked entities
- [ ] DEV RESET requires confirmation click, shows deleted counts and "season re-imported"
- [ ] Reset button absent in production (`NODE_ENV=production`)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)