### PR TITLE
Enforce unique trader usernames

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -51,6 +51,8 @@ export default defineSchema({
     // Privy subject for fast ownership queries without join
     ownerSubject: v.string(),
     name: v.string(),
+    // Case-insensitive uniqueness key for trader handles.
+    nameLower: v.optional(v.string()),
     // agent status
     status: v.union(
       v.literal("active"),
@@ -103,7 +105,9 @@ export default defineSchema({
     .index("byOwner", ["ownerSubject"])
     .index("byDeskManager", ["deskManagerId"])
     .index("byStatusAndWalletStatus", ["status", "walletStatus"])
+    .index("byName", ["name"])
     .index("byOwnerAndName", ["ownerSubject", "name"])
+    .index("byNameLower", ["nameLower"])
     .index("byCreatedAt", ["createdAt"]),
 
   deals: defineTable({

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -314,6 +314,7 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     const trimmedName = args.name.trim();
+    const normalizedName = trimmedName.toLowerCase();
     if (!TRADER_NAME_REGEX.test(trimmedName)) {
       throw new Error("Invalid trader name");
     }
@@ -332,26 +333,74 @@ export const create = mutation({
       throw new Error("Fund your wallet before hiring a trader");
     }
 
-    // Idempotency: check for existing trader with same owner+name
-    const dupe = await ctx.db
+    // Idempotency (owner + exact name): preserve existing behavior for retries.
+    const dupeByOwnerAndName = await ctx.db
       .query("traders")
       .withIndex("byOwnerAndName", (q) =>
         q.eq("ownerSubject", identity.subject).eq("name", trimmedName)
       )
       .unique();
 
-    if (dupe) {
+    if (dupeByOwnerAndName) {
       // Re-hire never strands the existing row. Reschedule wallet setup only
       // when the prior attempt is stuck (pending) or failed (error). A row
       // already in `creating` has its own re-entry guard in wallet.createForTrader.
       const needsRetry =
-        dupe.walletStatus === "pending" || dupe.walletStatus === "error";
+        dupeByOwnerAndName.walletStatus === "pending" ||
+        dupeByOwnerAndName.walletStatus === "error";
       if (needsRetry && !skipWalletSchedule()) {
         await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
-          traderId: dupe._id,
+          traderId: dupeByOwnerAndName._id,
         });
       }
-      return dupe._id;
+      return dupeByOwnerAndName._id;
+    }
+
+    // Legacy fallback: rows created before `nameLower` existed still need a guard.
+    const exactNameConflicts = await ctx.db
+      .query("traders")
+      .withIndex("byName", (q) => q.eq("name", trimmedName))
+      .take(10);
+    if (exactNameConflicts.length > 0) {
+      const sameOwnerConflict = exactNameConflicts.find(
+        (trader) => trader.ownerSubject === identity.subject
+      );
+      if (sameOwnerConflict) {
+        const needsRetry =
+          sameOwnerConflict.walletStatus === "pending" ||
+          sameOwnerConflict.walletStatus === "error";
+        if (needsRetry && !skipWalletSchedule()) {
+          await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
+            traderId: sameOwnerConflict._id,
+          });
+        }
+        return sameOwnerConflict._id;
+      }
+      throw new Error("Trader name already taken");
+    }
+
+    // Global uniqueness (case-insensitive): prevent duplicate usernames.
+    const conflicts = await ctx.db
+      .query("traders")
+      .withIndex("byNameLower", (q) => q.eq("nameLower", normalizedName))
+      .take(10);
+    const matchingConflict = conflicts.find(
+      (trader) => trader.name.toLowerCase() === normalizedName
+    );
+    if (matchingConflict) {
+      // If this is the same owner creating a case-variant handle, treat as idempotent.
+      if (matchingConflict.ownerSubject === identity.subject) {
+        const needsRetry =
+          matchingConflict.walletStatus === "pending" ||
+          matchingConflict.walletStatus === "error";
+        if (needsRetry && !skipWalletSchedule()) {
+          await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
+            traderId: matchingConflict._id,
+          });
+        }
+        return matchingConflict._id;
+      }
+      throw new Error("Trader name already taken");
     }
 
     const now = Date.now();
@@ -365,6 +414,7 @@ export const create = mutation({
       deskManagerId: existing._id,
       ownerSubject: identity.subject,
       name: trimmedName,
+      nameLower: normalizedName,
       status: "paused",
       mandate: args.mandate ?? {},
       personality: args.personality,
@@ -707,6 +757,63 @@ export const syncEscrowBalance = internalMutation({
       escrowBalanceUsdc: balanceUsdc,
       updatedAt: Date.now(),
     });
+  },
+});
+
+/** Internal ops: rename trader with the same validation and uniqueness rules as create. */
+export const renameInternalForOps = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    name: v.string(),
+  },
+  handler: async (ctx, { traderId, name }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader) throw new Error("Trader not found");
+
+    const trimmedName = name.trim();
+    const normalizedName = trimmedName.toLowerCase();
+    if (!TRADER_NAME_REGEX.test(trimmedName)) {
+      throw new Error("Invalid trader name");
+    }
+
+    if (trader.name === trimmedName) {
+      if (trader.nameLower !== normalizedName) {
+        await ctx.db.patch(traderId, {
+          nameLower: normalizedName,
+          updatedAt: Date.now(),
+        });
+      }
+      return { ok: true as const, traderId };
+    }
+
+    const exactNameConflicts = await ctx.db
+      .query("traders")
+      .withIndex("byName", (q) => q.eq("name", trimmedName))
+      .take(10);
+    const exactConflict = exactNameConflicts.find(
+      (doc) => doc._id !== traderId
+    );
+    if (exactConflict) {
+      throw new Error("Trader name already taken");
+    }
+
+    const normalizedConflicts = await ctx.db
+      .query("traders")
+      .withIndex("byNameLower", (q) => q.eq("nameLower", normalizedName))
+      .take(10);
+    const normalizedConflict = normalizedConflicts.find(
+      (doc) => doc._id !== traderId && doc.name.toLowerCase() === normalizedName
+    );
+    if (normalizedConflict) {
+      throw new Error("Trader name already taken");
+    }
+
+    await ctx.db.patch(traderId, {
+      name: trimmedName,
+      nameLower: normalizedName,
+      updatedAt: Date.now(),
+    });
+    return { ok: true as const, traderId };
   },
 });
 

