### PR TITLE
feat(agent): decide deal win/loss mechanically, LLM only narrates

### DIFF
--- a/convex/agent/_constants.ts
+++ b/convex/agent/_constants.ts
@@ -12,6 +12,24 @@ export const RAKE_PERCENTAGE = 10;
 /** 25% of pot per win (max extraction). */
 export const MAX_EXTRACTION_PERCENTAGE = 25;
 
+/**
+ * Win/loss is decided mechanically in code (not by the LLM). These tune the
+ * odds and sizing; the LLM only narrates the pre-decided result.
+ */
+/** Baseline probability a deal resolves as a win, before market modifiers. */
+export const BASE_WIN_PROBABILITY = 0.5;
+/** Max amount market mood / SEC heat can shift the win probability each way. */
+export const WIN_PROB_MARKET_SWING = 0.15;
+/** Hard bounds on the modified win probability. */
+export const MIN_WIN_PROBABILITY = 0.15;
+export const MAX_WIN_PROBABILITY = 0.85;
+/** On a win, trader gains a random fraction of maxValuePerWin. */
+export const WIN_MAGNITUDE_MIN_FRACTION = 0.3;
+export const WIN_MAGNITUDE_MAX_FRACTION = 1.0;
+/** On a loss, trader loses a random fraction of the entry cost. */
+export const LOSS_MAGNITUDE_MIN_FRACTION = 0.4;
+export const LOSS_MAGNITUDE_MAX_FRACTION = 1.0;
+
 /** Approval expiry: 24 hours from request time. */
 export const APPROVAL_EXPIRY_MS = 24 * 60 * 60 * 1000;
 

