### PR TITLE
Convex portrait pipeline and Vitest scheduler skips

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -31,6 +31,8 @@ import type * as lib_profileImage from "../lib/profileImage.js";
 import type * as marketNarratives from "../marketNarratives.js";
 import type * as me from "../me.js";
 import type * as portfolio from "../portfolio.js";
+import type * as portraitActions from "../portraitActions.js";
+import type * as portraits from "../portraits.js";
 import type * as seasons from "../seasons.js";
 import type * as seeds_systemPrompts from "../seeds/systemPrompts.js";
 import type * as seeds_wireSeason01 from "../seeds/wireSeason01.js";
@@ -80,6 +82,8 @@ declare const fullApi: ApiFromModules<{
   marketNarratives: typeof marketNarratives;
   me: typeof me;
   portfolio: typeof portfolio;
+  portraitActions: typeof portraitActions;
+  portraits: typeof portraits;
   seasons: typeof seasons;
   "seeds/systemPrompts": typeof seeds_systemPrompts;
   "seeds/wireSeason01": typeof seeds_wireSeason01;

--- a/convex/portraitActions.ts
+++ b/convex/portraitActions.ts
@@ -1,0 +1,154 @@
+"use node";
+
+import { internalAction } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+
+const OPENAI_IMAGE_MODEL = "gpt-image-1";
+const OPENAI_IMAGE_SIZE = "1024x1024";
+const OPENAI_IMAGE_QUALITY = "medium";
+const OPENAI_IMAGE_FORMAT = "png";
+
+type PortraitGenerationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | "missing"
+        | "ready"
+        | "max_attempts"
+        | "in_flight"
+        | "missing_prompt"
+        | "generation_failed";
+    };
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`Missing required Convex env var: ${name}`);
+  }
+  return value;
+}
+
+function toInternalError(err: unknown): string {
+  if (err instanceof Error && err.message.trim()) {
+    return err.message.slice(0, 500);
+  }
+  return String(err).slice(0, 500);
+}
+
+function buildGenerationPrompt(input: {
+  imagePrompt: string;
+  imagePromptSource?: unknown;
+  imageStyleSeed?: string;
+  imageVariant?: string;
+}): string {
+  const source =
+    input.imagePromptSource === undefined
+      ? "unavailable"
+      : JSON.stringify(input.imagePromptSource).slice(0, 1200);
+
+  return [
+    input.imagePrompt,
+    `Image variant: ${input.imageVariant ?? "default_wall_street_operator"}.`,
+    `Style seed: ${input.imageStyleSeed ?? "portrait-v1-default"}.`,
+    `Snapshotted trader source data: ${source}.`,
+  ].join("\n");
+}
+
+async function generateOpenAIImage(prompt: string): Promise<Blob> {
+  const response = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${requireEnv("OPENAI_API_KEY")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: OPENAI_IMAGE_MODEL,
+      prompt,
+      size: OPENAI_IMAGE_SIZE,
+      quality: OPENAI_IMAGE_QUALITY,
+      output_format: OPENAI_IMAGE_FORMAT,
+      n: 1,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      `OpenAI image generation failed: ${response.status} ${body.slice(0, 300)}`
+    );
+  }
+
+  const payload = (await response.json()) as {
+    data?: Array<{ b64_json?: string }>;
+  };
+  const imageBase64 = payload.data?.[0]?.b64_json;
+  if (!imageBase64) {
+    throw new Error("OpenAI image generation returned no image data");
+  }
+
+  const bytes = Buffer.from(imageBase64, "base64");
+  return new Blob([bytes], { type: "image/png" });
+}
+
+/**
+ * Internal action: generate one trader portrait, store it in Convex Storage,
+ * and only mark the trader ready after storage succeeds.
+ */
+export const generateForTrader = internalAction({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }): Promise<PortraitGenerationResult> => {
+    const markResult = await ctx.runMutation(
+      internal.portraits.markGenerating,
+      {
+        traderId,
+      }
+    );
+    if (!markResult.ok) return markResult;
+
+    const input = await ctx.runQuery(internal.portraits.loadGenerationInput, {
+      traderId,
+    });
+    if (!input?.imagePrompt) {
+      await ctx.runMutation(internal.portraits.applyGenerationFailure, {
+        traderId,
+        error: "Missing portrait generation prompt",
+      });
+      return { ok: false as const, reason: "missing_prompt" as const };
+    }
+
+    try {
+      const blob = await generateOpenAIImage(
+        buildGenerationPrompt({
+          imagePrompt: input.imagePrompt,
+          imagePromptSource: input.imagePromptSource,
+          imageStyleSeed: input.imageStyleSeed,
+          imageVariant: input.imageVariant,
+        })
+      );
+      const profileImageStorageId = await ctx.storage.store(blob);
+      await ctx.runMutation(internal.portraits.applyGeneratedImage, {
+        traderId,
+        profileImageStorageId,
+      });
+      return { ok: true as const };
+    } catch (err) {
+      const failure = await ctx.runMutation(
+        internal.portraits.applyGenerationFailure,
+        {
+          traderId,
+          error: toInternalError(err),
+        }
+      );
+      if (failure.shouldRetry && failure.retryDelayMs !== null) {
+        await ctx.scheduler.runAfter(
+          failure.retryDelayMs,
+          internal.portraitActions.generateForTrader,
+          { traderId }
+        );
+      }
+      return { ok: false as const, reason: "generation_failed" as const };
+    }
+  },
+});

