### PR TITLE
feat(mcp): high-stakes approvals loop via answer_approval + TTL auto-reject

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -46,4 +46,19 @@ crons.hourly(
   {}
 );
 
+/**
+ * Auto-reject MCP high-stakes deal approvals that have passed their TTL.
+ * Without this sweep an unanswered pending row would block the trader cycle
+ * (see `findPendingByTraderAndDeal` in convex/dealApprovals.ts) indefinitely —
+ * the trader would keep selecting the same deal and stalling out. Running
+ * every 5 minutes keeps Claude's approval loop honest while staying well
+ * inside the agent scheduler's per-minute heartbeat.
+ */
+crons.interval(
+  "mcp-approvals-auto-reject-expired",
+  { minutes: 5 },
+  internal.mcp.approvals.autoRejectExpiredAction,
+  {}
+);
+
 export default crons;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -48,16 +48,13 @@ crons.hourly(
 
 /**
  * Auto-reject MCP high-stakes deal approvals that have passed their TTL.
- * Without this sweep an unanswered pending row would block the trader cycle
- * (see `findPendingByTraderAndDeal` in convex/dealApprovals.ts) indefinitely —
- * the trader would keep selecting the same deal and stalling out. Running
- * every 5 minutes keeps Claude's approval loop honest while staying well
- * inside the agent scheduler's per-minute heartbeat.
+ * Unanswered pending rows would otherwise block the trader cycle
+ * (see `findPendingByTraderAndDeal` in convex/dealApprovals.ts).
  */
 crons.interval(
   "mcp-approvals-auto-reject-expired",
   { minutes: 5 },
-  internal.mcp.approvals.autoRejectExpiredAction,
+  internal.mcp.approvals.autoRejectExpired,
   {}
 );
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -168,6 +168,28 @@ function parseWithdrawTraderBody(body: Record<string, unknown>) {
   return parseFundTraderBody(body);
 }
 
+function parseAnswerApprovalBody(body: Record<string, unknown>) {
+  const base = parseMcpWriteBase(body);
+  if ("ok" in base) return base;
+  if (typeof body.approvalId !== "string" || body.approvalId.trim() === "") {
+    return { ok: false as const, message: "approvalId required" };
+  }
+  if (body.decision !== "approve" && body.decision !== "reject") {
+    return {
+      ok: false as const,
+      message: 'decision must be "approve" or "reject"',
+    };
+  }
+  return {
+    ok: true as const,
+    parsed: {
+      deskManagerId: base.deskManagerId,
+      idempotencyKey: base.idempotencyKey,
+      requestBody: base.requestBody,
+    },
+  };
+}
+
 http.route({
   path: "/mcp/desks/get",
   method: "POST",
@@ -513,6 +535,35 @@ http.route({
           }
         );
         return { result, txHash: result.txHash };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/approvals/answer",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "answer_approval",
+    parseBody: parseAnswerApprovalBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const result = await ctx.runMutation(
+          internal.mcp.approvals.answerForMcp,
+          {
+            deskManagerId,
+            approvalId: requestBody.approvalId as Id<"dealApprovals">,
+            decision: requestBody.decision as "approve" | "reject",
+            reason:
+              typeof requestBody.reason === "string"
+                ? requestBody.reason
+                : undefined,
+            now: Date.now(),
+          }
+        );
+        return { result };
       } catch (e: unknown) {
         return { error: e instanceof Error ? e.message : String(e) };
       }

--- a/convex/mcp/approvals.ts
+++ b/convex/mcp/approvals.ts
@@ -1,5 +1,12 @@
-import { internalQuery } from "../_generated/server";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+  type MutationCtx,
+} from "../_generated/server";
 import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
 
 /**
  * Pending high-stakes approvals for the desk (MCP `get_pending_approvals`).
@@ -58,5 +65,213 @@ export const getPending = internalQuery({
       count: items.length,
       oldestAgeSeconds,
     };
+  },
+});
+
+/**
+ * Count remaining pending (non-expired) approvals for a desk at `now`.
+ * Used by `answer_approval` to enrich the action's summary with portfolio
+ * context (how many approvals still need attention after this decision).
+ */
+async function countRemainingPendingApprovals(
+  ctx: MutationCtx,
+  deskManagerId: Id<"deskManagers">,
+  now: number
+): Promise<number> {
+  const rows = await ctx.db
+    .query("dealApprovals")
+    .withIndex("byDeskManagerAndStatus", (q) =>
+      q.eq("deskManagerId", deskManagerId).eq("status", "pending")
+    )
+    .filter((q) => q.gt(q.field("expiresAt"), now))
+    .take(51);
+  return rows.length;
+}
+
+export type McpAnswerApprovalResult = {
+  approvalId: string;
+  traderId: string;
+  dealId: string;
+  status: "approved" | "rejected" | "expired" | "noop";
+  remainingPendingApprovals: number;
+  summary: string;
+};
+
+/**
+ * MCP `answer_approval`: approve or reject a pending high-stakes deal for an
+ * owned trader. Ownership is enforced server-side; only the desk that owns
+ * the trader (and the approval row) may answer it. Transitions only fire on
+ * pending rows that have not yet expired; everything else is a no-op replay
+ * that returns the current status.
+ *
+ * On approve, schedules an immediate trader cycle so the autonomous loop
+ * picks the deal up without waiting for the next scheduler heartbeat.
+ *
+ * Summary includes the deal prompt snippet, trader name + escrow balance, and
+ * remaining pending approval count so Claude can reason about portfolio change
+ * from the action result alone.
+ */
+export const answerForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    approvalId: v.id("dealApprovals"),
+    decision: v.union(v.literal("approve"), v.literal("reject")),
+    reason: v.optional(v.string()),
+    now: v.number(),
+  },
+  handler: async (
+    ctx,
+    { deskManagerId, approvalId, decision, now }
+  ): Promise<McpAnswerApprovalResult> => {
+    const approval = await ctx.db.get(approvalId);
+    if (!approval) throw new Error("Approval not found");
+    if (approval.deskManagerId !== deskManagerId) {
+      throw new Error("Forbidden: approval belongs to another desk");
+    }
+
+    const trader: Doc<"traders"> | null = await ctx.db.get(approval.traderId);
+    if (!trader || trader.deskManagerId !== deskManagerId) {
+      throw new Error("Forbidden: trader not owned by this desk");
+    }
+
+    const deal = await ctx.db.get(approval.dealId);
+
+    const dealPromptSnippet = (() => {
+      const p = deal?.prompt ?? "";
+      if (p.length <= 80) return p;
+      return `${p.slice(0, 77)}…`;
+    })();
+    const escrow = trader.escrowBalanceUsdc ?? 0;
+
+    // Replay-safe: if already resolved, return the current status without
+    // changing state. The HTTP idempotency cache layer will catch identical
+    // (deskId, idempotencyKey) replays earlier; this handles legitimate races
+    // where the approval was already finalized (e.g. expired by the cron).
+    if (approval.status !== "pending") {
+      const remaining = await countRemainingPendingApprovals(
+        ctx,
+        deskManagerId,
+        now
+      );
+      return {
+        approvalId: String(approvalId),
+        traderId: String(approval.traderId),
+        dealId: String(approval.dealId),
+        status: "noop",
+        remainingPendingApprovals: remaining,
+        summary: `Approval for "${trader.name}" already ${approval.status} — no change. ${remaining} pending approval(s) remain on this desk.`,
+      };
+    }
+
+    // Pending but already expired → record expiry, treat as no-op for caller.
+    if (approval.expiresAt <= now) {
+      await ctx.db.patch(approvalId, {
+        status: "expired",
+        resolvedAt: now,
+      });
+      const remaining = await countRemainingPendingApprovals(
+        ctx,
+        deskManagerId,
+        now
+      );
+      return {
+        approvalId: String(approvalId),
+        traderId: String(approval.traderId),
+        dealId: String(approval.dealId),
+        status: "expired",
+        remainingPendingApprovals: remaining,
+        summary: `Approval for "${trader.name}" expired before you answered — the trader's cycle will pick a fresh deal on its next tick. ${remaining} pending approval(s) remain on this desk.`,
+      };
+    }
+
+    const newStatus = decision === "approve" ? "approved" : "rejected";
+    await ctx.db.patch(approvalId, {
+      status: newStatus,
+      resolvedAt: now,
+    });
+
+    // On approve, kick the trader cycle immediately so the entry doesn't
+    // wait for the next scheduler heartbeat — same behaviour as the web
+    // mutation in convex/dealApprovals.ts.
+    if (newStatus === "approved") {
+      await ctx.scheduler.runAfter(0, internal.agent.cycle.cycle, {
+        traderId: approval.traderId,
+      });
+    }
+
+    const remaining = await countRemainingPendingApprovals(
+      ctx,
+      deskManagerId,
+      now
+    );
+
+    const verb = newStatus === "approved" ? "Approved" : "Rejected";
+    const tail =
+      newStatus === "approved"
+        ? `Trader cycle scheduled — autonomous loop will enter on next tick. Escrow balance ${escrow.toFixed(2)} USDC; ${remaining} pending approval(s) remain.`
+        : `Trader cycle will pick a different deal on its next tick. Escrow balance ${escrow.toFixed(2)} USDC; ${remaining} pending approval(s) remain.`;
+
+    return {
+      approvalId: String(approvalId),
+      traderId: String(approval.traderId),
+      dealId: String(approval.dealId),
+      status: newStatus as "approved" | "rejected",
+      remainingPendingApprovals: remaining,
+      summary: `${verb} "${trader.name}" on deal: ${dealPromptSnippet || "(no prompt)"} (entry ${approval.entryCostUsdc.toFixed(2)} / pot ${approval.potUsdc.toFixed(2)} USDC). ${tail}`,
+    };
+  },
+});
+
+/**
+ * Internal: scan and auto-reject pending approvals past their TTL. Mutations
+ * have transaction limits, so we cap the batch at 50 per invocation — the
+ * cron tick rate (~5 min) keeps this comfortably ahead of normal load.
+ * Returns the number of approvals expired so the cron logs are useful.
+ */
+export const autoRejectExpired = internalMutation({
+  args: { now: v.number(), limit: v.optional(v.number()) },
+  handler: async (ctx, { now, limit = 50 }) => {
+    const bounded = Math.min(Math.max(1, limit), 200);
+    const rows = await ctx.db
+      .query("dealApprovals")
+      .withIndex("byStatus", (q) => q.eq("status", "pending"))
+      .filter((q) => q.lte(q.field("expiresAt"), now))
+      .take(bounded);
+
+    let expired = 0;
+    for (const row of rows) {
+      // Defensive: re-check status + expiry inside the batch.
+      if (row.status !== "pending") continue;
+      if (row.expiresAt > now) continue;
+      await ctx.db.patch(row._id, {
+        status: "expired",
+        resolvedAt: now,
+      });
+      expired += 1;
+    }
+    return { expired, scanned: rows.length };
+  },
+});
+
+/**
+ * Internal action: cron entrypoint for auto-rejecting expired approvals.
+ * Wrapping the mutation in an action lets us call Date.now() once outside
+ * the transaction (Convex guideline: queries/mutations should not embed
+ * non-deterministic time) and emits a single log line per tick.
+ */
+export const autoRejectExpiredAction = internalAction({
+  args: {},
+  handler: async (ctx): Promise<{ expired: number; scanned: number }> => {
+    const now = Date.now();
+    const result: { expired: number; scanned: number } = await ctx.runMutation(
+      internal.mcp.approvals.autoRejectExpired,
+      { now }
+    );
+    if (result.expired > 0) {
+      console.log(
+        `[mcp/approvals] auto-rejected ${result.expired} expired approval(s) (scanned ${result.scanned})`
+      );
+    }
+    return result;
   },
 });

