### PR TITLE
feat(mcp): create_trader tool with idempotency (#140)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -39,6 +39,7 @@ import type * as mcp_activity from "../mcp/activity.js";
 import type * as mcp_approvals from "../mcp/approvals.js";
 import type * as mcp_deals from "../mcp/deals.js";
 import type * as mcp_desks from "../mcp/desks.js";
+import type * as mcp_httpHelpers from "../mcp/httpHelpers.js";
 import type * as mcp_outcomes from "../mcp/outcomes.js";
 import type * as mcp_requests from "../mcp/requests.js";
 import type * as mcp_traders from "../mcp/traders.js";
@@ -104,6 +105,7 @@ declare const fullApi: ApiFromModules<{
   "mcp/approvals": typeof mcp_approvals;
   "mcp/deals": typeof mcp_deals;
   "mcp/desks": typeof mcp_desks;
+  "mcp/httpHelpers": typeof mcp_httpHelpers;
   "mcp/outcomes": typeof mcp_outcomes;
   "mcp/requests": typeof mcp_requests;
   "mcp/traders": typeof mcp_traders;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,7 +1,17 @@
 import { httpRouter } from "convex/server";
-import { httpAction, type ActionCtx } from "./_generated/server";
+import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
+import {
+  authorizeMcpServiceRequest,
+  badRequest,
+  jsonResponse,
+  logMcpRequest,
+  mcpReadRoute,
+  mcpWriteRoute,
+  parseJsonBody,
+  THIRTY_DAYS_MS,
+} from "./mcp/httpHelpers";
 
 /**
  * Convex HTTP router for server-to-server endpoints. Routes under /mcp/* are
@@ -12,98 +22,33 @@ import type { Id } from "./_generated/dataModel";
 
 const http = httpRouter();
 
-const SERVICE_TOKEN = process.env.MCP_SERVICE_TOKEN ?? "";
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
-
-function unauthorized() {
-  return jsonResponse({ error: "forbidden" }, 403);
-}
-
-function badRequest(msg: string) {
-  return jsonResponse({ error: msg }, 400);
-}
-
-async function parseJsonBody<T>(req: Request): Promise<T | null> {
-  try {
-    return (await req.json()) as T;
-  } catch {
-    return null;
+function parseCreateTraderBody(body: Record<string, unknown>) {
+  if (typeof body.deskManagerId !== "string" || !body.deskManagerId) {
+    return { ok: false as const, message: "deskManagerId required" };
   }
-}
-
-type McpBody = {
-  deskManagerId?: string;
-  traderId?: string;
-  limit?: number;
-  includeClosed?: boolean;
-};
-
-type McpRouteSpec<R> = {
-  tool: string;
-  /** Build query args from request body + a server-side `startedAt`. */
-  buildArgs: (body: McpBody, startedAt: number) => R;
-  /** Invoke the underlying internal query. */
-  runQuery: (ctx: ActionCtx, args: R) => Promise<unknown>;
-};
-
-function mcpRoute<R>(spec: McpRouteSpec<R>) {
-  return httpAction(async (ctx, req) => {
-    if (!SERVICE_TOKEN) return unauthorized();
-    if (req.headers.get("authorization") !== `Bearer ${SERVICE_TOKEN}`) {
-      return unauthorized();
-    }
-
-    const body = await parseJsonBody<McpBody>(req);
-    if (!body?.deskManagerId) return badRequest("deskManagerId required");
-
-    const deskManagerId = body.deskManagerId as Id<"deskManagers">;
-    const startedAt = Date.now();
-    const args = spec.buildArgs(body, startedAt);
-
-    let result: unknown;
-    let errMsg: string | undefined;
-    try {
-      result = await spec.runQuery(ctx, args);
-    } catch (e: unknown) {
-      errMsg = e instanceof Error ? e.message : String(e);
-      result = { error: errMsg };
-    }
-
-    const durationMs = Date.now() - startedAt;
-    try {
-      await ctx.runMutation(internal.mcp.requests.log, {
-        deskManagerId,
-        tool: spec.tool,
-        durationMs,
-        result: errMsg ? undefined : result,
-        error: errMsg,
-        createdAt: startedAt,
-      });
-    } catch (logErr) {
-      console.error("[mcp] failed to write mcpRequests log", logErr);
-    }
-
-    return jsonResponse(
-      {
-        ok: !errMsg,
-        ...(errMsg ? { error: errMsg } : (result as Record<string, unknown>)),
-      },
-      errMsg ? 500 : 200
-    );
-  });
+  if (
+    typeof body.idempotencyKey !== "string" ||
+    body.idempotencyKey.trim() === ""
+  ) {
+    return { ok: false as const, message: "idempotencyKey required" };
+  }
+  if (typeof body.name !== "string" || body.name.trim() === "") {
+    return { ok: false as const, message: "name required" };
+  }
+  return {
+    ok: true as const,
+    parsed: {
+      deskManagerId: body.deskManagerId as Id<"deskManagers">,
+      idempotencyKey: body.idempotencyKey.trim(),
+      requestBody: body,
+    },
+  };
 }
 
 http.route({
   path: "/mcp/desks/get",
   method: "POST",
-  handler: mcpRoute({
+  handler: mcpReadRoute({
     tool: "get_desk",
     buildArgs: (body, startedAt) => ({
       deskManagerId: body.deskManagerId as Id<"deskManagers">,
@@ -114,18 +59,13 @@ http.route({
   }),
 });
 
-// sync_wallet: the on-chain read stays in the Next.js route (httpAction +
-// "use node" unsupported per Convex). This handler receives the read result
-// and performs only the internal sync + mcpRequests log (SERVICE_TOKEN),
-// exactly like the other six /mcp/* tools.
+// sync_wallet: on-chain read stays in Next.js (httpAction + "use node" unsupported).
 http.route({
   path: "/mcp/desks/sync-wallet",
   method: "POST",
   handler: httpAction(async (ctx, req) => {
-    if (!SERVICE_TOKEN) return unauthorized();
-    if (req.headers.get("authorization") !== `Bearer ${SERVICE_TOKEN}`) {
-      return unauthorized();
-    }
+    const authErr = authorizeMcpServiceRequest(req);
+    if (authErr) return authErr;
 
     const body = await parseJsonBody<{
       deskManagerId?: string;
@@ -142,15 +82,13 @@ http.route({
     const deskManagerId = body.deskManagerId as Id<"deskManagers">;
     const walletAddress = body.walletAddress;
     const balanceUsdc = Number(body.balanceUsdc);
-
     const startedAt = Date.now();
     let errMsg: string | undefined;
+
     try {
-      // Need subject for the existing syncWalletBalance internal (it keys on subject).
-      // The wallet passed was just read for this desk; we still fetch to obtain subject.
-      const dm = (await ctx.runQuery(internal.deskManagers.getByIdInternal, {
+      const dm = await ctx.runQuery(internal.deskManagers.getByIdInternal, {
         id: deskManagerId,
-      })) as { subject?: string } | null;
+      });
       if (!dm?.subject) {
         errMsg = "Desk not found for sync_wallet";
       } else {
@@ -166,21 +104,14 @@ http.route({
     }
 
     const durationMs = Date.now() - startedAt;
-    try {
-      await ctx.runMutation(internal.mcp.requests.log, {
-        deskManagerId,
-        tool: "sync_wallet",
-        durationMs,
-        result: errMsg ? undefined : { balanceUsdc, walletAddress },
-        error: errMsg,
-        createdAt: startedAt,
-      });
-    } catch (logErr) {
-      console.error(
-        "[mcp] failed to write mcpRequests log for sync_wallet",
-        logErr
-      );
-    }
+    await logMcpRequest(ctx, {
+      deskManagerId,
+      tool: "sync_wallet",
+      durationMs,
+      result: errMsg ? undefined : { balanceUsdc, walletAddress },
+      error: errMsg,
+      createdAt: startedAt,
+    });
 
     return jsonResponse(
       {
@@ -193,9 +124,37 @@ http.route({
 });
 
 http.route({
+  path: "/mcp/traders/create",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "create_trader",
+    parseBody: parseCreateTraderBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const raw = await ctx.runAction(internal.mcp.traders.createForMcp, {
+          deskManagerId,
+          name: requestBody.name as string,
+          mandate: requestBody.mandate,
+          personality:
+            typeof requestBody.personality === "string"
+              ? requestBody.personality
+              : undefined,
+        });
+        const { auditTxHash, ...result } = raw;
+        return { result, txHash: auditTxHash };
+      } catch (e: unknown) {
+        return {
+          error: e instanceof Error ? e.message : String(e),
+        };
+      }
+    },
+  }),
+});
+
+http.route({
   path: "/mcp/traders/list",
   method: "POST",
-  handler: mcpRoute({
+  handler: mcpReadRoute({
     tool: "list_traders",
     buildArgs: (body, startedAt) => ({
       deskManagerId: body.deskManagerId as Id<"deskManagers">,
@@ -209,7 +168,7 @@ http.route({
 http.route({
   path: "/mcp/deals/list",
   method: "POST",
-  handler: mcpRoute({
+  handler: mcpReadRoute({
     tool: "list_deals",
     buildArgs: (body) => ({
       deskManagerId: body.deskManagerId as Id<"deskManagers">,
@@ -223,7 +182,7 @@ http.route({
 http.route({
   path: "/mcp/activity/get",
   method: "POST",
-  handler: mcpRoute({
+  handler: mcpReadRoute({
     tool: "get_activity",
     buildArgs: (body, startedAt) => ({
       deskManagerId: body.deskManagerId as Id<"deskManagers">,
@@ -238,7 +197,7 @@ http.route({
 http.route({
   path: "/mcp/outcomes/get",
   method: "POST",
-  handler: mcpRoute({
+  handler: mcpReadRoute({
     tool: "get_outcomes",
     buildArgs: (body, startedAt) => ({
       deskManagerId: body.deskManagerId as Id<"deskManagers">,
@@ -253,7 +212,7 @@ http.route({
 http.route({
   path: "/mcp/approvals/pending",
   method: "POST",
-  handler: mcpRoute({
+  handler: mcpReadRoute({
     tool: "get_pending_approvals",
     buildArgs: (body, startedAt) => ({
       deskManagerId: body.deskManagerId as Id<"deskManagers">,

--- a/convex/mcp/httpHelpers.ts
+++ b/convex/mcp/httpHelpers.ts
@@ -1,0 +1,220 @@
+import { httpAction, type ActionCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+export const SERVICE_TOKEN = process.env.MCP_SERVICE_TOKEN ?? "";
+export const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+export const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function unauthorized() {
+  return jsonResponse({ error: "forbidden" }, 403);
+}
+
+export function badRequest(msg: string) {
+  return jsonResponse({ error: msg }, 400);
+}
+
+export function authorizeMcpServiceRequest(req: Request): Response | null {
+  if (!SERVICE_TOKEN) return unauthorized();
+  if (req.headers.get("authorization") !== `Bearer ${SERVICE_TOKEN}`) {
+    return unauthorized();
+  }
+  return null;
+}
+
+export async function parseJsonBody<T>(req: Request): Promise<T | null> {
+  try {
+    return (await req.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+type LogMcpRequestArgs = {
+  deskManagerId: Id<"deskManagers">;
+  tool: string;
+  durationMs: number;
+  createdAt: number;
+  requestBody?: unknown;
+  /** Omit on idempotent replay rows so cache lookup stays stable. */
+  idempotencyKey?: string;
+  result?: unknown;
+  error?: string;
+  txHash?: string;
+};
+
+export async function logMcpRequest(ctx: ActionCtx, args: LogMcpRequestArgs) {
+  try {
+    await ctx.runMutation(internal.mcp.requests.log, args);
+  } catch (logErr) {
+    console.error(
+      `[mcp] failed to write mcpRequests log (${args.tool})`,
+      logErr
+    );
+  }
+}
+
+export type McpWriteExecuteResult = {
+  result?: Record<string, unknown>;
+  error?: string;
+  txHash?: string;
+};
+
+export type McpWriteParsedBody = {
+  deskManagerId: Id<"deskManagers">;
+  idempotencyKey: string;
+  requestBody: Record<string, unknown>;
+};
+
+export type McpWriteRouteSpec = {
+  tool: string;
+  parseBody: (
+    body: Record<string, unknown>
+  ) =>
+    | { ok: true; parsed: McpWriteParsedBody }
+    | { ok: false; message: string };
+  execute: (
+    ctx: ActionCtx,
+    parsed: McpWriteParsedBody
+  ) => Promise<McpWriteExecuteResult>;
+};
+
+export function mcpWriteRoute(spec: McpWriteRouteSpec) {
+  return httpAction(async (ctx, req) => {
+    const authErr = authorizeMcpServiceRequest(req);
+    if (authErr) return authErr;
+
+    const raw = await parseJsonBody<Record<string, unknown>>(req);
+    if (!raw) return badRequest("Invalid JSON body");
+
+    const parsedBody = spec.parseBody(raw);
+    if (!parsedBody.ok) return badRequest(parsedBody.message);
+
+    const { deskManagerId, idempotencyKey, requestBody } = parsedBody.parsed;
+    const startedAt = Date.now();
+    const minCreatedAt = startedAt - IDEMPOTENCY_TTL_MS;
+
+    const cached = await ctx.runQuery(internal.mcp.requests.findRecentByKey, {
+      deskManagerId,
+      idempotencyKey,
+      tool: spec.tool,
+      minCreatedAt,
+    });
+
+    if (cached?.result !== undefined && cached.result !== null) {
+      const durationMs = Date.now() - startedAt;
+      const cachedResult =
+        typeof cached.result === "object" &&
+        cached.result !== null &&
+        !Array.isArray(cached.result)
+          ? (cached.result as Record<string, unknown>)
+          : { value: cached.result };
+
+      await logMcpRequest(ctx, {
+        deskManagerId,
+        tool: spec.tool,
+        requestBody,
+        result: { ...cachedResult, cached: true },
+        durationMs,
+        txHash: cached.txHash,
+        createdAt: startedAt,
+      });
+
+      return jsonResponse({ ok: true, ...cachedResult, cached: true }, 200);
+    }
+
+    if (cached?.error) {
+      const durationMs = Date.now() - startedAt;
+      await logMcpRequest(ctx, {
+        deskManagerId,
+        tool: spec.tool,
+        requestBody,
+        error: cached.error,
+        durationMs,
+        createdAt: startedAt,
+      });
+      return jsonResponse({ ok: false, error: cached.error }, 500);
+    }
+
+    const outcome = await spec.execute(ctx, parsedBody.parsed);
+    const durationMs = Date.now() - startedAt;
+
+    await logMcpRequest(ctx, {
+      deskManagerId,
+      tool: spec.tool,
+      requestBody,
+      idempotencyKey,
+      result: outcome.error ? undefined : outcome.result,
+      error: outcome.error,
+      durationMs,
+      txHash: outcome.txHash,
+      createdAt: startedAt,
+    });
+
+    if (outcome.error) {
+      return jsonResponse({ ok: false, error: outcome.error }, 500);
+    }
+    return jsonResponse({ ok: true, ...outcome.result }, 200);
+  });
+}
+
+export type McpReadBody = {
+  deskManagerId?: string;
+  traderId?: string;
+  limit?: number;
+  includeClosed?: boolean;
+};
+
+export type McpReadRouteSpec<R> = {
+  tool: string;
+  buildArgs: (body: McpReadBody, startedAt: number) => R;
+  runQuery: (ctx: ActionCtx, args: R) => Promise<unknown>;
+};
+
+export function mcpReadRoute<R>(spec: McpReadRouteSpec<R>) {
+  return httpAction(async (ctx, req) => {
+    const authErr = authorizeMcpServiceRequest(req);
+    if (authErr) return authErr;
+
+    const body = await parseJsonBody<McpReadBody>(req);
+    if (!body?.deskManagerId) return badRequest("deskManagerId required");
+
+    const deskManagerId = body.deskManagerId as Id<"deskManagers">;
+    const startedAt = Date.now();
+    const args = spec.buildArgs(body, startedAt);
+
+    let result: unknown;
+    let errMsg: string | undefined;
+    try {
+      result = await spec.runQuery(ctx, args);
+    } catch (e: unknown) {
+      errMsg = e instanceof Error ? e.message : String(e);
+      result = { error: errMsg };
+    }
+
+    const durationMs = Date.now() - startedAt;
+    await logMcpRequest(ctx, {
+      deskManagerId,
+      tool: spec.tool,
+      durationMs,
+      result: errMsg ? undefined : result,
+      error: errMsg,
+      createdAt: startedAt,
+    });
+
+    return jsonResponse(
+      {
+        ok: !errMsg,
+        ...(errMsg ? { error: errMsg } : (result as Record<string, unknown>)),
+      },
+      errMsg ? 500 : 200
+    );
+  });
+}

--- a/convex/mcp/requests.ts
+++ b/convex/mcp/requests.ts
@@ -1,5 +1,40 @@
-import { internalMutation } from "../_generated/server";
+import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
+
+/** For HTTP write idempotency: latest matching audit row within the TTL window. */
+export const findRecentByKey = internalQuery({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    idempotencyKey: v.string(),
+    tool: v.string(),
+    /** Only consider rows with createdAt >= minCreatedAt (caller: now - 24h). */
+    minCreatedAt: v.number(),
+  },
+  handler: async (
+    ctx,
+    { deskManagerId, idempotencyKey, tool, minCreatedAt }
+  ) => {
+    const rows = await ctx.db
+      .query("mcpRequests")
+      .withIndex("byDeskManagerAndIdempotencyKey", (q) =>
+        q
+          .eq("deskManagerId", deskManagerId)
+          .eq("idempotencyKey", idempotencyKey)
+      )
+      .collect();
+
+    let newest: (typeof rows)[number] | null = null;
+    for (const row of rows) {
+      if (row.tool !== tool) continue;
+      if (row.createdAt < minCreatedAt) continue;
+      if (row.result === undefined && row.error === undefined) continue;
+      if (!newest || row.createdAt > newest.createdAt) {
+        newest = row;
+      }
+    }
+    return newest;
+  },
+});
 
 /**
  * Audit logger for MCP tool invocations. `requestBody` and `idempotencyKey`

--- a/convex/mcp/traders.ts
+++ b/convex/mcp/traders.ts
@@ -1,5 +1,92 @@
-import { internalQuery } from "../_generated/server";
+import { internalAction, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+
+export type McpCreateTraderResult = {
+  traderId: string;
+  tokenId: number;
+  walletAddress: string | undefined;
+  txHashes: { mint: string | null; transfer: string | null };
+  summary: string;
+  auditTxHash: string | undefined;
+};
+
+/** Terminal + audit payload for a successfully provisioned MCP trader. */
+export function buildCreateTraderResult(
+  trader: Doc<"traders">
+): McpCreateTraderResult {
+  if (trader.walletStatus === "error") {
+    throw new Error(trader.walletError ?? "Wallet provisioning failed");
+  }
+  if (trader.walletStatus !== "ready" || trader.tokenId == null) {
+    throw new Error(
+      `Wallet not ready after provisioning (status=${trader.walletStatus})`
+    );
+  }
+
+  const summary = `Hired trader "${trader.name}" (ERC-8004 token #${trader.tokenId}). CDP smart-account wallet ${trader.cdpWalletAddress ?? "?"} (${trader.cdpAccountName ?? ""}).`;
+
+  return {
+    traderId: String(trader._id),
+    tokenId: trader.tokenId,
+    walletAddress: trader.cdpWalletAddress,
+    txHashes: {
+      mint: trader.mintTxHash ?? null,
+      transfer: trader.transferTxHash ?? null,
+    },
+    summary,
+    auditTxHash: trader.transferTxHash ?? trader.mintTxHash ?? undefined,
+  };
+}
+
+/**
+ * MCP `create_trader`: desk gate → shared createRecord → blocking wallet pipeline.
+ * Called from the /mcp/traders/create HTTP action (after idempotency shell).
+ */
+export const createForMcp = internalAction({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    name: v.string(),
+    mandate: v.optional(v.any()),
+    personality: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<McpCreateTraderResult> => {
+    const dm: Doc<"deskManagers"> | null = await ctx.runQuery(
+      internal.deskManagers.getByIdInternal,
+      { id: args.deskManagerId }
+    );
+    if (!dm?.subject) {
+      throw new Error("Desk not found");
+    }
+    if ((dm.walletBalanceUsdc ?? 0) <= 0) {
+      throw new Error("Fund your wallet before hiring a trader");
+    }
+
+    const traderId: Id<"traders"> = await ctx.runMutation(
+      internal.traders.createRecord,
+      {
+        deskManagerId: args.deskManagerId,
+        ownerSubject: dm.subject,
+        name: args.name,
+        mandate: args.mandate,
+        personality: args.personality,
+      }
+    );
+
+    await ctx.runAction(internal.wallet.createForTrader, { traderId });
+
+    const trader: Doc<"traders"> | null = await ctx.runQuery(
+      internal.traders.loadInternal,
+      { traderId }
+    );
+    if (!trader) {
+      throw new Error("Trader row missing after provisioning");
+    }
+
+    return buildCreateTraderResult(trader);
+  },
+});
 
 /**
  * Read-only list of a desk's traders for MCP `list_traders`.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -103,6 +103,10 @@ export default defineSchema({
     cdpAccountName: v.optional(v.string()),
     tokenId: v.optional(v.number()),
     tbaAddress: v.optional(v.string()),
+    /** ERC-8004 mint transaction hash (wallet pipeline). */
+    mintTxHash: v.optional(v.string()),
+    /** ERC-8004 transfer NFT to canonical smart-account tx hash. */
+    transferTxHash: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })
@@ -417,5 +421,9 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("byDeskManagerAndCreatedAt", ["deskManagerId", "createdAt"])
+    .index("byDeskManagerAndIdempotencyKey", [
+      "deskManagerId",
+      "idempotencyKey",
+    ])
     .index("byCreatedAt", ["createdAt"]),
 });

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -3,10 +3,11 @@ import {
   internalQuery,
   mutation,
   query,
+  type MutationCtx,
   type QueryCtx,
 } from "./_generated/server";
 import { v } from "convex/values";
-import type { Doc } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
 import {
   resolveReadyProfileImageUrl,
@@ -28,6 +29,22 @@ import { normalizeEmail } from "../src/lib/email";
 // ctx.runQuery fails with "Transaction not started" and spams stderr —
 // behavior tests seed traders directly or call markCreating instead.
 const skipWalletSchedule = () => process.env.MC_SKIP_WALLET_SCHEDULE === "1";
+
+/** Browser create path: schedule async wallet pipeline when row is pending/error. */
+async function scheduleWalletForTrader(
+  ctx: MutationCtx,
+  traderId: Id<"traders">
+) {
+  if (skipWalletSchedule()) return;
+  const trader = await ctx.db.get(traderId);
+  if (!trader || trader.walletStatus === "ready") return;
+  if (trader.walletStatus === "creating") return;
+  if (trader.walletStatus === "pending" || trader.walletStatus === "error") {
+    await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
+      traderId,
+    });
+  }
+}
 
 async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
   return {
@@ -51,6 +68,8 @@ async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
     cdpAccountName: trader.cdpAccountName,
     tokenId: trader.tokenId,
     tbaAddress: trader.tbaAddress,
+    mintTxHash: trader.mintTxHash,
+    transferTxHash: trader.transferTxHash,
     imageStatus: trader.imageStatus,
     profileImageUrl: await resolveTraderProfileImageUrl(ctx, trader),
     traits: readPublicTraits(trader.imagePromptSource),
@@ -311,9 +330,15 @@ export const setStatus = mutation({
   },
 });
 
-/** Public: create a trader, schedule wallet creation. Idempotent on (ownerSubject, name). */
-export const create = mutation({
+/**
+ * Internal: insert trader row + schedule portrait. Wallet provisioning is
+ * owned by callers (browser `create` schedules; MCP action awaits).
+ * Idempotent on (ownerSubject, name).
+ */
+export const createRecord = internalMutation({
   args: {
+    deskManagerId: v.id("deskManagers"),
+    ownerSubject: v.string(),
     name: v.string(),
     mandate: v.optional(v.any()),
     personality: v.optional(v.string()),
@@ -325,40 +350,17 @@ export const create = mutation({
       throw new Error("Invalid trader name");
     }
 
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Unauthenticated");
-
-    // Resolve or create deskManager row
-    const existing = await ctx.db
-      .query("deskManagers")
-      .withIndex("bySubject", (q) => q.eq("subject", identity.subject))
-      .unique();
-    if (!existing)
-      throw new Error("Desk manager not found — call upsertMe first");
-    if ((existing.walletBalanceUsdc ?? 0) <= 0) {
-      throw new Error("Fund your wallet before hiring a trader");
-    }
+    const { ownerSubject, deskManagerId } = args;
 
     // Idempotency (owner + exact name): preserve existing behavior for retries.
     const dupeByOwnerAndName = await ctx.db
       .query("traders")
       .withIndex("byOwnerAndName", (q) =>
-        q.eq("ownerSubject", identity.subject).eq("name", trimmedName)
+        q.eq("ownerSubject", ownerSubject).eq("name", trimmedName)
       )
       .unique();
 
     if (dupeByOwnerAndName) {
-      // Re-hire never strands the existing row. Reschedule wallet setup only
-      // when the prior attempt is stuck (pending) or failed (error). A row
-      // already in `creating` has its own re-entry guard in wallet.createForTrader.
-      const needsRetry =
-        dupeByOwnerAndName.walletStatus === "pending" ||
-        dupeByOwnerAndName.walletStatus === "error";
-      if (needsRetry && !skipWalletSchedule()) {
-        await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
-          traderId: dupeByOwnerAndName._id,
-        });
-      }
       return dupeByOwnerAndName._id;
     }
 
@@ -369,17 +371,9 @@ export const create = mutation({
       .take(10);
     if (exactNameConflicts.length > 0) {
       const sameOwnerConflict = exactNameConflicts.find(
-        (trader) => trader.ownerSubject === identity.subject
+        (trader) => trader.ownerSubject === ownerSubject
       );
       if (sameOwnerConflict) {
-        const needsRetry =
-          sameOwnerConflict.walletStatus === "pending" ||
-          sameOwnerConflict.walletStatus === "error";
-        if (needsRetry && !skipWalletSchedule()) {
-          await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
-            traderId: sameOwnerConflict._id,
-          });
-        }
         return sameOwnerConflict._id;
       }
       throw new Error("Trader name already taken");
@@ -394,16 +388,7 @@ export const create = mutation({
       (trader) => trader.name.toLowerCase() === normalizedName
     );
     if (matchingConflict) {
-      // If this is the same owner creating a case-variant handle, treat as idempotent.
-      if (matchingConflict.ownerSubject === identity.subject) {
-        const needsRetry =
-          matchingConflict.walletStatus === "pending" ||
-          matchingConflict.walletStatus === "error";
-        if (needsRetry && !skipWalletSchedule()) {
-          await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
-            traderId: matchingConflict._id,
-          });
-        }
+      if (matchingConflict.ownerSubject === ownerSubject) {
         return matchingConflict._id;
       }
       throw new Error("Trader name already taken");
@@ -411,14 +396,14 @@ export const create = mutation({
 
     const now = Date.now();
     const portraitSeed = buildPortraitSeed({
-      ownerSubject: identity.subject,
+      ownerSubject,
       name: trimmedName,
       mandate: args.mandate ?? {},
       personality: args.personality,
     });
     const traderId = await ctx.db.insert("traders", {
-      deskManagerId: existing._id,
-      ownerSubject: identity.subject,
+      deskManagerId,
+      ownerSubject,
       name: trimmedName,
       nameLower: normalizedName,
       status: "paused",
@@ -431,16 +416,48 @@ export const create = mutation({
       updatedAt: now,
     });
 
-    // Schedule wallet creation as an internal action (no CDP inside mutations).
     if (!skipWalletSchedule()) {
-      await ctx.scheduler.runAfter(0, internal.wallet.createForTrader, {
-        traderId,
-      });
       await ctx.scheduler.runAfter(0, internal.portraits.generateForTrader, {
         traderId,
       });
     }
 
+    return traderId;
+  },
+});
+
+/** Public: create a trader, schedule wallet creation. Idempotent on (ownerSubject, name). */
+export const create = mutation({
+  args: {
+    name: v.string(),
+    mandate: v.optional(v.any()),
+    personality: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Id<"traders">> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+
+    const existing = await ctx.db
+      .query("deskManagers")
+      .withIndex("bySubject", (q) => q.eq("subject", identity.subject))
+      .unique();
+    if (!existing)
+      throw new Error("Desk manager not found — call upsertMe first");
+    if ((existing.walletBalanceUsdc ?? 0) <= 0) {
+      throw new Error("Fund your wallet before hiring a trader");
+    }
+
+    const traderId: Id<"traders"> = await ctx.runMutation(
+      internal.traders.createRecord,
+      {
+        deskManagerId: existing._id,
+        ownerSubject: identity.subject,
+        name: args.name,
+        mandate: args.mandate,
+        personality: args.personality,
+      }
+    );
+    await scheduleWalletForTrader(ctx, traderId);
     return traderId;
   },
 });
@@ -556,6 +573,8 @@ export const applyWalletReady = internalMutation({
     cdpOwnerAddress: v.string(),
     cdpAccountName: v.string(),
     tokenId: v.number(),
+    mintTxHash: v.optional(v.string()),
+    transferTxHash: v.optional(v.string()),
   },
   handler: async (ctx, { traderId, ...walletMeta }) => {
     const trader = await ctx.db.get(traderId);
@@ -568,6 +587,8 @@ export const applyWalletReady = internalMutation({
       cdpOwnerAddress: walletMeta.cdpOwnerAddress,
       cdpAccountName: walletMeta.cdpAccountName,
       tokenId: walletMeta.tokenId,
+      mintTxHash: walletMeta.mintTxHash,
+      transferTxHash: walletMeta.transferTxHash,
       walletError: undefined,
       updatedAt: Date.now(),
     });

--- a/convex/wallet.ts
+++ b/convex/wallet.ts
@@ -142,6 +142,12 @@ export const createForTrader = internalAction({
         throw new Error(`Mint UserOp failed: ${mintReceipt.status}`);
       }
 
+      const mintTxHash =
+        typeof mintReceipt.transactionHash === "string"
+          ? mintReceipt.transactionHash
+          : "";
+      let transferTxHash = "";
+
       // Parse Transfer event to get tokenId
       const publicClient = createPublicClient({
         chain: baseSepolia,
@@ -209,6 +215,10 @@ export const createForTrader = internalAction({
               `Transfer UserOp failed: ${transferReceipt.status}`
             );
           }
+          transferTxHash =
+            typeof transferReceipt.transactionHash === "string"
+              ? transferReceipt.transactionHash
+              : "";
           break;
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -229,6 +239,8 @@ export const createForTrader = internalAction({
         cdpOwnerAddress: owner.address,
         cdpAccountName: `trader-sa-${tokenId}`,
         tokenId,
+        mintTxHash: mintTxHash || undefined,
+        transferTxHash: transferTxHash || undefined,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,7 +4,7 @@
  *
  * Tools:
  *   get_desk, list_traders, list_deals, get_activity, get_outcomes,
- *   get_pending_approvals, sync_wallet
+ *   get_pending_approvals, sync_wallet, create_trader
  *
  * Each MCP key maps 1:1 to a dedicated desk with subject `mcp:cdp-wallet:<id>`
  * and its own CDP server wallet (provisioned at key issuance).
@@ -47,7 +47,7 @@ const server = new McpServer({
   name: "margin-call",
   version: "0.1.0-phase1",
   description:
-    "Margin Call 1980s Wall Street desk manager for Claude. Phase 1 read-only surface: get_desk, list_traders, list_deals, get_activity, get_outcomes, get_pending_approvals. Inspect full game state from the terminal without browser auth.",
+    "Margin Call 1980s Wall Street desk manager for Claude (read + MCP desk writes where implemented). Inspect state via get_desk, list_traders, list_deals, activity, outcomes, approvals; sync balances; hire traders via create_trader.",
 });
 
 function buildQueryString(
@@ -224,12 +224,45 @@ server.tool(
   async () => callMcpApi("/api/mcp/desks/sync-wallet")
 );
 
+server.tool(
+  "create_trader",
+  "Hire a new trader for this MCP desk. Performs the SAME on-chain flow as the web app: ERC-8004 NFT mint plus CDP smart-account provisioning on Base Sepolia. Expect roughly 5–15 seconds wall-clock latency (multiple sponsored user ops). REQUIRED: stable idempotencyKey — reuse the exact same key when retrying timeouts so the API returns cached trader + tx hashes without re-submitting on-chain txs; generating a fresh key intentionally starts another hire attempt. Prerequisites: funded desk wallet and positive synced balance (get_desk, send USDC, sync_wallet). Returns traderId, tokenId, walletAddress, txHashes {mint,transfer}, summary.",
+  {
+    name: z
+      .string()
+      .min(1)
+      .describe(
+        "Trader handle (same rules as web: letters, digits, underscore, max 15 chars after trim)"
+      ),
+    mandate: z
+      .any()
+      .optional()
+      .describe("Optional mandate object (strategy knobs) — JSON-serializable"),
+    personality: z
+      .string()
+      .optional()
+      .describe("Optional trader personality text"),
+    idempotencyKey: z
+      .string()
+      .min(8)
+      .describe(
+        "Stable key for this hire intent (e.g. UUID). Mandatory on retries: same key within 24h replays cached result without new transactions."
+      ),
+  },
+  async ({ name, mandate, personality, idempotencyKey }) =>
+    callMcpApi("/api/mcp/traders/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, mandate, personality, idempotencyKey }),
+    })
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // Log to stderr only (stdio transport uses stdout for protocol)
   console.error(
-    `[margin-call-mcp] Phase 2 ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet  (key last4=${API_KEY.slice(-4)})`
+    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet,create_trader  (key last4=${API_KEY.slice(-4)})`
   );
 }
 

--- a/src/app/api/mcp/traders/create/route.ts
+++ b/src/app/api/mcp/traders/create/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/traders/create
+ * MCP write: full trader provisioning (ERC-8004 mint + CDP smart account), then
+ * Convex row update. Requires `idempotencyKey` per request (24h replay cache
+ * in Convex). Body: `name`, optional `mandate`, `personality`, `idempotencyKey`.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "traders/create",
+    requireIdempotencyKey: true,
+  });
+}

--- a/src/lib/mcp/proxy.ts
+++ b/src/lib/mcp/proxy.ts
@@ -63,54 +63,31 @@ export async function validateMcpKey(
   return { deskManagerId };
 }
 
-export interface ProxyMcpReadOptions {
-  /** The Convex HTTP action path under /mcp, e.g. "traders/list" */
-  convexAction: string;
+/** Convex MCP HTTP endpoints are hosted on *.convex.site (not *.convex.cloud). */
+function convexMcpActionUrl(convexAction: string): string | null {
+  if (!CONVEX_URL) return null;
+  const httpActionBase = CONVEX_URL.replace(/\/$/, "").replace(
+    /\.convex\.cloud$/,
+    ".convex.site"
+  );
+  return `${httpActionBase}/mcp/${convexAction}`;
 }
 
-/**
- * Shared handler for all MCP read-only Next.js routes.
- * Validates the mc_live_* Bearer key, touches lastUsed (debounced), then
- * proxies the request (with whitelisted URL params) as JSON body to the
- * corresponding Convex /mcp/* httpAction (authenticated by SERVICE_TOKEN).
- *
- * Returns the upstream payload + _meta (duration, deskManagerId).
- */
-export async function proxyMcpRead(
-  request: NextRequest,
-  { convexAction }: ProxyMcpReadOptions
+async function proxyMcpUpstream(
+  deskManagerId: Id<"deskManagers">,
+  body: Record<string, unknown>,
+  convexAction: string
 ) {
-  if (!SERVICE_TOKEN || !CONVEX_URL) {
+  const mcpActionUrl = convexMcpActionUrl(convexAction);
+  if (!mcpActionUrl) {
     return NextResponse.json(
       { error: "MCP is not configured on this server" },
       { status: 500 }
     );
   }
 
-  const authResult = await validateMcpKey(request);
-  if (authResult instanceof NextResponse) return authResult;
-  const { deskManagerId } = authResult;
-
-  const search = request.nextUrl.searchParams;
-  const body: Record<string, unknown> = {
-    deskManagerId: String(deskManagerId),
-  };
-  const limit = search.get("limit");
-  if (limit) body.limit = Number(limit);
-  const traderId = search.get("traderId");
-  if (traderId) body.traderId = traderId;
-  const includeClosed = search.get("includeClosed");
-  if (includeClosed) body.includeClosed = includeClosed === "true";
-
-  // Convex HTTP actions are served on .convex.site, not .convex.cloud.
-  const httpActionBase = CONVEX_URL.replace(/\/$/, "").replace(
-    /\.convex\.cloud$/,
-    ".convex.site"
-  );
-  const mcpActionUrl = `${httpActionBase}/mcp/${convexAction}`;
-
-  let upstream: Response;
   const started = Date.now();
+  let upstream: Response;
   try {
     upstream = await fetch(mcpActionUrl, {
       method: "POST",
@@ -155,4 +132,91 @@ export async function proxyMcpRead(
       deskManagerId: String(deskManagerId),
     },
   });
+}
+
+export interface ProxyMcpReadOptions {
+  /** The Convex HTTP action path under /mcp, e.g. "traders/list" */
+  convexAction: string;
+}
+
+/**
+ * MCP write helper: validates API key + forwards JSON body to Convex /mcp/*.
+ */
+export interface ProxyMcpWriteOptions {
+  convexAction: string;
+  /** When true, rejects missing/blank `idempotencyKey` before hitting Convex. */
+  requireIdempotencyKey?: boolean;
+}
+
+export async function proxyMcpWrite(
+  request: NextRequest,
+  { convexAction, requireIdempotencyKey }: ProxyMcpWriteOptions
+) {
+  if (!SERVICE_TOKEN || !CONVEX_URL) {
+    return NextResponse.json(
+      { error: "MCP is not configured on this server" },
+      { status: 500 }
+    );
+  }
+
+  const authResult = await validateMcpKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { deskManagerId } = authResult;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (
+    requireIdempotencyKey &&
+    (typeof body.idempotencyKey !== "string" || !body.idempotencyKey.trim())
+  ) {
+    return NextResponse.json(
+      { error: "idempotencyKey is required for this write" },
+      { status: 400 }
+    );
+  }
+
+  body.deskManagerId = String(deskManagerId);
+  return proxyMcpUpstream(deskManagerId, body, convexAction);
+}
+
+/**
+ * Shared handler for all MCP read-only Next.js routes.
+ * Validates the mc_live_* Bearer key, touches lastUsed (debounced), then
+ * proxies the request (with whitelisted URL params) as JSON body to the
+ * corresponding Convex /mcp/* httpAction (authenticated by SERVICE_TOKEN).
+ *
+ * Returns the upstream payload + _meta (duration, deskManagerId).
+ */
+export async function proxyMcpRead(
+  request: NextRequest,
+  { convexAction }: ProxyMcpReadOptions
+) {
+  if (!SERVICE_TOKEN || !CONVEX_URL) {
+    return NextResponse.json(
+      { error: "MCP is not configured on this server" },
+      { status: 500 }
+    );
+  }
+
+  const authResult = await validateMcpKey(request);
+  if (authResult instanceof NextResponse) return authResult;
+  const { deskManagerId } = authResult;
+
+  const search = request.nextUrl.searchParams;
+  const body: Record<string, unknown> = {
+    deskManagerId: String(deskManagerId),
+  };
+  const limit = search.get("limit");
+  if (limit) body.limit = Number(limit);
+  const traderId = search.get("traderId");
+  if (traderId) body.traderId = traderId;
+  const includeClosed = search.get("includeClosed");
+  if (includeClosed) body.includeClosed = includeClosed === "true";
+
+  return proxyMcpUpstream(deskManagerId, body, convexAction);
 }

--- a/tests/convex/mcp-trader-create.test.ts
+++ b/tests/convex/mcp-trader-create.test.ts
@@ -1,0 +1,248 @@
+/**
+ * MCP create_trader path: shared internal `traders.createRecord`, idempotency lookup,
+ * and result shaping for the MCP traders action.
+ */
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../convex/schema";
+import { internal } from "../../convex/_generated/api";
+import { buildCreateTraderResult } from "../../convex/mcp/traders";
+import { seedDeskManager } from "./setup";
+
+const modules = import.meta.glob("../../convex/**/*.ts");
+
+describe("internal traders.createRecord (MCP/shared path)", () => {
+  it("inserts trader for MCP desk subject without scheduling wallet", async () => {
+    const prev = process.env.MC_SKIP_WALLET_SCHEDULE;
+    process.env.MC_SKIP_WALLET_SCHEDULE = "1";
+    try {
+      const t = convexTest(schema, modules);
+      const deskId = await seedDeskManager(t, {
+        subject: "mcp:cdp-wallet:testwallet12",
+        walletBalance: 100,
+      });
+
+      const traderId = await t.mutation(internal.traders.createRecord, {
+        deskManagerId: deskId,
+        ownerSubject: "mcp:cdp-wallet:testwallet12",
+        name: "MCP_Trader_1",
+        mandate: { bankroll_pct: 10 },
+        personality: "Gruff",
+      });
+
+      const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+      expect(trader).toBeTruthy();
+      expect(trader!.ownerSubject).toBe("mcp:cdp-wallet:testwallet12");
+      expect(trader!.deskManagerId).toEqual(deskId);
+      expect(trader!.walletStatus).toBe("pending");
+    } finally {
+      if (prev === undefined) delete process.env.MC_SKIP_WALLET_SCHEDULE;
+      else process.env.MC_SKIP_WALLET_SCHEDULE = prev;
+    }
+  });
+
+  it("returns existing trader id for same owner + name (name idempotency)", async () => {
+    const prev = process.env.MC_SKIP_WALLET_SCHEDULE;
+    process.env.MC_SKIP_WALLET_SCHEDULE = "1";
+    try {
+      const t = convexTest(schema, modules);
+      const deskId = await seedDeskManager(t, {
+        subject: "mcp:cdp-wallet:retry_desk",
+        walletBalance: 100,
+      });
+
+      const first = await t.mutation(internal.traders.createRecord, {
+        deskManagerId: deskId,
+        ownerSubject: "mcp:cdp-wallet:retry_desk",
+        name: "RetryMe",
+      });
+      const second = await t.mutation(internal.traders.createRecord, {
+        deskManagerId: deskId,
+        ownerSubject: "mcp:cdp-wallet:retry_desk",
+        name: "RetryMe",
+      });
+      expect(second).toEqual(first);
+    } finally {
+      if (prev === undefined) delete process.env.MC_SKIP_WALLET_SCHEDULE;
+      else process.env.MC_SKIP_WALLET_SCHEDULE = prev;
+    }
+  });
+
+  it("throws when trader name is globally taken by another desk", async () => {
+    const prev = process.env.MC_SKIP_WALLET_SCHEDULE;
+    process.env.MC_SKIP_WALLET_SCHEDULE = "1";
+    try {
+      const t = convexTest(schema, modules);
+      const dm1 = await seedDeskManager(t, {
+        subject: "mcp:cdp-wallet:desk_a",
+        walletBalance: 100,
+      });
+      await t.mutation(internal.traders.createRecord, {
+        deskManagerId: dm1,
+        ownerSubject: "mcp:cdp-wallet:desk_a",
+        name: "AlphaHandle",
+      });
+
+      const dm2 = await seedDeskManager(t, {
+        subject: "mcp:cdp-wallet:desk_b",
+        walletBalance: 100,
+      });
+      await expect(
+        t.mutation(internal.traders.createRecord, {
+          deskManagerId: dm2,
+          ownerSubject: "mcp:cdp-wallet:desk_b",
+          name: "AlphaHandle",
+        })
+      ).rejects.toThrow(/already taken/i);
+    } finally {
+      if (prev === undefined) delete process.env.MC_SKIP_WALLET_SCHEDULE;
+      else process.env.MC_SKIP_WALLET_SCHEDULE = prev;
+    }
+  });
+});
+
+describe("buildCreateTraderResult", () => {
+  it("throws when wallet is in error state", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, { walletBalance: 50 });
+    const traderId = await t.run(async (ctx) =>
+      ctx.db.insert("traders", {
+        deskManagerId: deskId,
+        ownerSubject: "mcp:cdp-wallet:x",
+        name: "BadWallet",
+        nameLower: "badwallet",
+        status: "paused",
+        walletStatus: "error",
+        walletError: "Mint failed",
+        escrowBalanceUsdc: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    );
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+    expect(() => buildCreateTraderResult(trader!)).toThrow(/Mint failed/);
+  });
+
+  it("builds terminal payload when wallet is ready", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, { walletBalance: 50 });
+    const traderId = await t.run(async (ctx) =>
+      ctx.db.insert("traders", {
+        deskManagerId: deskId,
+        ownerSubject: "mcp:cdp-wallet:x",
+        name: "ReadyTrader",
+        nameLower: "readytrader",
+        status: "paused",
+        walletStatus: "ready",
+        tokenId: 42,
+        cdpWalletAddress: "0xabc",
+        cdpAccountName: "trader-sa-42",
+        mintTxHash: "0xmint",
+        transferTxHash: "0xtransfer",
+        escrowBalanceUsdc: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    );
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+    const result = buildCreateTraderResult(trader!);
+    expect(result.traderId).toBe(String(traderId));
+    expect(result.tokenId).toBe(42);
+    expect(result.txHashes).toEqual({ mint: "0xmint", transfer: "0xtransfer" });
+    expect(result.auditTxHash).toBe("0xtransfer");
+    expect(result.summary).toContain("ReadyTrader");
+  });
+});
+
+describe("mcp.requests.findRecentByKey", () => {
+  it("returns the newest canonical audit row within the window for desk + tool + key", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, { walletBalance: 50 });
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("mcpRequests", {
+        deskManagerId: deskId,
+        tool: "create_trader",
+        idempotencyKey: "idem-test-1",
+        result: { traderId: "older" },
+        durationMs: 5,
+        createdAt: now - 9000,
+      });
+      await ctx.db.insert("mcpRequests", {
+        deskManagerId: deskId,
+        tool: "create_trader",
+        idempotencyKey: "idem-test-1",
+        result: { traderId: "newer" },
+        durationMs: 8,
+        createdAt: now - 2000,
+      });
+      // Replay audit row (no idempotencyKey) must not win the cache lookup.
+      await ctx.db.insert("mcpRequests", {
+        deskManagerId: deskId,
+        tool: "create_trader",
+        result: { traderId: "replay", cached: true },
+        durationMs: 1,
+        createdAt: now - 1000,
+      });
+    });
+
+    const found = await t.query(internal.mcp.requests.findRecentByKey, {
+      deskManagerId: deskId,
+      idempotencyKey: "idem-test-1",
+      tool: "create_trader",
+      minCreatedAt: now - 24 * 60 * 60 * 1000,
+    });
+
+    expect(found).toBeTruthy();
+    expect(found!.result).toEqual({ traderId: "newer" });
+  });
+
+  it("returns cached error rows for idempotent failure replay", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, { walletBalance: 50 });
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("mcpRequests", {
+        deskManagerId: deskId,
+        tool: "create_trader",
+        idempotencyKey: "fail-key",
+        error: "Wallet provisioning failed",
+        durationMs: 12000,
+        createdAt: now - 5000,
+      });
+    });
+
+    const found = await t.query(internal.mcp.requests.findRecentByKey, {
+      deskManagerId: deskId,
+      idempotencyKey: "fail-key",
+      tool: "create_trader",
+      minCreatedAt: now - 24 * 60 * 60 * 1000,
+    });
+
+    expect(found?.error).toBe("Wallet provisioning failed");
+  });
+
+  it("returns null when newest row predates minCreatedAt", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, { walletBalance: 50 });
+    const old = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    await t.run(async (ctx) => {
+      await ctx.db.insert("mcpRequests", {
+        deskManagerId: deskId,
+        tool: "create_trader",
+        idempotencyKey: "stale-key",
+        result: { x: 1 },
+        durationMs: 5,
+        createdAt: old,
+      });
+    });
+
+    const found = await t.query(internal.mcp.requests.findRecentByKey, {
+      deskManagerId: deskId,
+      idempotencyKey: "stale-key",
+      tool: "create_trader",
+      minCreatedAt: Date.now() - 24 * 60 * 60 * 1000,
+    });
+    expect(found).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds end-to-end MCP `create_trader`: MCP server tool → Next.js POST `/api/mcp/traders/create` → Convex `/mcp/traders/create` → shared `traders.createRecord` + blocking ERC-8004/CDP wallet provisioning.
- Introduces reusable MCP write infrastructure (`mcpWriteRoute`, `logMcpRequest`, idempotency lookup) and moves orchestration into `internal.mcp.traders.createForMcp`.
- Requires `idempotencyKey` on writes (24h cache); returns trader id, token id, wallet address, tx hashes, and summary.

## Test plan
- [ ] `npx convex typecheck` passes
- [ ] `pnpm test tests/convex/mcp-trader-create.test.ts` passes
- [ ] Issue MCP key, fund desk wallet, `sync_wallet`, then `create_trader` via curl or MCP server
- [ ] Retry with same `idempotencyKey` returns cached result without new on-chain txs
- [ ] Verify `mcpRequests` audit row and trader visible in `list_traders`


Made with [Cursor](https://cursor.com)