--- a/convex/portraits.ts
+++ b/convex/portraits.ts
@@ -1,0 +1,113 @@
+import { internalMutation, internalQuery } from "./_generated/server";
+import { v } from "convex/values";
+
+const MAX_IMAGE_ATTEMPTS = 3;
+const GENERATION_LEASE_MS = 10 * 60 * 1000;
+const RETRY_DELAYS_MS = [30_000, 2 * 60_000];
+
+/**
+ * Internal: load only the prompt fields needed by the Node image action.
+ * Raw prompt/source data never leaves Convex internals.
+ */
+export const loadGenerationInput = internalQuery({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return null;
+    return {
+      imageStatus: trader.imageStatus ?? "pending",
+      imagePrompt: trader.imagePrompt,
+      imagePromptSource: trader.imagePromptSource,
+      imageStyleSeed: trader.imageStyleSeed,
+      imageVariant: trader.imageVariant,
+      imageRetryCount: trader.imageRetryCount ?? 0,
+      imageLastAttemptAt: trader.imageLastAttemptAt,
+      updatedAt: trader.updatedAt,
+    };
+  },
+});
+
+/**
+ * Internal: atomically reserve a portrait generation attempt.
+ * The retry count tracks failed attempts, so it is incremented only in
+ * applyGenerationFailure.
+ */
+export const markGenerating = internalMutation({
+  args: { traderId: v.id("traders") },
+  handler: async (ctx, { traderId }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) return { ok: false as const, reason: "missing" as const };
+    if (trader.imageStatus === "ready") {
+      return { ok: false as const, reason: "ready" as const };
+    }
+
+    const retryCount = trader.imageRetryCount ?? 0;
+    if (retryCount >= MAX_IMAGE_ATTEMPTS) {
+      await ctx.db.patch(traderId, {
+        imageStatus: "error",
+        updatedAt: Date.now(),
+      });
+      return { ok: false as const, reason: "max_attempts" as const };
+    }
+
+    const now = Date.now();
+    const leaseActive =
+      trader.imageStatus === "generating" &&
+      trader.imageLastAttemptAt !== undefined &&
+      now - trader.imageLastAttemptAt < GENERATION_LEASE_MS;
+    if (leaseActive) {
+      return { ok: false as const, reason: "in_flight" as const };
+    }
+
+    await ctx.db.patch(traderId, {
+      imageStatus: "generating",
+      imageLastAttemptAt: now,
+      imageError: undefined,
+      updatedAt: now,
+    });
+    return { ok: true as const };
+  },
+});
+
+/** Internal: commit a stored portrait after Convex Storage succeeds. */
+export const applyGeneratedImage = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    profileImageStorageId: v.id("_storage"),
+  },
+  handler: async (ctx, { traderId, profileImageStorageId }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader || trader.imageStatus === "ready") return;
+    await ctx.db.patch(traderId, {
+      profileImageStorageId,
+      imageStatus: "ready",
+      imageError: undefined,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Internal: record a failed attempt without exposing raw errors publicly. */
+export const applyGenerationFailure = internalMutation({
+  args: { traderId: v.id("traders"), error: v.string() },
+  handler: async (ctx, { traderId, error }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader || trader.imageStatus === "ready") {
+      return { shouldRetry: false as const, retryDelayMs: null };
+    }
+
+    const nextRetryCount = (trader.imageRetryCount ?? 0) + 1;
+    const exhausted = nextRetryCount >= MAX_IMAGE_ATTEMPTS;
+    await ctx.db.patch(traderId, {
+      imageStatus: exhausted ? "error" : "pending",
+      imageRetryCount: nextRetryCount,
+      imageError: error,
+      updatedAt: Date.now(),
+    });
+
+    return {
+      shouldRetry: !exhausted,
+      retryDelayMs: RETRY_DELAYS_MS[nextRetryCount - 1] ?? RETRY_DELAYS_MS[0],
+    };
+  },
+});

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -384,15 +384,23 @@ export const create = mutation({
       updatedAt: now,
     });
 
-    // Schedule wallet creation as an internal action (no CDP inside mutations).
-    // Vitest sets MC_SKIP_WALLET_SCHEDULE (see vitest.config.ts):
-    // convex-test runs scheduled actions without a full transaction context, so
-    // createForTrader's ctx.runQuery fails with "Transaction not started" and
-    // spams stderr — behavior tests seed traders directly or use markCreating instead.
-    if (process.env.MC_SKIP_WALLET_SCHEDULE !== "1") {
+    // Vitest sets MC_SKIP_* (vitest.config.ts): convex-test runs scheduled work
+    // without full runtime context, so wallet/portrait actions are skipped
+    // there; integration relies on seeded traders or internal helpers.
+    const skipWalletSchedule = process.env.MC_SKIP_WALLET_SCHEDULE === "1";
+    const skipPortraitSchedule = process.env.MC_SKIP_PORTRAIT_SCHEDULE === "1";
+
+    if (!skipWalletSchedule) {
       await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
         traderId,
       });
+    }
+    if (!skipPortraitSchedule) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.portraitActions.generateForTrader,
+        { traderId }
+      );
     }
 
     return traderId;