--- a/convex/mcp/approvals.ts
+++ b/convex/mcp/approvals.ts
@@ -1,12 +1,7 @@
-import {
-  internalAction,
-  internalMutation,
-  internalQuery,
-  type MutationCtx,
-} from "../_generated/server";
+import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
-import type { Doc, Id } from "../_generated/dataModel";
+import { assertTraderOwnedByDesk } from "../traders";
 
 /**
  * Pending high-stakes approvals for the desk (MCP `get_pending_approvals`).
@@ -68,26 +63,6 @@ export const getPending = internalQuery({
   },
 });
 
-/**
- * Count remaining pending (non-expired) approvals for a desk at `now`.
- * Used by `answer_approval` to enrich the action's summary with portfolio
- * context (how many approvals still need attention after this decision).
- */
-async function countRemainingPendingApprovals(
-  ctx: MutationCtx,
-  deskManagerId: Id<"deskManagers">,
-  now: number
-): Promise<number> {
-  const rows = await ctx.db
-    .query("dealApprovals")
-    .withIndex("byDeskManagerAndStatus", (q) =>
-      q.eq("deskManagerId", deskManagerId).eq("status", "pending")
-    )
-    .filter((q) => q.gt(q.field("expiresAt"), now))
-    .take(51);
-  return rows.length;
-}
-
 export type McpAnswerApprovalResult = {
   approvalId: string;
   traderId: string;
@@ -97,19 +72,17 @@ export type McpAnswerApprovalResult = {
   summary: string;
 };
 
+function truncatePrompt(p: string): string {
+  return p.length <= 80 ? p : `${p.slice(0, 77)}…`;
+}
+
 /**
  * MCP `answer_approval`: approve or reject a pending high-stakes deal for an
- * owned trader. Ownership is enforced server-side; only the desk that owns
- * the trader (and the approval row) may answer it. Transitions only fire on
- * pending rows that have not yet expired; everything else is a no-op replay
- * that returns the current status.
- *
- * On approve, schedules an immediate trader cycle so the autonomous loop
- * picks the deal up without waiting for the next scheduler heartbeat.
- *
- * Summary includes the deal prompt snippet, trader name + escrow balance, and
- * remaining pending approval count so Claude can reason about portfolio change
- * from the action result alone.
+ * owned trader. On approve, schedules an immediate trader cycle so the entry
+ * doesn't wait for the next scheduler heartbeat (same as the web mutation in
+ * convex/dealApprovals.ts). Already-resolved or expired rows are no-op
+ * replays — the HTTP idempotency cache handles identical retries earlier;
+ * this path handles legitimate races (e.g. the cron expired it first).
  */
 export const answerForMcp = internalMutation({
   args: {
@@ -129,55 +102,45 @@ export const answerForMcp = internalMutation({
       throw new Error("Forbidden: approval belongs to another desk");
     }
 
-    const trader: Doc<"traders"> | null = await ctx.db.get(approval.traderId);
-    if (!trader || trader.deskManagerId !== deskManagerId) {
-      throw new Error("Forbidden: trader not owned by this desk");
-    }
+    const trader = await ctx.db.get(approval.traderId);
+    assertTraderOwnedByDesk(trader, deskManagerId);
 
     const deal = await ctx.db.get(approval.dealId);
-
-    const dealPromptSnippet = (() => {
-      const p = deal?.prompt ?? "";
-      if (p.length <= 80) return p;
-      return `${p.slice(0, 77)}…`;
-    })();
+    const dealPromptSnippet = truncatePrompt(deal?.prompt ?? "");
     const escrow = trader.escrowBalanceUsdc ?? 0;
 
-    // Replay-safe: if already resolved, return the current status without
-    // changing state. The HTTP idempotency cache layer will catch identical
-    // (deskId, idempotencyKey) replays earlier; this handles legitimate races
-    // where the approval was already finalized (e.g. expired by the cron).
+    const countRemaining = async () => {
+      const rows = await ctx.db
+        .query("dealApprovals")
+        .withIndex("byDeskManagerAndStatus", (q) =>
+          q.eq("deskManagerId", deskManagerId).eq("status", "pending")
+        )
+        .filter((q) => q.gt(q.field("expiresAt"), now))
+        .collect();
+      return rows.length;
+    };
+
+    const baseResult = {
+      approvalId: String(approvalId),
+      traderId: String(approval.traderId),
+      dealId: String(approval.dealId),
+    };
+
     if (approval.status !== "pending") {
-      const remaining = await countRemainingPendingApprovals(
-        ctx,
-        deskManagerId,
-        now
-      );
+      const remaining = await countRemaining();
       return {
-        approvalId: String(approvalId),
-        traderId: String(approval.traderId),
-        dealId: String(approval.dealId),
+        ...baseResult,
         status: "noop",
         remainingPendingApprovals: remaining,
         summary: `Approval for "${trader.name}" already ${approval.status} — no change. ${remaining} pending approval(s) remain on this desk.`,
       };
     }
 
-    // Pending but already expired → record expiry, treat as no-op for caller.
     if (approval.expiresAt <= now) {
-      await ctx.db.patch(approvalId, {
-        status: "expired",
-        resolvedAt: now,
-      });
-      const remaining = await countRemainingPendingApprovals(
-        ctx,
-        deskManagerId,
-        now
-      );
+      await ctx.db.patch(approvalId, { status: "expired", resolvedAt: now });
+      const remaining = await countRemaining();
       return {
-        approvalId: String(approvalId),
-        traderId: String(approval.traderId),
-        dealId: String(approval.dealId),
+        ...baseResult,
         status: "expired",
         remainingPendingApprovals: remaining,
         summary: `Approval for "${trader.name}" expired before you answered — the trader's cycle will pick a fresh deal on its next tick. ${remaining} pending approval(s) remain on this desk.`,
@@ -185,26 +148,15 @@ export const answerForMcp = internalMutation({
     }
 
     const newStatus = decision === "approve" ? "approved" : "rejected";
-    await ctx.db.patch(approvalId, {
-      status: newStatus,
-      resolvedAt: now,
-    });
+    await ctx.db.patch(approvalId, { status: newStatus, resolvedAt: now });
 
-    // On approve, kick the trader cycle immediately so the entry doesn't
-    // wait for the next scheduler heartbeat — same behaviour as the web
-    // mutation in convex/dealApprovals.ts.
     if (newStatus === "approved") {
       await ctx.scheduler.runAfter(0, internal.agent.cycle.cycle, {
         traderId: approval.traderId,
       });
     }
 
-    const remaining = await countRemainingPendingApprovals(
-      ctx,
-      deskManagerId,
-      now
-    );
-
+    const remaining = await countRemaining();
     const verb = newStatus === "approved" ? "Approved" : "Rejected";
     const tail =
       newStatus === "approved"
@@ -212,10 +164,8 @@ export const answerForMcp = internalMutation({
         : `Trader cycle will pick a different deal on its next tick. Escrow balance ${escrow.toFixed(2)} USDC; ${remaining} pending approval(s) remain.`;
 
     return {
-      approvalId: String(approvalId),
-      traderId: String(approval.traderId),
-      dealId: String(approval.dealId),
-      status: newStatus as "approved" | "rejected",
+      ...baseResult,
+      status: newStatus,
       remainingPendingApprovals: remaining,
       summary: `${verb} "${trader.name}" on deal: ${dealPromptSnippet || "(no prompt)"} (entry ${approval.entryCostUsdc.toFixed(2)} / pot ${approval.potUsdc.toFixed(2)} USDC). ${tail}`,
     };
@@ -223,55 +173,29 @@ export const answerForMcp = internalMutation({
 });
 
 /**
- * Internal: scan and auto-reject pending approvals past their TTL. Mutations
- * have transaction limits, so we cap the batch at 50 per invocation — the
- * cron tick rate (~5 min) keeps this comfortably ahead of normal load.
- * Returns the number of approvals expired so the cron logs are useful.
+ * Cron entrypoint: scan and auto-reject pending approvals past their TTL.
+ * Without this sweep an unanswered pending row blocks the trader cycle
+ * (see `findPendingByTraderAndDeal` in convex/dealApprovals.ts) indefinitely.
+ * Batch cap of 200 stays well within Convex mutation transaction limits.
  */
 export const autoRejectExpired = internalMutation({
-  args: { now: v.number(), limit: v.optional(v.number()) },
-  handler: async (ctx, { now, limit = 50 }) => {
-    const bounded = Math.min(Math.max(1, limit), 200);
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
     const rows = await ctx.db
       .query("dealApprovals")
       .withIndex("byStatus", (q) => q.eq("status", "pending"))
       .filter((q) => q.lte(q.field("expiresAt"), now))
-      .take(bounded);
+      .take(200);
 
-    let expired = 0;
     for (const row of rows) {
-      // Defensive: re-check status + expiry inside the batch.
-      if (row.status !== "pending") continue;
-      if (row.expiresAt > now) continue;
-      await ctx.db.patch(row._id, {
-        status: "expired",
-        resolvedAt: now,
-      });
-      expired += 1;
+      await ctx.db.patch(row._id, { status: "expired", resolvedAt: now });
     }
-    return { expired, scanned: rows.length };
-  },
-});
-
-/**
- * Internal action: cron entrypoint for auto-rejecting expired approvals.
- * Wrapping the mutation in an action lets us call Date.now() once outside
- * the transaction (Convex guideline: queries/mutations should not embed
- * non-deterministic time) and emits a single log line per tick.
- */
-export const autoRejectExpiredAction = internalAction({
-  args: {},
-  handler: async (ctx): Promise<{ expired: number; scanned: number }> => {
-    const now = Date.now();
-    const result: { expired: number; scanned: number } = await ctx.runMutation(
-      internal.mcp.approvals.autoRejectExpired,
-      { now }
-    );
-    if (result.expired > 0) {
+    if (rows.length > 0) {
       console.log(
-        `[mcp/approvals] auto-rejected ${result.expired} expired approval(s) (scanned ${result.scanned})`
+        `[mcp/approvals] auto-rejected ${rows.length} expired approval(s)`
       );
     }
-    return result;
+    return { expired: rows.length };
   },
 });

--- a/convex/mcp/traders.ts
+++ b/convex/mcp/traders.ts
@@ -143,9 +143,10 @@ export const configureForMcp = internalMutation({
     assertTraderOwnedByDesk(trader, args.deskManagerId);
     const patch = buildMandatePatch(trader, args.mandate, args.personality);
     await ctx.db.patch(args.traderId, patch);
+    const escrow = trader.escrowBalanceUsdc ?? 0;
     return {
       traderId: String(args.traderId),
-      summary: `Updated trader "${trader.name}" mandate and personality.`,
+      summary: `Updated trader "${trader.name}" mandate and personality (status ${trader.status}, escrow ${escrow.toFixed(2)} USDC). No on-chain change; takes effect on the next cycle.`,
     };
   },
 });
@@ -164,9 +165,10 @@ export const pauseForMcp = internalMutation({
       status: "paused",
       updatedAt: args.now,
     });
+    const escrow = trader.escrowBalanceUsdc ?? 0;
     return {
       traderId: String(args.traderId),
-      summary: `Paused trader "${trader.name}".`,
+      summary: `Paused trader "${trader.name}" — autonomous cycle will skip them. Escrow balance retained at ${escrow.toFixed(2)} USDC; resume_trader reactivates with no on-chain change.`,
     };
   },
 });
@@ -188,9 +190,11 @@ export const resumeForMcp = internalMutation({
         now: args.now,
       }
     );
+    const trader = await ctx.db.get(args.traderId);
+    const escrow = trader?.escrowBalanceUsdc ?? 0;
     return {
       traderId: String(args.traderId),
-      summary: `Resumed trader "${traderName}" — autonomous deal cycle will pick entries while the market is open.`,
+      summary: `Resumed trader "${traderName}" — autonomous deal cycle will pick entries while the market is open (escrow ${escrow.toFixed(2)} USDC available).`,
     };
   },
 });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,7 +4,7 @@
  *
  * Tools:
  *   get_desk, list_traders, list_deals, get_activity, get_outcomes,
- *   get_pending_approvals, sync_wallet, create_trader,
+ *   get_pending_approvals, answer_approval, sync_wallet, create_trader,
  *   configure_trader, fund_trader, resume_trader, pause_trader, withdraw_from_trader,
  *   register_withdraw_address, withdraw_to_address
  *
@@ -408,12 +408,46 @@ server.tool(
     })
 );
 
+server.tool(
+  "answer_approval",
+  "Approve or reject a pending high-stakes deal approval for one of your traders. Use after get_desk shows pendingApprovals.count > 0 (call get_pending_approvals to inspect prompt + remaining TTL). Ownership is enforced server-side. `approve` schedules an immediate trader cycle so the deal is entered without waiting for the next scheduler tick. `reject` lets the trader pick a different deal. Approvals not answered before their TTL are auto-rejected server-side; calling answer_approval on an already-resolved row returns the current status without mutating state. Requires stable idempotencyKey — same key within 24h replays the cached result. Response.summary includes trader name, deal prompt snippet, escrow balance, and the remaining pendingApprovals count so portfolio change is visible without another get_desk call.",
+  {
+    approvalId: z
+      .string()
+      .min(1)
+      .describe(
+        "Convex dealApprovals document id from get_pending_approvals.approvals[].approvalId"
+      ),
+    decision: z
+      .enum(["approve", "reject"])
+      .describe(
+        '"approve" to authorize the high-stakes deal entry; "reject" to skip it and free the trader to pick another deal'
+      ),
+    reason: z
+      .string()
+      .optional()
+      .describe("Optional free-text reason recorded in the audit log"),
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ approvalId, decision, reason, idempotencyKey }) =>
+    callMcpApi("/api/mcp/approvals/answer", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        approvalId,
+        decision,
+        reason,
+        idempotencyKey,
+      }),
+    })
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // Log to stderr only (stdio transport uses stdout for protocol)
   console.error(
-    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet,create_trader,configure_trader,fund_trader,resume_trader,pause_trader,withdraw_from_trader,register_withdraw_address,withdraw_to_address  (key last4=${API_KEY.slice(-4)})`
+    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,answer_approval,sync_wallet,create_trader,configure_trader,fund_trader,resume_trader,pause_trader,withdraw_from_trader,register_withdraw_address,withdraw_to_address  (key last4=${API_KEY.slice(-4)})`
   );
 }
 