--- a/tests/convex/trader-wallet-provisioning.test.ts
+++ b/tests/convex/trader-wallet-provisioning.test.ts
@@ -10,6 +10,13 @@ function asDeskManager(t: ReturnType<typeof makeT>) {
   });
 }
 
+function asOtherDeskManager(t: ReturnType<typeof makeT>) {
+  return t.withIdentity({
+    subject: "did:privy:test-subject-002",
+    issuer: "test",
+  });
+}
+
 describe("trader wallet provisioning recovery", () => {
   it("rejects trader creation until the desk wallet is funded", async () => {
     const t = makeT();
@@ -49,6 +56,27 @@ describe("trader wallet provisioning recovery", () => {
 
     const rows = await asDeskManager(t).query(api.traders.listByDesk, {});
     expect(rows).toHaveLength(1);
+  });
+
+  it("rejects duplicate trader names across desks (case-insensitive)", async () => {
+    const t = makeT();
+    await seedDeskManager(t, { subject: "did:privy:test-subject-001" });
+    await seedDeskManager(t, {
+      subject: "did:privy:test-subject-002",
+      walletAddress: "0xdef456",
+    });
+
+    await asDeskManager(t).mutation(api.traders.create, {
+      name: "Lilly",
+      mandate: {},
+    });
+
+    await expect(
+      asOtherDeskManager(t).mutation(api.traders.create, {
+        name: "lIlLy",
+        mandate: {},
+      })
+    ).rejects.toThrow("Trader name already taken");
   });
 
   it("retryWalletProvisioning clears walletError and sets status to pending", async () => {


### PR DESCRIPTION
## Summary
- enforce trader username uniqueness globally (not just per-owner) in `convex/traders.ts`
- add normalized `nameLower` plus `byName`/`byNameLower` indexes in `convex/schema.ts` for efficient exact + case-insensitive conflict checks
- add `renameInternalForOps` internal mutation for safe one-off trader renames under the same validation/uniqueness rules
- add regression coverage for cross-desk case-insensitive duplicates in `tests/convex/trader-wallet-provisioning.test.ts`

## Why
Creating traders with names like `hurls` and `Hurls` allowed duplicate usernames in the product. This change closes that gap while preserving idempotent retries for re-hiring an existing trader.

## Test plan
- [x] `pnpm test tests/convex/trader-wallet-provisioning.test.ts`
- [x] `pnpm test tests/convex/x402-auth.test.ts`
- [x] manually renamed one existing trader to `hurls1` via `traders:renameInternalForOps` and verified with `pnpm convex data traders`

## Notes
- no PR template exists in this repository
- base branch: `main`

Made with [Cursor](https://cursor.com)