### PR TITLE
feat(mcp): add create_deal and close_deal tools (Phase 4)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -38,6 +38,7 @@ import type * as marketNarratives from "../marketNarratives.js";
 import type * as mcp_activity from "../mcp/activity.js";
 import type * as mcp_approvals from "../mcp/approvals.js";
 import type * as mcp_deals from "../mcp/deals.js";
+import type * as mcp_dealsEscrow from "../mcp/dealsEscrow.js";
 import type * as mcp_desks from "../mcp/desks.js";
 import type * as mcp_httpHelpers from "../mcp/httpHelpers.js";
 import type * as mcp_outcomes from "../mcp/outcomes.js";
@@ -105,6 +106,7 @@ declare const fullApi: ApiFromModules<{
   "mcp/activity": typeof mcp_activity;
   "mcp/approvals": typeof mcp_approvals;
   "mcp/deals": typeof mcp_deals;
+  "mcp/dealsEscrow": typeof mcp_dealsEscrow;
   "mcp/desks": typeof mcp_desks;
   "mcp/httpHelpers": typeof mcp_httpHelpers;
   "mcp/outcomes": typeof mcp_outcomes;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -168,6 +168,58 @@ function parseWithdrawTraderBody(body: Record<string, unknown>) {
   return parseFundTraderBody(body);
 }
 
+function parseCreateDealBody(body: Record<string, unknown>) {
+  const base = parseMcpWriteBase(body);
+  if ("ok" in base) return base;
+  if (typeof body.prompt !== "string" || body.prompt.trim() === "") {
+    return { ok: false as const, message: "prompt required" };
+  }
+  const pot = Number(body.potUsdc);
+  if (!Number.isFinite(pot) || pot <= 0) {
+    return {
+      ok: false as const,
+      message: "potUsdc must be a positive number",
+    };
+  }
+  const entryCost = Number(body.entryCostUsdc);
+  if (!Number.isFinite(entryCost) || entryCost <= 0) {
+    return {
+      ok: false as const,
+      message: "entryCostUsdc must be a positive number",
+    };
+  }
+  if (entryCost > pot) {
+    return {
+      ok: false as const,
+      message: "entryCostUsdc must be <= potUsdc",
+    };
+  }
+  return {
+    ok: true as const,
+    parsed: {
+      deskManagerId: base.deskManagerId,
+      idempotencyKey: base.idempotencyKey,
+      requestBody: base.requestBody,
+    },
+  };
+}
+
+function parseCloseDealBody(body: Record<string, unknown>) {
+  const base = parseMcpWriteBase(body);
+  if ("ok" in base) return base;
+  if (typeof body.dealId !== "string" || body.dealId.trim() === "") {
+    return { ok: false as const, message: "dealId required" };
+  }
+  return {
+    ok: true as const,
+    parsed: {
+      deskManagerId: base.deskManagerId,
+      idempotencyKey: base.idempotencyKey,
+      requestBody: body,
+    },
+  };
+}
+
 http.route({
   path: "/mcp/desks/get",
   method: "POST",
@@ -510,6 +562,54 @@ http.route({
             deskManagerId,
             traderId: requestBody.traderId as Id<"traders">,
             amountUsdc: Number(requestBody.amountUsdc),
+          }
+        );
+        return { result, txHash: result.txHash };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/deals/create",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "create_deal",
+    parseBody: parseCreateDealBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const result = await ctx.runAction(
+          internal.mcp.dealsEscrow.createForMcp,
+          {
+            deskManagerId,
+            prompt: requestBody.prompt as string,
+            potUsdc: Number(requestBody.potUsdc),
+            entryCostUsdc: Number(requestBody.entryCostUsdc),
+          }
+        );
+        return { result, txHash: result.txHash };
+      } catch (e: unknown) {
+        return { error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+  }),
+});
+
+http.route({
+  path: "/mcp/deals/close",
+  method: "POST",
+  handler: mcpWriteRoute({
+    tool: "close_deal",
+    parseBody: parseCloseDealBody,
+    execute: async (ctx, { deskManagerId, requestBody }) => {
+      try {
+        const result = await ctx.runAction(
+          internal.mcp.dealsEscrow.closeForMcp,
+          {
+            deskManagerId,
+            dealId: requestBody.dealId as Id<"deals">,
           }
         );
         return { result, txHash: result.txHash };

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -215,7 +215,7 @@ function parseCloseDealBody(body: Record<string, unknown>) {
     parsed: {
       deskManagerId: base.deskManagerId,
       idempotencyKey: base.idempotencyKey,
-      requestBody: body,
+      requestBody: base.requestBody,
     },
   };
 }

--- a/convex/mcp/deals.ts
+++ b/convex/mcp/deals.ts
@@ -1,6 +1,6 @@
 import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
-import type { Doc, Id } from "../_generated/dataModel";
+import type { Id } from "../_generated/dataModel";
 
 export type McpDealWriteResult = {
   dealId: string;
@@ -126,29 +126,15 @@ export const recordOnChainCreationForMcp = internalMutation({
 });
 
 /**
- * MCP `close_deal` pre-flight: load a deal by Convex id and confirm it is
- * owned by this MCP desk and currently open. Returns the on-chain deal id
- * (required by the escrow `closeDeal(uint256)` call) and the desk wallet
- * address so the wrapping action can verify the CDP signer matches.
+ * MCP `close_deal` pre-flight: load + ownership-check a deal, returning the
+ * fields the wrapping action needs to sign and submit `escrow.closeDeal`.
  */
 export const loadOwnedDealForClose = internalQuery({
   args: {
     deskManagerId: v.id("deskManagers"),
     dealId: v.id("deals"),
   },
-  handler: async (
-    ctx,
-    { deskManagerId, dealId }
-  ): Promise<{
-    dealId: Id<"deals">;
-    onChainDealId: number;
-    walletAddress: string | undefined;
-    cdpAccountName: string | undefined;
-    subject: string;
-    status: Doc<"deals">["status"];
-    potUsdc: number;
-    entryCount: number;
-  }> => {
+  handler: async (ctx, { deskManagerId, dealId }) => {
     const deal = await ctx.db.get(dealId);
     if (!deal) throw new Error("Deal not found");
     if (deal.creatorDeskManagerId !== deskManagerId) {
@@ -165,14 +151,9 @@ export const loadOwnedDealForClose = internalQuery({
     if (!desk?.subject) throw new Error("Desk not found");
 
     return {
-      dealId: deal._id,
       onChainDealId: deal.onChainDealId,
       walletAddress: desk.walletAddress,
-      cdpAccountName: desk.cdpAccountName,
       subject: desk.subject,
-      status: deal.status,
-      potUsdc: deal.potUsdc,
-      entryCount: deal.entryCount ?? 0,
     };
   },
 });

--- a/convex/mcp/deals.ts
+++ b/convex/mcp/deals.ts
@@ -1,5 +1,14 @@
-import { internalQuery } from "../_generated/server";
+import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
+import type { Doc, Id } from "../_generated/dataModel";
+
+export type McpDealWriteResult = {
+  dealId: string;
+  onChainDealId?: number;
+  txHash?: string;
+  walletAddress?: string;
+  summary: string;
+};
 
 /**
  * Read-only list of open (or recent) deals for MCP `list_deals`.
@@ -49,5 +58,143 @@ export const list = internalQuery({
       deals: items,
       count: items.length,
     };
+  },
+});
+
+/**
+ * MCP `create_deal`: insert the Convex `deals` row for a deal already
+ * created on-chain by the MCP desk wallet. Idempotent on `onChainDealId`.
+ *
+ * Owner check: deskManagerId is supplied by the MCP HTTP layer after
+ * mc_live_* key validation, so this mutation only needs to verify the desk
+ * exists. The on-chain creator address is asserted to match the desk wallet
+ * inside the action that wraps this mutation.
+ */
+export const recordOnChainCreationForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    onChainDealId: v.number(),
+    onChainTxHash: v.string(),
+    prompt: v.string(),
+    potUsdc: v.number(),
+    entryCostUsdc: v.number(),
+  },
+  handler: async (ctx, args): Promise<McpDealWriteResult> => {
+    const desk = await ctx.db.get(args.deskManagerId);
+    if (!desk) throw new Error("Desk not found");
+
+    const existing = await ctx.db
+      .query("deals")
+      .withIndex("byOnChainDealId", (q) =>
+        q.eq("onChainDealId", args.onChainDealId)
+      )
+      .unique();
+    if (existing) {
+      return {
+        dealId: String(existing._id),
+        onChainDealId: existing.onChainDealId,
+        txHash: existing.onChainTxHash,
+        walletAddress: desk.walletAddress,
+        summary: `Deal #${existing.onChainDealId ?? "?"} already recorded (${existing.potUsdc.toFixed(2)} USDC pot, ${existing.entryCostUsdc.toFixed(2)} USDC entry cost).`,
+      };
+    }
+
+    const now = Date.now();
+    const newId: Id<"deals"> = await ctx.db.insert("deals", {
+      creatorDeskManagerId: args.deskManagerId,
+      creatorAddress: desk.walletAddress,
+      creatorType: "desk_manager",
+      prompt: args.prompt,
+      potUsdc: args.potUsdc,
+      entryCostUsdc: args.entryCostUsdc,
+      status: "open",
+      onChainDealId: args.onChainDealId,
+      onChainTxHash: args.onChainTxHash,
+      entryCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return {
+      dealId: String(newId),
+      onChainDealId: args.onChainDealId,
+      txHash: args.onChainTxHash,
+      walletAddress: desk.walletAddress,
+      summary: `Created an open deal with ${args.potUsdc.toFixed(2)} USDC pot and ${args.entryCostUsdc.toFixed(2)} USDC entry cost.`,
+    };
+  },
+});
+
+/**
+ * MCP `close_deal` pre-flight: load a deal by Convex id and confirm it is
+ * owned by this MCP desk and currently open. Returns the on-chain deal id
+ * (required by the escrow `closeDeal(uint256)` call) and the desk wallet
+ * address so the wrapping action can verify the CDP signer matches.
+ */
+export const loadOwnedDealForClose = internalQuery({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    dealId: v.id("deals"),
+  },
+  handler: async (
+    ctx,
+    { deskManagerId, dealId }
+  ): Promise<{
+    dealId: Id<"deals">;
+    onChainDealId: number;
+    walletAddress: string | undefined;
+    cdpAccountName: string | undefined;
+    subject: string;
+    status: Doc<"deals">["status"];
+    potUsdc: number;
+    entryCount: number;
+  }> => {
+    const deal = await ctx.db.get(dealId);
+    if (!deal) throw new Error("Deal not found");
+    if (deal.creatorDeskManagerId !== deskManagerId) {
+      throw new Error("Deal is not owned by this desk");
+    }
+    if (typeof deal.onChainDealId !== "number") {
+      throw new Error("Deal has no on-chain id (cannot close on escrow)");
+    }
+    if (deal.status !== "open") {
+      throw new Error(`Deal is already ${deal.status}`);
+    }
+
+    const desk = await ctx.db.get(deskManagerId);
+    if (!desk?.subject) throw new Error("Desk not found");
+
+    return {
+      dealId: deal._id,
+      onChainDealId: deal.onChainDealId,
+      walletAddress: desk.walletAddress,
+      cdpAccountName: desk.cdpAccountName,
+      subject: desk.subject,
+      status: deal.status,
+      potUsdc: deal.potUsdc,
+      entryCount: deal.entryCount ?? 0,
+    };
+  },
+});
+
+/**
+ * MCP `close_deal` post-tx: mark the Convex `deals` row as closed.
+ * Idempotent — if the row is already closed (e.g. via the web UI sync), this is
+ * a no-op. Re-verifies desk ownership defensively.
+ */
+export const markDealClosedForMcp = internalMutation({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    dealId: v.id("deals"),
+  },
+  handler: async (ctx, { deskManagerId, dealId }) => {
+    const deal = await ctx.db.get(dealId);
+    if (!deal) throw new Error("Deal not found");
+    if (deal.creatorDeskManagerId !== deskManagerId) {
+      throw new Error("Deal is not owned by this desk");
+    }
+    if (deal.status === "closed") return { alreadyClosed: true as const };
+    await ctx.db.patch(dealId, { status: "closed", updatedAt: Date.now() });
+    return { alreadyClosed: false as const };
   },
 });

--- a/convex/mcp/dealsEscrow.ts
+++ b/convex/mcp/dealsEscrow.ts
@@ -3,10 +3,10 @@
 import { internalAction } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
-import type { Doc, Id } from "../_generated/dataModel";
+import type { Doc } from "../_generated/dataModel";
 import { mcpDeskCdpAccountName, parseAmountUsdc } from "./traders";
 import type { McpDealWriteResult } from "./deals";
-import { isTradingHours, MARKET_CLOSED_MESSAGE } from "../lib/tradingHours";
+import { assertTradingHours } from "../lib/tradingHours";
 
 const USDC_DECIMALS = 1_000_000;
 
@@ -119,9 +119,7 @@ export const createForMcp = internalAction({
     entryCostUsdc: v.number(),
   },
   handler: async (ctx, args): Promise<McpDealWriteResult> => {
-    if (!isTradingHours()) {
-      throw new Error(MARKET_CLOSED_MESSAGE);
-    }
+    assertTradingHours();
 
     if (typeof args.prompt !== "string" || args.prompt.trim() === "") {
       throw new Error("prompt is required");
@@ -276,23 +274,15 @@ export const closeForMcp = internalAction({
     dealId: v.id("deals"),
   },
   handler: async (ctx, args): Promise<McpDealWriteResult> => {
-    if (!isTradingHours()) {
-      throw new Error(MARKET_CLOSED_MESSAGE);
-    }
+    assertTradingHours();
 
-    const loaded: {
-      dealId: Id<"deals">;
-      onChainDealId: number;
-      walletAddress: string | undefined;
-      cdpAccountName: string | undefined;
-      subject: string;
-      status: "open" | "closed" | "depleted";
-      potUsdc: number;
-      entryCount: number;
-    } = await ctx.runQuery(internal.mcp.deals.loadOwnedDealForClose, {
-      deskManagerId: args.deskManagerId,
-      dealId: args.dealId,
-    });
+    const loaded = await ctx.runQuery(
+      internal.mcp.deals.loadOwnedDealForClose,
+      {
+        deskManagerId: args.deskManagerId,
+        dealId: args.dealId,
+      }
+    );
 
     if (!loaded.walletAddress) {
       throw new Error("Desk wallet not provisioned");
@@ -326,24 +316,17 @@ export const closeForMcp = internalAction({
     });
 
     // Pre-flight: confirm the escrow agrees there are no pending entries.
-    const onChainDeal = (await publicClient.readContract({
+    const onChainDeal = await publicClient.readContract({
       address: ESCROW_ADDRESS,
       abi: escrowAbi,
       functionName: "getDeal",
       args: [BigInt(loaded.onChainDealId)],
-    })) as {
-      creator: `0x${string}`;
-      prompt: string;
-      potAmount: bigint;
-      entryCost: bigint;
-      fee: bigint;
-      status: number;
-      pendingEntries: bigint;
-    };
+    });
+    const pendingEntries = onChainDeal.pendingEntries;
 
-    if (onChainDeal.pendingEntries > BigInt(0)) {
+    if (pendingEntries > BigInt(0)) {
       throw new Error(
-        `Cannot close deal: ${onChainDeal.pendingEntries.toString()} pending entr${onChainDeal.pendingEntries === BigInt(1) ? "y" : "ies"} on-chain. Wait for the agent cycle to resolve them.`
+        `Cannot close deal: ${pendingEntries.toString()} pending entr${pendingEntries === BigInt(1) ? "y" : "ies"} on-chain. Wait for the agent cycle to resolve them.`
       );
     }
 

--- a/convex/mcp/dealsEscrow.ts
+++ b/convex/mcp/dealsEscrow.ts
@@ -1,0 +1,384 @@
+"use node";
+
+import { internalAction } from "../_generated/server";
+import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import type { Doc, Id } from "../_generated/dataModel";
+import { mcpDeskCdpAccountName, parseAmountUsdc } from "./traders";
+import type { McpDealWriteResult } from "./deals";
+import { isTradingHours, MARKET_CLOSED_MESSAGE } from "../lib/tradingHours";
+
+const USDC_DECIMALS = 1_000_000;
+
+/**
+ * Large allowance used when topping up the desk's USDC approval for the escrow
+ * at deal-creation time. See `tradersEscrow.ts` for the same rationale: making
+ * approve a one-time setup cost means subsequent create_deal calls only need
+ * the single createDeal tx.
+ */
+const LARGE_APPROVE_ALLOWANCE = BigInt(10_000_000) * BigInt(USDC_DECIMALS); // 10M USDC
+
+const ESCROW_ADDRESS = "0x8AA5768AC08755cd9AEf07892e6c40edD1B5a609" as const;
+const USDC_SEPOLIA_ADDRESS =
+  "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+
+const erc20Abi = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+const escrowAbi = [
+  {
+    type: "function",
+    name: "createDeal",
+    inputs: [
+      { name: "prompt", type: "string" },
+      { name: "potAmount", type: "uint256" },
+      { name: "entryCost", type: "uint256" },
+    ],
+    outputs: [{ name: "dealId", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "closeDeal",
+    inputs: [{ name: "dealId", type: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "getDeal",
+    inputs: [{ name: "dealId", type: "uint256" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          { name: "creator", type: "address" },
+          { name: "prompt", type: "string" },
+          { name: "potAmount", type: "uint256" },
+          { name: "entryCost", type: "uint256" },
+          { name: "fee", type: "uint256" },
+          { name: "status", type: "uint8" },
+          { name: "pendingEntries", type: "uint256" },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+  {
+    type: "event",
+    name: "DealCreated",
+    inputs: [
+      { name: "dealId", type: "uint256", indexed: true },
+      { name: "creator", type: "address", indexed: true },
+      { name: "prompt", type: "string", indexed: false },
+      { name: "pot", type: "uint256", indexed: false },
+      { name: "entryCost", type: "uint256", indexed: false },
+    ],
+  },
+] as const;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`Missing required Convex env var: ${name}`);
+  }
+  return value;
+}
+
+/**
+ * MCP `create_deal`: approve USDC if needed, call escrow `createDeal` from the
+ * MCP desk CDP wallet, decode the `DealCreated` event to extract the on-chain
+ * deal id, then record the open deal in Convex.
+ */
+export const createForMcp = internalAction({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    prompt: v.string(),
+    potUsdc: v.number(),
+    entryCostUsdc: v.number(),
+  },
+  handler: async (ctx, args): Promise<McpDealWriteResult> => {
+    if (!isTradingHours()) {
+      throw new Error(MARKET_CLOSED_MESSAGE);
+    }
+
+    if (typeof args.prompt !== "string" || args.prompt.trim() === "") {
+      throw new Error("prompt is required");
+    }
+
+    const potAtomic = parseAmountUsdc(args.potUsdc);
+    const entryCostAtomic = parseAmountUsdc(args.entryCostUsdc);
+    if (entryCostAtomic > potAtomic) {
+      throw new Error("entryCostUsdc must be <= potUsdc");
+    }
+
+    const dm: Doc<"deskManagers"> | null = await ctx.runQuery(
+      internal.deskManagers.getByIdInternal,
+      { id: args.deskManagerId }
+    );
+    if (!dm?.subject || !dm.walletAddress) {
+      throw new Error("Desk not found or wallet not provisioned");
+    }
+    if ((dm.walletBalanceUsdc ?? 0) < args.potUsdc) {
+      throw new Error(
+        "Insufficient desk wallet balance — sync_wallet after funding the desk"
+      );
+    }
+
+    const cdpApiKeyId = requireEnv("CDP_API_KEY_ID");
+    const cdpApiKeySecret = requireEnv("CDP_API_KEY_SECRET");
+    const cdpWalletSecret = requireEnv("CDP_WALLET_SECRET");
+
+    const { CdpClient } = await import("@coinbase/cdp-sdk");
+    const { encodeFunctionData, createPublicClient, http, decodeEventLog } =
+      await import("viem");
+    const { baseSepolia } = await import("viem/chains");
+
+    const cdp = new CdpClient({
+      apiKeyId: cdpApiKeyId,
+      apiKeySecret: cdpApiKeySecret,
+      walletSecret: cdpWalletSecret,
+    });
+
+    const accountName = mcpDeskCdpAccountName(dm.subject);
+    const deskAccount = await cdp.evm.getOrCreateAccount({ name: accountName });
+    const deskAddress = deskAccount.address as `0x${string}`;
+
+    if (deskAddress.toLowerCase() !== dm.walletAddress.toLowerCase()) {
+      throw new Error("Desk CDP wallet address mismatch — contact support");
+    }
+
+    const publicClient = createPublicClient({
+      chain: baseSepolia,
+      transport: http(),
+    });
+
+    // ── Allowance top-up (rare thanks to LARGE_APPROVE_ALLOWANCE) ─────────────
+    // Same rationale as fund_trader: a large one-time approve makes any later
+    // create_deal cheap (single createDeal tx). Idempotency on retries is
+    // enforced one level up by mcpWriteRoute.
+    const currentAllowance = (await publicClient.readContract({
+      address: USDC_SEPOLIA_ADDRESS,
+      abi: erc20Abi,
+      functionName: "allowance",
+      args: [deskAddress, ESCROW_ADDRESS],
+    })) as bigint;
+
+    if (currentAllowance < potAtomic) {
+      const approveData = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [ESCROW_ADDRESS, LARGE_APPROVE_ALLOWANCE],
+      });
+      const { transactionHash: approveHash } =
+        await deskAccount.sendTransaction({
+          transaction: {
+            to: USDC_SEPOLIA_ADDRESS,
+            value: BigInt(0),
+            data: approveData,
+          },
+          network: "base-sepolia",
+        });
+      await publicClient.waitForTransactionReceipt({
+        hash: approveHash as `0x${string}`,
+      });
+    }
+
+    // ── escrow.createDeal ────────────────────────────────────────────────────
+    const createData = encodeFunctionData({
+      abi: escrowAbi,
+      functionName: "createDeal",
+      args: [args.prompt, potAtomic, entryCostAtomic],
+    });
+    const { transactionHash: createHash } = await deskAccount.sendTransaction({
+      transaction: {
+        to: ESCROW_ADDRESS,
+        value: BigInt(0),
+        data: createData,
+      },
+      network: "base-sepolia",
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: createHash as `0x${string}`,
+      confirmations: 2,
+    });
+    if (receipt.status === "reverted") {
+      throw new Error("escrow.createDeal reverted");
+    }
+
+    let onChainDealId: number | undefined;
+    for (const log of receipt.logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: escrowAbi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "DealCreated") {
+          onChainDealId = Number((decoded.args as { dealId: bigint }).dealId);
+          break;
+        }
+      } catch {
+        // not our event
+      }
+    }
+    if (onChainDealId === undefined) {
+      throw new Error(
+        "createDeal succeeded but DealCreated event was not found in tx logs"
+      );
+    }
+
+    const recorded: McpDealWriteResult = await ctx.runMutation(
+      internal.mcp.deals.recordOnChainCreationForMcp,
+      {
+        deskManagerId: args.deskManagerId,
+        onChainDealId,
+        onChainTxHash: createHash,
+        prompt: args.prompt,
+        potUsdc: args.potUsdc,
+        entryCostUsdc: args.entryCostUsdc,
+      }
+    );
+
+    return recorded;
+  },
+});
+
+/**
+ * MCP `close_deal`: verify the deal is owned by this MCP desk and currently
+ * open with zero pending entries on-chain, call escrow `closeDeal`, then mark
+ * the Convex `deals` row as closed.
+ */
+export const closeForMcp = internalAction({
+  args: {
+    deskManagerId: v.id("deskManagers"),
+    dealId: v.id("deals"),
+  },
+  handler: async (ctx, args): Promise<McpDealWriteResult> => {
+    if (!isTradingHours()) {
+      throw new Error(MARKET_CLOSED_MESSAGE);
+    }
+
+    const loaded: {
+      dealId: Id<"deals">;
+      onChainDealId: number;
+      walletAddress: string | undefined;
+      cdpAccountName: string | undefined;
+      subject: string;
+      status: "open" | "closed" | "depleted";
+      potUsdc: number;
+      entryCount: number;
+    } = await ctx.runQuery(internal.mcp.deals.loadOwnedDealForClose, {
+      deskManagerId: args.deskManagerId,
+      dealId: args.dealId,
+    });
+
+    if (!loaded.walletAddress) {
+      throw new Error("Desk wallet not provisioned");
+    }
+
+    const cdpApiKeyId = requireEnv("CDP_API_KEY_ID");
+    const cdpApiKeySecret = requireEnv("CDP_API_KEY_SECRET");
+    const cdpWalletSecret = requireEnv("CDP_WALLET_SECRET");
+
+    const { CdpClient } = await import("@coinbase/cdp-sdk");
+    const { encodeFunctionData, createPublicClient, http } =
+      await import("viem");
+    const { baseSepolia } = await import("viem/chains");
+
+    const cdp = new CdpClient({
+      apiKeyId: cdpApiKeyId,
+      apiKeySecret: cdpApiKeySecret,
+      walletSecret: cdpWalletSecret,
+    });
+
+    const accountName = mcpDeskCdpAccountName(loaded.subject);
+    const deskAccount = await cdp.evm.getOrCreateAccount({ name: accountName });
+    const deskAddress = deskAccount.address as `0x${string}`;
+    if (deskAddress.toLowerCase() !== loaded.walletAddress.toLowerCase()) {
+      throw new Error("Desk CDP wallet address mismatch — contact support");
+    }
+
+    const publicClient = createPublicClient({
+      chain: baseSepolia,
+      transport: http(),
+    });
+
+    // Pre-flight: confirm the escrow agrees there are no pending entries.
+    const onChainDeal = (await publicClient.readContract({
+      address: ESCROW_ADDRESS,
+      abi: escrowAbi,
+      functionName: "getDeal",
+      args: [BigInt(loaded.onChainDealId)],
+    })) as {
+      creator: `0x${string}`;
+      prompt: string;
+      potAmount: bigint;
+      entryCost: bigint;
+      fee: bigint;
+      status: number;
+      pendingEntries: bigint;
+    };
+
+    if (onChainDeal.pendingEntries > BigInt(0)) {
+      throw new Error(
+        `Cannot close deal: ${onChainDeal.pendingEntries.toString()} pending entr${onChainDeal.pendingEntries === BigInt(1) ? "y" : "ies"} on-chain. Wait for the agent cycle to resolve them.`
+      );
+    }
+
+    const closeData = encodeFunctionData({
+      abi: escrowAbi,
+      functionName: "closeDeal",
+      args: [BigInt(loaded.onChainDealId)],
+    });
+    const { transactionHash } = await deskAccount.sendTransaction({
+      transaction: {
+        to: ESCROW_ADDRESS,
+        value: BigInt(0),
+        data: closeData,
+      },
+      network: "base-sepolia",
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: transactionHash as `0x${string}`,
+      confirmations: 2,
+    });
+    if (receipt.status === "reverted") {
+      throw new Error("escrow.closeDeal reverted");
+    }
+
+    await ctx.runMutation(internal.mcp.deals.markDealClosedForMcp, {
+      deskManagerId: args.deskManagerId,
+      dealId: args.dealId,
+    });
+
+    return {
+      dealId: String(args.dealId),
+      onChainDealId: loaded.onChainDealId,
+      txHash: transactionHash,
+      walletAddress: loaded.walletAddress,
+      summary: `Closed deal #${loaded.onChainDealId}. Remaining pot returned to desk wallet — call sync_wallet to refresh balance.`,
+    };
+  },
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,7 +6,8 @@
  *   get_desk, list_traders, list_deals, get_activity, get_outcomes,
  *   get_pending_approvals, sync_wallet, create_trader,
  *   configure_trader, fund_trader, resume_trader, pause_trader, withdraw_from_trader,
- *   register_withdraw_address, withdraw_to_address
+ *   register_withdraw_address, withdraw_to_address,
+ *   create_deal, close_deal
  *
  * Each MCP key maps 1:1 to a dedicated desk with subject `mcp:cdp-wallet:<id>`
  * and its own CDP server wallet (provisioned at key issuance).
@@ -408,12 +409,62 @@ server.tool(
     })
 );
 
+server.tool(
+  "create_deal",
+  "Create a NEW market deal as a trap for rival desks, signed and submitted by this MCP desk's CDP wallet. Performs: USDC.approve (rare after first call thanks to large allowance) + escrow.createDeal + Convex record. Expect ~3–10s wall time. The desk's traders are blocked from entering this deal (own-desk rule) — both in selection and at recordVerifiedEntry. Requires the market to be open (9:30–16:00 ET, weekdays); errors explicitly when closed. Prerequisites: synced desk wallet balance >= potUsdc. REQUIRED: stable idempotencyKey — reusing the same key within 24h returns the cached result without re-submitting on-chain txs; generate a *fresh* key to intentionally create another deal. Returns Convex deal id, on-chain deal id, tx hash, walletAddress, and summary.",
+  {
+    prompt: z
+      .string()
+      .min(1)
+      .describe(
+        "Deal prompt (the headline/scenario the LLM uses to resolve outcomes)"
+      ),
+    potUsdc: z
+      .number()
+      .positive()
+      .describe(
+        "Total USDC pot funded from the desk wallet (human units, e.g. 100 for $100)"
+      ),
+    entryCostUsdc: z
+      .number()
+      .positive()
+      .describe(
+        "Cost per trader entry in USDC (human units). Must be <= potUsdc."
+      ),
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ prompt, potUsdc, entryCostUsdc, idempotencyKey }) =>
+    callMcpApi("/api/mcp/deals/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt, potUsdc, entryCostUsdc, idempotencyKey }),
+    })
+);
+
+server.tool(
+  "close_deal",
+  "Close an MCP-desk-owned open deal via escrow.closeDeal from the desk CDP wallet, returning any remaining pot to the desk wallet. Refuses to close if the on-chain deal still has pending entries (the autonomous cycle is mid-resolution); wait for those to resolve and retry. Refuses to close deals not owned by this desk. Requires the market to be open. Slow on-chain operation (~3–10s). Supply stable idempotencyKey. Call sync_wallet after success to refresh the desk balance.",
+  {
+    dealId: z
+      .string()
+      .min(1)
+      .describe("Convex deal id (from list_deals or create_deal)"),
+    idempotencyKey: idempotencyKeySchema,
+  },
+  async ({ dealId, idempotencyKey }) =>
+    callMcpApi("/api/mcp/deals/close", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ dealId, idempotencyKey }),
+    })
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   // Log to stderr only (stdio transport uses stdout for protocol)
   console.error(
-    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet,create_trader,configure_trader,fund_trader,resume_trader,pause_trader,withdraw_from_trader,register_withdraw_address,withdraw_to_address  (key last4=${API_KEY.slice(-4)})`
+    `[margin-call-mcp] MCP tools ready. API=${API_URL}  Tools: get_desk,list_traders,list_deals,get_activity,get_outcomes,get_pending_approvals,sync_wallet,create_trader,configure_trader,fund_trader,resume_trader,pause_trader,withdraw_from_trader,register_withdraw_address,withdraw_to_address,create_deal,close_deal  (key last4=${API_KEY.slice(-4)})`
   );
 }
 

--- a/src/app/api/mcp/deals/close/route.ts
+++ b/src/app/api/mcp/deals/close/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/deals/close
+ * MCP write: close an MCP-desk-owned deal via the desk CDP wallet, then mark
+ * the Convex row closed. Rejects when on-chain pending entries > 0.
+ * Body: dealId, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "deals/close",
+    requireIdempotencyKey: true,
+  });
+}

--- a/src/app/api/mcp/deals/create/route.ts
+++ b/src/app/api/mcp/deals/create/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+import { proxyMcpWrite } from "@/lib/mcp/proxy";
+
+/**
+ * POST /api/mcp/deals/create
+ * MCP write: approve USDC if needed + escrow createDeal via desk CDP wallet,
+ * then record the on-chain deal in Convex.
+ * Body: prompt, potUsdc, entryCostUsdc, idempotencyKey.
+ */
+export async function POST(request: NextRequest) {
+  return proxyMcpWrite(request, {
+    convexAction: "deals/create",
+    requireIdempotencyKey: true,
+  });
+}


### PR DESCRIPTION
Closes #142

## Summary

Adds the two MCP write tools for Phase 4 of the Margin Call MCP plan, letting Claude Code create trap deals for rival desks and close owned deals from the terminal — both signed by the MCP desk's CDP wallet.

### `create_deal`
- USDC.approve (large allowance — rare after first call) + escrow `createDeal` from the MCP desk CDP wallet.
- Decodes `DealCreated` to extract the on-chain deal id.
- Inserts a Convex `deals` row with `creatorDeskManagerId = <MCP desk>` and `creatorType: "desk_manager"`.
- Idempotent on `onChainDealId` at the record step; idempotent on `idempotencyKey` (24h cache) at the HTTP layer.
- Returns `{ dealId, onChainDealId, txHash, walletAddress, summary }`.

### `close_deal`
- Refuses to close non-owned deals (`creatorDeskManagerId !== deskManagerId`) and non-open deals.
- Reads `getDeal` on-chain and refuses if `pendingEntries > 0`.
- Calls escrow `closeDeal` from the desk CDP wallet, then patches the Convex row to `status: "closed"`.
- Returns `{ dealId, onChainDealId, txHash, walletAddress, summary }`.

### Safety / spec alignment
- Both tools explicitly error when the market is closed.
- Both writes require `idempotencyKey` and flow through `mcpWriteRoute`, which already implements the 24h replay cache + `mcpRequests` audit log used by every other MCP write.
- Own-desk entry blocking was already in place — verified in `convex/agent/dealSelection.ts` (via `isOwnDeskCreatedDeal`) and `convex/deals.recordVerifiedEntry`. MCP-owned traders cannot enter MCP-created deals by the same desk, and own-desk blocking covers MCP↔MCP, web↔web, and the cross combinations.

### Files changed
- `convex/_generated/api.d.ts` — registered new `mcp/dealsEscrow` module (manual edit; codegen normally does this).
- `convex/http.ts` — added `/mcp/deals/create` and `/mcp/deals/close` routes via `mcpWriteRoute`.
- `convex/mcp/deals.ts` — added `recordOnChainCreationForMcp`, `loadOwnedDealForClose`, `markDealClosedForMcp` and the shared `McpDealWriteResult` type.
- `convex/mcp/dealsEscrow.ts` — new Node action file with `createForMcp` + `closeForMcp` (mirrors `tradersEscrow.ts`).
- `packages/mcp-server/src/index.ts` — registered `create_deal` and `close_deal` tools (appended; no existing entries reordered to minimize merge conflict with #143).
- `src/app/api/mcp/deals/create/route.ts` and `src/app/api/mcp/deals/close/route.ts` — thin proxy routes.

## Test plan
- [ ] `pnpm lint` — passes (no new errors beyond the 5 pre-existing in `convex/mcp/desks.ts` + `src/components/mcp-operator-dialog.tsx` owned by issue #143).
- [ ] `pnpm build` — passes (Next.js build emits both `/api/mcp/deals/create` and `/api/mcp/deals/close` server routes).
- [ ] Manual end-to-end against a funded MCP desk on Base Sepolia: `create_deal` → `list_deals` → resolve a trader entry (autonomous cycle) → `close_deal` after pending entries clear.
- [ ] Confirm own-desk blocking: MCP desk creates a deal; one of the same desk's traders is excluded in selection (`dealSelection.ts`) and `recordVerifiedEntry` rejects with `"Trader cannot enter deals created by its own desk."`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)