### PR TITLE
Public trader NFT metadata API and Convex getPublicMetadata

### DIFF
--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -96,6 +96,41 @@ async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
   };
 }
 
+function humanizeImageVariant(variant: string | undefined): string {
+  if (!variant) return "Wall Street Operator";
+  return variant
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function deriveRiskProfile(mandate: unknown): string {
+  if (!mandate || typeof mandate !== "object" || Array.isArray(mandate)) {
+    return "Balanced";
+  }
+
+  const values = mandate as Record<string, unknown>;
+  const bankrollPct = Number(values.bankroll_pct ?? 0);
+  const maxEntryCost = Number(values.max_entry_cost_usdc ?? 0);
+
+  if (bankrollPct >= 50 || maxEntryCost >= 500) return "Aggressive";
+  if ((bankrollPct > 0 && bankrollPct <= 10) || maxEntryCost <= 25) {
+    return "Conservative";
+  }
+  return "Balanced";
+}
+
+async function resolveReadyProfileImageUrl(
+  ctx: QueryCtx,
+  trader: Doc<"traders">
+): Promise<string | null> {
+  if (trader.imageStatus !== "ready" || !trader.profileImageStorageId) {
+    return null;
+  }
+
+  return (await ctx.storage.getUrl(trader.profileImageStorageId)) ?? null;
+}
+
 /** Public: list traders owned by the calling desk manager. */
 export const listByDesk = query({
   args: {},
@@ -119,6 +154,30 @@ export const getById = query({
     const trader = await ctx.db.get(traderId);
     if (!trader || trader.ownerSubject !== identity.subject) return null;
     return toTraderReadModel(ctx, trader);
+  },
+});
+
+/**
+ * Public: curated trader metadata read model for NFT metadata routes.
+ * This intentionally excludes owner, wallet, mandate, personality, raw image
+ * prompt/source, dedupe, and error fields.
+ */
+export const getPublicMetadata = query({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return null;
+
+    return {
+      traderId: trader._id,
+      name: trader.name,
+      status: trader.status,
+      portraitStatus: trader.imageStatus ?? "pending",
+      archetype: humanizeImageVariant(trader.imageVariant),
+      riskProfile: deriveRiskProfile(trader.mandate),
+      tokenId: trader.tokenId ?? null,
+      profileImageUrl: await resolveReadyProfileImageUrl(ctx, trader),
+    };
   },
 });
 

--- a/convex/wallet.ts
+++ b/convex/wallet.ts
@@ -3,6 +3,7 @@
 import { internalAction } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
+import { buildTraderMetadataUrl } from "../src/lib/trader-metadata";
 
 /**
  * Required Convex env vars:
@@ -10,6 +11,7 @@ import { internal } from "./_generated/api";
  *   CDP_API_KEY_SECRET    — Coinbase CDP API key secret (PEM)
  *   CDP_WALLET_SECRET     — Coinbase CDP wallet encryption secret
  *   IDENTITY_REGISTRY_ADDRESS — ERC-8004 identity registry contract address
+ *   NEXT_PUBLIC_APP_URL   — public app URL used for ERC-721 metadata
  *
  * Set via: npx convex env set CDP_API_KEY_ID <value>
  *          npx convex env set CDP_API_KEY_SECRET <value>
@@ -60,10 +62,11 @@ export const createForTrader = internalAction({
       const identityRegistryAddress = requireEnv(
         "IDENTITY_REGISTRY_ADDRESS"
       ) as `0x${string}`;
+      const appUrl = requireEnv("NEXT_PUBLIC_APP_URL");
 
       const { CdpClient } = await import("@coinbase/cdp-sdk");
-      const { encodeFunctionData } = await import("viem");
-      const { createPublicClient, http, decodeEventLog } = await import("viem");
+      const { createPublicClient, decodeEventLog, encodeFunctionData, http } =
+        await import("viem");
       const { baseSepolia } = await import("viem/chains");
 
       const cdp = new CdpClient({
@@ -114,7 +117,7 @@ export const createForTrader = internalAction({
       });
 
       // Step 2: Mint ERC-8004 identity NFT
-      const agentURI = `data:application/json,${JSON.stringify({ name: trader.name })}`;
+      const agentURI = buildTraderMetadataUrl(appUrl, traderId);
       const mintData = encodeFunctionData({
         abi: identityRegistryAbi,
         functionName: "register",

--- a/src/app/api/trader/[id]/metadata/route.ts
+++ b/src/app/api/trader/[id]/metadata/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../../../../../convex/_generated/api";
+import type { Id } from "../../../../../../convex/_generated/dataModel";
+import { getBaseUrl } from "@/lib/agent/auth";
+import {
+  buildTraderNftMetadata,
+  type PublicTraderMetadataModel,
+} from "@/lib/trader-metadata";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function createPublicConvexClient(): ConvexHttpClient {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!url) {
+    throw new Error(
+      "NEXT_PUBLIC_CONVEX_URL is not set. Add it to your environment."
+    );
+  }
+  return new ConvexHttpClient(url);
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  try {
+    const convex = createPublicConvexClient();
+    const trader = (await convex.query(api.traders.getPublicMetadata, {
+      traderId: id as Id<"traders">,
+    })) as PublicTraderMetadataModel | null;
+
+    if (!trader) {
+      return NextResponse.json({ error: "Trader not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      buildTraderNftMetadata(trader, getBaseUrl(request))
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("Invalid ID")) {
+      return NextResponse.json({ error: "Invalid trader id" }, { status: 400 });
+    }
+
+    throw error;
+  }
+}

--- a/src/lib/__tests__/trader-metadata.test.ts
+++ b/src/lib/__tests__/trader-metadata.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTraderMetadataUrl,
+  buildTraderNftMetadata,
+} from "@/lib/trader-metadata";
+
+describe("trader NFT metadata helpers", () => {
+  it("builds a stable public metadata URL for minting", () => {
+    expect(
+      buildTraderMetadataUrl("https://margin-call.example/", "abc123")
+    ).toBe("https://margin-call.example/api/trader/abc123/metadata");
+  });
+
+  it("uses the absolute placeholder PNG when the portrait is not ready", () => {
+    const metadata = buildTraderNftMetadata(
+      {
+        traderId: "trader-1",
+        name: "Gordon Gecko",
+        status: "active",
+        portraitStatus: "pending",
+        archetype: "Junk Bond Operator",
+        riskProfile: "Aggressive",
+        tokenId: null,
+        profileImageUrl: null,
+      },
+      "https://margin-call.example"
+    );
+
+    expect(metadata).toMatchObject({
+      name: "Gordon Gecko",
+      image: "https://margin-call.example/trader-placeholder.png",
+      external_url: "https://margin-call.example/traders/trader-1",
+    });
+    expect(metadata.attributes.map((attr) => attr.trait_type)).not.toContain(
+      "Token ID"
+    );
+  });
+
+  it("uses the generated image URL and token ID attribute when ready", () => {
+    const metadata = buildTraderNftMetadata(
+      {
+        traderId: "trader-2",
+        name: "Bud Fox",
+        status: "active",
+        portraitStatus: "ready",
+        archetype: "Equity Salesman",
+        riskProfile: "Balanced",
+        tokenId: 42,
+        profileImageUrl: "https://storage.example/portrait.png",
+      },
+      "https://margin-call.example"
+    );
+
+    expect(metadata.image).toBe("https://storage.example/portrait.png");
+    expect(metadata.attributes).toContainEqual({
+      trait_type: "Token ID",
+      value: 42,
+    });
+  });
+});

--- a/src/lib/trader-metadata.ts
+++ b/src/lib/trader-metadata.ts
@@ -1,0 +1,68 @@
+export const TRADER_METADATA_ROUTE_PREFIX = "/api/trader";
+export const TRADER_PUBLIC_ROUTE_PREFIX = "/traders";
+export const TRADER_PLACEHOLDER_IMAGE_PATH = "/trader-placeholder.png";
+
+export type PublicTraderMetadataModel = {
+  traderId: string;
+  name: string;
+  status: string;
+  portraitStatus: string;
+  archetype: string;
+  riskProfile: string;
+  tokenId: number | null;
+  profileImageUrl: string | null;
+};
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
+}
+
+export function buildTraderMetadataUrl(
+  baseUrl: string,
+  traderId: string
+): string {
+  return `${normalizeBaseUrl(baseUrl)}${TRADER_METADATA_ROUTE_PREFIX}/${encodeURIComponent(traderId)}/metadata`;
+}
+
+export function buildTraderExternalUrl(
+  baseUrl: string,
+  traderId: string
+): string {
+  return `${normalizeBaseUrl(baseUrl)}${TRADER_PUBLIC_ROUTE_PREFIX}/${encodeURIComponent(traderId)}`;
+}
+
+export function buildTraderPlaceholderImageUrl(baseUrl: string): string {
+  return `${normalizeBaseUrl(baseUrl)}${TRADER_PLACEHOLDER_IMAGE_PATH}`;
+}
+
+export function buildTraderNftMetadata(
+  trader: PublicTraderMetadataModel,
+  baseUrl: string
+) {
+  let image: string;
+  if (trader.portraitStatus === "ready" && trader.profileImageUrl) {
+    image = trader.profileImageUrl;
+  } else {
+    image = buildTraderPlaceholderImageUrl(baseUrl);
+  }
+
+  const attributes: Array<{ trait_type: string; value: string | number }> = [
+    { trait_type: "Status", value: trader.status },
+    { trait_type: "Portrait Status", value: trader.portraitStatus },
+    { trait_type: "Archetype", value: trader.archetype },
+    { trait_type: "Risk Profile", value: trader.riskProfile },
+  ];
+
+  if (trader.tokenId !== null) {
+    attributes.push({ trait_type: "Token ID", value: trader.tokenId });
+  }
+
+  return {
+    name: trader.name,
+    description:
+      "AI trader identity for Margin Call, a PvP trading game set on 1980s Wall Street.",
+    image,
+    external_url: buildTraderExternalUrl(baseUrl, trader.traderId),
+    attributes,
+  };
+}

--- a/tests/convex/x402-auth.test.ts
+++ b/tests/convex/x402-auth.test.ts
@@ -200,44 +200,15 @@ describe("recordVerifiedEntry same-desk rule (no self-dealing)", () => {
 // ── x402 boundary: no public mutation surface for verified flags ───────────────
 
 describe("x402 boundary: public mutation surface regression", () => {
-  /**
-   * The PRD mandates: "no public mutation accepts verified, paid, settled, or
-   * paymentId flags from untrusted client input."
-   *
-   * We verify this at the TypeScript type level: `api.deals` must NOT expose
-   * `recordVerifiedEntry` as a public mutation. The `convex-test` harness uses
-   * `anyApi` for both `api` and `internal` at runtime (no production HTTP
-   * surface in tests), so the enforcement is the TypeScript FilterApi type
-   * (`FilterApi<..., "public">`) — which strips internal-only functions from
-   * the public api object. This test documents that contract explicitly.
-   *
-   * Additionally we verify at runtime that the internal path correctly writes
-   * the entry, which would be the only way a verified entry enters the system.
-   */
+  // PRD: no public mutation accepts verified/paid/paymentId from clients.
+  // FilterApi strips internal paths from `api` types; convex-test still proxies runtime.
   it("recordVerifiedEntry is NOT present on the TypeScript public api type (structural regression)", () => {
-    // TypeScript compile-time check: api.deals should not have recordVerifiedEntry.
-    // If someone converts internalMutation → mutation, TypeScript will error here.
-    // We cast to any to access it at runtime to check the structural contract.
-
+    // FilterApi strips internal-only paths from `api.deals` at compile time; runtime
+    // convex-test still exposes a Proxy (expect "object"). Accidental `mutation` export
+    // would widen types and fail CI typecheck.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const publicDealsApi = api.deals as any;
-
-    // The public api type (FilterApi) strips internal functions. At runtime in
-    // convex-test anyApi resolves all paths, but the TypeScript type guard is
-    // the enforcement mechanism for the public surface.
-    // We document the path does NOT appear in the generated public type declaration
-    // by asserting the type-level contract via a comment and verifying that
-    // production callers MUST use internal.deals.recordVerifiedEntry.
-
-    // Structural assertion: the path exists on anyApi at runtime (expected in test
-    // harness), but this test serves as a documentation + future regression marker.
-    // If the function were accidentally made public, the TypeScript type would widen
-    // and a type-check-only CI step would catch it. For runtime, we just verify
-    // that the internal path is the only tested path by asserting it's callable.
-    expect(typeof publicDealsApi.recordVerifiedEntry).toBe("object"); // anyApi proxy
-    // The above resolves because anyApi is a JS Proxy — this is expected in test env.
-    // The real enforcement is: `api.deals.recordVerifiedEntry` does NOT compile
-    // without `as any` because FilterApi removes internal functions from the type.
+    expect(typeof publicDealsApi.recordVerifiedEntry).toBe("object");
   });
 
   it("api.dealEntries does not exist as a public namespace", async () => {
@@ -479,6 +450,81 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
     const traders = await authed.query(api.traders.listByDesk, {});
     expect(traders).toHaveLength(1);
     expect(traders[0].profileImageUrl).toBe("/trader-placeholder.svg");
+  });
+
+  it("traders.getPublicMetadata returns curated fallback metadata without auth", async () => {
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t, { subject: mockIdentity.subject });
+    const traderId = await seedActiveTrader(t, dmId, {
+      name: "Public Metadata Trader",
+      ownerSubject: mockIdentity.subject,
+      mandate: { bankroll_pct: 5, max_entry_cost_usdc: 20 },
+    });
+
+    const trader = await t.query(api.traders.getPublicMetadata, {
+      traderId: traderId as never,
+    });
+
+    expect(trader).toMatchObject({
+      traderId,
+      name: "Public Metadata Trader",
+      status: "active",
+      portraitStatus: "pending",
+      archetype: "Wall Street Operator",
+      riskProfile: "Conservative",
+      tokenId: null,
+      profileImageUrl: null,
+    });
+    expect(trader).not.toHaveProperty("ownerSubject");
+    expect(trader).not.toHaveProperty("mandate");
+    expect(trader).not.toHaveProperty("personality");
+    expect(trader).not.toHaveProperty("cdpWalletAddress");
+    expect(trader).not.toHaveProperty("walletError");
+    expect(trader).not.toHaveProperty("imagePrompt");
+    expect(trader).not.toHaveProperty("imageError");
+  });
+
+  it("traders.getPublicMetadata returns generated portrait URL when ready", async () => {
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t, { subject: mockIdentity.subject });
+
+    const storageId = await t.run(async (ctx) =>
+      ctx.storage.store(new Blob(["portrait"], { type: "image/png" }))
+    );
+    const traderId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("traders", {
+        deskManagerId: dmId as never,
+        ownerSubject: mockIdentity.subject,
+        name: "Ready Portrait Trader",
+        status: "active",
+        mandate: { bankroll_pct: 75 },
+        profileImageStorageId: storageId,
+        imageStatus: "ready",
+        imageVariant: "junk_bond_operator",
+        walletStatus: "ready",
+        escrowBalanceUsdc: 1000,
+        tokenId: 99,
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const trader = await t.query(api.traders.getPublicMetadata, {
+      traderId: traderId as never,
+    });
+
+    expect(trader).toMatchObject({
+      traderId,
+      name: "Ready Portrait Trader",
+      portraitStatus: "ready",
+      archetype: "Junk Bond Operator",
+      riskProfile: "Aggressive",
+      tokenId: 99,
+    });
+    expect(trader?.profileImageUrl).toContain(
+      "https://some-deployment.convex.cloud/api/storage/"
+    );
   });
 
   it("traders.listByDesk returns owned traders for authenticated caller", async () => {


### PR DESCRIPTION
Adds `traders.getPublicMetadata` for a curated read model, Next.js `/api/trader/[id]/metadata` for ERC-721 JSON, shared `trader-metadata` helpers (URL builders + NFT payload), wallet mint integration, and tests (Vitest).

Made with [Cursor](https://cursor.com)