### PR TITLE
feat(mcp): trader lifecycle (configure/fund/resume/pause/withdraw) for Phase 3 (#141)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -43,6 +43,7 @@ import type * as mcp_httpHelpers from "../mcp/httpHelpers.js";
 import type * as mcp_outcomes from "../mcp/outcomes.js";
 import type * as mcp_requests from "../mcp/requests.js";
 import type * as mcp_traders from "../mcp/traders.js";
+import type * as mcp_tradersEscrow from "../mcp/tradersEscrow.js";
 import type * as mcpApiKeys from "../mcpApiKeys.js";
 import type * as me from "../me.js";
 import type * as portfolio from "../portfolio.js";
@@ -109,6 +110,7 @@ declare const fullApi: ApiFromModules<{
   "mcp/outcomes": typeof mcp_outcomes;
   "mcp/requests": typeof mcp_requests;
   "mcp/traders": typeof mcp_traders;
+  "mcp/tradersEscrow": typeof mcp_tradersEscrow;
   mcpApiKeys: typeof mcpApiKeys;
   me: typeof me;
   portfolio: typeof portfolio;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -22,27 +22,111 @@ import {
 
 const http = httpRouter();
 
-function parseCreateTraderBody(body: Record<string, unknown>) {
+type McpWriteParseFail = { ok: false; message: string };
+type McpWriteParseOk = {
+  deskManagerId: Id<"deskManagers">;
+  idempotencyKey: string;
+  requestBody: Record<string, unknown>;
+};
+
+function parseMcpWriteBase(
+  body: Record<string, unknown>
+): McpWriteParseFail | McpWriteParseOk {
   if (typeof body.deskManagerId !== "string" || !body.deskManagerId) {
-    return { ok: false as const, message: "deskManagerId required" };
+    return { ok: false, message: "deskManagerId required" };
   }
   if (
     typeof body.idempotencyKey !== "string" ||
     body.idempotencyKey.trim() === ""
   ) {
-    return { ok: false as const, message: "idempotencyKey required" };
+    return { ok: false, message: "idempotencyKey required" };
   }
+  return {
+    deskManagerId: body.deskManagerId as Id<"deskManagers">,
+    idempotencyKey: body.idempotencyKey.trim(),
+    requestBody: body,
+  };
+}
+
+function parseTraderIdField(
+  body: Record<string, unknown>
+): { ok: false; message: string } | { ok: true; traderId: Id<"traders"> } {
+  if (typeof body.traderId !== "string" || body.traderId.trim() === "") {
+    return { ok: false, message: "traderId required" };
+  }
+  return { ok: true, traderId: body.traderId.trim() as Id<"traders"> };
+}
+
+function parseCreateTraderBody(body: Record<string, unknown>) {
+  const base = parseMcpWriteBase(body);
+  if ("ok" in base) return base;
   if (typeof body.name !== "string" || body.name.trim() === "") {
     return { ok: false as const, message: "name required" };
   }
   return {
     ok: true as const,
     parsed: {
-      deskManagerId: body.deskManagerId as Id<"deskManagers">,
-      idempotencyKey: body.idempotencyKey.trim(),
-      requestBody: body,
+      deskManagerId: base.deskManagerId,
+      idempotencyKey: base.idempotencyKey,
+      requestBody: base.requestBody,
     },
   };
+}
+
+function parseConfigureTraderBody(body: Record<string, unknown>) {
+  const base = parseMcpWriteBase(body);
+  if ("ok" in base) return base;
+  const tid = parseTraderIdField(body);
+  if (!tid.ok) return tid;
+  if (
+    !body.mandate ||
+    typeof body.mandate !== "object" ||
+    Array.isArray(body.mandate)
+  ) {
+    return { ok: false as const, message: "mandate required (object)" };
+  }
+  return {
+    ok: true as const,
+    parsed: {
+      deskManagerId: base.deskManagerId,
+      idempotencyKey: base.idempotencyKey,
+      requestBody: base.requestBody,
+      traderId: tid.traderId,
+    },
+  };
+}
+
+function parseTraderLifecycleBody(body: Record<string, unknown>) {
+  const base = parseMcpWriteBase(body);
+  if ("ok" in base) return base;
+  const tid = parseTraderIdField(body);
+  if (!tid.ok) return tid;
+  return {
+    ok: true as const,
+    parsed: {
+      deskManagerId: base.deskManagerId,
+      idempotencyKey: base.idempotencyKey,
+      requestBody: base.requestBody,
+      traderId: tid.traderId,
+    },
+  };
+}
+
+function parseFundTraderBody(body: Record<string, unknown>) {
+  const base = parseTraderLifecycleBody(body);
+  if (!base.ok) return base;
+  const amountUsdc = Number(body.amountUsdc);
+  if (!Number.isFinite(amountUsdc) || amountUsdc <= 0) {
+    return {
+      ok: false as const,
+      message: "amountUsdc must be a positive number",
+    };
+  }
+  return { ok: true as const, parsed: { ...base.parsed, amountUsdc } };
+}
+
+function parseWithdrawTraderBody(body: Record<string, unknown>) {
+  return parseFundTraderBody(body);
 }
 
 http.route({
@@ -221,6 +305,130 @@ http.route({
     }),
     runQuery: (ctx, args) =>
       ctx.runQuery(internal.mcp.approvals.getPending, args),
+  }),
+});
+
+http.route({
+  path: "/mcp/traders/configure",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "configure_trader",
+    parseBody: parseConfigureTraderBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const result = await ctx.runMutation(
+          internal.mcp.traders.configureForMcp,
+          {
+            deskManagerId,
+            traderId: requestBody.traderId as Id<"traders">,
+            mandate: requestBody.mandate,
+            personality:
+              requestBody.personality === null ||
+              typeof requestBody.personality === "string"
+                ? (requestBody.personality as string | null | undefined)
+                : undefined,
+          }
+        );
+        return { result };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/traders/fund",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "fund_trader",
+    parseBody: parseFundTraderBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const result = await ctx.runAction(
+          internal.mcp.tradersEscrow.fundForMcp,
+          {
+            deskManagerId,
+            traderId: requestBody.traderId as Id<"traders">,
+            amountUsdc: Number(requestBody.amountUsdc),
+          }
+        );
+        return { result, txHash: result.txHash };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/traders/resume",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "resume_trader",
+    parseBody: parseTraderLifecycleBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      const now = Date.now();
+      try {
+        const result = await ctx.runMutation(
+          internal.mcp.traders.resumeForMcp,
+          {
+            deskManagerId,
+            traderId: requestBody.traderId as Id<"traders">,
+            now,
+          }
+        );
+        return { result };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/traders/pause",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "pause_trader",
+    parseBody: parseTraderLifecycleBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      const now = Date.now();
+      try {
+        const result = await ctx.runMutation(internal.mcp.traders.pauseForMcp, {
+          deskManagerId,
+          traderId: requestBody.traderId as Id<"traders">,
+          now,
+        });
+        return { result };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/traders/withdraw",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "withdraw_from_trader",
+    parseBody: parseWithdrawTraderBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const result = await ctx.runAction(
+          internal.mcp.tradersEscrow.withdrawForMcp,
+          {
+            deskManagerId,
+            traderId: requestBody.traderId as Id<"traders">,
+            amountUsdc: Number(requestBody.amountUsdc),
+          }
+        );
+        return { result, txHash: result.txHash };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
   }),
 });
 

--- a/convex/mcp/traders.ts
+++ b/convex/mcp/traders.ts
@@ -1,7 +1,12 @@
-import { internalAction, internalQuery } from "../_generated/server";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
+import { assertTraderOwnedByDesk, buildMandatePatch } from "../traders";
 
 export type McpCreateTraderResult = {
   traderId: string;
@@ -11,6 +16,15 @@ export type McpCreateTraderResult = {
   summary: string;
   auditTxHash: string | undefined;
 };
+
+export type McpTraderWriteResult = {
+  traderId: string;
+  summary: string;
+  txHash?: string;
+};
+
+const USDC_DECIMALS = 1_000_000;
+const MAX_AMOUNT_USDC = 1_000_000;
 
 /** Terminal + audit payload for a successfully provisioned MCP trader. */
 export function buildCreateTraderResult(
@@ -38,6 +52,34 @@ export function buildCreateTraderResult(
     summary,
     auditTxHash: trader.transferTxHash ?? trader.mintTxHash ?? undefined,
   };
+}
+
+/** Validates human USDC amount and returns atomic units. */
+export function parseAmountUsdc(amountUsdc: number): bigint {
+  if (!Number.isFinite(amountUsdc) || amountUsdc <= 0) {
+    throw new Error("amountUsdc must be a positive number");
+  }
+  if (amountUsdc > MAX_AMOUNT_USDC) {
+    throw new Error(`amountUsdc must be at most ${MAX_AMOUNT_USDC}`);
+  }
+  const atomic = Math.round(amountUsdc * USDC_DECIMALS);
+  if (atomic <= 0) {
+    throw new Error("amountUsdc is too small after conversion");
+  }
+  return BigInt(atomic);
+}
+
+/** Derive CDP account name from MCP desk subject `mcp:cdp-wallet:<id>`. */
+export function mcpDeskCdpAccountName(subject: string): string {
+  const prefix = "mcp:cdp-wallet:";
+  if (!subject.startsWith(prefix)) {
+    throw new Error("Desk is not an MCP CDP wallet subject");
+  }
+  const walletId = subject.slice(prefix.length);
+  if (!walletId) {
+    throw new Error("Invalid MCP desk subject");
+  }
+  return `mcp-desk-${walletId}`;
 }
 
 /**
@@ -85,6 +127,71 @@ export const createForMcp = internalAction({
     }
 
     return buildCreateTraderResult(trader);
+  },
+});
+
+/** MCP `configure_trader`: update mandate + personality for owned trader. */
+export const configureForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    mandate: v.any(),
+    personality: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    const trader = await ctx.db.get(args.traderId);
+    assertTraderOwnedByDesk(trader, args.deskManagerId);
+    const patch = buildMandatePatch(trader, args.mandate, args.personality);
+    await ctx.db.patch(args.traderId, patch);
+    return {
+      traderId: String(args.traderId),
+      summary: `Updated trader "${trader.name}" mandate and personality.`,
+    };
+  },
+});
+
+/** MCP `pause_trader`: pause an owned trader. */
+export const pauseForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    now: v.number(),
+  },
+  handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    const trader = await ctx.db.get(args.traderId);
+    assertTraderOwnedByDesk(trader, args.deskManagerId);
+    await ctx.db.patch(args.traderId, {
+      status: "paused",
+      updatedAt: args.now,
+    });
+    return {
+      traderId: String(args.traderId),
+      summary: `Paused trader "${trader.name}".`,
+    };
+  },
+});
+
+/** MCP `resume_trader`: activate owned funded trader when market is open. */
+export const resumeForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    now: v.number(),
+  },
+  handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    const { traderName } = await ctx.runMutation(
+      internal.traders.setStatusForMcp,
+      {
+        deskManagerId: args.deskManagerId,
+        traderId: args.traderId,
+        status: "active",
+        now: args.now,
+      }
+    );
+    return {
+      traderId: String(args.traderId),
+      summary: `Resumed trader "${traderName}" — autonomous deal cycle will pick entries while the market is open.`,
+    };
   },
 });
 