--- a/tests/convex/x402-auth.test.ts
+++ b/tests/convex/x402-auth.test.ts
@@ -452,6 +452,95 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
     expect(traders[0].profileImageUrl).toBe("/trader-placeholder.svg");
   });
 
+  it("portrait internals transition generating trader to ready after storage succeeds", async () => {
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t, { subject: mockIdentity.subject });
+    const traderId = await seedActiveTrader(t, dmId, {
+      name: "Ready Internal Trader",
+      ownerSubject: mockIdentity.subject,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId as never, {
+        imageStatus: "pending",
+        imagePrompt: "Generate a 1987 Wall Street trader portrait.",
+        imagePromptSource: { version: 1 },
+        imageStyleSeed: "portrait-v1-ready",
+        imageVariant: "execution_desk",
+        imageRetryCount: 0,
+      });
+    });
+
+    const mark = await t.mutation(internal.portraits.markGenerating, {
+      traderId: traderId as never,
+    });
+    expect(mark).toEqual({ ok: true });
+
+    const storageId = await t.run(async (ctx) =>
+      ctx.storage.store(new Blob(["portrait"], { type: "image/png" }))
+    );
+    await t.mutation(internal.portraits.applyGeneratedImage, {
+      traderId: traderId as never,
+      profileImageStorageId: storageId as never,
+    });
+
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId as never));
+    expect(trader?.imageStatus).toBe("ready");
+    expect(trader?.profileImageStorageId).toBe(storageId);
+    expect(trader?.imageError).toBeUndefined();
+    expect(trader?.walletStatus).toBe("ready");
+  });
+
+  it("portrait internals retry failures up to the cap before marking error", async () => {
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t, { subject: mockIdentity.subject });
+    const traderId = await seedActiveTrader(t, dmId, {
+      name: "Retry Internal Trader",
+      ownerSubject: mockIdentity.subject,
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId as never, {
+        imageStatus: "generating",
+        imagePrompt: "Generate a 1987 Wall Street trader portrait.",
+        imageRetryCount: 0,
+      });
+    });
+
+    const first = await t.mutation(internal.portraits.applyGenerationFailure, {
+      traderId: traderId as never,
+      error: "private provider failure one",
+    });
+    expect(first.shouldRetry).toBe(true);
+    let trader = await t.run(async (ctx) => ctx.db.get(traderId as never));
+    expect(trader?.imageStatus).toBe("pending");
+    expect(trader?.imageRetryCount).toBe(1);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId as never, { imageStatus: "generating" });
+    });
+    const second = await t.mutation(internal.portraits.applyGenerationFailure, {
+      traderId: traderId as never,
+      error: "private provider failure two",
+    });
+    expect(second.shouldRetry).toBe(true);
+    trader = await t.run(async (ctx) => ctx.db.get(traderId as never));
+    expect(trader?.imageStatus).toBe("pending");
+    expect(trader?.imageRetryCount).toBe(2);
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId as never, { imageStatus: "generating" });
+    });
+    const third = await t.mutation(internal.portraits.applyGenerationFailure, {
+      traderId: traderId as never,
+      error: "private provider failure three",
+    });
+    expect(third.shouldRetry).toBe(false);
+    trader = await t.run(async (ctx) => ctx.db.get(traderId as never));
+    expect(trader?.imageStatus).toBe("error");
+    expect(trader?.imageRetryCount).toBe(3);
+    expect(trader?.imageError).toBe("private provider failure three");
+    expect(trader?.walletStatus).toBe("ready");
+  });
+
   it("traders.getPublicMetadata returns curated fallback metadata without auth", async () => {
     const t = convexTest(schema, modules);
     const dmId = await seedDeskManager(t, { subject: mockIdentity.subject });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,10 +4,11 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
-    // Skip scheduling wallet:createForTrader during Vitest — convex-test executes
-    // that internal action with incomplete transaction context (runQuery throws).
+    // Skip async creation side effects during Vitest — convex-test executes
+    // scheduled actions with incomplete external runtime context.
     env: {
       MC_SKIP_WALLET_SCHEDULE: "1",
+      MC_SKIP_PORTRAIT_SCHEDULE: "1",
     },
     include: [
       "src/**/*.test.ts",


### PR DESCRIPTION
Adds internal portrait generation (OpenAI → Convex Storage), hooks `traders.create` scheduling with `MC_SKIP_PORTRAIT_SCHEDULE` alongside wallet skip in Vitest, expands x402 auth tests for public metadata/profile and portrait internals, and updates generated API types.

Made with [Cursor](https://cursor.com)