### PR TITLE
PR-B: MCP key rotation + revocation

### DIFF
--- a/convex/mcpApiKeys.ts
+++ b/convex/mcpApiKeys.ts
@@ -41,6 +41,19 @@ type ConfirmWithdrawCeremonyResult = {
   ceremonyCompletedAt?: number;
 };
 
+type RevokeKeyResult = {
+  ok: true;
+  alreadyRevoked: boolean;
+  revokedAt: number;
+  deskManagerId: Id<"deskManagers">;
+};
+
+type RotateKeyResult = {
+  ok: true;
+  newKeyId: Id<"mcpApiKeys">;
+  deskManagerId: Id<"deskManagers">;
+};
+
 type McpRequestDebugRow = {
   _id: string;
   tool: string;
@@ -209,11 +222,8 @@ export const confirmWithdrawCeremony = internalMutation({
   },
 });
 
-/**
- * Internal: revoke an MCP key. Verifies the caller is the original issuer
- * (via Privy DID), sets `revokedAt = Date.now()`. Idempotent — re-calling
- * on an already-revoked key returns the existing revocation time.
- */
+/** Revoke an MCP key. Verifies the caller is the original issuer (Privy DID).
+ * Idempotent — re-calling on an already-revoked key returns the existing revocation time. */
 export const revoke = internalMutation({
   args: {
     keyId: v.id("mcpApiKeys"),
@@ -246,13 +256,9 @@ export const revoke = internalMutation({
   },
 });
 
-/**
- * Internal: atomically rotate an MCP key — revoke the old hash and insert a
- * new one bound to the SAME `deskManagerId` (so the desk's CDP wallet,
- * traders, deals, allowlist, etc. all carry over). Hard cut: the old hash
- * stops working immediately. Raw-key generation happens in Next.js; Convex
- * only ever sees the HMAC hashes.
- */
+/** Atomically rotate an MCP key — revoke the old hash and insert a new one bound to the
+ * SAME deskManagerId. Hard cut: the old hash stops working immediately. Raw-key
+ * generation happens in Next.js; Convex only ever sees the HMAC hashes. */
 export const rotate = internalMutation({
   args: {
     keyId: v.id("mcpApiKeys"),
@@ -294,53 +300,31 @@ export const revokeMyKey = mutation({
   handler: async (
     ctx: MutationCtx,
     { keyId }: { keyId: Id<"mcpApiKeys"> }
-  ): Promise<{
-    ok: true;
-    alreadyRevoked: boolean;
-    revokedAt: number;
-    deskManagerId: Id<"deskManagers">;
-  }> => {
+  ): Promise<RevokeKeyResult> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Unauthenticated");
     return (await ctx.runMutation(internal.mcpApiKeys.revoke, {
       keyId,
       revokedByPrivySubject: identity.subject,
-    })) as {
-      ok: true;
-      alreadyRevoked: boolean;
-      revokedAt: number;
-      deskManagerId: Id<"deskManagers">;
-    };
+    })) as RevokeKeyResult;
   },
 });
 
-/**
- * Public (browser) wrapper: atomically rotate one of my issued MCP keys.
- * The raw key + hash are generated in the Next.js route; Convex only sees
- * the hash. Response shape matches `POST /api/mcp/keys` so the UI reuses
- * the same "shown once" panel.
- */
+/** Public (browser) wrapper: atomically rotate one of my issued MCP keys.
+ * Raw key + hash are generated in the Next.js route; Convex only sees the hash. */
 export const rotateMyKey = mutation({
   args: { keyId: v.id("mcpApiKeys"), newKeyHash: v.string() },
   handler: async (
     ctx: MutationCtx,
     { keyId, newKeyHash }: { keyId: Id<"mcpApiKeys">; newKeyHash: string }
-  ): Promise<{
-    ok: true;
-    newKeyId: Id<"mcpApiKeys">;
-    deskManagerId: Id<"deskManagers">;
-  }> => {
+  ): Promise<RotateKeyResult> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Unauthenticated");
     return (await ctx.runMutation(internal.mcpApiKeys.rotate, {
       keyId,
       newKeyHash,
       rotatedByPrivySubject: identity.subject,
-    })) as {
-      ok: true;
-      newKeyId: Id<"mcpApiKeys">;
-      deskManagerId: Id<"deskManagers">;
-    };
+    })) as RotateKeyResult;
   },
 });
 

