### PR TITLE
chore: Cursor worktree setup for .env.local copy

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,10 @@
+{
+  "setup-worktree-unix": [
+    "pnpm install",
+    "test -f \"$ROOT_WORKTREE_PATH/.env.local\" && cp \"$ROOT_WORKTREE_PATH/.env.local\" .env.local || echo \"worktree-setup: no .env.local on root checkout — copy from .env.example or your main worktree\""
+  ],
+  "setup-worktree-windows": [
+    "pnpm install",
+    "if exist \"%ROOT_WORKTREE_PATH%\\.env.local\" (copy \"%ROOT_WORKTREE_PATH%\\.env.local\" .env.local) else (echo worktree-setup: no .env.local on root checkout — copy from .env.example or your main worktree)"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds [`.cursor/worktrees.json`](.cursor/worktrees.json) so Cursor agent worktrees automatically run `pnpm install` and copy `.env.local` from the root checkout (`$ROOT_WORKTREE_PATH`).
- Follows [Cursor's worktrees configuration docs](https://cursor.com/docs/configuration/worktrees); avoids manual env copying for each new agent checkout.

## Test plan
- [ ] Create a new Cursor agent worktree and confirm **Output → Worktrees Setup** runs `pnpm install` and copies `.env.local` when present on the main checkout
- [ ] Confirm setup completes gracefully when root checkout has no `.env.local` (prints hint, does not fail)


Made with [Cursor](https://cursor.com)