--- a/src/app/api/mcp/approvals/answer/route.ts
+++ b/src/app/api/mcp/approvals/answer/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/approvals/answer
+ * MCP write: approve or reject a pending high-stakes deal approval for a
+ * trader owned by this desk. Ownership is enforced server-side. Requires
+ * `idempotencyKey`; the 24h MCP request cache replays identical retries
+ * without re-running the mutation.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "approvals/answer",
+    requireIdempotencyKey: true,
+  });
+}


### PR DESCRIPTION
Closes #143

## Summary

Implements the Phase 5 high-stakes approvals surface so Claude can run an approval loop entirely from MCP tools (`get_desk` → `get_pending_approvals` → `answer_approval` → trader resumes cycling).

## Changes

- **`answer_approval` MCP tool** — approve/reject pending `dealApprovals` for traders owned by this desk. Strict ownership check against both the approval row and the trader. Replay-safe on already-resolved rows (returns current status without mutating). On approve, schedules an immediate `internal.agent.cycle.cycle` so the deal is entered without waiting for the next scheduler heartbeat. Idempotency enforced via the existing 24h `mcpRequests` cache shell.
- **TTL auto-reject cron** — `internal.mcp.approvals.autoRejectExpiredAction` runs every 5 minutes (`crons.interval`) and batch-expires pending rows past `expiresAt`. Once a row flips to `expired`, the cycle's `findPendingByTraderAndDeal` filter (which requires `expiresAt > now`) returns null, letting the trader re-evaluate. Capped at 50 rows per tick to stay within mutation transaction limits.
- **`get_desk` enrichment** — already includes `pendingApprovals: { count, oldestAgeSeconds }` via `convex/mcp/desks.ts` when called through the standard HTTP route (which always passes `now`). No code change needed; confirmed via `convex/http.ts:178-182`.
- **Better write summaries** — `answer_approval`, `pause_trader`, `resume_trader`, and `configure_trader` now include trader escrow balance, status, and (for `answer_approval`) the remaining pending-approvals count and a deal-prompt snippet, so Claude can reason about portfolio change from action results without another `get_desk` round-trip.

## Test plan

- [ ] Provision an MCP desk + trader with an approval threshold; let the cycle create a pending approval; call `answer_approval` with `decision: "approve"` and verify the trader enters the deal on the next tick
- [ ] Call `answer_approval` with `decision: "reject"` and verify the trader picks a different deal next tick
- [ ] Re-call `answer_approval` with the same `idempotencyKey` and verify the cached result is returned (no second mutation)
- [ ] Re-call `answer_approval` on an already-resolved row (different key) and verify it returns `status: "noop"` with the current state
- [ ] Let an approval expire past `APPROVAL_EXPIRY_MS` without answering; verify the cron auto-rejects it and the trader resumes cycling
- [ ] Verify `get_desk` shows `pendingApprovals.count` matching `get_pending_approvals` for a desk with active pending rows
- [ ] Ownership: attempt `answer_approval` from a different desk's MCP key and verify the response is a 500 with the `Forbidden` error