--- a/convex/mcpApiKeys.ts
+++ b/convex/mcpApiKeys.ts
@@ -209,6 +209,141 @@ export const confirmWithdrawCeremony = internalMutation({
   },
 });
 
+/**
+ * Internal: revoke an MCP key. Verifies the caller is the original issuer
+ * (via Privy DID), sets `revokedAt = Date.now()`. Idempotent — re-calling
+ * on an already-revoked key returns the existing revocation time.
+ */
+export const revoke = internalMutation({
+  args: {
+    keyId: v.id("mcpApiKeys"),
+    revokedByPrivySubject: v.string(),
+  },
+  handler: async (ctx, { keyId, revokedByPrivySubject }) => {
+    const keyDoc = await ctx.db.get(keyId);
+    if (!keyDoc) throw new Error("Key not found");
+    if (keyDoc.issuedByPrivySubject !== revokedByPrivySubject) {
+      throw new Error(
+        "Not authorized: you did not issue this MCP key (only the original issuer can revoke it)"
+      );
+    }
+    if (keyDoc.revokedAt != null) {
+      return {
+        ok: true as const,
+        alreadyRevoked: true,
+        revokedAt: keyDoc.revokedAt,
+        deskManagerId: keyDoc.deskManagerId,
+      };
+    }
+    const now = Date.now();
+    await ctx.db.patch(keyId, { revokedAt: now });
+    return {
+      ok: true as const,
+      alreadyRevoked: false,
+      revokedAt: now,
+      deskManagerId: keyDoc.deskManagerId,
+    };
+  },
+});
+
+/**
+ * Internal: atomically rotate an MCP key — revoke the old hash and insert a
+ * new one bound to the SAME `deskManagerId` (so the desk's CDP wallet,
+ * traders, deals, allowlist, etc. all carry over). Hard cut: the old hash
+ * stops working immediately. Raw-key generation happens in Next.js; Convex
+ * only ever sees the HMAC hashes.
+ */
+export const rotate = internalMutation({
+  args: {
+    keyId: v.id("mcpApiKeys"),
+    newKeyHash: v.string(),
+    rotatedByPrivySubject: v.string(),
+  },
+  handler: async (ctx, { keyId, newKeyHash, rotatedByPrivySubject }) => {
+    const oldKey = await ctx.db.get(keyId);
+    if (!oldKey) throw new Error("Key not found");
+    if (oldKey.issuedByPrivySubject !== rotatedByPrivySubject) {
+      throw new Error(
+        "Not authorized: you did not issue this MCP key (only the original issuer can rotate it)"
+      );
+    }
+    if (oldKey.revokedAt != null) {
+      throw new Error(
+        "Cannot rotate an already-revoked key. Issue a fresh key from the operator dialog instead."
+      );
+    }
+    const now = Date.now();
+    await ctx.db.patch(keyId, { revokedAt: now });
+    const newKeyId = await ctx.db.insert("mcpApiKeys", {
+      keyHash: newKeyHash,
+      deskManagerId: oldKey.deskManagerId,
+      issuedByPrivySubject: rotatedByPrivySubject,
+      createdAt: now,
+    });
+    return {
+      ok: true as const,
+      newKeyId,
+      deskManagerId: oldKey.deskManagerId,
+    };
+  },
+});
+
+/** Public (browser) wrapper: revoke one of my issued MCP keys. */
+export const revokeMyKey = mutation({
+  args: { keyId: v.id("mcpApiKeys") },
+  handler: async (
+    ctx: MutationCtx,
+    { keyId }: { keyId: Id<"mcpApiKeys"> }
+  ): Promise<{
+    ok: true;
+    alreadyRevoked: boolean;
+    revokedAt: number;
+    deskManagerId: Id<"deskManagers">;
+  }> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    return (await ctx.runMutation(internal.mcpApiKeys.revoke, {
+      keyId,
+      revokedByPrivySubject: identity.subject,
+    })) as {
+      ok: true;
+      alreadyRevoked: boolean;
+      revokedAt: number;
+      deskManagerId: Id<"deskManagers">;
+    };
+  },
+});
+
+/**
+ * Public (browser) wrapper: atomically rotate one of my issued MCP keys.
+ * The raw key + hash are generated in the Next.js route; Convex only sees
+ * the hash. Response shape matches `POST /api/mcp/keys` so the UI reuses
+ * the same "shown once" panel.
+ */
+export const rotateMyKey = mutation({
+  args: { keyId: v.id("mcpApiKeys"), newKeyHash: v.string() },
+  handler: async (
+    ctx: MutationCtx,
+    { keyId, newKeyHash }: { keyId: Id<"mcpApiKeys">; newKeyHash: string }
+  ): Promise<{
+    ok: true;
+    newKeyId: Id<"mcpApiKeys">;
+    deskManagerId: Id<"deskManagers">;
+  }> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    return (await ctx.runMutation(internal.mcpApiKeys.rotate, {
+      keyId,
+      newKeyHash,
+      rotatedByPrivySubject: identity.subject,
+    })) as {
+      ok: true;
+      newKeyId: Id<"mcpApiKeys">;
+      deskManagerId: Id<"deskManagers">;
+    };
+  },
+});
+
 /** Public (browser) wrapper: list MCP desks issued by the currently authenticated Privy user. */
 export const listMyIssuedMcpDesks = query({
   args: { limit: v.optional(v.number()) },

--- a/src/app/api/mcp/keys/[keyId]/rotate/route.ts
+++ b/src/app/api/mcp/keys/[keyId]/rotate/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyPrivyToken, canonicalPrivySubject } from "@/lib/privy/server";
+import { createConvexAdminClient } from "@/lib/convex/server-client";
+import { generateMcpKey, hashMcpKey } from "@/lib/mcp/keys";
+import { internal } from "../../../../../../../convex/_generated/api";
+import type { Id } from "../../../../../../../convex/_generated/dataModel";
+
+/**
+ * POST /api/mcp/keys/{keyId}/rotate
+ * Privy-authenticated atomic rotation: revoke the old key and issue a new
+ * one bound to the SAME deskManager (so wallet, traders, deals carry over).
+ * Hard cut — the old key stops working immediately. The raw new key is
+ * returned exactly once; only its HMAC hash is persisted in Convex.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ keyId: string }> }
+) {
+  if (!process.env.MCP_API_KEY_SECRET || !process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return NextResponse.json(
+      { error: "MCP is not configured on this server (missing env)" },
+      { status: 500 }
+    );
+  }
+
+  let rotatedByPrivySubject: string;
+  try {
+    const { claims, user } = await verifyPrivyToken(request);
+    rotatedByPrivySubject = canonicalPrivySubject(claims.userId, user.id);
+  } catch {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const { keyId } = await context.params;
+  if (!keyId) {
+    return NextResponse.json({ error: "keyId required" }, { status: 400 });
+  }
+
+  const rawKey = generateMcpKey();
+  const newKeyHash = hashMcpKey(rawKey);
+
+  const convex = createConvexAdminClient();
+
+  try {
+    const result = (await convex.mutation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      internal.mcpApiKeys.rotate as any,
+      {
+        keyId: keyId as Id<"mcpApiKeys">,
+        newKeyHash,
+        rotatedByPrivySubject,
+      }
+    )) as {
+      ok: true;
+      newKeyId: Id<"mcpApiKeys">;
+      deskManagerId: Id<"deskManagers">;
+    };
+
+    return NextResponse.json({
+      ok: true,
+      key: rawKey,
+      keyId: result.newKeyId,
+      deskId: result.deskManagerId,
+      note: "Store this key securely — it is shown only once. The old key has been revoked and will be rejected on the next request. Update your MCP client (Claude Code, Cursor) with this new key before continuing.",
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Failed to rotate key";
+    const status = msg.includes("Not authorized")
+      ? 403
+      : msg.includes("not found")
+        ? 404
+        : msg.includes("already-revoked")
+          ? 409
+          : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/app/api/mcp/keys/[keyId]/rotate/route.ts
+++ b/src/app/api/mcp/keys/[keyId]/rotate/route.ts
@@ -32,9 +32,6 @@ export async function POST(
   }
 
   const { keyId } = await context.params;
-  if (!keyId) {
-    return NextResponse.json({ error: "keyId required" }, { status: 400 });
-  }
 
   const rawKey = generateMcpKey();
   const newKeyHash = hashMcpKey(rawKey);

--- a/src/app/api/mcp/keys/[keyId]/route.ts
+++ b/src/app/api/mcp/keys/[keyId]/route.ts
@@ -30,10 +30,6 @@ export async function DELETE(
   }
 
   const { keyId } = await context.params;
-  if (!keyId) {
-    return NextResponse.json({ error: "keyId required" }, { status: 400 });
-  }
-
   const convex = createConvexAdminClient();
 
   try {

--- a/src/app/api/mcp/keys/[keyId]/route.ts
+++ b/src/app/api/mcp/keys/[keyId]/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyPrivyToken, canonicalPrivySubject } from "@/lib/privy/server";
+import { createConvexAdminClient } from "@/lib/convex/server-client";
+import { internal } from "../../../../../../convex/_generated/api";
+import type { Id } from "../../../../../../convex/_generated/dataModel";
+
+/**
+ * DELETE /api/mcp/keys/{keyId}
+ * Privy-authenticated revocation of one of the caller's MCP keys.
+ * Hard cut — the old key stops working on the very next request.
+ * Idempotent: revoking an already-revoked key returns `alreadyRevoked: true`.
+ */
+export async function DELETE(
+  request: NextRequest,
+  context: { params: Promise<{ keyId: string }> }
+) {
+  if (!process.env.NEXT_PUBLIC_CONVEX_URL) {
+    return NextResponse.json(
+      { error: "MCP is not configured on this server" },
+      { status: 500 }
+    );
+  }
+
+  let revokedByPrivySubject: string;
+  try {
+    const { claims, user } = await verifyPrivyToken(request);
+    revokedByPrivySubject = canonicalPrivySubject(claims.userId, user.id);
+  } catch {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const { keyId } = await context.params;
+  if (!keyId) {
+    return NextResponse.json({ error: "keyId required" }, { status: 400 });
+  }
+
+  const convex = createConvexAdminClient();
+
+  try {
+    const result = (await convex.mutation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      internal.mcpApiKeys.revoke as any,
+      {
+        keyId: keyId as Id<"mcpApiKeys">,
+        revokedByPrivySubject,
+      }
+    )) as {
+      ok: true;
+      alreadyRevoked: boolean;
+      revokedAt: number;
+      deskManagerId: Id<"deskManagers">;
+    };
+    return NextResponse.json(result);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Failed to revoke key";
+    const status = msg.includes("Not authorized")
+      ? 403
+      : msg.includes("not found")
+        ? 404
+        : 500;
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/src/components/mcp-operator-dialog.tsx
+++ b/src/components/mcp-operator-dialog.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 
 type MyDesk = {
+  keyId: Id<"mcpApiKeys">;
   deskManagerId: Id<"deskManagers">;
   deskSubject?: string;
   walletAddress?: string;
@@ -66,6 +67,12 @@ export function McpOperatorDialog({
   const [confirmError, setConfirmError] = useState<string | null>(null);
   const [requests, setRequests] = useState<McpRequestRow[]>([]);
   const [loadingRequests, setLoadingRequests] = useState(false);
+
+  // Rotation / revocation UI state.
+  const [isRotating, setIsRotating] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [keyOpError, setKeyOpError] = useState<string | null>(null);
+  const [rotatedKey, setRotatedKey] = useState<string | null>(null);
 
   const confirmCeremony = useMutation(api.mcpApiKeys.confirmMyWithdrawCeremony);
   const listRequests = useQuery; // we call manually via refetch pattern, but use the query fn? For simplicity use direct in effect no, use lazy via button
@@ -116,6 +123,68 @@ export function McpOperatorDialog({
 
   const copy = (text: string) => {
     navigator.clipboard?.writeText(text).catch(() => {});
+  };
+
+  // Reset any previously-displayed new key when the user switches desks.
+  React.useEffect(() => {
+    setRotatedKey(null);
+    setKeyOpError(null);
+  }, [selectedDeskId]);
+
+  const handleRotate = async (keyId: Id<"mcpApiKeys">) => {
+    const confirmed = window.confirm(
+      "Rotate this MCP key?\n\nThe old key stops working IMMEDIATELY. Update your MCP client (Claude Code / Cursor) with the new key before continuing.\n\nThe new key is shown ONCE and never again."
+    );
+    if (!confirmed) return;
+    setIsRotating(true);
+    setKeyOpError(null);
+    setRotatedKey(null);
+    try {
+      const res = await fetch(`/api/mcp/keys/${keyId}/rotate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = (await res.json()) as {
+        ok?: boolean;
+        key?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.key) {
+        throw new Error(data.error ?? `Rotate failed (${res.status})`);
+      }
+      setRotatedKey(data.key);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Rotation failed";
+      setKeyOpError(msg);
+    } finally {
+      setIsRotating(false);
+    }
+  };
+
+  const handleRevoke = async (keyId: Id<"mcpApiKeys">) => {
+    const confirmed = window.confirm(
+      "Revoke this MCP key?\n\nThe key stops working IMMEDIATELY. This is permanent — to keep using this desk you must rotate (or issue a fresh key)."
+    );
+    if (!confirmed) return;
+    setIsRevoking(true);
+    setKeyOpError(null);
+    try {
+      const res = await fetch(`/api/mcp/keys/${keyId}`, { method: "DELETE" });
+      const data = (await res.json()) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!res.ok) {
+        throw new Error(data.error ?? `Revoke failed (${res.status})`);
+      }
+      // Reactive listIssuedBy will drop this row from `myDesks` automatically.
+      setSelectedDeskId(null);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Revocation failed";
+      setKeyOpError(msg);
+    } finally {
+      setIsRevoking(false);
+    }
   };
 
   if (!open) return null;
@@ -346,6 +415,72 @@ export function McpOperatorDialog({
                     </div>
                   )}
                 </div>
+              </div>
+
+              {/* Key actions: rotate / revoke */}
+              <div className="mt-5 rounded border border-[var(--t-border)]/40 bg-black/20 p-3">
+                <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-widest text-[var(--t-text)]/60">
+                  <ShieldCheck className="h-3.5 w-3.5" /> KEY ACTIONS
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => handleRotate(selectedDesk.keyId)}
+                    disabled={isRotating || isRevoking}
+                    className="inline-flex items-center gap-1.5 rounded border border-[var(--t-amber)]/50 bg-[var(--t-amber)]/10 px-3 py-1 text-xs font-semibold text-[var(--t-amber)] hover:bg-[var(--t-amber)]/20 disabled:opacity-50"
+                    title="Issue a new key bound to this same desk; the old key is revoked immediately."
+                  >
+                    {isRotating ? (
+                      <RefreshCw className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3 w-3" />
+                    )}
+                    ROTATE KEY
+                  </button>
+                  <button
+                    onClick={() => handleRevoke(selectedDesk.keyId)}
+                    disabled={isRotating || isRevoking}
+                    className="inline-flex items-center gap-1.5 rounded border border-[var(--t-red)]/50 bg-[var(--t-red)]/10 px-3 py-1 text-xs font-semibold text-[var(--t-red)] hover:bg-[var(--t-red)]/20 disabled:opacity-50"
+                    title="Permanently disable this key. Desk remains; traders/deals continue under any other unrevoked key for this desk."
+                  >
+                    {isRevoking ? (
+                      <RefreshCw className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <X className="h-3 w-3" />
+                    )}
+                    REVOKE KEY
+                  </button>
+                  <div className="ml-auto font-mono text-[10px] text-[var(--t-text)]/50">
+                    keyId {String(selectedDesk.keyId).slice(0, 8)}…
+                  </div>
+                </div>
+                {keyOpError && (
+                  <div className="mt-2 text-[10px] text-[var(--t-red)]">
+                    {keyOpError}
+                  </div>
+                )}
+                {rotatedKey && (
+                  <div className="mt-3 rounded border border-[var(--t-green)]/50 bg-[var(--t-green)]/5 p-3">
+                    <div className="mb-1 text-[10px] uppercase tracking-widest text-[var(--t-green)]">
+                      NEW KEY — SHOWN ONCE
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 break-all rounded bg-black/40 p-2 font-mono text-[11px] text-[var(--t-text)]">
+                        {rotatedKey}
+                      </code>
+                      <button
+                        onClick={() => copy(rotatedKey)}
+                        className="inline-flex items-center gap-1 rounded bg-[var(--t-green)]/90 px-2 py-1 text-[10px] font-semibold text-black"
+                      >
+                        <Clipboard className="h-3 w-3" /> COPY
+                      </button>
+                    </div>
+                    <div className="mt-2 text-[10px] text-[var(--t-text)]/60">
+                      Paste this into <code>MARGIN_CALL_MCP_KEY</code> in your
+                      MCP client config (Claude Code / Cursor). The old key has
+                      already been revoked.
+                    </div>
+                  </div>
+                )}
               </div>
 
               {/* Recent mcpRequests debug table */}

--- a/src/components/mcp-operator-dialog.tsx
+++ b/src/components/mcp-operator-dialog.tsx
@@ -69,8 +69,7 @@ export function McpOperatorDialog({
   const [loadingRequests, setLoadingRequests] = useState(false);
 
   // Rotation / revocation UI state.
-  const [isRotating, setIsRotating] = useState(false);
-  const [isRevoking, setIsRevoking] = useState(false);
+  const [keyOp, setKeyOp] = useState<"rotating" | "revoking" | null>(null);
   const [keyOpError, setKeyOpError] = useState<string | null>(null);
   const [rotatedKey, setRotatedKey] = useState<string | null>(null);
 
@@ -131,61 +130,53 @@ export function McpOperatorDialog({
     setKeyOpError(null);
   }, [selectedDeskId]);
 
-  const handleRotate = async (keyId: Id<"mcpApiKeys">) => {
-    const confirmed = window.confirm(
-      "Rotate this MCP key?\n\nThe old key stops working IMMEDIATELY. Update your MCP client (Claude Code / Cursor) with the new key before continuing.\n\nThe new key is shown ONCE and never again."
-    );
-    if (!confirmed) return;
-    setIsRotating(true);
+  const runKeyOp = async (
+    op: "rotating" | "revoking",
+    confirmMsg: string,
+    doFetch: () => Promise<Response>,
+    onSuccess: (data: Record<string, unknown>) => void
+  ) => {
+    if (!window.confirm(confirmMsg)) return;
+    setKeyOp(op);
     setKeyOpError(null);
-    setRotatedKey(null);
     try {
-      const res = await fetch(`/api/mcp/keys/${keyId}/rotate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-      const data = (await res.json()) as {
-        ok?: boolean;
-        key?: string;
-        error?: string;
-      };
-      if (!res.ok || !data.key) {
-        throw new Error(data.error ?? `Rotate failed (${res.status})`);
-      }
-      setRotatedKey(data.key);
+      const res = await doFetch();
+      const data = (await res.json()) as Record<string, unknown>;
+      if (!res.ok)
+        throw new Error(
+          (data.error as string) ?? `${op} failed (${res.status})`
+        );
+      onSuccess(data);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Rotation failed";
-      setKeyOpError(msg);
+      setKeyOpError(e instanceof Error ? e.message : `${op} failed`);
     } finally {
-      setIsRotating(false);
+      setKeyOp(null);
     }
   };
 
-  const handleRevoke = async (keyId: Id<"mcpApiKeys">) => {
-    const confirmed = window.confirm(
-      "Revoke this MCP key?\n\nThe key stops working IMMEDIATELY. This is permanent — to keep using this desk you must rotate (or issue a fresh key)."
-    );
-    if (!confirmed) return;
-    setIsRevoking(true);
-    setKeyOpError(null);
-    try {
-      const res = await fetch(`/api/mcp/keys/${keyId}`, { method: "DELETE" });
-      const data = (await res.json()) as {
-        ok?: boolean;
-        error?: string;
-      };
-      if (!res.ok) {
-        throw new Error(data.error ?? `Revoke failed (${res.status})`);
+  const handleRotate = (keyId: Id<"mcpApiKeys">) =>
+    runKeyOp(
+      "rotating",
+      "Rotate this MCP key?\n\nThe old key stops working IMMEDIATELY. Update your MCP client (Claude Code / Cursor) with the new key before continuing.\n\nThe new key is shown ONCE and never again.",
+      () =>
+        fetch(`/api/mcp/keys/${keyId}/rotate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      (data) => {
+        if (!data.key) throw new Error("No key returned");
+        setRotatedKey(data.key as string);
       }
+    );
+
+  const handleRevoke = (keyId: Id<"mcpApiKeys">) =>
+    runKeyOp(
+      "revoking",
+      "Revoke this MCP key?\n\nThe key stops working IMMEDIATELY. This is permanent — to keep using this desk you must rotate (or issue a fresh key).",
+      () => fetch(`/api/mcp/keys/${keyId}`, { method: "DELETE" }),
       // Reactive listIssuedBy will drop this row from `myDesks` automatically.
-      setSelectedDeskId(null);
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Revocation failed";
-      setKeyOpError(msg);
-    } finally {
-      setIsRevoking(false);
-    }
-  };
+      () => setSelectedDeskId(null)
+    );
 
   if (!open) return null;
 
@@ -425,24 +416,22 @@ export function McpOperatorDialog({
                 <div className="flex flex-wrap items-center gap-2">
                   <button
                     onClick={() => handleRotate(selectedDesk.keyId)}
-                    disabled={isRotating || isRevoking}
+                    disabled={keyOp != null}
                     className="inline-flex items-center gap-1.5 rounded border border-[var(--t-amber)]/50 bg-[var(--t-amber)]/10 px-3 py-1 text-xs font-semibold text-[var(--t-amber)] hover:bg-[var(--t-amber)]/20 disabled:opacity-50"
                     title="Issue a new key bound to this same desk; the old key is revoked immediately."
                   >
-                    {isRotating ? (
-                      <RefreshCw className="h-3 w-3 animate-spin" />
-                    ) : (
-                      <RefreshCw className="h-3 w-3" />
-                    )}
+                    <RefreshCw
+                      className={`h-3 w-3${keyOp === "rotating" ? " animate-spin" : ""}`}
+                    />
                     ROTATE KEY
                   </button>
                   <button
                     onClick={() => handleRevoke(selectedDesk.keyId)}
-                    disabled={isRotating || isRevoking}
+                    disabled={keyOp != null}
                     className="inline-flex items-center gap-1.5 rounded border border-[var(--t-red)]/50 bg-[var(--t-red)]/10 px-3 py-1 text-xs font-semibold text-[var(--t-red)] hover:bg-[var(--t-red)]/20 disabled:opacity-50"
                     title="Permanently disable this key. Desk remains; traders/deals continue under any other unrevoked key for this desk."
                   >
-                    {isRevoking ? (
+                    {keyOp === "revoking" ? (
                       <RefreshCw className="h-3 w-3 animate-spin" />
                     ) : (
                       <X className="h-3 w-3" />

--- a/tests/convex/mcp-key-rotation.test.ts
+++ b/tests/convex/mcp-key-rotation.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { makeT, seedDeskManager } from "./setup";
+
+const ISSUER = "did:privy:issuer-001";
+const OUTSIDER = "did:privy:outsider-001";
+const OLD_HASH = "hash-old-key-aaaa";
+const NEW_HASH = "hash-new-key-bbbb";
+
+async function seedKey(
+  t: ReturnType<typeof makeT>,
+  deskManagerId: Id<"deskManagers">,
+  keyHash: string,
+  issuedBy: string
+) {
+  return t.run(async (ctx) => {
+    return ctx.db.insert("mcpApiKeys", {
+      keyHash,
+      deskManagerId,
+      issuedByPrivySubject: issuedBy,
+      createdAt: Date.now(),
+    });
+  });
+}
+
+describe("MCP key rotation + revocation", () => {
+  it("revoke marks the key revokedAt and lookup returns null for it", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t, { subject: "mcp:cdp-wallet:zz" });
+    const keyId = await seedKey(
+      t,
+      deskId as Id<"deskManagers">,
+      OLD_HASH,
+      ISSUER
+    );
+
+    const before = await t.query(internal.mcpApiKeys.lookupDeskByKeyHash, {
+      keyHash: OLD_HASH,
+    });
+    expect(before?.deskManagerId).toBe(deskId);
+
+    const res = await t.mutation(internal.mcpApiKeys.revoke, {
+      keyId,
+      revokedByPrivySubject: ISSUER,
+    });
+    expect(res.ok).toBe(true);
+    expect(res.alreadyRevoked).toBe(false);
+
+    const after = await t.query(internal.mcpApiKeys.lookupDeskByKeyHash, {
+      keyHash: OLD_HASH,
+    });
+    expect(after).toBeNull();
+  });
+
+  it("revoke is idempotent — second call reports alreadyRevoked", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t);
+    const keyId = await seedKey(
+      t,
+      deskId as Id<"deskManagers">,
+      OLD_HASH,
+      ISSUER
+    );
+
+    const first = await t.mutation(internal.mcpApiKeys.revoke, {
+      keyId,
+      revokedByPrivySubject: ISSUER,
+    });
+    expect(first.alreadyRevoked).toBe(false);
+
+    const second = await t.mutation(internal.mcpApiKeys.revoke, {
+      keyId,
+      revokedByPrivySubject: ISSUER,
+    });
+    expect(second.alreadyRevoked).toBe(true);
+    expect(second.revokedAt).toBe(first.revokedAt);
+  });
+
+  it("revoke from a non-issuer subject is rejected", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t);
+    const keyId = await seedKey(
+      t,
+      deskId as Id<"deskManagers">,
+      OLD_HASH,
+      ISSUER
+    );
+
+    await expect(
+      t.mutation(internal.mcpApiKeys.revoke, {
+        keyId,
+        revokedByPrivySubject: OUTSIDER,
+      })
+    ).rejects.toThrow(/Not authorized/);
+  });
+
+  it("rotate atomically revokes old key and binds new key to the same desk", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t);
+    const oldKeyId = await seedKey(
+      t,
+      deskId as Id<"deskManagers">,
+      OLD_HASH,
+      ISSUER
+    );
+
+    const res = await t.mutation(internal.mcpApiKeys.rotate, {
+      keyId: oldKeyId,
+      newKeyHash: NEW_HASH,
+      rotatedByPrivySubject: ISSUER,
+    });
+    expect(res.ok).toBe(true);
+    expect(res.deskManagerId).toBe(deskId);
+
+    // Old hash → null (revoked).
+    const oldLookup = await t.query(internal.mcpApiKeys.lookupDeskByKeyHash, {
+      keyHash: OLD_HASH,
+    });
+    expect(oldLookup).toBeNull();
+
+    // New hash → same desk.
+    const newLookup = await t.query(internal.mcpApiKeys.lookupDeskByKeyHash, {
+      keyHash: NEW_HASH,
+    });
+    expect(newLookup?.deskManagerId).toBe(deskId);
+  });
+
+  it("rotate from a non-issuer subject is rejected", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t);
+    const keyId = await seedKey(
+      t,
+      deskId as Id<"deskManagers">,
+      OLD_HASH,
+      ISSUER
+    );
+
+    await expect(
+      t.mutation(internal.mcpApiKeys.rotate, {
+        keyId,
+        newKeyHash: NEW_HASH,
+        rotatedByPrivySubject: OUTSIDER,
+      })
+    ).rejects.toThrow(/Not authorized/);
+  });
+
+  it("rotate against an already-revoked key is rejected", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t);
+    const keyId = await seedKey(
+      t,
+      deskId as Id<"deskManagers">,
+      OLD_HASH,
+      ISSUER
+    );
+
+    await t.mutation(internal.mcpApiKeys.revoke, {
+      keyId,
+      revokedByPrivySubject: ISSUER,
+    });
+
+    await expect(
+      t.mutation(internal.mcpApiKeys.rotate, {
+        keyId,
+        newKeyHash: NEW_HASH,
+        rotatedByPrivySubject: ISSUER,
+      })
+    ).rejects.toThrow(/already-revoked/);
+  });
+});


### PR DESCRIPTION
## Summary
- Convex mutations `revoke` / `revokeMyKey` (hard cut, idempotent, only the original Privy DID issuer can revoke) and `rotate` / `rotateMyKey` (atomic — revoke old hash + insert new hash bound to the same `deskManagerId`, so wallet/traders/deals/allowlist all carry over).
- Next.js routes `DELETE /api/mcp/keys/{keyId}` and `POST /api/mcp/keys/{keyId}/rotate`. Raw new key is generated in Next.js (Convex only sees the HMAC hash) and returned exactly once with a "shown only once" notice.
- Operator dialog `mcp-operator-dialog.tsx` gains a **KEY ACTIONS** panel inside the selected-desk view with Rotate + Revoke buttons. Browser `confirm()` warns "old key stops working immediately — update your MCP client first." Rotate displays the new key in a one-time copy panel; revoke clears the selection and the reactive `listIssuedBy` filter hides the row.

This is **PR-B of 3** for issue #145 (Phase 6). Independent of PR-A (#157); branched from main.

Closes acceptance criteria 4 + 6 (API key rotation/revocation supported, API key management UI exists) from #145.

## Test plan
- [x] `pnpm vitest run tests/convex/mcp-key-rotation.test.ts` — 6/6 passing (revoke happy path, idempotency, non-issuer rejection, atomic rotate, rotate-non-issuer rejection, rotate-on-revoked rejection)
- [x] `pnpm build` — clean
- [x] `pnpm lint` — no new errors (21 pre-existing problems, identical to main)
- [ ] Manual: issue a key → open operator dialog → Rotate → confirm new key works in Claude Code while old key returns 401
- [ ] Manual: Revoke → confirm desk row disappears + subsequent calls with the revoked key return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)