--- a/convex/mcp/tradersEscrow.ts
+++ b/convex/mcp/tradersEscrow.ts
@@ -13,6 +13,16 @@ import { assertTraderOwnedByDesk } from "../traders";
 
 const USDC_DECIMALS = 1_000_000;
 
+/**
+ * Large allowance used when topping up the desk's USDC approval for the escrow.
+ * Using a large value (instead of the exact per-fund amount) makes the approve
+ * transaction a rare, one-time (or very infrequent) setup cost per desk.
+ * All subsequent fund calls — including retries with fresh idempotencyKeys after
+ * a prior partial failure — will see a sufficient allowance and skip the approve
+ * step entirely, keeping the expensive on-chain leg to the actual depositFor.
+ */
+const LARGE_APPROVE_ALLOWANCE = BigInt(10_000_000) * BigInt(USDC_DECIMALS); // 10M USDC
+
 const ESCROW_ADDRESS = "0x8AA5768AC08755cd9AEf07892e6c40edD1B5a609" as const;
 const USDC_SEPOLIA_ADDRESS =
   "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
@@ -138,7 +148,13 @@ async function ensureDepositorOnChain(
 }
 
 /**
- * MCP `fund_trader`: approve USDC (if needed), depositFor, sync escrow balance.
+ * MCP `fund_trader`: ensure depositor, top-up allowance (large amount when needed),
+ * call escrow depositFor, then sync the Convex escrow balance.
+ *
+ * The large allowance strategy + fresh-key-on-error contract makes the overall
+ * flow resilient to the inherent non-atomicity of two on-chain transactions
+ * from a plain EVM server account. See the LARGE_APPROVE_ALLOWANCE constant
+ * and the comments inside the implementation for the detailed rationale.
  */
 export const fundForMcp = internalAction({
   args: {
@@ -201,20 +217,29 @@ export const fundForMcp = internalAction({
 
     await ensureDepositorOnChain(trader.tokenId, deskAddress);
 
-    const allowance = (await publicClient.readContract({
+    // ── Allowance top-up (rare thanks to LARGE_APPROVE_ALLOWANCE) ─────────────
+    // We deliberately approve a *large* amount (not the exact per-call amount)
+    // when the current allowance is insufficient. This turns the approve tx
+    // into a one-time (or extremely rare) setup cost for the desk. Any later
+    // fund_trader call — including a retry with a *fresh* idempotencyKey after
+    // a previous partial failure (approve succeeded, deposit failed, etc.) —
+    // will see a sufficient allowance and execute *only* the single depositFor
+    // transaction. This is the practical mitigation for the non-atomic nature
+    // of funding from a plain EVM server account (two separate on-chain txs).
+    let lastTxHash: string | undefined;
+
+    const currentAllowance = (await publicClient.readContract({
       address: USDC_SEPOLIA_ADDRESS,
       abi: erc20Abi,
       functionName: "allowance",
       args: [deskAddress, ESCROW_ADDRESS],
     })) as bigint;
 
-    let lastTxHash: string | undefined;
-
-    if (allowance < amountAtomic) {
+    if (currentAllowance < amountAtomic) {
       const approveData = encodeFunctionData({
         abi: erc20Abi,
         functionName: "approve",
-        args: [ESCROW_ADDRESS, amountAtomic],
+        args: [ESCROW_ADDRESS, LARGE_APPROVE_ALLOWANCE],
       });
       const { transactionHash } = await deskAccount.sendTransaction({
         transaction: {
@@ -230,6 +255,13 @@ export const fundForMcp = internalAction({
       });
     }
 
+    // ── Core money movement for this funding intent ───────────────────────────
+    // The depositFor is the on-chain step that actually moves the USDC into
+    // the trader's escrow. It is the last on-chain write on the happy path.
+    // Per the documented contract for all MCP writes, any failure (including
+    // after the tx has confirmed but before Convex is updated) requires a
+    // *fresh* idempotencyKey to re-attempt. The large allowance above ensures
+    // such retries are cheap (usually just the deposit tx).
     const depositData = encodeFunctionData({
       abi: escrowAbi,
       functionName: "depositFor",

--- a/convex/mcp/tradersEscrow.ts
+++ b/convex/mcp/tradersEscrow.ts
@@ -1,0 +1,367 @@
+"use node";
+
+import { internalAction } from "../_generated/server";
+import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import {
+  mcpDeskCdpAccountName,
+  parseAmountUsdc,
+  type McpTraderWriteResult,
+} from "./traders";
+import { assertTraderOwnedByDesk } from "../traders";
+
+const USDC_DECIMALS = 1_000_000;
+
+const ESCROW_ADDRESS = "0x8AA5768AC08755cd9AEf07892e6c40edD1B5a609" as const;
+const USDC_SEPOLIA_ADDRESS =
+  "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+
+const erc20Abi = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+const escrowAbi = [
+  {
+    type: "function",
+    name: "depositFor",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "depositors",
+    inputs: [{ name: "", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "setDepositor",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "depositor", type: "address" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getBalance",
+    inputs: [{ name: "traderId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`Missing required Convex env var: ${name}`);
+  }
+  return value;
+}
+
+/** Operator-signed setDepositor when desk wallet is not yet registered. */
+async function ensureDepositorOnChain(
+  tokenId: number,
+  depositorAddress: string
+): Promise<void> {
+  const { createWalletClient, http } = await import("viem");
+  const { privateKeyToAccount } = await import("viem/accounts");
+  const { baseSepolia } = await import("viem/chains");
+
+  const operatorKey = requireEnv("OPERATOR_PRIVATE_KEY");
+  const account = privateKeyToAccount(operatorKey as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: baseSepolia,
+    transport: http(),
+  });
+  const { createPublicClient } = await import("viem");
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(),
+  });
+
+  const current = (await publicClient.readContract({
+    address: ESCROW_ADDRESS,
+    abi: escrowAbi,
+    functionName: "depositors",
+    args: [BigInt(tokenId)],
+  })) as string;
+
+  if (current.toLowerCase() === depositorAddress.toLowerCase()) {
+    return;
+  }
+
+  const hash = await walletClient.writeContract({
+    address: ESCROW_ADDRESS,
+    abi: escrowAbi,
+    functionName: "setDepositor",
+    args: [BigInt(tokenId), depositorAddress as `0x${string}`],
+  });
+  await publicClient.waitForTransactionReceipt({ hash });
+}
+
+/**
+ * MCP `fund_trader`: approve USDC (if needed), depositFor, sync escrow balance.
+ */
+export const fundForMcp = internalAction({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    amountUsdc: v.number(),
+  },
+  handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    const amountAtomic = parseAmountUsdc(args.amountUsdc);
+
+    const dm: Doc<"deskManagers"> | null = await ctx.runQuery(
+      internal.deskManagers.getByIdInternal,
+      { id: args.deskManagerId }
+    );
+    if (!dm?.subject || !dm.walletAddress) {
+      throw new Error("Desk not found or wallet not provisioned");
+    }
+    if ((dm.walletBalanceUsdc ?? 0) < args.amountUsdc) {
+      throw new Error(
+        "Insufficient desk wallet balance — sync_wallet after funding the desk"
+      );
+    }
+
+    const trader: Doc<"traders"> | null = await ctx.runQuery(
+      internal.traders.loadInternal,
+      { traderId: args.traderId }
+    );
+    assertTraderOwnedByDesk(trader, args.deskManagerId);
+    if (trader.walletStatus !== "ready" || trader.tokenId == null) {
+      throw new Error("Trader wallet must be ready before funding");
+    }
+
+    const cdpApiKeyId = requireEnv("CDP_API_KEY_ID");
+    const cdpApiKeySecret = requireEnv("CDP_API_KEY_SECRET");
+    const cdpWalletSecret = requireEnv("CDP_WALLET_SECRET");
+
+    const { CdpClient } = await import("@coinbase/cdp-sdk");
+    const { encodeFunctionData, createPublicClient, http } =
+      await import("viem");
+    const { baseSepolia } = await import("viem/chains");
+
+    const cdp = new CdpClient({
+      apiKeyId: cdpApiKeyId,
+      apiKeySecret: cdpApiKeySecret,
+      walletSecret: cdpWalletSecret,
+    });
+
+    const accountName = mcpDeskCdpAccountName(dm.subject);
+    const deskAccount = await cdp.evm.getOrCreateAccount({ name: accountName });
+    const deskAddress = deskAccount.address as `0x${string}`;
+
+    if (deskAddress.toLowerCase() !== dm.walletAddress.toLowerCase()) {
+      throw new Error("Desk CDP wallet address mismatch — contact support");
+    }
+
+    const publicClient = createPublicClient({
+      chain: baseSepolia,
+      transport: http(),
+    });
+
+    await ensureDepositorOnChain(trader.tokenId, deskAddress);
+
+    const allowance = (await publicClient.readContract({
+      address: USDC_SEPOLIA_ADDRESS,
+      abi: erc20Abi,
+      functionName: "allowance",
+      args: [deskAddress, ESCROW_ADDRESS],
+    })) as bigint;
+
+    let lastTxHash: string | undefined;
+
+    if (allowance < amountAtomic) {
+      const approveData = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [ESCROW_ADDRESS, amountAtomic],
+      });
+      const { transactionHash } = await deskAccount.sendTransaction({
+        transaction: {
+          to: USDC_SEPOLIA_ADDRESS,
+          value: BigInt(0),
+          data: approveData,
+        },
+        network: "base-sepolia",
+      });
+      lastTxHash = transactionHash;
+      await publicClient.waitForTransactionReceipt({
+        hash: transactionHash as `0x${string}`,
+      });
+    }
+
+    const depositData = encodeFunctionData({
+      abi: escrowAbi,
+      functionName: "depositFor",
+      args: [BigInt(trader.tokenId), amountAtomic],
+    });
+    const { transactionHash: depositHash } = await deskAccount.sendTransaction({
+      transaction: {
+        to: ESCROW_ADDRESS,
+        value: BigInt(0),
+        data: depositData,
+      },
+      network: "base-sepolia",
+    });
+    lastTxHash = depositHash;
+    await publicClient.waitForTransactionReceipt({
+      hash: depositHash as `0x${string}`,
+      confirmations: 2,
+    });
+
+    const escrowRaw = await publicClient.readContract({
+      address: ESCROW_ADDRESS,
+      abi: escrowAbi,
+      functionName: "getBalance",
+      args: [BigInt(trader.tokenId)],
+    });
+    const escrowBalanceUsdc = Number(escrowRaw) / USDC_DECIMALS;
+    await ctx.runMutation(internal.traders.syncEscrowBalance, {
+      traderId: args.traderId,
+      balanceUsdc: escrowBalanceUsdc,
+    });
+
+    return {
+      traderId: String(args.traderId),
+      txHash: lastTxHash,
+      summary: `Funded trader "${trader.name}" with ${args.amountUsdc.toFixed(2)} USDC (escrow balance now ${escrowBalanceUsdc.toFixed(2)} USDC).`,
+    };
+  },
+});
+
+/**
+ * MCP `withdraw_from_trader`: escrow withdraw → desk wallet, sync escrow balance.
+ */
+export const withdrawForMcp = internalAction({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    amountUsdc: v.number(),
+  },
+  handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    const amountAtomic = parseAmountUsdc(args.amountUsdc);
+
+    const dm: Doc<"deskManagers"> | null = await ctx.runQuery(
+      internal.deskManagers.getByIdInternal,
+      { id: args.deskManagerId }
+    );
+    if (!dm?.subject || !dm.walletAddress) {
+      throw new Error("Desk not found or wallet not provisioned");
+    }
+
+    const trader: Doc<"traders"> | null = await ctx.runQuery(
+      internal.traders.loadInternal,
+      { traderId: args.traderId }
+    );
+    assertTraderOwnedByDesk(trader, args.deskManagerId);
+    if (trader.walletStatus !== "ready" || trader.tokenId == null) {
+      throw new Error("Trader wallet must be ready before withdrawal");
+    }
+
+    const escrowBalance = trader.escrowBalanceUsdc ?? 0;
+    if (escrowBalance < args.amountUsdc) {
+      throw new Error(
+        `Insufficient escrow balance (${escrowBalance.toFixed(2)} USDC available)`
+      );
+    }
+
+    const cdpApiKeyId = requireEnv("CDP_API_KEY_ID");
+    const cdpApiKeySecret = requireEnv("CDP_API_KEY_SECRET");
+    const cdpWalletSecret = requireEnv("CDP_WALLET_SECRET");
+
+    const { CdpClient } = await import("@coinbase/cdp-sdk");
+    const { encodeFunctionData, createPublicClient, http } =
+      await import("viem");
+    const { baseSepolia } = await import("viem/chains");
+
+    const cdp = new CdpClient({
+      apiKeyId: cdpApiKeyId,
+      apiKeySecret: cdpApiKeySecret,
+      walletSecret: cdpWalletSecret,
+    });
+
+    const accountName = mcpDeskCdpAccountName(dm.subject);
+    const deskAccount = await cdp.evm.getOrCreateAccount({ name: accountName });
+
+    const publicClient = createPublicClient({
+      chain: baseSepolia,
+      transport: http(),
+    });
+
+    const withdrawData = encodeFunctionData({
+      abi: escrowAbi,
+      functionName: "withdraw",
+      args: [BigInt(trader.tokenId), amountAtomic],
+    });
+    const { transactionHash } = await deskAccount.sendTransaction({
+      transaction: {
+        to: ESCROW_ADDRESS,
+        value: BigInt(0),
+        data: withdrawData,
+      },
+      network: "base-sepolia",
+    });
+    await publicClient.waitForTransactionReceipt({
+      hash: transactionHash as `0x${string}`,
+      confirmations: 2,
+    });
+
+    const escrowRaw = await publicClient.readContract({
+      address: ESCROW_ADDRESS,
+      abi: escrowAbi,
+      functionName: "getBalance",
+      args: [BigInt(trader.tokenId)],
+    });
+    const escrowBalanceUsdc = Number(escrowRaw) / USDC_DECIMALS;
+    await ctx.runMutation(internal.traders.syncEscrowBalance, {
+      traderId: args.traderId,
+      balanceUsdc: escrowBalanceUsdc,
+    });
+
+    return {
+      traderId: String(args.traderId),
+      txHash: transactionHash,
+      summary: `Withdrew ${args.amountUsdc.toFixed(2)} USDC from trader "${trader.name}" to desk wallet (escrow balance now ${escrowBalanceUsdc.toFixed(2)} USDC). Use sync_wallet to refresh desk balance.`,
+    };
+  },
+});

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -210,6 +210,90 @@ const MANDATE_NUMERIC_KEYS = [
   "approval_threshold_usdc",
 ] as const;
 
+export type MandatePatch = Partial<
+  Pick<Doc<"traders">, "mandate" | "personality" | "updatedAt">
+>;
+
+/**
+ * Validates mandate fields and builds a patch for mandate/personality updates.
+ * Shared by browser `updateMandate` and MCP `updateMandateForMcp`.
+ */
+export function buildMandatePatch(
+  trader: Doc<"traders">,
+  mandate: unknown,
+  personality: string | null | undefined
+): MandatePatch {
+  if (!mandate || typeof mandate !== "object" || Array.isArray(mandate)) {
+    throw new Error("mandate must be an object");
+  }
+
+  const cleaned: Record<string, unknown> = {};
+
+  for (const key of MANDATE_NUMERIC_KEYS) {
+    if (!(key in mandate)) continue;
+    const val = (mandate as Record<string, unknown>)[key];
+    if (val === null || val === undefined) continue;
+    const num = Number(val);
+    if (Number.isNaN(num) || num < 0) {
+      throw new Error(`${key} must be a non-negative number`);
+    }
+    if (key === "bankroll_pct" && (num <= 0 || num > 100)) {
+      throw new Error("bankroll_pct must be between 1 and 100");
+    }
+    cleaned[key] = num;
+  }
+
+  if ("keywords" in mandate) {
+    const val = (mandate as Record<string, unknown>).keywords;
+    if (
+      !Array.isArray(val) ||
+      !val.every((entry) => typeof entry === "string")
+    ) {
+      throw new Error("keywords must be an array of strings");
+    }
+    cleaned.keywords = val;
+  }
+
+  if ("llm_deal_selection" in mandate) {
+    const val = (mandate as Record<string, unknown>).llm_deal_selection;
+    if (typeof val !== "boolean") {
+      throw new Error("llm_deal_selection must be a boolean");
+    }
+    cleaned.llm_deal_selection = val;
+  }
+
+  const existingMandate =
+    (trader.mandate as Record<string, unknown> | undefined) ?? {};
+
+  const patch: MandatePatch = {
+    mandate: { ...existingMandate, ...cleaned },
+    updatedAt: Date.now(),
+  };
+
+  if (personality !== undefined) {
+    if (personality !== null && typeof personality !== "string") {
+      throw new Error("personality must be a string or null");
+    }
+    if (typeof personality === "string" && personality.length > 2000) {
+      throw new Error("personality must be at most 2000 characters");
+    }
+    patch.personality =
+      personality === null ? undefined : personality.trim() || undefined;
+  }
+
+  return patch;
+}
+
+/** Assert trader belongs to the given desk (MCP + internal callers). */
+export function assertTraderOwnedByDesk(
+  trader: Doc<"traders"> | null,
+  deskManagerId: Id<"deskManagers">
+): asserts trader is Doc<"traders"> {
+  if (!trader || trader.deskManagerId !== deskManagerId) {
+    throw new Error("Forbidden");
+  }
+}
+
 /** Update mandate + personality for owned trader (Convex-native; replaces desk/configure for game UI). */
 export const updateMandate = mutation({
   args: {
@@ -226,70 +310,45 @@ export const updateMandate = mutation({
       throw new Error("Forbidden");
     }
 
-    if (!mandate || typeof mandate !== "object" || Array.isArray(mandate)) {
-      throw new Error("mandate must be an object");
-    }
-
-    const cleaned: Record<string, unknown> = {};
-
-    for (const key of MANDATE_NUMERIC_KEYS) {
-      if (!(key in mandate)) continue;
-      const val = (mandate as Record<string, unknown>)[key];
-      if (val === null || val === undefined) continue;
-      const num = Number(val);
-      if (Number.isNaN(num) || num < 0) {
-        throw new Error(`${key} must be a non-negative number`);
-      }
-      if (key === "bankroll_pct" && (num <= 0 || num > 100)) {
-        throw new Error("bankroll_pct must be between 1 and 100");
-      }
-      cleaned[key] = num;
-    }
-
-    if ("keywords" in mandate) {
-      const val = (mandate as Record<string, unknown>).keywords;
-      if (
-        !Array.isArray(val) ||
-        !val.every((entry) => typeof entry === "string")
-      ) {
-        throw new Error("keywords must be an array of strings");
-      }
-      cleaned.keywords = val;
-    }
-
-    if ("llm_deal_selection" in mandate) {
-      const val = (mandate as Record<string, unknown>).llm_deal_selection;
-      if (typeof val !== "boolean") {
-        throw new Error("llm_deal_selection must be a boolean");
-      }
-      cleaned.llm_deal_selection = val;
-    }
-
-    const existingMandate =
-      (trader.mandate as Record<string, unknown> | undefined) ?? {};
-
-    const patch: Partial<
-      Pick<Doc<"traders">, "mandate" | "personality" | "updatedAt">
-    > = {
-      mandate: { ...existingMandate, ...cleaned },
-      updatedAt: Date.now(),
-    };
-
-    if (personality !== undefined) {
-      if (personality !== null && typeof personality !== "string") {
-        throw new Error("personality must be a string or null");
-      }
-      if (typeof personality === "string" && personality.length > 2000) {
-        throw new Error("personality must be at most 2000 characters");
-      }
-      patch.personality =
-        personality === null ? undefined : personality.trim() || undefined;
-    }
-
+    const patch = buildMandatePatch(trader, mandate, personality);
     await ctx.db.patch(traderId, patch);
     return { ok: true as const };
   },
 });
+
+/** Internal (MCP): update mandate + personality for a desk-owned trader. */
+export const updateMandateForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    mandate: v.any(),
+    personality: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, { deskManagerId, traderId, mandate, personality }) => {
+    const trader = await ctx.db.get(traderId);
+    assertTraderOwnedByDesk(trader, deskManagerId);
+    const patch = buildMandatePatch(trader, mandate, personality);
+    await ctx.db.patch(traderId, patch);
+    return { ok: true as const, traderName: trader.name };
+  },
+});
+
+/** Shared activation guards for resume/setStatus active transitions. */
+export function assertCanActivateTrader(
+  trader: Doc<"traders">,
+  nowMs: number
+): void {
+  if (trader.status === "wiped_out") {
+    throw new Error("Cannot activate a wiped out trader");
+  }
+  if (trader.walletStatus !== "ready") {
+    throw new Error("Trader wallet must be ready before activation");
+  }
+  if ((trader.escrowBalanceUsdc ?? 0) <= 0) {
+    throw new Error("Fund trader before activating");
+  }
+  assertTradingHours(nowMs, "(cannot activate trader)");
+}
 
 /** Public: set status (pause/resume/revive) for an owned trader. */
 export const setStatus = mutation({
@@ -311,22 +370,36 @@ export const setStatus = mutation({
     }
 
     if (status === "active") {
-      if (trader.status === "wiped_out") {
-        throw new Error("Cannot activate a wiped out trader");
-      }
-      if (trader.walletStatus !== "ready") {
-        throw new Error("Trader wallet must be ready before activation");
-      }
-      if ((trader.escrowBalanceUsdc ?? 0) <= 0) {
-        throw new Error("Fund trader before activating");
-      }
-      // Trading-hours gate: only enforce when transitioning to "active".
-      // Must follow wallet-ready check so precedence stays intuitive (spec §9.2).
-      assertTradingHours(Date.now(), "(cannot activate trader)");
+      assertCanActivateTrader(trader, Date.now());
     }
 
     await ctx.db.patch(traderId, { status, updatedAt: Date.now() });
     return { ok: true as const };
+  },
+});
+
+/** Internal (MCP): set trader status for a desk-owned trader. */
+export const setStatusForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    traderId: v.id("traders"),
+    status: v.union(
+      v.literal("active"),
+      v.literal("paused"),
+      v.literal("wiped_out")
+    ),
+    now: v.number(),
+  },
+  handler: async (ctx, { deskManagerId, traderId, status, now }) => {
+    const trader = await ctx.db.get(traderId);
+    assertTraderOwnedByDesk(trader, deskManagerId);
+
+    if (status === "active") {
+      assertCanActivateTrader(trader, now);
+    }
+
+    await ctx.db.patch(traderId, { status, updatedAt: now });
+    return { ok: true as const, traderName: trader.name, status };
   },
 });
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -15,7 +15,7 @@ The key can be used from Claude Code with no further browser session. MCP desks 
 
 Public UI surfaces now tag these desks with an **AGENT DESK** badge (terminal glyph).
 
-Writes (create trader, fund, create deal, answer approvals...) are Phase 3+.
+**Phase 3 trader management** (via MCP): `create_trader`, `configure_trader`, `fund_trader`, `resume_trader`, `pause_trader`, `withdraw_from_trader`. Deal creation and approvals are later phases.
 
 All tools log compact rows to the `mcpRequests` audit table.
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -297,7 +297,7 @@ server.tool(
 
 server.tool(
   "fund_trader",
-  "Fund a trader escrow from the desk CDP wallet: USDC approve (if needed), escrow depositFor, sync escrow balance. Expect ~2–8s (on-chain txs). Requires idempotencyKey, positive amountUsdc, funded desk (get_desk → send USDC → sync_wallet). Trader wallet must be ready. Returns txHash and summary.",
+  "Fund a trader escrow from the desk CDP wallet. Performs USDC approve (large allowance when needed — this step is rare after the first funding) + escrow depositFor + Convex balance sync. Expect ~2–8s wall time. REQUIRES: stable idempotencyKey (reuse on transient failure replays the cached error; generate a *fresh* key to re-attempt the funding intent). Prerequisites: positive synced desk balance, trader wallet ready. Returns txHash + concise summary. The large allowance makes retries after partial failures cheap (usually just the deposit tx).",
   {
     traderId: traderIdSchema,
     amountUsdc: z

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,7 +4,8 @@
  *
  * Tools:
  *   get_desk, list_traders, list_deals, get_activity, get_outcomes,
- *   get_pending_approvals, sync_wallet, create_trader
+ *   get_pending_approvals, sync_wallet, create_trader,
+ *   configure_trader, fund_trader, resume_trader, pause_trader, withdraw_from_trader
  *
  * Each MCP key maps 1:1 to a dedicated desk with subject `mcp:cdp-wallet:<id>`
  * and its own CDP server wallet (provisioned at key issuance).
@@ -47,7 +48,7 @@ const server = new McpServer({
   name: "margin-call",
   version: "0.1.0-phase1",
   description:
-    "Margin Call 1980s Wall Street desk manager for Claude (read + MCP desk writes where implemented). Inspect state via get_desk, list_traders, list_deals, activity, outcomes, approvals; sync balances; hire traders via create_trader.",
+    "Margin Call 1980s Wall Street desk manager for Claude. Read desk state; hire and manage traders (configure, fund, pause, resume, withdraw); sync wallet balances. Autonomous cron picks deals for active funded traders.",
 });
 
 function buildQueryString(
@@ -257,12 +258,117 @@ server.tool(
     })
 );
 
+const idempotencyKeySchema = z
+  .string()
+  .min(8)
+  .describe(
+    "Stable key for this intent (e.g. UUID). Reuse the same key on retries within 24h to replay cached results without re-submitting on-chain txs."
+  );
+
+const traderIdSchema = z
+  .string()
+  .min(1)
+  .describe("Convex trader document id from list_traders or create_trader");
+
+server.tool(
+  "configure_trader",
+  "Update mandate and personality for a trader owned by this MCP desk. Requires idempotencyKey. Does not change trader status or on-chain state.",
+  {
+    traderId: traderIdSchema,
+    mandate: z
+      .any()
+      .describe(
+        "Mandate object (strategy knobs): bankroll_pct, keywords, etc."
+      ),
+    personality: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Trader personality text, or null to clear"),
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ traderId, mandate, personality, idempotencyKey }) =>
+    callMcpApi(`/api/mcp/traders/${traderId}/configure`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ traderId, mandate, personality, idempotencyKey }),
+    })
+);
+
+server.tool(
+  "fund_trader",
+  "Fund a trader escrow from the desk CDP wallet: USDC approve (if needed), escrow depositFor, sync escrow balance. Expect ~2–8s (on-chain txs). Requires idempotencyKey, positive amountUsdc, funded desk (get_desk → send USDC → sync_wallet). Trader wallet must be ready. Returns txHash and summary.",
+  {
+    traderId: traderIdSchema,
+    amountUsdc: z
+      .number()
+      .positive()
+      .describe("USDC amount in human units (e.g. 50 for $50)"),
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ traderId, amountUsdc, idempotencyKey }) =>
+    callMcpApi(`/api/mcp/traders/${traderId}/fund`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ traderId, amountUsdc, idempotencyKey }),
+    })
+);
+
+server.tool(
+  "resume_trader",
+  "Activate an owned trader for the autonomous deal cycle. Same gates as the web app: wallet ready, escrow balance > 0, not wiped out, market open. Requires idempotencyKey.",
+  {
+    traderId: traderIdSchema,
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ traderId, idempotencyKey }) =>
+    callMcpApi(`/api/mcp/traders/${traderId}/resume`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ traderId, idempotencyKey }),
+    })
+);
+
+server.tool(
+  "pause_trader",
+  "Pause an owned trader (stops autonomous deal entry). Requires idempotencyKey.",
+  {
+    traderId: traderIdSchema,
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ traderId, idempotencyKey }) =>
+    callMcpApi(`/api/mcp/traders/${traderId}/pause`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ traderId, idempotencyKey }),
+    })
+);
+
+server.tool(
+  "withdraw_from_trader",
+  "Withdraw USDC from trader escrow to the desk CDP wallet (escrow withdraw). Syncs escrow balance; call sync_wallet to refresh desk balance. Expect ~2–8s. Requires explicit positive amountUsdc and idempotencyKey.",
+  {
+    traderId: traderIdSchema,
+    amountUsdc: z
+      .number()
+      .positive()
+      .describe("USDC to withdraw in human units"),
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ traderId, amountUsdc, idempotencyKey }) =>
+    callMcpApi(`/api/mcp/traders/${traderId}/withdraw`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ traderId, amountUsdc, idempotencyKey }),
+    })
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // Log to stderr only (stdio transport uses stdout for protocol)
   console.error(
-    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet,create_trader  (key last4=${API_KEY.slice(-4)})`
+    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet,create_trader,configure_trader,fund_trader,resume_trader,pause_trader,withdraw_from_trader  (key last4=${API_KEY.slice(-4)})`
   );
 }
 

