### PR TITLE
PR-A: MCP safety rails (per-action caps, tx simulation, rate limits)

### DIFF
--- a/convex/mcp/dealsEscrow.ts
+++ b/convex/mcp/dealsEscrow.ts
@@ -7,6 +7,12 @@ import type { Doc } from "../_generated/dataModel";
 import { mcpDeskCdpAccountName, parseAmountUsdc } from "./traders";
 import type { McpDealWriteResult } from "./deals";
 import { assertTradingHours } from "../lib/tradingHours";
+import { assertPerActionCap } from "./limits";
+import {
+  simulateUsdcApprove,
+  simulateEscrowCreateDeal,
+  simulateEscrowCloseDeal,
+} from "./simulate";
 
 const USDC_DECIMALS = 1_000_000;
 
@@ -125,6 +131,13 @@ export const createForMcp = internalAction({
       throw new Error("prompt is required");
     }
 
+    await assertPerActionCap(
+      ctx,
+      args.deskManagerId,
+      "create_deal",
+      args.potUsdc
+    );
+
     const potAtomic = parseAmountUsdc(args.potUsdc);
     const entryCostAtomic = parseAmountUsdc(args.entryCostUsdc);
     if (entryCostAtomic > potAtomic) {
@@ -184,6 +197,13 @@ export const createForMcp = internalAction({
     })) as bigint;
 
     if (currentAllowance < potAtomic) {
+      await simulateUsdcApprove(
+        publicClient,
+        USDC_SEPOLIA_ADDRESS,
+        deskAddress,
+        ESCROW_ADDRESS,
+        LARGE_APPROVE_ALLOWANCE
+      );
       const approveData = encodeFunctionData({
         abi: erc20Abi,
         functionName: "approve",
@@ -204,6 +224,18 @@ export const createForMcp = internalAction({
     }
 
     // ── escrow.createDeal ────────────────────────────────────────────────────
+    // Pre-flight: simulate the createDeal call against the desk wallet.
+    // Surfaces escrow reverts (insufficient allowance, paused, bad params)
+    // before any tx is submitted.
+    await simulateEscrowCreateDeal(
+      publicClient,
+      ESCROW_ADDRESS,
+      deskAddress,
+      args.prompt,
+      potAtomic,
+      entryCostAtomic
+    );
+
     const createData = encodeFunctionData({
       abi: escrowAbi,
       functionName: "createDeal",
@@ -329,6 +361,14 @@ export const closeForMcp = internalAction({
         `Cannot close deal: ${pendingEntries.toString()} pending entr${pendingEntries === BigInt(1) ? "y" : "ies"} on-chain. Wait for the agent cycle to resolve them.`
       );
     }
+
+    // Pre-flight: simulate the escrow.closeDeal call before submitting.
+    await simulateEscrowCloseDeal(
+      publicClient,
+      ESCROW_ADDRESS,
+      deskAddress,
+      BigInt(loaded.onChainDealId)
+    );
 
     const closeData = encodeFunctionData({
       abi: escrowAbi,

--- a/convex/mcp/dealsEscrow.ts
+++ b/convex/mcp/dealsEscrow.ts
@@ -224,9 +224,6 @@ export const createForMcp = internalAction({
     }
 
     // ── escrow.createDeal ────────────────────────────────────────────────────
-    // Pre-flight: simulate the createDeal call against the desk wallet.
-    // Surfaces escrow reverts (insufficient allowance, paused, bad params)
-    // before any tx is submitted.
     await simulateEscrowCreateDeal(
       publicClient,
       ESCROW_ADDRESS,
@@ -362,7 +359,6 @@ export const closeForMcp = internalAction({
       );
     }
 
-    // Pre-flight: simulate the escrow.closeDeal call before submitting.
     await simulateEscrowCloseDeal(
       publicClient,
       ESCROW_ADDRESS,

--- a/convex/mcp/desks.ts
+++ b/convex/mcp/desks.ts
@@ -5,6 +5,8 @@ import {
 } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
+import { assertPerActionCap } from "./limits";
+import { simulateUsdcTransfer } from "./simulate";
 
 /**
  * Read-only desk snapshot for MCP get_desk. Called from the mcp/* HTTP action
@@ -248,6 +250,13 @@ export const withdrawToAddress = internalAction({
     ctx: any,
     { deskManagerId, address, amountUsdc }: any
   ): Promise<WithdrawToAddressResult> => {
+    await assertPerActionCap(
+      ctx,
+      deskManagerId,
+      "withdraw_to_address",
+      amountUsdc
+    );
+
     const desk = await ctx.runQuery(internal.deskManagers.getByIdInternal, {
       id: deskManagerId,
     });
@@ -314,6 +323,26 @@ export const withdrawToAddress = internalAction({
 
     // amount in USDC smallest units (6 decimals)
     const amountUnits = BigInt(Math.floor(amountUsdc * 1_000_000));
+
+    // Pre-flight: simulate the USDC transfer against the desk wallet. Catches
+    // insufficient balance / paused USDC / blacklisted recipient *before*
+    // any user-op is submitted; the revert reason is surfaced as a clear
+    // error and cached under the idempotency key by mcpWriteRoute.
+    const { createPublicClient, http } = await import("viem");
+    const { baseSepolia } = await import("viem/chains");
+    const publicClient = createPublicClient({
+      chain: baseSepolia,
+      transport: http(),
+    });
+    const USDC_SEPOLIA_ADDRESS =
+      "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+    await simulateUsdcTransfer(
+      publicClient,
+      USDC_SEPOLIA_ADDRESS,
+      account.address as `0x${string}`,
+      normDest as `0x${string}`,
+      amountUnits
+    );
 
     const { transactionHash } = await account.transfer({
       to: normDest as `0x${string}`,

--- a/convex/mcp/desks.ts
+++ b/convex/mcp/desks.ts
@@ -324,10 +324,6 @@ export const withdrawToAddress = internalAction({
     // amount in USDC smallest units (6 decimals)
     const amountUnits = BigInt(Math.floor(amountUsdc * 1_000_000));
 
-    // Pre-flight: simulate the USDC transfer against the desk wallet. Catches
-    // insufficient balance / paused USDC / blacklisted recipient *before*
-    // any user-op is submitted; the revert reason is surfaced as a clear
-    // error and cached under the idempotency key by mcpWriteRoute.
     const { createPublicClient, http } = await import("viem");
     const { baseSepolia } = await import("viem/chains");
     const publicClient = createPublicClient({

--- a/convex/mcp/limits.ts
+++ b/convex/mcp/limits.ts
@@ -1,0 +1,59 @@
+import type { ActionCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+
+/**
+ * Default per-action USDC ceiling when a desk has not set `perActionCapUsdc`.
+ * Daily caps remain the cumulative ceiling; per-action is the single-tx
+ * ceiling that protects against a single runaway prompt from Claude.
+ */
+export const DEFAULT_PER_ACTION_CAP_USDC = 500;
+
+/**
+ * Resolve the per-action USDC cap for a tool on a given desk. Honors the
+ * optional `perToolCapUsdc` override map first, then `perActionCapUsdc`,
+ * then `DEFAULT_PER_ACTION_CAP_USDC`.
+ */
+export function resolvePerActionCapUsdc(
+  desk: {
+    perActionCapUsdc?: number;
+    perToolCapUsdc?: unknown;
+  } | null,
+  tool: string
+): number {
+  if (!desk) return DEFAULT_PER_ACTION_CAP_USDC;
+  const overrides =
+    desk.perToolCapUsdc && typeof desk.perToolCapUsdc === "object"
+      ? (desk.perToolCapUsdc as Record<string, unknown>)
+      : undefined;
+  const override = overrides?.[tool];
+  if (typeof override === "number" && override > 0) return override;
+  if (typeof desk.perActionCapUsdc === "number" && desk.perActionCapUsdc > 0) {
+    return desk.perActionCapUsdc;
+  }
+  return DEFAULT_PER_ACTION_CAP_USDC;
+}
+
+/**
+ * Enforce the per-action USDC cap for an MCP write tool. Throws when
+ * exceeded; the caller (mcpWriteRoute) catches and surfaces as a cached
+ * error under the idempotency key so retries with the same key return
+ * the same error message.
+ */
+export async function assertPerActionCap(
+  ctx: ActionCtx,
+  deskManagerId: Id<"deskManagers">,
+  tool: string,
+  usdcAmount: number
+): Promise<void> {
+  if (!Number.isFinite(usdcAmount) || usdcAmount <= 0) return;
+  const desk = await ctx.runQuery(internal.deskManagers.getByIdInternal, {
+    id: deskManagerId,
+  });
+  const cap = resolvePerActionCapUsdc(desk, tool);
+  if (usdcAmount > cap) {
+    throw new Error(
+      `Per-action cap exceeded for ${tool}: ${usdcAmount.toFixed(2)} USDC > ${cap.toFixed(2)} USDC. Adjust perActionCapUsdc / perToolCapUsdc on this desk to raise the ceiling.`
+    );
+  }
+}

--- a/convex/mcp/requests.ts
+++ b/convex/mcp/requests.ts
@@ -1,6 +1,19 @@
 import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
 
+/**
+ * MCP audit log helpers. The `mcpRequests` table doubles as both:
+ *
+ *   1. A durable audit log (every read + write logged, never purged).
+ *   2. The 24h idempotency replay cache (write tools only).
+ *
+ * The 24h replay window is enforced **purely by the `minCreatedAt` filter in
+ * `findRecentByKey`** — the caller in `mcpWriteRoute` passes `now - 24h`.
+ * There is intentionally NO cleanup cron: rows older than 24h are simply
+ * invisible to the replay query but remain available for operator audit /
+ * forensics indefinitely. This is by design.
+ */
+
 /** For HTTP write idempotency: latest matching audit row within the TTL window. */
 export const findRecentByKey = internalQuery({
   args: {

--- a/convex/mcp/simulate.ts
+++ b/convex/mcp/simulate.ts
@@ -1,0 +1,227 @@
+/**
+ * Pre-flight viem `simulateContract` wrappers for every on-chain write the MCP
+ * surface performs. Each helper simulates the underlying call against the desk
+ * CDP smart-account address (`account`) and surfaces revert reasons up the
+ * stack as a clear `Error("simulation reverted: ...")`. The caller (always an
+ * `internalAction` wrapped by `mcpWriteRoute`) turns the throw into a cached
+ * error under the idempotency key — i.e. a retry with the same key returns the
+ * same human-readable reason without re-attempting the on-chain submission.
+ *
+ * Why simulate?
+ *   - Catches >90% of failure modes (insufficient USDC, allowlist mismatch,
+ *     escrow status, paused contract) before any user-op is submitted.
+ *   - Free and fast (single RPC call vs a full user-op submission).
+ *   - Gas estimation is intentionally left to CDP — sponsored gas on Base
+ *     Sepolia means estimation is best handled by the bundler, not this layer.
+ *
+ * Smart-account note: viem's `simulateContract` runs against `account` (the
+ * desk wallet). For ERC-4337 user-ops the underlying call is the same call
+ * the bundler will execute, so a successful simulate is a strong signal that
+ * the user-op will succeed (modulo gas/paymaster issues handled by CDP).
+ */
+
+import type { Abi } from "viem";
+
+/**
+ * Structural shape of the only viem PublicClient method we use. Avoids
+ * pulling in the strict `PublicClient` generic instantiation (which causes
+ * incompatibility across callers that construct clients with different
+ * transport/chain combos).
+ */
+type SimClient = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  simulateContract: (args: any) => Promise<unknown>;
+};
+
+const erc20Abi = [
+  {
+    type: "function",
+    name: "transfer",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const satisfies Abi;
+
+const escrowAbi = [
+  {
+    type: "function",
+    name: "depositFor",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "createDeal",
+    inputs: [
+      { name: "prompt", type: "string" },
+      { name: "potAmount", type: "uint256" },
+      { name: "entryCost", type: "uint256" },
+    ],
+    outputs: [{ name: "dealId", type: "uint256" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "closeDeal",
+    inputs: [{ name: "dealId", type: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+] as const satisfies Abi;
+
+async function runSimulation<T>(
+  label: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    // Lazy-import the viem error class so this file stays cheap to load.
+    const viem = await import("viem");
+    const short =
+      err instanceof viem.ContractFunctionRevertedError
+        ? (err.shortMessage ?? err.message)
+        : err instanceof viem.BaseError
+          ? err.shortMessage
+          : err instanceof Error
+            ? err.message
+            : String(err);
+    throw new Error(`simulation reverted: ${label}: ${short}`);
+  }
+}
+
+export async function simulateUsdcTransfer(
+  publicClient: SimClient,
+  usdcAddress: `0x${string}`,
+  account: `0x${string}`,
+  to: `0x${string}`,
+  amountAtomic: bigint
+): Promise<void> {
+  await runSimulation("USDC.transfer", () =>
+    publicClient.simulateContract({
+      address: usdcAddress,
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [to, amountAtomic],
+      account,
+    })
+  );
+}
+
+export async function simulateUsdcApprove(
+  publicClient: SimClient,
+  usdcAddress: `0x${string}`,
+  account: `0x${string}`,
+  spender: `0x${string}`,
+  amountAtomic: bigint
+): Promise<void> {
+  await runSimulation("USDC.approve", () =>
+    publicClient.simulateContract({
+      address: usdcAddress,
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [spender, amountAtomic],
+      account,
+    })
+  );
+}
+
+export async function simulateEscrowDepositFor(
+  publicClient: SimClient,
+  escrowAddress: `0x${string}`,
+  account: `0x${string}`,
+  traderId: bigint,
+  amountAtomic: bigint
+): Promise<void> {
+  await runSimulation("escrow.depositFor", () =>
+    publicClient.simulateContract({
+      address: escrowAddress,
+      abi: escrowAbi,
+      functionName: "depositFor",
+      args: [traderId, amountAtomic],
+      account,
+    })
+  );
+}
+
+export async function simulateEscrowTraderWithdraw(
+  publicClient: SimClient,
+  escrowAddress: `0x${string}`,
+  account: `0x${string}`,
+  traderId: bigint,
+  amountAtomic: bigint
+): Promise<void> {
+  await runSimulation("escrow.withdraw", () =>
+    publicClient.simulateContract({
+      address: escrowAddress,
+      abi: escrowAbi,
+      functionName: "withdraw",
+      args: [traderId, amountAtomic],
+      account,
+    })
+  );
+}
+
+export async function simulateEscrowCreateDeal(
+  publicClient: SimClient,
+  escrowAddress: `0x${string}`,
+  account: `0x${string}`,
+  prompt: string,
+  potAtomic: bigint,
+  entryCostAtomic: bigint
+): Promise<void> {
+  await runSimulation("escrow.createDeal", () =>
+    publicClient.simulateContract({
+      address: escrowAddress,
+      abi: escrowAbi,
+      functionName: "createDeal",
+      args: [prompt, potAtomic, entryCostAtomic],
+      account,
+    })
+  );
+}
+
+export async function simulateEscrowCloseDeal(
+  publicClient: SimClient,
+  escrowAddress: `0x${string}`,
+  account: `0x${string}`,
+  dealId: bigint
+): Promise<void> {
+  await runSimulation("escrow.closeDeal", () =>
+    publicClient.simulateContract({
+      address: escrowAddress,
+      abi: escrowAbi,
+      functionName: "closeDeal",
+      args: [dealId],
+      account,
+    })
+  );
+}

--- a/convex/mcp/simulate.ts
+++ b/convex/mcp/simulate.ts
@@ -28,7 +28,7 @@ import type { Abi } from "viem";
  * incompatibility across callers that construct clients with different
  * transport/chain combos).
  */
-type SimClient = {
+export type SimClient = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   simulateContract: (args: any) => Promise<unknown>;
 };
@@ -97,12 +97,25 @@ const escrowAbi = [
   },
 ] as const satisfies Abi;
 
-async function runSimulation<T>(
+async function simulate(
+  client: SimClient,
   label: string,
-  fn: () => Promise<T>
-): Promise<T> {
+  address: `0x${string}`,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  abi: any,
+  functionName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: any[],
+  account: `0x${string}`
+): Promise<void> {
   try {
-    return await fn();
+    await client.simulateContract({
+      address,
+      abi,
+      functionName,
+      args,
+      account,
+    });
   } catch (err) {
     // Lazy-import the viem error class so this file stays cheap to load.
     const viem = await import("viem");
@@ -118,110 +131,110 @@ async function runSimulation<T>(
   }
 }
 
-export async function simulateUsdcTransfer(
-  publicClient: SimClient,
+export function simulateUsdcTransfer(
+  client: SimClient,
   usdcAddress: `0x${string}`,
   account: `0x${string}`,
   to: `0x${string}`,
   amountAtomic: bigint
 ): Promise<void> {
-  await runSimulation("USDC.transfer", () =>
-    publicClient.simulateContract({
-      address: usdcAddress,
-      abi: erc20Abi,
-      functionName: "transfer",
-      args: [to, amountAtomic],
-      account,
-    })
+  return simulate(
+    client,
+    "USDC.transfer",
+    usdcAddress,
+    erc20Abi,
+    "transfer",
+    [to, amountAtomic],
+    account
   );
 }
 
-export async function simulateUsdcApprove(
-  publicClient: SimClient,
+export function simulateUsdcApprove(
+  client: SimClient,
   usdcAddress: `0x${string}`,
   account: `0x${string}`,
   spender: `0x${string}`,
   amountAtomic: bigint
 ): Promise<void> {
-  await runSimulation("USDC.approve", () =>
-    publicClient.simulateContract({
-      address: usdcAddress,
-      abi: erc20Abi,
-      functionName: "approve",
-      args: [spender, amountAtomic],
-      account,
-    })
+  return simulate(
+    client,
+    "USDC.approve",
+    usdcAddress,
+    erc20Abi,
+    "approve",
+    [spender, amountAtomic],
+    account
   );
 }
 
-export async function simulateEscrowDepositFor(
-  publicClient: SimClient,
+export function simulateEscrowDepositFor(
+  client: SimClient,
   escrowAddress: `0x${string}`,
   account: `0x${string}`,
   traderId: bigint,
   amountAtomic: bigint
 ): Promise<void> {
-  await runSimulation("escrow.depositFor", () =>
-    publicClient.simulateContract({
-      address: escrowAddress,
-      abi: escrowAbi,
-      functionName: "depositFor",
-      args: [traderId, amountAtomic],
-      account,
-    })
+  return simulate(
+    client,
+    "escrow.depositFor",
+    escrowAddress,
+    escrowAbi,
+    "depositFor",
+    [traderId, amountAtomic],
+    account
   );
 }
 
-export async function simulateEscrowTraderWithdraw(
-  publicClient: SimClient,
+export function simulateEscrowTraderWithdraw(
+  client: SimClient,
   escrowAddress: `0x${string}`,
   account: `0x${string}`,
   traderId: bigint,
   amountAtomic: bigint
 ): Promise<void> {
-  await runSimulation("escrow.withdraw", () =>
-    publicClient.simulateContract({
-      address: escrowAddress,
-      abi: escrowAbi,
-      functionName: "withdraw",
-      args: [traderId, amountAtomic],
-      account,
-    })
+  return simulate(
+    client,
+    "escrow.withdraw",
+    escrowAddress,
+    escrowAbi,
+    "withdraw",
+    [traderId, amountAtomic],
+    account
   );
 }
 
-export async function simulateEscrowCreateDeal(
-  publicClient: SimClient,
+export function simulateEscrowCreateDeal(
+  client: SimClient,
   escrowAddress: `0x${string}`,
   account: `0x${string}`,
   prompt: string,
   potAtomic: bigint,
   entryCostAtomic: bigint
 ): Promise<void> {
-  await runSimulation("escrow.createDeal", () =>
-    publicClient.simulateContract({
-      address: escrowAddress,
-      abi: escrowAbi,
-      functionName: "createDeal",
-      args: [prompt, potAtomic, entryCostAtomic],
-      account,
-    })
+  return simulate(
+    client,
+    "escrow.createDeal",
+    escrowAddress,
+    escrowAbi,
+    "createDeal",
+    [prompt, potAtomic, entryCostAtomic],
+    account
   );
 }
 
-export async function simulateEscrowCloseDeal(
-  publicClient: SimClient,
+export function simulateEscrowCloseDeal(
+  client: SimClient,
   escrowAddress: `0x${string}`,
   account: `0x${string}`,
   dealId: bigint
 ): Promise<void> {
-  await runSimulation("escrow.closeDeal", () =>
-    publicClient.simulateContract({
-      address: escrowAddress,
-      abi: escrowAbi,
-      functionName: "closeDeal",
-      args: [dealId],
-      account,
-    })
+  return simulate(
+    client,
+    "escrow.closeDeal",
+    escrowAddress,
+    escrowAbi,
+    "closeDeal",
+    [dealId],
+    account
   );
 }

--- a/convex/mcp/tradersEscrow.ts
+++ b/convex/mcp/tradersEscrow.ts
@@ -230,10 +230,6 @@ export const fundForMcp = internalAction({
 
     await ensureDepositorOnChain(trader.tokenId, deskAddress);
 
-    // Pre-flight: simulate the depositFor call (the actual money movement).
-    // Surfaces escrow reverts (paused, bad trader id, allowance issues) before
-    // any on-chain tx is submitted. The approve simulate is gated on the
-    // allowance check below.
     await simulateEscrowDepositFor(
       publicClient,
       ESCROW_ADDRESS,
@@ -261,7 +257,6 @@ export const fundForMcp = internalAction({
     })) as bigint;
 
     if (currentAllowance < amountAtomic) {
-      // Simulate the approve before submitting (catches paused USDC, etc.).
       await simulateUsdcApprove(
         publicClient,
         USDC_SEPOLIA_ADDRESS,
@@ -400,7 +395,6 @@ export const withdrawForMcp = internalAction({
       transport: http(),
     });
 
-    // Pre-flight: simulate the escrow withdraw before submitting.
     await simulateEscrowTraderWithdraw(
       publicClient,
       ESCROW_ADDRESS,

--- a/convex/mcp/tradersEscrow.ts
+++ b/convex/mcp/tradersEscrow.ts
@@ -10,6 +10,12 @@ import {
   type McpTraderWriteResult,
 } from "./traders";
 import { assertTraderOwnedByDesk } from "../traders";
+import { assertPerActionCap } from "./limits";
+import {
+  simulateUsdcApprove,
+  simulateEscrowDepositFor,
+  simulateEscrowTraderWithdraw,
+} from "./simulate";
 
 const USDC_DECIMALS = 1_000_000;
 
@@ -163,6 +169,13 @@ export const fundForMcp = internalAction({
     amountUsdc: v.number(),
   },
   handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    await assertPerActionCap(
+      ctx,
+      args.deskManagerId,
+      "fund_trader",
+      args.amountUsdc
+    );
+
     const amountAtomic = parseAmountUsdc(args.amountUsdc);
 
     const dm: Doc<"deskManagers"> | null = await ctx.runQuery(
@@ -217,6 +230,18 @@ export const fundForMcp = internalAction({
 
     await ensureDepositorOnChain(trader.tokenId, deskAddress);
 
+    // Pre-flight: simulate the depositFor call (the actual money movement).
+    // Surfaces escrow reverts (paused, bad trader id, allowance issues) before
+    // any on-chain tx is submitted. The approve simulate is gated on the
+    // allowance check below.
+    await simulateEscrowDepositFor(
+      publicClient,
+      ESCROW_ADDRESS,
+      deskAddress,
+      BigInt(trader.tokenId),
+      amountAtomic
+    );
+
     // ── Allowance top-up (rare thanks to LARGE_APPROVE_ALLOWANCE) ─────────────
     // We deliberately approve a *large* amount (not the exact per-call amount)
     // when the current allowance is insufficient. This turns the approve tx
@@ -236,6 +261,14 @@ export const fundForMcp = internalAction({
     })) as bigint;
 
     if (currentAllowance < amountAtomic) {
+      // Simulate the approve before submitting (catches paused USDC, etc.).
+      await simulateUsdcApprove(
+        publicClient,
+        USDC_SEPOLIA_ADDRESS,
+        deskAddress,
+        ESCROW_ADDRESS,
+        LARGE_APPROVE_ALLOWANCE
+      );
       const approveData = encodeFunctionData({
         abi: erc20Abi,
         functionName: "approve",
@@ -311,6 +344,13 @@ export const withdrawForMcp = internalAction({
     amountUsdc: v.number(),
   },
   handler: async (ctx, args): Promise<McpTraderWriteResult> => {
+    await assertPerActionCap(
+      ctx,
+      args.deskManagerId,
+      "withdraw_from_trader",
+      args.amountUsdc
+    );
+
     const amountAtomic = parseAmountUsdc(args.amountUsdc);
 
     const dm: Doc<"deskManagers"> | null = await ctx.runQuery(
@@ -359,6 +399,15 @@ export const withdrawForMcp = internalAction({
       chain: baseSepolia,
       transport: http(),
     });
+
+    // Pre-flight: simulate the escrow withdraw before submitting.
+    await simulateEscrowTraderWithdraw(
+      publicClient,
+      ESCROW_ADDRESS,
+      deskAccount.address as `0x${string}`,
+      BigInt(trader.tokenId),
+      amountAtomic
+    );
 
     const withdrawData = encodeFunctionData({
       abi: escrowAbi,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -32,6 +32,11 @@ export default defineSchema({
     dailyWithdrawCapUsdc: v.optional(v.number()), // per-desk daily cap in USDC (human units)
     dailyWithdrawUsedUsdc: v.optional(v.number()),
     dailyWithdrawResetAt: v.optional(v.number()),
+    // Per-action USDC ceiling for MCP writes (single-tx). Default in code is
+    // 500 USDC when unset. The optional `perToolCapUsdc` override map (e.g.
+    // { withdraw_to_address: 250, create_deal: 1000 }) takes precedence per tool.
+    perActionCapUsdc: v.optional(v.number()),
+    perToolCapUsdc: v.optional(v.any()),
     withdrawCeremonyCompletedAt: v.optional(v.number()),
     boundHumanSubject: v.optional(v.string()), // Privy DID of human who completed ceremony
     pendingWithdrawAddress: v.optional(v.string()), // proposed by first register_withdraw_address

--- a/src/lib/mcp/proxy.ts
+++ b/src/lib/mcp/proxy.ts
@@ -4,6 +4,12 @@ import { createConvexAdminClient } from "@/lib/convex/server-client";
 import { hashMcpKey, MCP_KEY_PREFIX } from "./keys";
 import { internal } from "../../../convex/_generated/api";
 import type { Id } from "../../../convex/_generated/dataModel";
+import {
+  checkRateLimit,
+  deskLimit,
+  getClientIdentifier,
+  mcpIpLimit,
+} from "@/lib/rate-limit";
 
 const API_KEY_SECRET = process.env.MCP_API_KEY_SECRET;
 const SERVICE_TOKEN = process.env.MCP_SERVICE_TOKEN;
@@ -159,9 +165,20 @@ export async function proxyMcpWrite(
     );
   }
 
+  // Pre-auth IP rate limit: protects against malformed-key floods.
+  const ipLimited = await checkRateLimit(
+    mcpIpLimit,
+    getClientIdentifier(request)
+  );
+  if (ipLimited) return ipLimited;
+
   const authResult = await validateMcpKey(request);
   if (authResult instanceof NextResponse) return authResult;
   const { deskManagerId } = authResult;
+
+  // Post-auth per-desk ceiling.
+  const deskLimited = await checkRateLimit(deskLimit, `mcp:${deskManagerId}`);
+  if (deskLimited) return deskLimited;
 
   let body: Record<string, unknown>;
   try {
@@ -203,9 +220,20 @@ export async function proxyMcpRead(
     );
   }
 
+  // Pre-auth IP rate limit: protects against malformed-key floods.
+  const ipLimited = await checkRateLimit(
+    mcpIpLimit,
+    getClientIdentifier(request)
+  );
+  if (ipLimited) return ipLimited;
+
   const authResult = await validateMcpKey(request);
   if (authResult instanceof NextResponse) return authResult;
   const { deskManagerId } = authResult;
+
+  // Post-auth per-desk ceiling.
+  const deskLimited = await checkRateLimit(deskLimit, `mcp:${deskManagerId}`);
+  if (deskLimited) return deskLimited;
 
   const search = request.nextUrl.searchParams;
   const body: Record<string, unknown> = {

--- a/src/lib/mcp/proxy.ts
+++ b/src/lib/mcp/proxy.ts
@@ -154,17 +154,13 @@ export interface ProxyMcpWriteOptions {
   requireIdempotencyKey?: boolean;
 }
 
-export async function proxyMcpWrite(
-  request: NextRequest,
-  { convexAction, requireIdempotencyKey }: ProxyMcpWriteOptions
-) {
-  if (!SERVICE_TOKEN || !CONVEX_URL) {
-    return NextResponse.json(
-      { error: "MCP is not configured on this server" },
-      { status: 500 }
-    );
-  }
-
+/**
+ * Apply IP + per-desk rate limits for an MCP request. Returns a 429
+ * NextResponse when limited, or `{ deskManagerId }` on success.
+ */
+async function applyMcpRateLimits(
+  request: NextRequest
+): Promise<{ deskManagerId: Id<"deskManagers"> } | NextResponse> {
   // Pre-auth IP rate limit: protects against malformed-key floods.
   const ipLimited = await checkRateLimit(
     mcpIpLimit,
@@ -179,6 +175,24 @@ export async function proxyMcpWrite(
   // Post-auth per-desk ceiling.
   const deskLimited = await checkRateLimit(deskLimit, `mcp:${deskManagerId}`);
   if (deskLimited) return deskLimited;
+
+  return { deskManagerId };
+}
+
+export async function proxyMcpWrite(
+  request: NextRequest,
+  { convexAction, requireIdempotencyKey }: ProxyMcpWriteOptions
+) {
+  if (!SERVICE_TOKEN || !CONVEX_URL) {
+    return NextResponse.json(
+      { error: "MCP is not configured on this server" },
+      { status: 500 }
+    );
+  }
+
+  const rateLimitResult = await applyMcpRateLimits(request);
+  if (rateLimitResult instanceof NextResponse) return rateLimitResult;
+  const { deskManagerId } = rateLimitResult;
 
   let body: Record<string, unknown>;
   try {
@@ -220,20 +234,9 @@ export async function proxyMcpRead(
     );
   }
 
-  // Pre-auth IP rate limit: protects against malformed-key floods.
-  const ipLimited = await checkRateLimit(
-    mcpIpLimit,
-    getClientIdentifier(request)
-  );
-  if (ipLimited) return ipLimited;
-
-  const authResult = await validateMcpKey(request);
-  if (authResult instanceof NextResponse) return authResult;
-  const { deskManagerId } = authResult;
-
-  // Post-auth per-desk ceiling.
-  const deskLimited = await checkRateLimit(deskLimit, `mcp:${deskManagerId}`);
-  if (deskLimited) return deskLimited;
+  const rateLimitResult = await applyMcpRateLimits(request);
+  if (rateLimitResult instanceof NextResponse) return rateLimitResult;
+  const { deskManagerId } = rateLimitResult;
 
   const search = request.nextUrl.searchParams;
   const body: Record<string, unknown> = {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -56,6 +56,14 @@ export const deskLimit = createLimit("rl:desk", 30, "1 m");
 /** /api/trader/* — 30 requests per minute per wallet */
 export const traderLimit = createLimit("rl:trader", 30, "1 m");
 
+/**
+ * /api/mcp/* — 60 requests per minute per client IP. Applied BEFORE
+ * Bearer-key validation so that floods from malformed keys can't burn
+ * CPU on hashing + DB lookups. The post-auth per-desk ceiling is the
+ * existing `deskLimit` (30/min), applied with a `mcp:` identifier.
+ */
+export const mcpIpLimit = createLimit("rl:mcp-ip", 60, "1 m");
+
 // ---------------------------------------------------------------------------
 // Helper: apply rate limit and return 429 if exceeded
 // ---------------------------------------------------------------------------

--- a/tests/convex/mcp-per-action-cap.test.ts
+++ b/tests/convex/mcp-per-action-cap.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolvePerActionCapUsdc,
+  DEFAULT_PER_ACTION_CAP_USDC,
+} from "../../convex/mcp/limits";
+
+describe("MCP per-action cap resolution", () => {
+  it("falls back to DEFAULT_PER_ACTION_CAP_USDC when desk is null or no caps set", () => {
+    expect(resolvePerActionCapUsdc(null, "withdraw_to_address")).toBe(
+      DEFAULT_PER_ACTION_CAP_USDC
+    );
+    expect(resolvePerActionCapUsdc({}, "create_deal")).toBe(
+      DEFAULT_PER_ACTION_CAP_USDC
+    );
+  });
+
+  it("uses perActionCapUsdc when set without per-tool override", () => {
+    expect(
+      resolvePerActionCapUsdc({ perActionCapUsdc: 250 }, "fund_trader")
+    ).toBe(250);
+  });
+
+  it("prefers a per-tool override over perActionCapUsdc", () => {
+    expect(
+      resolvePerActionCapUsdc(
+        {
+          perActionCapUsdc: 250,
+          perToolCapUsdc: { withdraw_to_address: 100, create_deal: 750 },
+        },
+        "withdraw_to_address"
+      )
+    ).toBe(100);
+    expect(
+      resolvePerActionCapUsdc(
+        {
+          perActionCapUsdc: 250,
+          perToolCapUsdc: { withdraw_to_address: 100, create_deal: 750 },
+        },
+        "create_deal"
+      )
+    ).toBe(750);
+  });
+
+  it("ignores non-numeric or non-positive overrides", () => {
+    expect(
+      resolvePerActionCapUsdc(
+        {
+          perActionCapUsdc: 400,
+          perToolCapUsdc: { withdraw_to_address: "lots" },
+        },
+        "withdraw_to_address"
+      )
+    ).toBe(400);
+    expect(
+      resolvePerActionCapUsdc(
+        { perActionCapUsdc: 400, perToolCapUsdc: { fund_trader: 0 } },
+        "fund_trader"
+      )
+    ).toBe(400);
+  });
+
+  it("falls through to default when the override map is not an object", () => {
+    expect(
+      resolvePerActionCapUsdc(
+        // simulate a corrupted settings value
+        { perActionCapUsdc: undefined, perToolCapUsdc: "oops" as unknown },
+        "create_deal"
+      )
+    ).toBe(DEFAULT_PER_ACTION_CAP_USDC);
+  });
+});

--- a/tests/convex/mcp-simulate.test.ts
+++ b/tests/convex/mcp-simulate.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  simulateUsdcTransfer,
+  simulateUsdcApprove,
+  simulateEscrowDepositFor,
+  simulateEscrowTraderWithdraw,
+  simulateEscrowCreateDeal,
+  simulateEscrowCloseDeal,
+} from "../../convex/mcp/simulate";
+
+const usdc = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as const;
+const escrow = "0x8AA5768AC08755cd9AEf07892e6c40edD1B5a609" as const;
+const account = "0x000000000000000000000000000000000000beef" as const;
+const dest = "0x000000000000000000000000000000000000cafe" as const;
+
+function clientThatThrows(reason: string) {
+  return {
+    simulateContract: vi.fn(async () => {
+      throw new Error(reason);
+    }),
+  } as unknown as Parameters<typeof simulateUsdcTransfer>[0];
+}
+
+function clientThatResolves() {
+  return {
+    simulateContract: vi.fn(async () => ({ request: {} })),
+  } as unknown as Parameters<typeof simulateUsdcTransfer>[0];
+}
+
+describe("MCP simulate wrappers", () => {
+  it("surfaces a USDC.transfer revert with a labeled error", async () => {
+    const c = clientThatThrows("ERC20: insufficient balance");
+    await expect(
+      simulateUsdcTransfer(c, usdc, account, dest, BigInt(1_000_000))
+    ).rejects.toThrow(
+      /simulation reverted: USDC\.transfer: ERC20: insufficient balance/
+    );
+  });
+
+  it("surfaces a USDC.approve revert with a labeled error", async () => {
+    const c = clientThatThrows("paused");
+    await expect(
+      simulateUsdcApprove(c, usdc, account, escrow, BigInt(1_000_000))
+    ).rejects.toThrow(/simulation reverted: USDC\.approve: paused/);
+  });
+
+  it("surfaces an escrow.depositFor revert with a labeled error", async () => {
+    const c = clientThatThrows("Escrow: trader missing");
+    await expect(
+      simulateEscrowDepositFor(
+        c,
+        escrow,
+        account,
+        BigInt(42),
+        BigInt(1_000_000)
+      )
+    ).rejects.toThrow(
+      /simulation reverted: escrow\.depositFor: Escrow: trader missing/
+    );
+  });
+
+  it("surfaces an escrow.withdraw revert with a labeled error", async () => {
+    const c = clientThatThrows("Escrow: insufficient");
+    await expect(
+      simulateEscrowTraderWithdraw(
+        c,
+        escrow,
+        account,
+        BigInt(42),
+        BigInt(1_000_000)
+      )
+    ).rejects.toThrow(
+      /simulation reverted: escrow\.withdraw: Escrow: insufficient/
+    );
+  });
+
+  it("surfaces an escrow.createDeal revert with a labeled error", async () => {
+    const c = clientThatThrows("Escrow: paused");
+    await expect(
+      simulateEscrowCreateDeal(
+        c,
+        escrow,
+        account,
+        "test prompt",
+        BigInt(100_000_000),
+        BigInt(10_000_000)
+      )
+    ).rejects.toThrow(
+      /simulation reverted: escrow\.createDeal: Escrow: paused/
+    );
+  });
+
+  it("surfaces an escrow.closeDeal revert with a labeled error", async () => {
+    const c = clientThatThrows("Escrow: pending entries");
+    await expect(
+      simulateEscrowCloseDeal(c, escrow, account, BigInt(99))
+    ).rejects.toThrow(
+      /simulation reverted: escrow\.closeDeal: Escrow: pending entries/
+    );
+  });
+
+  it("resolves silently when the simulation succeeds", async () => {
+    const c = clientThatResolves();
+    await expect(
+      simulateUsdcTransfer(c, usdc, account, dest, BigInt(1_000_000))
+    ).resolves.toBeUndefined();
+    await expect(
+      simulateEscrowCloseDeal(c, escrow, account, BigInt(1))
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Per-action USDC caps (default 500, configurable via `perActionCapUsdc` and optional `perToolCapUsdc` override map) enforced in `withdraw_to_address`, `fund_trader`, `withdraw_from_trader`, `create_deal`.
- Pre-submission viem `simulateContract` on every on-chain write — revert reasons surface as cached errors keyed by `idempotencyKey` so retries with the same key get the same human-readable reason without re-submitting.
- Rate limits wired at the MCP proxy seam: pre-auth IP limit (60/min) catches malformed-key floods, post-auth desk limit (30/min) caps per-credential throughput. One insertion point covers all 18 MCP routes.
- Formalize 24h idempotency replay semantics — the existing `minCreatedAt` filter in `findRecentByKey` already enforces it; `mcpRequests` stays as the durable audit log (no cleanup cron).

This is **PR-A of 3** for issue #145 (Phase 6 production hardening). PR-B will add key rotation + revocation; PR-C will prepare the npm publish.

Closes acceptance criteria 1, 2, 5 (per-action caps, transaction simulation, rate limits by desk and IP) and clarifies criterion 3 (idempotency semantics) from #145.

## Test plan
- [x] `pnpm vitest run tests/convex/mcp-per-action-cap.test.ts tests/convex/mcp-simulate.test.ts` — 12/12 passing
- [x] `pnpm build` — clean
- [x] `pnpm lint` — no new errors introduced (21 pre-existing problems on main, identical on this branch)
- [ ] Manual: hit `/api/mcp/desks` 31 times in one minute from a single key → 429 with `Retry-After`
- [ ] Manual: try `withdraw_to_address` with `amountUsdc: 600` against a desk with the default cap → "Per-action cap exceeded for withdraw_to_address: 600.00 USDC > 500.00 USDC"
- [ ] Manual: retry the same write with the same idempotencyKey → cached error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)