### PR TITLE
Enforce globally unique trader names and send welcome signup email

### DIFF
--- a/convex/deskManagers.ts
+++ b/convex/deskManagers.ts
@@ -4,6 +4,7 @@ import {
   mutation,
   query,
 } from "./_generated/server";
+import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import { normalizeEmail } from "../src/lib/email";
 
@@ -38,6 +39,17 @@ export const getMe = query({
   },
 });
 
+/** Internal: mark welcome email sent after Resend succeeds (idempotency). */
+export const markWelcomeEmailSent = internalMutation({
+  args: { deskManagerId: v.id("deskManagers") },
+  handler: async (ctx, { deskManagerId }) => {
+    await ctx.db.patch(deskManagerId, {
+      welcomeEmailSentAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 /**
  * Creates or updates the deskManager row keyed on Privy subject.
  * `walletAddress` is write-once: the first non-null value is persisted and
@@ -63,6 +75,11 @@ export const upsertMe = mutation({
 
     if (existing) {
       const patch: Record<string, unknown> = { updatedAt: now };
+      const shouldScheduleWelcomeEmail =
+        existing.email === undefined &&
+        email !== undefined &&
+        existing.welcomeEmailSentAt === undefined;
+
       if (
         args.walletAddress !== undefined &&
         existing.walletAddress === undefined
@@ -72,10 +89,16 @@ export const upsertMe = mutation({
       if (args.settings !== undefined) patch.settings = args.settings;
       if (email !== undefined) patch.email = email;
       await ctx.db.patch(existing._id, patch);
+
+      if (shouldScheduleWelcomeEmail) {
+        await ctx.scheduler.runAfter(0, internal.emails.sendWelcomeEmail, {
+          deskManagerId: existing._id,
+        });
+      }
       return existing._id;
     }
 
-    return await ctx.db.insert("deskManagers", {
+    const id = await ctx.db.insert("deskManagers", {
       subject: identity.subject,
       email,
       walletAddress: args.walletAddress,
@@ -84,6 +107,12 @@ export const upsertMe = mutation({
       createdAt: now,
       updatedAt: now,
     });
+    if (email !== undefined) {
+      await ctx.scheduler.runAfter(0, internal.emails.sendWelcomeEmail, {
+        deskManagerId: id,
+      });
+    }
+    return id;
   },
 });
 
@@ -104,7 +133,7 @@ export const syncWalletBalance = internalMutation({
       .unique();
 
     if (!existing) {
-      await ctx.db.insert("deskManagers", {
+      const id = await ctx.db.insert("deskManagers", {
         subject,
         email: normalizedEmail,
         walletAddress,
@@ -114,6 +143,11 @@ export const syncWalletBalance = internalMutation({
         createdAt: now,
         updatedAt: now,
       });
+      if (normalizedEmail !== undefined) {
+        await ctx.scheduler.runAfter(0, internal.emails.sendWelcomeEmail, {
+          deskManagerId: id,
+        });
+      }
       return { ok: true as const };
     }
 
@@ -135,6 +169,11 @@ export const syncWalletBalance = internalMutation({
     if (needsAddress) patch.walletAddress = walletAddress;
     if (needsEmail) patch.email = normalizedEmail;
     await ctx.db.patch(existing._id, patch);
+    if (needsEmail && existing.welcomeEmailSentAt === undefined) {
+      await ctx.scheduler.runAfter(0, internal.emails.sendWelcomeEmail, {
+        deskManagerId: existing._id,
+      });
+    }
     return { ok: true as const };
   },
 });

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -10,6 +10,12 @@ import { normalizeEmail } from "../src/lib/email";
 
 const FROM_EMAIL = "Margin Call <admin@margincall.fun>";
 const APP_URL = "https://margincall.fun";
+const CIRCLE_FAUCET_URL = "https://faucet.circle.com/";
+
+type SendWelcomeEmailResult =
+  | { ok: false; status: "failed"; error?: string }
+  | { ok: true; status: "sent"; resendId?: string }
+  | { ok: true; status: "skipped" };
 
 type SendWipeoutEmailResult =
   | { ok: false; status: "missing" | "failed" }
@@ -22,6 +28,71 @@ type WipeoutNotificationContext = {
 
 export function isResendConfigured(apiKey = process.env.RESEND_API_KEY) {
   return typeof apiKey === "string" && apiKey.trim().length > 0;
+}
+
+export function buildWelcomeEmail(args: { walletAddress?: string }) {
+  const deskWalletLine =
+    args.walletAddress?.trim() ||
+    "(Open the desk and copy your desk wallet — it shows in Fund Wallet.)";
+  const subject =
+    "Welcome to the floor — fund your desk and hire your first trader";
+  const text = [
+    "THE WIRE IS OPEN.",
+    "",
+    "You are not here to click every trade. You are here to run a desk.",
+    "",
+    "STEP 1 — FUND THE DESK WALLET",
+    "",
+    `Send test USDC on Base Sepolia to your desk wallet address:`,
+    deskWalletLine,
+    "",
+    `Use the Circle faucet (${CIRCLE_FAUCET_URL}) and choose Base Sepolia as the network.`,
+    "",
+    "STEP 2 — HIRE A TRADER",
+    "",
+    "Open Hire Trader. Name them. Dial mandate — risk appetite, oversight, style.",
+    "",
+    "STEP 3 — FUND THEIR ESCROW",
+    "",
+    "Stake USDC from your desk wallet so they can hit the wire.",
+    "",
+    "STEP 4 — ACTIVATE & WRITE DEALS",
+    "",
+    "NYSE hours: send them to the floor. Open The Wire, turn a headline into a funded deal, lure rival agents.",
+    "",
+    `OPEN THE TERMINAL: ${APP_URL}`,
+    "",
+    "Build your desk. Break theirs.",
+    "",
+    "— Margin Call",
+  ].join("\n");
+
+  const addr = args.walletAddress?.trim();
+  const walletHtmlBlock = addr
+    ? `<code style="word-break:break-all">${escapeHtml(addr)}</code>`
+    : `<span style="opacity:0.85">${escapeHtml(deskWalletLine)}</span>`;
+
+  const html = `
+    <div style="font-family:ui-monospace,Consolas,Menlo,monospace;font-size:13px;line-height:1.55;color:#111;max-width:560px">
+      <p style="letter-spacing:0.12em;font-weight:bold">THE WIRE IS OPEN.</p>
+      <p>You are not here to click every trade. You are here to run a desk.</p>
+      <p style="margin-top:1.25rem;letter-spacing:0.1em;font-weight:bold">STEP 1 — FUND THE DESK WALLET</p>
+      <p>Send test USDC on <strong>Base Sepolia</strong> to your desk wallet:</p>
+      <p>${walletHtmlBlock}</p>
+      <p>Use the <a href="${CIRCLE_FAUCET_URL}" style="color:#15803d;font-weight:bold">Circle faucet</a> and choose <strong>Base Sepolia</strong>.</p>
+      <p style="margin-top:1.25rem;letter-spacing:0.1em;font-weight:bold">STEP 2 — HIRE A TRADER</p>
+      <p>Open <em>Hire Trader</em>. Name them. Set mandate: risk appetite, oversight, style.</p>
+      <p style="margin-top:1.25rem;letter-spacing:0.1em;font-weight:bold">STEP 3 — FUND THEIR ESCROW</p>
+      <p>Stake USDC from your desk wallet so they can hit the wire.</p>
+      <p style="margin-top:1.25rem;letter-spacing:0.1em;font-weight:bold">STEP 4 — ACTIVATE &amp; WRITE DEALS</p>
+      <p>During NYSE hours, send them to the floor. Open <em>The Wire</em>, turn a headline into a deal.</p>
+      <p style="margin-top:1.5rem"><a href="${APP_URL}" style="display:inline-block;padding:10px 16px;background:#15803d;color:#fff;text-decoration:none;font-weight:bold;border-radius:2px">OPEN THE TERMINAL</a></p>
+      <p style="margin-top:1rem;font-weight:bold">Build your desk. Break theirs.</p>
+      <p style="opacity:0.7">— Margin Call</p>
+    </div>
+  `;
+
+  return { subject, text, html };
 }
 
 function buildWipeoutEmail(args: { traderName: string }) {
@@ -54,6 +125,31 @@ function escapeHtml(value: string) {
     .replaceAll('"', "&quot;");
 }
 
+async function sendWelcomeEmailMessage(args: {
+  toEmail: string;
+  walletAddress?: string;
+}) {
+  if (!isResendConfigured()) {
+    return { status: "skipped" as const };
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const message = buildWelcomeEmail({ walletAddress: args.walletAddress });
+  const result = await resend.emails.send({
+    from: FROM_EMAIL,
+    to: args.toEmail,
+    subject: message.subject,
+    text: message.text,
+    html: message.html,
+  });
+
+  if (result.error) {
+    throw new Error(result.error.message);
+  }
+
+  return { status: "sent" as const, resendId: result.data?.id };
+}
+
 async function sendWipeoutEmailMessage(args: {
   toEmail: string;
   traderName: string;
@@ -81,6 +177,52 @@ async function sendWipeoutEmailMessage(args: {
 
   return { status: "sent" as const, resendId: result.data?.id };
 }
+
+export const sendWelcomeEmail = internalAction({
+  args: { deskManagerId: v.id("deskManagers") },
+  handler: async (ctx, { deskManagerId }): Promise<SendWelcomeEmailResult> => {
+    try {
+      if (!isResendConfigured()) {
+        return { ok: true as const, status: "skipped" as const };
+      }
+
+      const deskBeforeSend = await ctx.runQuery(
+        internal.deskManagers.getByIdInternal,
+        { id: deskManagerId }
+      );
+      if (
+        !deskBeforeSend?.email ||
+        deskBeforeSend.welcomeEmailSentAt !== undefined
+      ) {
+        return { ok: true as const, status: "skipped" as const };
+      }
+
+      const result = await sendWelcomeEmailMessage({
+        toEmail: deskBeforeSend.email,
+        walletAddress: deskBeforeSend.walletAddress,
+      });
+      if (result.status === "skipped") {
+        return { ok: true as const, status: "skipped" as const };
+      }
+
+      await ctx.runMutation(internal.deskManagers.markWelcomeEmailSent, {
+        deskManagerId,
+      });
+      return {
+        ok: true as const,
+        status: "sent" as const,
+        resendId: result.resendId,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Welcome email failed to send.", {
+        deskManagerId,
+        error: message,
+      });
+      return { ok: false as const, status: "failed" as const, error: message };
+    }
+  },
+});
 
 export const sendWipeoutEmail = internalAction({
   args: { notificationId: v.id("emailNotifications") },
@@ -186,6 +328,51 @@ export const sendTestWipeoutEmail = action({
     const result = await sendWipeoutEmailMessage({
       toEmail,
       traderName: "Test Trader",
+    });
+    return { ok: true as const, ...result };
+  },
+});
+
+export const sendTestWelcomeEmail = action({
+  args: {
+    operatorSecret: v.optional(v.string()),
+    toEmail: v.optional(v.string()),
+    walletAddress: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    let toEmail = normalizeEmail(args.toEmail);
+
+    if (identity) {
+      assertOperatorSubject(identity.subject);
+
+      if (!toEmail) {
+        const desk = await ctx.runQuery(internal.deskManagers.getBySubject, {
+          subject: identity.subject,
+        });
+        toEmail = normalizeEmail(desk?.email ?? identity.email);
+      }
+    } else {
+      const expectedSecret = process.env.OPERATOR_SECRET?.trim();
+      if (!expectedSecret || args.operatorSecret !== expectedSecret) {
+        throw new Error("Unauthenticated");
+      }
+      if (!toEmail) {
+        throw new Error("toEmail is required when running without Privy auth");
+      }
+    }
+
+    if (!toEmail) {
+      return {
+        ok: true as const,
+        status: "skipped" as const,
+        reason: "missing_email" as const,
+      };
+    }
+
+    const result = await sendWelcomeEmailMessage({
+      toEmail,
+      walletAddress: args.walletAddress,
     });
     return { ok: true as const, ...result };
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,6 +19,8 @@ export default defineSchema({
     walletAddress: v.optional(v.string()),
     walletBalanceUsdc: v.optional(v.number()),
     walletBalanceSyncedAt: v.optional(v.number()),
+    /** Set when welcome email finishes sending successfully (for idempotency). */
+    welcomeEmailSentAt: v.optional(v.number()),
     displayName: v.optional(v.string()),
     settings: v.optional(v.any()),
     createdAt: v.number(),

--- a/tests/convex/desk-manager-welcome-email.test.ts
+++ b/tests/convex/desk-manager-welcome-email.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { convexTest } from "convex-test";
+import { api, internal } from "../../convex/_generated/api";
+import schema from "../../convex/schema";
+
+const modules = import.meta.glob("../../convex/**/*.ts");
+
+const resendMocks = vi.hoisted(() => ({
+  send: vi.fn(),
+}));
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = {
+      send: resendMocks.send,
+    };
+  },
+}));
+
+const mockSubjectPrefix = "did:privy:welcome-test";
+
+const originalResendApiKey = process.env.RESEND_API_KEY;
+const originalOperatorSecret = process.env.OPERATOR_SECRET;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resendMocks.send.mockReset();
+  delete process.env.RESEND_API_KEY;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalResendApiKey === undefined) {
+    delete process.env.RESEND_API_KEY;
+  } else {
+    process.env.RESEND_API_KEY = originalResendApiKey;
+  }
+  if (originalOperatorSecret === undefined) {
+    delete process.env.OPERATOR_SECRET;
+  } else {
+    process.env.OPERATOR_SECRET = originalOperatorSecret;
+  }
+});
+
+describe("welcome email on signup", () => {
+  it("schedules welcome on first upsertMe with email", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    resendMocks.send.mockResolvedValue({ data: { id: "welcome_1" } });
+    const t = convexTest(schema, modules);
+    const subj = `${mockSubjectPrefix}:first`;
+    const authed = t.withIdentity({
+      subject: subj,
+      tokenIdentifier: subj,
+      issuer: "https://auth.privy.io",
+      email: "NEW@MARGINCALL.FUN",
+    });
+
+    await authed.mutation(api.deskManagers.upsertMe, {
+      walletAddress: "0x1111111111111111111111111111111111111111",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+    expect(resendMocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "Margin Call <admin@margincall.fun>",
+        to: "new@margincall.fun",
+        subject:
+          "Welcome to the floor — fund your desk and hire your first trader",
+      })
+    );
+
+    const desk = await authed.query(api.deskManagers.getMe, {});
+    expect(desk?.welcomeEmailSentAt).toBeDefined();
+  });
+
+  it("does not send duplicate welcome on later upsertMe", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    resendMocks.send.mockResolvedValue({ data: { id: "welcome_1" } });
+    const t = convexTest(schema, modules);
+    const subj = `${mockSubjectPrefix}:dup`;
+    const authed = t.withIdentity({
+      subject: subj,
+      tokenIdentifier: subj,
+      issuer: "https://auth.privy.io",
+      email: "dup@margincall.fun",
+    });
+
+    await authed.mutation(api.deskManagers.upsertMe, {
+      walletAddress: "0x2222222222222222222222222222222222222222",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+
+    await authed.mutation(api.deskManagers.upsertMe, {
+      displayName: "Updated",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules welcome from syncWalletBalance insert when email present", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    resendMocks.send.mockResolvedValue({ data: { id: "welcome_sync" } });
+    const t = convexTest(schema, modules);
+    const subj = `${mockSubjectPrefix}:sync`;
+
+    await t.mutation(internal.deskManagers.syncWalletBalance, {
+      subject: subj,
+      walletAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      balanceUsdc: 0,
+      email: "SYNC@margincall.fun",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+
+    const desk = await t.run(async (ctx) =>
+      ctx.db
+        .query("deskManagers")
+        .withIndex("bySubject", (q) => q.eq("subject", subj))
+        .unique()
+    );
+    expect(desk?.email).toBe("sync@margincall.fun");
+    expect(desk?.welcomeEmailSentAt).toBeDefined();
+  });
+
+  it("schedules welcome when syncWalletBalance backfills email on patch", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    resendMocks.send.mockResolvedValue({ data: { id: "welcome_sync_patch" } });
+    const t = convexTest(schema, modules);
+    const subj = `${mockSubjectPrefix}:sync-patch`;
+
+    await t.mutation(internal.deskManagers.syncWalletBalance, {
+      subject: subj,
+      walletAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+      balanceUsdc: 0,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(resendMocks.send).not.toHaveBeenCalled();
+
+    await t.mutation(internal.deskManagers.syncWalletBalance, {
+      subject: subj,
+      walletAddress: "0xdddddddddddddddddddddddddddddddddddddddd",
+      balanceUsdc: 1,
+      email: "PATCHSYNC@margincall.fun",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+    expect(resendMocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "patchsync@margincall.fun" })
+    );
+  });
+
+  it("schedules welcome when email is backfilled on upsertMe patch", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    resendMocks.send.mockResolvedValue({ data: { id: "welcome_backfill" } });
+    const t = convexTest(schema, modules);
+    const subj = `${mockSubjectPrefix}:backfill`;
+
+    const noEmail = t.withIdentity({
+      subject: subj,
+      tokenIdentifier: subj,
+      issuer: "https://auth.privy.io",
+    });
+    await noEmail.mutation(api.deskManagers.upsertMe, {
+      walletAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(resendMocks.send).not.toHaveBeenCalled();
+
+    const withEmail = t.withIdentity({
+      subject: subj,
+      tokenIdentifier: subj,
+      issuer: "https://auth.privy.io",
+      email: "BACKFILL@margincall.fun",
+    });
+    await withEmail.mutation(api.deskManagers.upsertMe, {});
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(resendMocks.send).toHaveBeenCalledTimes(1);
+    expect(resendMocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "backfill@margincall.fun" })
+    );
+  });
+
+  it("sendWelcomeEmail skips without marking sent when Resend is unavailable", async () => {
+    const t = convexTest(schema, modules);
+    const dmId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return ctx.db.insert("deskManagers", {
+        subject: `${mockSubjectPrefix}:no-resend`,
+        email: "no-resend@margincall.fun",
+        walletAddress: "0xcccccccccccccccccccccccccccccccccccccccc",
+        settings: {},
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const result = await t.action(internal.emails.sendWelcomeEmail, {
+      deskManagerId: dmId,
+    });
+    expect(result).toMatchObject({ ok: true, status: "skipped" });
+
+    const desk = await t.run(async (ctx) => ctx.db.get(dmId));
+    expect(desk?.welcomeEmailSentAt).toBeUndefined();
+    expect(resendMocks.send).not.toHaveBeenCalled();
+  });
+
+  it("allows a guarded CLI test welcome email with OPERATOR_SECRET", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.OPERATOR_SECRET = "test-operator-secret";
+    resendMocks.send.mockResolvedValue({ data: { id: "email_welcome_cli" } });
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.action(api.emails.sendTestWelcomeEmail, {
+        operatorSecret: "test-operator-secret",
+        toEmail: "CLI@MARGINCALL.FUN",
+      })
+    ).resolves.toEqual({
+      ok: true,
+      status: "sent",
+      resendId: "email_welcome_cli",
+    });
+
+    expect(resendMocks.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "cli@margincall.fun",
+        subject:
+          "Welcome to the floor — fund your desk and hire your first trader",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Require case-insensitive unique trader handles across all desks (`nameLower`), with validation and Convex tests for create/rename/conflict flows.
- On first desk manager creation (or email backfill), schedule a Resend-powered welcome email with Base Sepolia funding steps; idempotency via `welcomeEmailSentAt`.

## Test plan
- [ ] Run `pnpm test tests/convex/trader-wallet-provisioning.test.ts tests/convex/desk-manager-welcome-email.test.ts` (or full `pnpm test`).
- [ ] Confirm Convex deployment has `RESEND_API_KEY` if testing welcome sends in staging/prod.


Made with [Cursor](https://cursor.com)