--- a/convex/agent/_schemas.ts
+++ b/convex/agent/_schemas.ts
@@ -32,7 +32,6 @@ const AssetGainedSchema = z.object({
 
 export const DealOutcomeSchema = z.object({
   narrative: z.string(),
-  balance_change_usdc: z.number(),
   assets_gained: z.array(AssetGainedSchema),
   assets_lost: z.array(z.string()),
   trader_wiped_out: z.boolean(),

--- a/convex/agent/outcomeResolver.ts
+++ b/convex/agent/outcomeResolver.ts
@@ -17,12 +17,24 @@ import { zodResponseFormat } from "openai/helpers/zod";
 import type { Id } from "../_generated/dataModel";
 import type { RunActionCtx } from "./_ctx";
 import { internal } from "../_generated/api";
-import { RAKE_PERCENTAGE, MAX_EXTRACTION_PERCENTAGE } from "./_constants";
+import {
+  RAKE_PERCENTAGE,
+  MAX_EXTRACTION_PERCENTAGE,
+  BASE_WIN_PROBABILITY,
+  WIN_PROB_MARKET_SWING,
+  MIN_WIN_PROBABILITY,
+  MAX_WIN_PROBABILITY,
+  WIN_MAGNITUDE_MIN_FRACTION,
+  WIN_MAGNITUDE_MAX_FRACTION,
+  LOSS_MAGNITUDE_MIN_FRACTION,
+  LOSS_MAGNITUDE_MAX_FRACTION,
+} from "./_constants";
 import { DealOutcomeSchema, type DealOutcomePayload } from "./_schemas";
 import type { Deal } from "./_types";
 
-const FALLBACK_DEAL_OUTCOME_SYSTEM = `You are the outcome engine for a 1980s Wall Street trading game.
-When a trader enters a deal, you resolve the outcome with vivid, terse prose and structured data.
+const FALLBACK_DEAL_OUTCOME_SYSTEM = `You are the narrator for a 1980s Wall Street trading game.
+The win/loss outcome has already been decided by the house — you only dramatize it with vivid, terse prose and structured data.
+Make wins feel earned and losses feel brutal, but never contradict the decided outcome.
 Always return valid JSON matching the schema. Keep narrative to 2-3 short sentences.`;
 
 export interface OutcomeResolverInput {
@@ -50,11 +62,35 @@ export interface ResolvedOutcome {
   assetsLost: string[];
 }
 
+const lerp = (min: number, max: number, t: number) => min + (max - min) * t;
+
+/**
+ * Compute the win probability for a deal from market signals. Starts at the
+ * baseline and shifts by up to ±WIN_PROB_MARKET_SWING based on mood and SEC
+ * heat, then clamps to [MIN_WIN_PROBABILITY, MAX_WIN_PROBABILITY].
+ */
+function computeWinProbability(worldMood: string, secHeat: number): number {
+  let shift = 0;
+  const mood = worldMood.toLowerCase();
+  if (/eupho|bull|greed|boom|frenzy|rally/.test(mood)) {
+    shift += WIN_PROB_MARKET_SWING;
+  } else if (/pani|bear|crash|fear|gloom|doom|collapse/.test(mood)) {
+    shift -= WIN_PROB_MARKET_SWING;
+  }
+  // SEC heat 0..10 → up to a full negative swing at max heat.
+  const heat = Math.max(0, Math.min(10, secHeat));
+  shift -= (heat / 10) * WIN_PROB_MARKET_SWING;
+
+  const p = BASE_WIN_PROBABILITY + shift;
+  return Math.max(MIN_WIN_PROBABILITY, Math.min(MAX_WIN_PROBABILITY, p));
+}
+
 /**
  * Resolve a deal outcome by calling the LLM.
  *
- * If the LLM fails, throws — the caller should release the cycle lease
- * and log the error so the next cycle retries.
+ * The win/loss decision AND magnitude are made mechanically in code — the LLM
+ * only narrates the pre-decided result. If the LLM fails, throws — the caller
+ * should release the cycle lease and log the error so the next cycle retries.
  */
 export async function resolveOutcome(
   ctx: RunActionCtx,
@@ -81,7 +117,6 @@ export async function resolveOutcome(
 
   // Max win value: MAX_EXTRACTION_PERCENTAGE % of pot
   const maxValuePerWin = deal.pot_usdc * (MAX_EXTRACTION_PERCENTAGE / 100);
-  const randomSeed = Math.random();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const narrative = marketNarrative as Record<string, any> | null;
@@ -90,37 +125,58 @@ export async function resolveOutcome(
   const activeStorylines: string[] =
     narrative?.worldState?.active_storylines ?? [];
 
+  // ── Decide the outcome mechanically (NOT via the LLM) ──────────────────────
+  // The LLM cannot reliably sample from a "random seed", so win/loss and its
+  // magnitude are rolled here with a real, market-modulated probability. The
+  // LLM is handed the result and only narrates it.
+  const winProbability = computeWinProbability(worldMood, secHeat);
+  const isWin = Math.random() < winProbability;
+  const decidedBalanceChange = isWin
+    ? maxValuePerWin *
+      lerp(
+        WIN_MAGNITUDE_MIN_FRACTION,
+        WIN_MAGNITUDE_MAX_FRACTION,
+        Math.random()
+      )
+    : -entryCostUsdc *
+      lerp(
+        LOSS_MAGNITUDE_MIN_FRACTION,
+        LOSS_MAGNITUDE_MAX_FRACTION,
+        Math.random()
+      );
+  const outcomeLabel = isWin
+    ? `WIN of $${decidedBalanceChange.toFixed(2)} USDC`
+    : `LOSS of $${Math.abs(decidedBalanceChange).toFixed(2)} USDC`;
+
   const systemPrompt = systemPromptContent ?? FALLBACK_DEAL_OUTCOME_SYSTEM;
 
   const messages = [
     { role: "system" as const, content: systemPrompt },
     {
       role: "user" as const,
-      content: `Resolve this deal for the trader and return the outcome as structured JSON.
+      content: `Narrate the outcome of this deal and return it as structured JSON.
+
+The outcome has ALREADY been decided by the house. Your job is to dramatize it,
+not to change it.
 
 DEAL: ${deal.prompt}
 
 TRADER: ${traderName}
 INVENTORY: ${inventoryDescription}
 PORTFOLIO BALANCE: $${escrowBalanceUsdc} USDC
-MAX LOSS: $${entryCostUsdc.toFixed(2)} USDC (normal deals cannot lose more than the entry cost)
-MAX WIN VALUE: $${maxValuePerWin.toFixed(2)} USDC (cannot exceed this)
-RANDOM SEED: ${randomSeed.toFixed(2)} (use this to introduce randomness — lower values favor losses, higher values favor gains)
 
-MARKET CONDITIONS:
+DECIDED OUTCOME: ${outcomeLabel}
+- The narrative MUST match this outcome: a WIN must read as a clear win, a LOSS must read as a clear loss. Never contradict the decided result.
+
+MARKET CONDITIONS (color for the narrative only — do NOT change the outcome):
 - Market mood: ${worldMood}
 - SEC heat level: ${secHeat}/10
 - Active storylines: ${activeStorylines.length > 0 ? activeStorylines.join(", ") : "none"}
 
-The market conditions should subtly influence outcomes. High SEC heat + insider trading = skew negative.
-Euphoric mood + bull play = can skew positive. Use these as soft signals, not hard rules.
-
 Rules:
-- balance_change_usdc must be between -${entryCostUsdc.toFixed(2)} and +${maxValuePerWin.toFixed(2)}
-- For normal deals, max downside is the entry cost, not the full portfolio balance
-- trader_wiped_out is advisory only; final wipeout is derived mechanically after validated PnL is applied
+- trader_wiped_out is advisory only; final wipeout is derived mechanically after PnL is applied
 - The narrative should be 2-3 short sentences only — vivid 1980s Wall Street tone, no rambling
-- Each assets_gained[].name must be exactly 2-3 words (no parentheses, no subtitles); thematic items (tips, contacts, documents)
+- Each assets_gained[].name must be exactly 2-3 words (no parentheses, no subtitles); thematic items (tips, contacts, documents). On a LOSS, assets_gained should normally be empty.
 - assets_lost entries must copy inventory names exactly as listed in INVENTORY (required for matching)`,
     },
   ];
@@ -147,8 +203,9 @@ Rules:
   const raw = msg.parsed as DealOutcomePayload;
 
   // ── Validate + clamp PnL ────────────────────────────────────────────────────
-  // balance_change_usdc from LLM: clamp to [-entry cost, +maxValuePerWin]
-  let balanceChange = raw.balance_change_usdc;
+  // PnL is the code-decided value, NOT the LLM's — the LLM only narrates.
+  // Clamp to [-entry cost, +maxValuePerWin] as a safety net.
+  let balanceChange = decidedBalanceChange;
   balanceChange = Math.min(balanceChange, maxValuePerWin);
   balanceChange = Math.max(balanceChange, -entryCostUsdc);
 

--- a/convex/seeds/systemPrompts.ts
+++ b/convex/seeds/systemPrompts.ts
@@ -11,7 +11,7 @@ export const systemPromptSeeds: SystemPromptSeed[] = [
     name: "deal_outcome",
     content: `${SHARED_NARRATOR_PREAMBLE}
 
-You are resolving deals on the floor of the exchange. Traders are greedy, desperate, and willing to risk everything. The market is a beast that devours the weak. Paint every outcome — win or wipeout — in dramatic, visceral detail. Reference real 1980s culture: power suits, car phones, cocaine-fueled all-nighters, corner offices, hostile takeovers, and the constant hum of the ticker tape.`,
+You narrate deal outcomes on the floor of the exchange. The win or loss has ALREADY been decided by the house — your job is to dramatize the result you are handed, never to change it. When a trader wins, make the triumph feel earned and electric; when a trader loses, make the damage feel brutal. Paint every outcome — windfall or wipeout — in dramatic, visceral detail. Reference real 1980s culture: power suits, car phones, cocaine-fueled all-nighters, corner offices, hostile takeovers, and the constant hum of the ticker tape.`,
   },
   {
     name: "prompt_suggestions",

--- a/data/newswire-posts.json
+++ b/data/newswire-posts.json
@@ -1,0 +1,610 @@
+[
+  {
+    "createdAt": "2026-06-11T15:30:12.786Z",
+    "dispatches": [
+      {
+        "body": "Forced liquidations deepen as PanAtlantic reveals an additional $300M asset loss. Market responds with heightened anxiety over potential further fallout.",
+        "category": "wire",
+        "dispatchKey": "panatl-new-loss-report",
+        "headline": "PanAtlantic Reports Additional $300M Asset Loss in Liquidation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Crisis Escalates: New Loss Reported Amid SEC Scrutiny",
+    "epoch": 32,
+    "epochSlot": 494775,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-11T14:30:13.168Z",
+    "dispatches": [
+      {
+        "body": "Rourke Capital ordered to unwind $100M in positions tied to PanAtlantic. Movement sparks concerns of further distress. Watch for counterparty responses.",
+        "category": "ticker",
+        "dispatchKey": "panatl-sec-action",
+        "headline": "SEC Forces Rourke Capital to Unwind Positions in PanAtlantic Holdings",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Fear Peaks as Mercer Probe Forces Major Action",
+    "epoch": 31,
+    "epochSlot": 494774,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-11T13:30:09.675Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms another $300M asset loss amid intensified SEC scrutiny. Conditions worsen as Rourke Capital deepens shorts. Watch for counterparty impact.",
+        "category": "wire",
+        "dispatchKey": "panatl-liquidation-update",
+        "headline": "SEC Forces Additional Liquidation at PanAtlantic: Losses Accelerate",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Morning Briefing: SEC Heat Reaches Critical Levels as PanAtlantic Faces Unprecedented Loss",
+    "epoch": 30,
+    "epochSlot": 494773,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-10T19:30:10.379Z",
+    "dispatches": [
+      {
+        "body": "Forced sell-off reveals total asset loss has escalated to $650M. Margin calls intensify pressure on remaining positions. Watch for further fallout.",
+        "category": "wire",
+        "dispatchKey": "panatl-collateral-loss",
+        "headline": "PanAtlantic Reports Additional $250M Asset Loss in Liquidation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Crisis Worsens Amid SEC Pressure",
+    "epoch": 29,
+    "epochSlot": 494755,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-10T18:30:09.558Z",
+    "dispatches": [
+      {
+        "body": "SEC confirms subpoenas issued to three more firms tied to PanAtlantic. Loss estimates from exposures top $250M. Industry dreads ripple effects. Watch for fallout.",
+        "category": "wire",
+        "dispatchKey": "panatl-counterparty-exposure",
+        "headline": "SEC Broadens Probe: Multiple Counterparties Exposed",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "SEC Action Escalates: Major Counterparty Exposures Revealed",
+    "epoch": 28,
+    "epochSlot": 494754,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-10T17:30:05.816Z",
+    "dispatches": [
+      {
+        "body": "SEC mandates immediate liquidation of remaining PanAtlantic assets, reducing value by $250M. Rourke Capital builds larger short position as desperation mounts.",
+        "category": "wire",
+        "dispatchKey": "panatl-sec-action",
+        "headline": "SEC Forces Major Forced Liquidation at PanAtlantic Holdings",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Panic Peaks: Forced Liquidations and SEC Pressure Mount",
+    "epoch": 27,
+    "epochSlot": 494753,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-10T16:30:10.845Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings reports a new $150M asset loss as forced liquidations continue. Market waits for CEO response amidst full-blown crisis.",
+        "category": "ticker",
+        "dispatchKey": "panatl-forced-liquidation",
+        "headline": "PanAtlantic Faces Additional $150M Loss Amid Forced Liquidation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Forced Liquidations Increase as PanAtlantic Faces Major Losses",
+    "epoch": 26,
+    "epochSlot": 494752,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-10T15:30:11.395Z",
+    "dispatches": [
+      {
+        "body": "SEC issues immediate freeze on assets tied to PanAtlantic Holdings amid ongoing investigation. Expected loss rises to $1.1B. Counterparties brace for potential fallout.",
+        "category": "wire",
+        "dispatchKey": "panatl-sec-followup",
+        "headline": "SEC Freezes PanAtlantic Holdings' Assets; Losses Mount",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Panic Deepens as SEC Tightens Grip on PanAtlantic Holdings",
+    "epoch": 25,
+    "epochSlot": 494751,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-10T14:30:09.165Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms an additional $400M asset loss today linked to its ongoing forced liquidation. Rourke Capital reportedly increases its short position, sensing further",
+        "category": "wire",
+        "dispatchKey": "panatl-new-asset-loss",
+        "headline": "PanAtlantic Reports $400M Total Asset Loss Amid Major Liquidation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Panic Peaks on PanAtlantic Floor as New Losses Emerge",
+    "epoch": 24,
+    "epochSlot": 494750,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-10T13:30:08.995Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms an additional $200M asset loss today, pushing total liquidation pressure towards $600M. Rourke Capital short position intensifies as the floor braces.",
+        "category": "wire",
+        "dispatchKey": "panatl-asset-loss",
+        "headline": "PanAtlantic Faces Fresh $200M Asset Blow Amid Forced Liquidations",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Morning Briefing: Anticipation Builds as PanAtlantic Crisis Peaks",
+    "epoch": 23,
+    "epochSlot": 494749,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-09T19:30:06.405Z",
+    "dispatches": [
+      {
+        "body": "Diane Mercer expands SEC investigation, issuing subpoenas to at least three new firms allegedly involved in PanAtlantic's toxic assets. Desks go silent.",
+        "category": "wire",
+        "dispatchKey": "mercer-new-subpoenas",
+        "headline": "SEC Issues New Subpoenas to Counterparties Linked to PanAtlantic Holdings",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "SEC Scrutiny Expands: New Subpoenas Hit Market",
+    "epoch": 22,
+    "epochSlot": 494731,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-09T18:30:12.071Z",
+    "dispatches": [
+      {
+        "body": "SEC investigation leads to a counterparty break as Blackwell & Co. withdraws from dealings with PanAtlantic Holdings. Risk exposure heightened. Watch for further moves.",
+        "category": "wire",
+        "dispatchKey": "panatl-sec-counterparty-break",
+        "headline": "SEC Connects with Counterparties Facing PanAtlantic Exposure",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Urgent: SEC Investigation Forces Serious Break at PanAtlantic Holdings",
+    "epoch": 21,
+    "epochSlot": 494730,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-09T17:30:10.549Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms internal assets liquidated to cover margin calls. Total losses approach $1.5B. Rourke Capital increases short position as trades clear.",
+        "category": "wire",
+        "dispatchKey": "panatl-liquidation-event",
+        "headline": "PanAtlantic Holdings Triggers Forced Liquidation Event",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Panic Settles Over PanAtlantic Holdings",
+    "epoch": 20,
+    "epochSlot": 494729,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 9,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-09T16:30:13.680Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms $500M asset unwind driven by forced liquidation. Rourke Capital anticipates profit on short position. Watch for further moves as assets liquidate.",
+        "category": "wire",
+        "dispatchKey": "panatl-position-unwind",
+        "headline": "PanAtlantic Holdings Executes Major Asset Unwind Amid Margin Calls",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Urgent: PanAtlantic Holdings Faces Critical Asset Unwind",
+    "epoch": 19,
+    "epochSlot": 494728,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-09T15:30:09.240Z",
+    "dispatches": [
+      {
+        "body": "Diane Mercer applies pressure as SEC enacts a compliance order demanding PanAtlantic provide full financial disclosures. Short sellers ready to capitalize on fallout.",
+        "category": "wire",
+        "dispatchKey": "panatl-sec-action",
+        "headline": "SEC Forces Data Release from PanAtlantic Holdings Amid Investigation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Holdings Faces Deepening Regulatory Fallout",
+    "epoch": 18,
+    "epochSlot": 494727,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-09T14:30:14.197Z",
+    "dispatches": [
+      {
+        "body": "Daily asset loss at PanAtlantic Holdings hits $300M as margin calls tighten on all desks. Rourke Capital triples short position, sensing imminent collapse.",
+        "category": "wire",
+        "dispatchKey": "panatl-asset-loss",
+        "headline": "PanAtlantic Holdings Reports Additional $300M Asset Loss Today",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Losses Accelerate Amid Ongoing SEC Probes",
+    "epoch": 17,
+    "epochSlot": 494726,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-09T13:30:14.587Z",
+    "dispatches": [
+      {
+        "body": "In a shocking development, sources confirm PanAtlantic loses another $100M, pushing total losses past $1B before today’s open. Rourke Capital aggressively positions to short.",
+        "category": "wire",
+        "dispatchKey": "panatl-silent-loss",
+        "headline": "PanAtlantic Holdings Faces Additional $100M Loss Ahead of Liquidation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Morning Briefing: PanAtlantic's Silent Demise Deepens",
+    "epoch": 16,
+    "epochSlot": 494725,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-08T19:30:12.171Z",
+    "dispatches": [
+      {
+        "body": "Diane Mercer confirms SEC has issued additional subpoenas to all major counterparties. Several firms scramble to unwind positions, raising further concerns. Watch closely.",
+        "category": "floor_talk",
+        "dispatchKey": "panatl-sec-regulatory-action",
+        "headline": "SEC Subpoenas Widen, PanAtlantic Counterparties Hemorrhage Risk Exposure",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "SEC Escalates Actions Against PanAtlantic Amid Widening Collapse",
+    "epoch": 15,
+    "epochSlot": 494707,
+    "mood": "tense",
+    "secHeat": 10,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-08T18:30:08.649Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic under severe pressure as another $100M loss reported, total asset losses now hit $1.1B. Liquidation fear grips trading desks.",
+        "category": "wire",
+        "dispatchKey": "panatl-collapse-update",
+        "headline": "PanAtlantic Holdings Faces $100M Additional Asset Loss Amid White-Knuckle Trading",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Demise Accelerates Amid Heightened Pressure",
+    "epoch": 14,
+    "epochSlot": 494706,
+    "mood": "tense",
+    "secHeat": 9,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-08T17:30:12.772Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings faces a $250M asset loss due to aggressive margin calls from lenders. Desperate measures expected as liquidations loom larger. Watch for counterplay.",
+        "category": "wire",
+        "dispatchKey": "panatl-margin-call",
+        "headline": "PanAtlantic Holdings Reports $250M Additional Asset Loss Amid Margin Calls",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Falls Deeper into Freefall, Margin Calls Resurface",
+    "epoch": 13,
+    "epochSlot": 494705,
+    "mood": "tense",
+    "secHeat": 8,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-08T16:30:12.122Z",
+    "dispatches": [
+      {
+        "body": "SEC reports total asset losses have surged to $900M for PanAtlantic Holdings amid ongoing investigations. Firms facing exposure should evaluate positions immediately.",
+        "category": "wire",
+        "dispatchKey": "panatl-sec-action",
+        "headline": "SEC Issues Emergency Filing on PanAtlantic Holdings, Losses Accelerate",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "SEC Investigation Triggers Shakeout at PanAtlantic Holdings",
+    "epoch": 12,
+    "epochSlot": 494704,
+    "mood": "tense",
+    "secHeat": 8,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-08T15:30:12.524Z",
+    "dispatches": [
+      {
+        "body": "Sources indicate PanAtlantic Holdings has suffered an additional $200M in asset loss during forced liquidation. Rourke Capital increases short position significantly.",
+        "category": "wire",
+        "dispatchKey": "panatl-additional-loss",
+        "headline": "PanAtlantic Holdings Faces $200M Asset Loss, Margin Calls Intensify",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Holdings Sees Additional $200M Asset Loss Amidst Growing Crisis",
+    "epoch": 11,
+    "epochSlot": 494703,
+    "mood": "tense",
+    "secHeat": 8,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-08T14:30:12.105Z",
+    "dispatches": [
+      {
+        "body": "SEC confirms new asset loss at PanAtlantic Holdings totaling $100M, attributed to ongoing liquidation pressures. Pressure mounts with margin calls looming. Watch closely.",
+        "category": "ticker",
+        "dispatchKey": "panatl-liquidation-update",
+        "headline": "PanAtlantic Holdings Faces $100M Additional Asset Loss",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Fallout Intensifies, SEC Responds",
+    "epoch": 10,
+    "epochSlot": 494702,
+    "mood": "tense",
+    "secHeat": 7,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-08T13:30:14.953Z",
+    "dispatches": [
+      {
+        "body": "SEC investigator Diane Mercer issues further subpoenas amid investigation. PanAtlantic Holdings faces an additional $200M asset loss risk from probing dealings. Watch positions.",
+        "category": "wire",
+        "dispatchKey": "mercer-sec-action",
+        "headline": "SEC Increases Scrutiny, Additional Subpoenas Sent to Counterparties",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Morning Briefing: SEC Probes Tighten Grip on PanAtlantic Holdings",
+    "epoch": 9,
+    "epochSlot": 494701,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-05T19:30:12.746Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms forced liquidation, total asset loss at $600M. Rourke Capital stands to gain from its aggressive short positions. The floor watches nervously.",
+        "category": "wire",
+        "dispatchKey": "panatl-final-blow",
+        "headline": "Forced Liquidation Confirms $600M Loss at PanAtlantic Holdings",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Holdings Faces Final Blow",
+    "epoch": 8,
+    "epochSlot": 494635,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-05T18:30:11.787Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings sees another $150M wiped as forced sales continue. Rourke Capital repositions, increasing short position amid ongoing turmoil. Watch for counteractions.",
+        "category": "wire",
+        "dispatchKey": "panatl-forced-liquidation",
+        "headline": "PanAtlantic Holdings Loses Additional $150M in Liquidation",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "PanAtlantic Collapse Worsens; Liquidation Hits",
+    "epoch": 7,
+    "epochSlot": 494634,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-05T17:30:11.389Z",
+    "dispatches": [
+      {
+        "body": "Diane Mercer announces a fresh $100M loss due to ongoing asset liquidation at PanAtlantic. Investigators are reportedly digging deeper into connected firms. Watch for fallout.",
+        "category": "wire",
+        "dispatchKey": "panatl-asset-loss",
+        "headline": "SEC Confirms Additional $100M Asset Loss at PanAtlantic Holdings",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Morning Briefing: Forced Liquidation Fallout Prompts Reckoning",
+    "epoch": 6,
+    "epochSlot": 494633,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-05T15:30:13.660Z",
+    "dispatches": [
+      {
+        "body": "Diane Mercer confirms new subpoenas related to PanAtlantic's filings. Total asset loss now $550M as scrutiny intensifies. Watch for fallout from this continued investigation.",
+        "category": "wire",
+        "dispatchKey": "panatl-forced-liquidation",
+        "headline": "SEC Expands Probe, PanAtlantic Faces Additional $100M Asset Loss",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "SEC Intensifies Focus on PanAtlantic Holdings, Forced Liquidation Executed",
+    "epoch": 5,
+    "epochSlot": 494631,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-05T14:30:10.518Z",
+    "dispatches": [
+      {
+        "body": "Liquidation today hits PanAtlantic Holdings, wiping out $450M across three desks. Rourke Capital's shorts fully execute. Market awaits fallout from remaining positions.",
+        "category": "wire",
+        "dispatchKey": "panatl-liquidation-event",
+        "headline": "Forced Liquidation Executes at PanAtlantic Holdings, $450M Wipeout",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Forced Liquidation Confirmed at PanAtlantic Holdings",
+    "epoch": 4,
+    "epochSlot": 494630,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 9,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-05T13:30:11.446Z",
+    "dispatches": [
+      {
+        "body": "Diane Mercer confirms subpoenas affect PanAtlantic and three other firms. Panic grips floor as $450M asset loss confirmed. Immediate liquidation seems inevitable.",
+        "category": "wire",
+        "dispatchKey": "mercer-investigation-panatl-holdings",
+        "headline": "SEC Subpoenas Hit PanAtlantic Holdings, Total Asset Loss Reaches $450M",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Trading Day Begins Amid Forced Liquidation Fears",
+    "epoch": 3,
+    "epochSlot": 494629,
+    "mood": "tense",
+    "secHeat": 6,
+    "topArcTension": 10,
+    "topArcTitle": "Mercer investigation widens"
+  },
+  {
+    "createdAt": "2026-06-04T19:30:08.299Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings confirms a $450M asset loss due to margin calls. Rourke Capital bolsters short position as the market anticipates further fallout. Watch closely.",
+        "category": "wire",
+        "dispatchKey": "panatl-forced-liquidation",
+        "headline": "Forced liquidation likely as PanAtlantic reports $450M asset loss",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Market Cautiously Awaits Panic After PanAtlantic Developments",
+    "epoch": 2,
+    "epochSlot": 494611,
+    "mood": "tense",
+    "secHeat": 5,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  },
+  {
+    "createdAt": "2026-06-04T18:30:05.616Z",
+    "dispatches": [
+      {
+        "body": "PanAtlantic Holdings begins to unwind positions as margin calls intensify. Rourke Capital scores $120M on short position. Rumors of further asset losses circulate.",
+        "category": "wire",
+        "dispatchKey": "panatl-position-unwind",
+        "headline": "PanAtlantic holdings faces forced liquidation amid intense scrutiny",
+        "role": "main"
+      }
+    ],
+    "dropTitle": "Market Tension Peaks Amid Forced Liquidation Rumors",
+    "epoch": 1,
+    "epochSlot": 494610,
+    "mood": "tense",
+    "secHeat": 5,
+    "topArcTension": 10,
+    "topArcTitle": "PanAtlantic blow-up"
+  }
+]


### PR DESCRIPTION
Move win/loss and PnL magnitude out of the LLM and into market-modulated code (computeWinProbability + rolled fractions). The LLM is handed the decided result and only dramatizes it. Drop the now-discarded balance_change_usdc from the outcome schema and prompt so the contract matches reality and saves tokens each cycle.