### PR TITLE
[codex] Fix SIWA auth for agent deal entry

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,2 @@
+.agents
+.codex

--- a/convex/agent/cycle.ts
+++ b/convex/agent/cycle.ts
@@ -76,7 +76,7 @@ async function callDealEnter(
   );
   const identityRegistryAddress =
     process.env.IDENTITY_REGISTRY_ADDRESS ??
-    "0x0000000000000000000000000000000000000000";
+    "0x8004A818BFB912233c491871b3d84c89A494BD9e";
 
   const signer = {
     getAddress: async () => smartAccount.address as `0x${string}`,

--- a/src/app/api/deal/enter/route.ts
+++ b/src/app/api/deal/enter/route.ts
@@ -42,7 +42,10 @@ async function handleAgentCycleDealEnter(
   const siwaMessage = Buffer.from(siwaMessageB64, "base64").toString("utf-8");
   const siwaResult = await verifySIWARequest(siwaMessage, siwaSignature);
   if (!siwaResult.valid) {
-    return NextResponse.json({ error: "Invalid SIWA auth" }, { status: 401 });
+    return NextResponse.json(
+      { error: `Invalid SIWA auth: ${siwaResult.error ?? "unknown"}` },
+      { status: 401 }
+    );
   }
 
   const convex = createConvexAdminClient();
@@ -54,6 +57,7 @@ async function handleAgentCycleDealEnter(
   })) as {
     tokenId?: number;
     cdpWalletAddress?: string;
+    cdpOwnerAddress?: string;
     walletStatus?: string;
   } | null;
 