--- a/src/app/api/mcp/traders/[id]/configure/route.ts
+++ b/src/app/api/mcp/traders/[id]/configure/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/traders/[id]/configure
+ * MCP write: update mandate + personality for an owned trader.
+ * Body: traderId, mandate, optional personality, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "traders/configure",
+    requireIdempotencyKey: true,
+  });
+}

--- a/src/app/api/mcp/traders/[id]/fund/route.ts
+++ b/src/app/api/mcp/traders/[id]/fund/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/traders/[id]/fund
+ * MCP write: approve USDC if needed, escrow depositFor, sync escrow balance.
+ * Body: traderId, amountUsdc, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "traders/fund",
+    requireIdempotencyKey: true,
+  });
+}

--- a/src/app/api/mcp/traders/[id]/pause/route.ts
+++ b/src/app/api/mcp/traders/[id]/pause/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/traders/[id]/pause
+ * MCP write: pause an owned trader.
+ * Body: traderId, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "traders/pause",
+    requireIdempotencyKey: true,
+  });
+}

--- a/src/app/api/mcp/traders/[id]/resume/route.ts
+++ b/src/app/api/mcp/traders/[id]/resume/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/traders/[id]/resume
+ * MCP write: activate owned funded trader (wallet ready, market open).
+ * Body: traderId, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "traders/resume",
+    requireIdempotencyKey: true,
+  });
+}