--- a/src/lib/siwa/__tests__/verify-binding.test.ts
+++ b/src/lib/siwa/__tests__/verify-binding.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { siwaAuthMatchesTrader } from "@/lib/siwa/binding";
+import { siwaAuthMatchesConvexTrader } from "@/lib/siwa/binding";
 import { getPrivyWalletAddress } from "@/lib/privy/server";
 
 describe("siwaAuthMatchesTrader", () => {
@@ -43,6 +44,42 @@ describe("siwaAuthMatchesTrader", () => {
         {
           token_id: 42,
           cdp_wallet_address: "0x2222222222222222222222222222222222222222",
+        }
+      )
+    ).toBe(false);
+  });
+});
+
+describe("siwaAuthMatchesConvexTrader", () => {
+  it("requires the SIWA smart account and recovered CDP owner to match the trader", () => {
+    expect(
+      siwaAuthMatchesConvexTrader(
+        {
+          agentId: 42,
+          address: "0x1111111111111111111111111111111111111111",
+          signerAddress: "0x2222222222222222222222222222222222222222",
+        },
+        {
+          tokenId: 42,
+          cdpWalletAddress: "0x1111111111111111111111111111111111111111",
+          cdpOwnerAddress: "0x2222222222222222222222222222222222222222",
+        }
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a matching smart account signed by the wrong CDP owner", () => {
+    expect(
+      siwaAuthMatchesConvexTrader(
+        {
+          agentId: 42,
+          address: "0x1111111111111111111111111111111111111111",
+          signerAddress: "0x3333333333333333333333333333333333333333",
+        },
+        {
+          tokenId: 42,
+          cdpWalletAddress: "0x1111111111111111111111111111111111111111",
+          cdpOwnerAddress: "0x2222222222222222222222222222222222222222",
         }
       )
     ).toBe(false);

--- a/src/lib/siwa/binding.ts
+++ b/src/lib/siwa/binding.ts
@@ -21,8 +21,12 @@ export function siwaAuthMatchesTrader(
  * (`tokenId` / `cdpWalletAddress` naming).
  */
 export function siwaAuthMatchesConvexTrader(
-  siwa: { agentId?: number; address?: string },
-  trader: { tokenId?: number; cdpWalletAddress?: string }
+  siwa: { agentId?: number; address?: string; signerAddress?: string },
+  trader: {
+    tokenId?: number;
+    cdpWalletAddress?: string;
+    cdpOwnerAddress?: string;
+  }
 ): boolean {
   if (
     siwa.agentId === undefined ||
@@ -34,5 +38,11 @@ export function siwaAuthMatchesConvexTrader(
   if (!siwa.address || !trader.cdpWalletAddress) {
     return false;
   }
-  return getAddress(siwa.address) === getAddress(trader.cdpWalletAddress);
+  if (getAddress(siwa.address) !== getAddress(trader.cdpWalletAddress)) {
+    return false;
+  }
+  if (!siwa.signerAddress || !trader.cdpOwnerAddress) {
+    return false;
+  }
+  return getAddress(siwa.signerAddress) === getAddress(trader.cdpOwnerAddress);
 }

--- a/src/lib/siwa/verify.ts
+++ b/src/lib/siwa/verify.ts
@@ -45,7 +45,13 @@ export async function createNonce(agentId: number, address: string) {
 export async function verifySIWARequest(
   message: string,
   signature: string
-): Promise<{ valid: boolean; agentId?: number; address?: string }> {
+): Promise<{
+  valid: boolean;
+  error?: string;
+  agentId?: number;
+  address?: string;
+  signerAddress?: string;
+}> {
   try {
     const fields = parseSIWAMessage(message);
 
@@ -53,7 +59,7 @@ export async function verifySIWARequest(
     const issuedAtMs = Date.parse(fields.issuedAt);
     if (Number.isNaN(issuedAtMs) || Date.now() - issuedAtMs > MAX_SIWA_AGE_MS) {
       console.error("[SIWA verify] Message too old or invalid issuedAt");
-      return { valid: false };
+      return { valid: false, error: "Message too old or invalid issuedAt" };
     }
 
     // 2. Expiration / notBefore checks
@@ -62,11 +68,11 @@ export async function verifySIWARequest(
       Date.now() > Date.parse(fields.expirationTime)
     ) {
       console.error("[SIWA verify] Message expired");
-      return { valid: false };
+      return { valid: false, error: "Message expired" };
     }
     if (fields.notBefore && Date.now() < Date.parse(fields.notBefore)) {
       console.error("[SIWA verify] Message not yet valid");
-      return { valid: false };
+      return { valid: false, error: "Message not yet valid" };
     }
 
     // 3. Domain binding
@@ -77,10 +83,23 @@ export async function verifySIWARequest(
         "!==",
         domain
       );
-      return { valid: false };
+      return { valid: false, error: "Domain mismatch" };
     }
 
-    // 4. Recover the actual EOA signer from the EIP-191 signature
+    // 4. Registry / chain binding
+    const registryParts = fields.agentRegistry.split(":");
+    if (
+      registryParts.length !== 3 ||
+      registryParts[0] !== "eip155" ||
+      Number(fields.chainId) !== CONTRACTS_CHAIN_ID ||
+      Number(registryParts[1]) !== CONTRACTS_CHAIN_ID ||
+      getAddress(registryParts[2]) !== getAddress(IDENTITY_REGISTRY_ADDRESS)
+    ) {
+      console.error("[SIWA verify] Agent registry or chain mismatch");
+      return { valid: false, error: "Agent registry or chain mismatch" };
+    }
+
+    // 5. Recover the actual EOA signer from the EIP-191 signature.
     let recoveredAddress: string;
     try {
       recoveredAddress = await recoverMessageAddress({
@@ -89,26 +108,25 @@ export async function verifySIWARequest(
       });
     } catch (err) {
       console.error("[SIWA verify] Failed to recover signer:", err);
-      return { valid: false };
+      return { valid: false, error: "Failed to recover signer" };
     }
 
-    // 5. Nonce consumption
+    // 6. Nonce consumption
     const nonceOk = await nonceStore.consume(fields.nonce);
 
     if (!nonceOk) {
       console.error("[SIWA verify] Invalid or already consumed nonce");
-      return { valid: false };
+      return { valid: false, error: "Invalid or already consumed nonce" };
     }
 
-    // The legacy SIWA verify endpoint is deprecated in favor of Convex-native
-    // auth flows; keep this path closed during migration.
-    console.warn(
-      "[SIWA verify] deprecated legacy verification path invoked; rejecting."
-    );
-    void getAddress(recoveredAddress);
-    return { valid: false };
+    return {
+      valid: true,
+      agentId: fields.agentId,
+      address: getAddress(fields.address),
+      signerAddress: getAddress(recoveredAddress),
+    };
   } catch (err) {
     console.error("[SIWA verify] failed:", err);
-    return { valid: false };
+    return { valid: false, error: "Malformed SIWA message" };
   }
 }


### PR DESCRIPTION
## Summary

Fixes agent-cycle deal entry SIWA auth so Convex-scheduled traders can successfully call `/api/deal/enter`.

## Root Cause

`verifySIWARequest` consumed the SIWA nonce and then always returned `valid: false` because the legacy verification path was left closed during migration. Convex agent cycles still use that Next.js route as the HTTP boundary for deal entry, so every cycle failed with `401 Invalid SIWA auth`.

## Changes

- Restore SIWA verification after freshness, domain, chain/registry, signature recovery, and nonce checks pass.
- Return the recovered CDP owner signer and require it to match `trader.cdpOwnerAddress` in addition to the SIWA smart-account address matching `trader.cdpWalletAddress`.
- Include non-secret SIWA failure reasons in the 401 response for easier Convex log debugging.
- Align the Convex cycle identity registry fallback with the deployed Base Sepolia registry address.
- Add `.vercelignore` so local Codex agent folders are not uploaded during Vercel deploys.

## Validation

- `pnpm test src/lib/siwa/__tests__/verify-binding.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`

Note: full `pnpm test` still has unrelated wire narrative failures around deal seed validator limits / fixture drift.