--- a/src/app/api/mcp/traders/[id]/withdraw/route.ts
+++ b/src/app/api/mcp/traders/[id]/withdraw/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/traders/[id]/withdraw
+ * MCP write: escrow withdraw to desk wallet, sync escrow balance.
+ * Body: traderId, amountUsdc, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "traders/withdraw",
+    requireIdempotencyKey: true,
+  });
+}

--- a/tests/convex/mcp-trader-lifecycle.test.ts
+++ b/tests/convex/mcp-trader-lifecycle.test.ts
@@ -1,0 +1,247 @@
+/**
+ * MCP trader lifecycle: configure, pause/resume, ownership, mandate helpers, amount parsing.
+ */
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../convex/schema";
+import { internal } from "../../convex/_generated/api";
+import {
+  buildMandatePatch,
+  assertCanActivateTrader,
+} from "../../convex/traders";
+import {
+  mcpDeskCdpAccountName,
+  parseAmountUsdc,
+} from "../../convex/mcp/traders";
+import { seedDeskManager, seedActiveTrader, useRealMarketHours } from "./setup";
+import { MARKET_CLOSED_MESSAGE } from "../../convex/lib/tradingHours";
+
+const modules = import.meta.glob("../../convex/**/*.ts");
+
+describe("parseAmountUsdc", () => {
+  it("converts human USDC to atomic units", () => {
+    expect(parseAmountUsdc(1)).toBe(1_000_000n);
+    expect(parseAmountUsdc(0.5)).toBe(500_000n);
+  });
+
+  it("rejects non-positive amounts", () => {
+    expect(() => parseAmountUsdc(0)).toThrow(/positive/i);
+    expect(() => parseAmountUsdc(-1)).toThrow(/positive/i);
+  });
+});
+
+describe("mcpDeskCdpAccountName", () => {
+  it("derives CDP account name from MCP subject", () => {
+    expect(mcpDeskCdpAccountName("mcp:cdp-wallet:abc123")).toBe(
+      "mcp-desk-abc123"
+    );
+  });
+
+  it("rejects non-MCP subjects", () => {
+    expect(() => mcpDeskCdpAccountName("did:privy:x")).toThrow(
+      /not an MCP CDP wallet/i
+    );
+  });
+});
+
+describe("internal traders.updateMandateForMcp", () => {
+  it("updates mandate for desk-owned trader only", async () => {
+    const t = convexTest(schema, modules);
+    const deskA = await seedDeskManager(t, {
+      subject: "mcp:cdp-wallet:desk_a",
+      walletBalance: 100,
+    });
+    const deskB = await seedDeskManager(t, {
+      subject: "mcp:cdp-wallet:desk_b",
+      walletBalance: 100,
+    });
+    const traderId = await seedActiveTrader(t, deskA, {
+      ownerSubject: "mcp:cdp-wallet:desk_a",
+      status: "paused",
+      mandate: { bankroll_pct: 10 },
+    });
+
+    await t.mutation(internal.traders.updateMandateForMcp, {
+      deskManagerId: deskA,
+      traderId,
+      mandate: { bankroll_pct: 25, keywords: ["oil"] },
+    });
+
+    const updated = await t.run(async (ctx) => ctx.db.get(traderId));
+    expect(updated?.mandate).toMatchObject({
+      bankroll_pct: 25,
+      keywords: ["oil"],
+    });
+
+    await expect(
+      t.mutation(internal.traders.updateMandateForMcp, {
+        deskManagerId: deskB,
+        traderId,
+        mandate: { bankroll_pct: 5 },
+      })
+    ).rejects.toThrow(/Forbidden/i);
+  });
+});
+
+describe("internal mcp.traders.configureForMcp", () => {
+  it("returns summary with trader name", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, {
+      subject: "mcp:cdp-wallet:cfg",
+      walletBalance: 50,
+    });
+    const traderId = await seedActiveTrader(t, deskId, {
+      ownerSubject: "mcp:cdp-wallet:cfg",
+      name: "ConfigMe",
+      status: "paused",
+    });
+
+    const result = await t.mutation(internal.mcp.traders.configureForMcp, {
+      deskManagerId: deskId,
+      traderId,
+      mandate: { bankroll_pct: 15 },
+      personality: "Bold",
+    });
+
+    expect(result.summary).toContain("ConfigMe");
+    expect(result.traderId).toBe(String(traderId));
+  });
+});
+
+describe("pause and resume (MCP)", () => {
+  it("pauses an active trader", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, {
+      subject: "mcp:cdp-wallet:pause_desk",
+      walletBalance: 50,
+    });
+    const traderId = await seedActiveTrader(t, deskId, {
+      ownerSubject: "mcp:cdp-wallet:pause_desk",
+      status: "active",
+      escrowBalance: 100,
+    });
+
+    const result = await t.mutation(internal.mcp.traders.pauseForMcp, {
+      deskManagerId: deskId,
+      traderId,
+      now: Date.now(),
+    });
+    expect(result.summary).toMatch(/Paused/i);
+
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+    expect(trader?.status).toBe("paused");
+  });
+
+  it("resumes a funded trader when market is open", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, {
+      subject: "mcp:cdp-wallet:resume_ok",
+      walletBalance: 50,
+    });
+    const traderId = await seedActiveTrader(t, deskId, {
+      ownerSubject: "mcp:cdp-wallet:resume_ok",
+      status: "paused",
+      escrowBalance: 50,
+      walletStatus: "ready",
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId, { tokenId: 99 });
+    });
+
+    const result = await t.mutation(internal.mcp.traders.resumeForMcp, {
+      deskManagerId: deskId,
+      traderId,
+      now: Date.UTC(2026, 4, 6, 15, 0, 0),
+    });
+    expect(result.summary).toMatch(/Resumed/i);
+
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+    expect(trader?.status).toBe("active");
+  });
+
+  it("rejects resume when market is closed", async () => {
+    const restore = useRealMarketHours();
+    try {
+      const t = convexTest(schema, modules);
+      const deskId = await seedDeskManager(t, {
+        subject: "mcp:cdp-wallet:resume_closed",
+        walletBalance: 50,
+      });
+      const traderId = await seedActiveTrader(t, deskId, {
+        ownerSubject: "mcp:cdp-wallet:resume_closed",
+        status: "paused",
+        escrowBalance: 50,
+        walletStatus: "ready",
+      });
+      await t.run(async (ctx) => {
+        await ctx.db.patch(traderId, { tokenId: 1 });
+      });
+
+      // Sat 2026-05-09 12:00 ET → 16:00 UTC (see trading-hours.test.ts)
+      const closedAt = Date.UTC(2026, 4, 9, 16, 0, 0);
+      await expect(
+        t.mutation(internal.mcp.traders.resumeForMcp, {
+          deskManagerId: deskId,
+          traderId,
+          now: closedAt,
+        })
+      ).rejects.toThrow(MARKET_CLOSED_MESSAGE);
+    } finally {
+      restore();
+    }
+  });
+
+  it("rejects resume when escrow is empty", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t, {
+      subject: "mcp:cdp-wallet:resume_unfunded",
+      walletBalance: 50,
+    });
+    const traderId = await seedActiveTrader(t, deskId, {
+      ownerSubject: "mcp:cdp-wallet:resume_unfunded",
+      status: "paused",
+      escrowBalance: 0,
+      walletStatus: "ready",
+    });
+
+    await expect(
+      t.mutation(internal.mcp.traders.resumeForMcp, {
+        deskManagerId: deskId,
+        traderId,
+        now: Date.UTC(2026, 4, 6, 15, 0, 0),
+      })
+    ).rejects.toThrow(/Fund trader/i);
+  });
+});
+
+describe("buildMandatePatch", () => {
+  it("merges mandate fields onto existing trader mandate", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskId, {
+      mandate: { bankroll_pct: 10, keywords: ["old"] },
+    });
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+    const patch = buildMandatePatch(trader!, { bankroll_pct: 20 }, undefined);
+    expect(patch.mandate).toMatchObject({
+      bankroll_pct: 20,
+      keywords: ["old"],
+    });
+  });
+});
+
+describe("assertCanActivateTrader", () => {
+  it("throws for wiped out traders", async () => {
+    const t = convexTest(schema, modules);
+    const deskId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskId, {
+      status: "wiped_out",
+      escrowBalance: 100,
+      walletStatus: "ready",
+    });
+    const trader = await t.run(async (ctx) => ctx.db.get(traderId));
+    expect(() =>
+      assertCanActivateTrader(trader!, Date.UTC(2026, 4, 6, 15, 0, 0))
+    ).toThrow(/wiped out/i);
+  });
+});


### PR DESCRIPTION
Implements GitHub #141 (MCP Phase 3).

Adds full trader management over the MCP boundary:
- configure_trader, fund_trader, resume_trader, pause_trader, withdraw_from_trader
- All writes enforce ownership, idempotency (24h), trading-hours, and funding preconditions
- On-chain actions (USDC approve + escrow depositFor/withdraw) executed via the desk's CDP server wallet
- Concise terminal-friendly summaries returned
- New Convex internal variants + thin Next.js proxies + MCP server tools
- Added lifecycle unit tests

Autonomous cron cycle continues to drive MCP-owned active traders with no changes.

Ready for review.

Made with [Cursor](https://cursor.com)