### PR TITLE
feat(ui): wallet onboarding checklist for the hire flow

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -57,6 +57,7 @@ import type * as mcp_tradersEscrow from "../mcp/tradersEscrow.js";
 import type * as mcp_wipeMcpDesks from "../mcp/wipeMcpDesks.js";
 import type * as mcpApiKeys from "../mcpApiKeys.js";
 import type * as me from "../me.js";
+import type * as ops__batchDelete from "../ops/_batchDelete.js";
 import type * as ops_clearNarrativeWorld from "../ops/clearNarrativeWorld.js";
 import type * as ops_resetGameState from "../ops/resetGameState.js";
 import type * as ops_wipeSmokeTraders from "../ops/wipeSmokeTraders.js";
@@ -142,6 +143,7 @@ declare const fullApi: ApiFromModules<{
   "mcp/wipeMcpDesks": typeof mcp_wipeMcpDesks;
   mcpApiKeys: typeof mcpApiKeys;
   me: typeof me;
+  "ops/_batchDelete": typeof ops__batchDelete;
   "ops/clearNarrativeWorld": typeof ops_clearNarrativeWorld;
   "ops/resetGameState": typeof ops_resetGameState;
   "ops/wipeSmokeTraders": typeof ops_wipeSmokeTraders;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -21,6 +21,14 @@ const firmStatusValidator = v.union(
   v.literal("dead")
 );
 
+// Last completed wallet-provisioning checkpoint, in pipeline order. Drives the
+// onboarding checklist UI; walletStatus === "ready" is the implicit final step.
+export const walletStepValidator = v.union(
+  v.literal("paperwork"), // lease acquired, mint in flight
+  v.literal("id_minted"), // identity NFT mint confirmed, tokenId extracted
+  v.literal("seat_registered") // canonical CDP accounts created, transfer in flight
+);
+
 export default defineSchema({
   deskManagers: defineTable({
     // Identity subject. Either a Privy DID ("did:privy:xxx") for browser desks
@@ -124,6 +132,10 @@ export default defineSchema({
       v.literal("error")
     ),
     walletError: v.optional(v.string()),
+    /** Last completed provisioning checkpoint (cosmetic; onboarding checklist UI). */
+    walletStep: v.optional(walletStepValidator),
+    /** tokenId surfaced mid-provisioning for the checklist; canonical `tokenId` is only set at applyWalletReady. */
+    walletStepTokenId: v.optional(v.number()),
     // wallet metadata (set when walletStatus === "ready")
     cdpWalletAddress: v.optional(v.string()),
     cdpOwnerAddress: v.optional(v.string()),

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -20,6 +20,7 @@ import {
   PORTRAIT_METADATA_VERSION,
   readPublicTraits,
 } from "./lib/portraitSeed";
+import { walletStepValidator } from "./schema";
 import { TRADER_NAME_REGEX } from "../src/lib/trader-name";
 import { normalizeEmail } from "../src/lib/email";
 import { isMcpSubject } from "./mcp/subject";
@@ -98,6 +99,8 @@ async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
     cycleGeneration: trader.cycleGeneration,
     walletStatus: trader.walletStatus,
     walletError: trader.walletError,
+    walletStep: trader.walletStep,
+    walletStepTokenId: trader.walletStepTokenId,
     cdpWalletAddress: trader.cdpWalletAddress,
     cdpOwnerAddress: trader.cdpOwnerAddress,
     cdpAccountName: trader.cdpAccountName,
@@ -575,6 +578,8 @@ export const retryWalletProvisioning = mutation({
     await ctx.db.patch(traderId, {
       walletStatus: "pending",
       walletError: undefined,
+      walletStep: undefined,
+      walletStepTokenId: undefined,
       updatedAt: Date.now(),
     });
 
@@ -647,9 +652,34 @@ export const markCreating = internalMutation({
 
     await ctx.db.patch(traderId, {
       walletStatus: "creating",
+      walletStep: "paperwork",
+      walletStepTokenId: undefined,
       updatedAt: Math.max(Date.now(), trader.updatedAt + 1),
     });
     return true;
+  },
+});
+
+/**
+ * Internal: record a wallet-provisioning checkpoint (cosmetic; drives the
+ * onboarding checklist). No-op unless a provisioning run is in flight, so a
+ * stale worker can't scribble over a ready/error trader. Bumping updatedAt
+ * also refreshes the createForTrader re-entry lease while progress is live.
+ */
+export const setWalletStep = internalMutation({
+  args: {
+    traderId: v.id("traders"),
+    step: walletStepValidator,
+    tokenId: v.optional(v.number()),
+  },
+  handler: async (ctx, { traderId, step, tokenId }) => {
+    const trader = await ctx.db.get(traderId);
+    if (!trader || trader.walletStatus !== "creating") return;
+    await ctx.db.patch(traderId, {
+      walletStep: step,
+      ...(tokenId !== undefined ? { walletStepTokenId: tokenId } : {}),
+      updatedAt: Date.now(),
+    });
   },
 });
 

--- a/convex/wallet.ts
+++ b/convex/wallet.ts
@@ -81,6 +81,23 @@ export const createForTrader = internalAction({
     }
     if (!acquired) return;
 
+    // Cosmetic checkpoint reporting for the onboarding checklist UI.
+    // Must never abort provisioning.
+    const reportStep = async (
+      step: "id_minted" | "seat_registered",
+      stepTokenId?: number
+    ) => {
+      try {
+        await ctx.runMutation(internal.traders.setWalletStep, {
+          traderId,
+          step,
+          tokenId: stepTokenId,
+        });
+      } catch (err) {
+        console.warn(`setWalletStep(${step}) failed (non-fatal)`, err);
+      }
+    };
+
     try {
       // Validate env vars with clear errors instead of opaque SDK failures.
       const cdpApiKeyId = requireEnv("CDP_API_KEY_ID");
@@ -199,6 +216,7 @@ export const createForTrader = internalAction({
       if (tokenId === undefined) {
         throw new Error("Failed to extract tokenId from mint transaction");
       }
+      await reportStep("id_minted", tokenId);
 
       // Step 3: Create canonical accounts
       const owner = await cdp.evm.getOrCreateAccount({
@@ -208,6 +226,7 @@ export const createForTrader = internalAction({
         name: `trader-sa-${tokenId}`,
         owner,
       });
+      await reportStep("seat_registered");
 
       // Step 4: Transfer NFT from mint SA → canonical SA
       const transferData = encodeFunctionData({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -510,9 +510,87 @@
   animation: mc-shimmer 1.6s ease-in-out infinite;
 }
 
+/* ── Back-office onboarding (hire flow) ── */
+
+@keyframes mc-crt-reveal {
+  0% {
+    clip-path: inset(0 0 100% 0);
+    filter: brightness(2.1) saturate(0.4);
+  }
+  60% {
+    clip-path: inset(0 0 0 0);
+    filter: brightness(1.5);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+    filter: brightness(1);
+  }
+}
+
+.mc-crt-reveal {
+  animation: mc-crt-reveal 700ms var(--mc-ease-out) both;
+}
+
+@keyframes mc-stamp-in {
+  0% {
+    opacity: 0;
+    transform: scale(1.5) rotate(-8deg);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(0.95) rotate(-3deg);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(-3deg);
+  }
+}
+
+.mc-stamp-in {
+  animation: mc-stamp-in 450ms var(--mc-ease-snap) both;
+}
+
+@keyframes mc-onboard-flash {
+  0% {
+    box-shadow: inset 0 0 0 0 transparent;
+  }
+  20% {
+    box-shadow: inset 0 0 calc(48px * var(--mc-glow)) rgba(121, 212, 155, 0.35);
+  }
+  100% {
+    box-shadow: inset 0 0 0 0 transparent;
+  }
+}
+
+.mc-onboard-flash {
+  animation: mc-onboard-flash calc(var(--mc-dur-flash) * 2) var(--mc-ease-out)
+    both;
+}
+
+@keyframes mc-flavor-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.mc-flavor-fade {
+  animation: mc-flavor-fade var(--mc-dur-slow) var(--mc-ease-out) both;
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
+  .mc-crt-reveal,
+  .mc-stamp-in,
+  .mc-onboard-flash,
+  .mc-flavor-fade {
+    animation: none;
+    opacity: 1;
+  }
+
   .mc-feed-enter,
   .mc-feed-enter-high,
   .mc-shimmer,

--- a/src/components/trader-creation-flow.tsx
+++ b/src/components/trader-creation-flow.tsx
@@ -18,6 +18,7 @@ import { DatumCell } from "@/components/datum-cell";
 import { MarketClosedButton } from "@/components/market-closed-button";
 import { useMarketHours } from "@/hooks/use-market-hours";
 import { WalletProvisioningError } from "@/components/wallet-provisioning-error";
+import { WalletOnboardingChecklist } from "@/components/wallet-onboarding-checklist";
 import type { Mandate } from "@/lib/agent/evaluator";
 import type { Id } from "../../convex/_generated/dataModel";
 import { TRADER_NAME_MAX, validateTraderName } from "@/lib/trader-name";
@@ -600,14 +601,22 @@ function FundAndActivateStep({
           </span>
         </div>
 
-        <div className="mb-4 grid grid-cols-2 gap-3">
-          <DatumCell
-            label="Wallet"
-            value={walletReady ? "Ready" : "Setting up..."}
-            valueClassName={
-              walletReady ? "text-[var(--t-green)]" : "text-[var(--t-amber)]"
-            }
-          />
+        <div className="mb-4 grid gap-3">
+          {walletErrored ? (
+            <WalletProvisioningError
+              traderId={convexTraderId as Id<"traders">}
+              walletError={walletErrorMsg}
+            />
+          ) : (
+            <WalletOnboardingChecklist
+              walletStatus={trader?.wallet_status ?? "pending"}
+              walletStep={trader?.wallet_step ?? null}
+              tokenId={trader?.wallet_step_token_id ?? (tokenId || null)}
+              traderName={traderName}
+              imageStatus={trader?.image_status ?? null}
+              profileImageUrl={trader?.profile_image_url ?? ""}
+            />
+          )}
           <DatumCell
             label="Escrow"
             value={balanceUsdc !== null ? `$${balanceUsdc.toFixed(2)}` : "..."}
@@ -616,18 +625,6 @@ function FundAndActivateStep({
             }
           />
         </div>
-        {walletErrored && (
-          <WalletProvisioningError
-            traderId={convexTraderId as Id<"traders">}
-            walletError={walletErrorMsg}
-            className="mb-4"
-          />
-        )}
-        {!walletReady && !walletErrored && (
-          <p className="mb-4 text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
-            Wallet provisioning can take a minute on first hire.
-          </p>
-        )}
 
         <form onSubmit={handleDeposit} className="flex flex-col gap-3">
           <label className="block">

--- a/src/components/wallet-onboarding-checklist.test.tsx
+++ b/src/components/wallet-onboarding-checklist.test.tsx
@@ -1,0 +1,104 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { WalletOnboardingChecklist } from "./wallet-onboarding-checklist";
+
+const baseProps = {
+  traderName: "Gordon Gekko",
+  imageStatus: "generating" as const,
+  profileImageUrl: "",
+};
+
+describe("WalletOnboardingChecklist", () => {
+  it("renders line 1 active and the rest dimmed when no step is recorded", () => {
+    const html = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        walletStatus="creating"
+        walletStep={null}
+        tokenId={null}
+      />
+    );
+
+    expect(html).toContain("FILING PAPERWORK");
+    expect(html).toContain("█");
+    expect(html).toContain("MINTING TRADER ID");
+    expect(html).toContain("ISSUING FLOOR BADGE");
+    expect(html).not.toContain("OK");
+    expect(html).not.toContain("TRADER ON THE FLOOR");
+  });
+
+  it("shows the minted tokenId and advances to the seat step", () => {
+    const html = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        walletStatus="creating"
+        walletStep="id_minted"
+        tokenId={128}
+      />
+    );
+
+    expect(html).toContain("PAPERWORK FILED");
+    expect(html).toContain("TRADER ID MINTED #128");
+    expect(html).toContain("OK");
+    expect(html).toContain("REGISTERING SEAT");
+    expect(html).not.toContain("SEAT REGISTERED");
+  });
+
+  it("tolerates jumping straight to seat_registered", () => {
+    const html = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        walletStatus="creating"
+        walletStep="seat_registered"
+        tokenId={null}
+      />
+    );
+
+    expect(html).toContain("PAPERWORK FILED");
+    expect(html).toContain("TRADER ID MINTED");
+    expect(html).toContain("SEAT REGISTERED");
+    expect(html).toContain("ISSUING FLOOR BADGE");
+    expect(html).not.toContain("FLOOR BADGE ISSUED");
+  });
+
+  it("renders all steps done plus the stamp when the wallet is ready", () => {
+    const html = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        walletStatus="ready"
+        walletStep="seat_registered"
+        tokenId={42}
+      />
+    );
+
+    expect(html).toContain("PAPERWORK FILED");
+    expect(html).toContain("TRADER ID MINTED #42");
+    expect(html).toContain("SEAT REGISTERED");
+    expect(html).toContain("FLOOR BADGE ISSUED");
+    expect(html).toContain("TRADER ON THE FLOOR");
+    expect(html).not.toContain("█");
+  });
+
+  it("shows a flavor line while provisioning and hides it when ready", () => {
+    const provisioning = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        walletStatus="pending"
+        walletStep={null}
+        tokenId={null}
+      />
+    );
+    expect(provisioning).toContain("COMPLIANCE NEVER SLEEPS");
+
+    const ready = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        walletStatus="ready"
+        walletStep={null}
+        tokenId={null}
+      />
+    );
+    expect(ready).not.toContain("COMPLIANCE NEVER SLEEPS");
+  });
+});

--- a/src/components/wallet-onboarding-checklist.tsx
+++ b/src/components/wallet-onboarding-checklist.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  TraderAvatar,
+  type TraderAvatarImageStatus,
+} from "@/components/trader-avatar";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import { useSfx } from "@/hooks/use-sfx";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+type WalletStatus = Doc<"traders">["walletStatus"];
+type WalletStep = Doc<"traders">["walletStep"];
+
+/** Ordinal of the last completed checkpoint; ready means all four are done. */
+const STEP_RANK: Record<NonNullable<WalletStep>, number> = {
+  paperwork: 1,
+  id_minted: 2,
+  seat_registered: 3,
+};
+const TOTAL_STEPS = 4;
+
+const FLAVOR_LINES = [
+  "COMPLIANCE NEVER SLEEPS",
+  "BADGE PHOTO IS NON-NEGOTIABLE",
+  "LEGAL IS REVIEWING THE REVIEW",
+  "THE FLOOR SMELLS LIKE MONEY",
+  "SHARPEN PENCILS. AND ELBOWS.",
+  "THE CORNER OFFICE IS WATCHING",
+  "DRESS CODE: PINSTRIPES, ALWAYS",
+];
+
+const FLAVOR_INTERVAL_MS = 4500;
+
+/**
+ * Sticky flag that flips true only when `value` is observed transitioning to
+ * `target` while mounted. Stays false if it was already at `target` on mount,
+ * so payoff animations fire on a real arrival — not on a re-open or re-render.
+ */
+function useArrivedAt<T>(value: T, target: T): boolean {
+  const [prev, setPrev] = useState(value);
+  const [arrived, setArrived] = useState(false);
+  if (prev !== value) {
+    setPrev(value);
+    if (value === target) setArrived(true);
+  }
+  return arrived;
+}
+
+export function WalletOnboardingChecklist({
+  walletStatus,
+  walletStep,
+  tokenId,
+  traderName,
+  imageStatus,
+  profileImageUrl,
+}: {
+  walletStatus: WalletStatus;
+  walletStep: WalletStep | null;
+  tokenId: number | null;
+  traderName: string;
+  imageStatus: TraderAvatarImageStatus | null;
+  profileImageUrl: string;
+}) {
+  const reducedMotion = useReducedMotion();
+  const { playStinger } = useSfx();
+
+  const ready = walletStatus === "ready";
+  const doneCount = ready
+    ? TOTAL_STEPS
+    : walletStep
+      ? STEP_RANK[walletStep]
+      : 0;
+
+  const lines = [
+    { active: "FILING PAPERWORK", done: "PAPERWORK FILED" },
+    {
+      active: "MINTING TRADER ID",
+      done: tokenId ? `TRADER ID MINTED #${tokenId}` : "TRADER ID MINTED",
+    },
+    { active: "REGISTERING SEAT", done: "SEAT REGISTERED" },
+    { active: "ISSUING FLOOR BADGE", done: "FLOOR BADGE ISSUED" },
+  ];
+
+  // Payoff only on an observed transition to ready — re-opening the dialog on
+  // an already-ready wallet renders the static completed state silently. Same
+  // guard for the portrait's CRT reveal: only when it lands while mounted.
+  const justCompleted = useArrivedAt(walletStatus, "ready");
+  const portraitRevealed = useArrivedAt(imageStatus, "ready");
+  useEffect(() => {
+    if (justCompleted) playStinger();
+  }, [justCompleted, playStinger]);
+
+  const [flavorIdx, setFlavorIdx] = useState(0);
+  const provisioning =
+    walletStatus === "pending" || walletStatus === "creating";
+  useEffect(() => {
+    if (!provisioning) return;
+    const interval = setInterval(
+      () => setFlavorIdx((i) => (i + 1) % FLAVOR_LINES.length),
+      FLAVOR_INTERVAL_MS
+    );
+    return () => clearInterval(interval);
+  }, [provisioning]);
+
+  return (
+    <div className="terminal-panel p-4">
+      {justCompleted && !reducedMotion && (
+        <span
+          aria-hidden
+          className="mc-onboard-flash pointer-events-none absolute inset-0"
+        />
+      )}
+      <div className="mb-3 flex items-baseline justify-between gap-3 border-b border-[var(--t-divider)] pb-3">
+        <h3 className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
+          Back office — onboarding
+        </h3>
+        <span className="hidden text-right text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]/70 sm:inline">
+          Getting {traderName} on the books
+        </span>
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <ul className="min-w-0 flex-1 space-y-1.5 text-[11px] uppercase tracking-[0.14em]">
+          {lines.map((line, idx) => {
+            const isDone = idx < doneCount;
+            const isCurrent = idx === doneCount && !ready;
+            return (
+              <li
+                key={line.active}
+                className={cn(
+                  "flex items-baseline gap-2",
+                  isDone && "text-[var(--t-green)]",
+                  isCurrent && "text-[var(--t-amber)]",
+                  !isDone && !isCurrent && "text-[var(--t-muted)]/40"
+                )}
+              >
+                <span className="shrink-0">
+                  {isDone ? "✓" : isCurrent ? "▸" : " "}
+                </span>
+                <span className="min-w-0 truncate">
+                  {isDone ? line.done : line.active}
+                </span>
+                {isDone && (
+                  <>
+                    <span className="mx-1 min-w-4 flex-1 overflow-hidden whitespace-nowrap text-[var(--t-green)]/30">
+                      ............................
+                    </span>
+                    <span className="shrink-0">OK</span>
+                  </>
+                )}
+                {isCurrent && <span className="cursor-blink shrink-0">█</span>}
+              </li>
+            );
+          })}
+        </ul>
+
+        <div
+          className={cn(
+            "h-20 w-20 shrink-0 border border-[var(--t-divider)]",
+            portraitRevealed && !reducedMotion && "mc-crt-reveal"
+          )}
+        >
+          <TraderAvatar
+            name={traderName}
+            src={profileImageUrl || null}
+            imageStatus={imageStatus}
+            size="lg"
+          />
+        </div>
+      </div>
+
+      {ready ? (
+        <div className="mt-4 flex justify-center">
+          <span
+            className={cn(
+              "inline-block -rotate-3 border-2 border-[var(--t-green)] px-3 py-1 text-xs font-black uppercase tracking-[0.2em] text-[var(--t-green)]",
+              justCompleted && !reducedMotion && "mc-stamp-in"
+            )}
+          >
+            TRADER ON THE FLOOR
+          </span>
+        </div>
+      ) : (
+        <p
+          key={flavorIdx}
+          className={cn(
+            "mt-4 border-t border-[var(--t-divider)] pt-2 text-center text-[10px] uppercase tracking-[0.18em] text-[var(--t-muted)]/70",
+            !reducedMotion && "mc-flavor-fade"
+          )}
+        >
+          {FLAVOR_LINES[flavorIdx]}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-traders.ts
+++ b/src/hooks/use-traders.ts
@@ -21,6 +21,8 @@ type TraderReadModel = Pick<
   | "escrowBalanceUsdc"
   | "walletStatus"
   | "walletError"
+  | "walletStep"
+  | "walletStepTokenId"
   | "lastCycleAt"
   | "cycleLeaseUntil"
   | "createdAt"
@@ -48,6 +50,8 @@ export interface Trader {
   escrow_balance_usdc: number;
   wallet_status: Doc<"traders">["walletStatus"];
   wallet_error: string | null;
+  wallet_step: Doc<"traders">["walletStep"] | null;
+  wallet_step_token_id: number | null;
   /** Epoch ms for agent cycle countdown UI */
   last_cycle_at_ms: number | null;
   cycle_lease_until_ms: number | null;
@@ -74,6 +78,8 @@ function mapTrader(doc: TraderReadModel, ownerAddress: string): Trader {
     escrow_balance_usdc: doc.escrowBalanceUsdc ?? 0,
     wallet_status: doc.walletStatus,
     wallet_error: doc.walletError ?? null,
+    wallet_step: doc.walletStep ?? null,
+    wallet_step_token_id: doc.walletStepTokenId ?? null,
     last_cycle_at_ms: doc.lastCycleAt ?? null,
     cycle_lease_until_ms: doc.cycleLeaseUntil ?? null,
     last_cycle_at: doc.lastCycleAt

--- a/tests/convex/trader-wallet-provisioning.test.ts
+++ b/tests/convex/trader-wallet-provisioning.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { api } from "../../convex/_generated/api";
+import { api, internal } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { makeT, seedDeskManager, seedActiveTrader } from "./setup";
 import { TRADER_NAME_TAKEN_MESSAGE } from "../../convex/traders";
@@ -109,5 +109,130 @@ describe("trader wallet provisioning recovery", () => {
     });
     expect(trader?.walletStatus).toBe("pending");
     expect(trader?.walletError).toBeUndefined();
+  });
+
+  it("retryWalletProvisioning clears walletStep checkpoint fields", async () => {
+    const t = makeT();
+    const deskManagerId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskManagerId, {
+      name: "Step Reset",
+      status: "paused",
+      walletStatus: "error",
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId as Id<"traders">, {
+        walletStep: "id_minted",
+        walletStepTokenId: 7,
+        updatedAt: Date.now(),
+      });
+    });
+
+    await asDeskManager(t).mutation(api.traders.retryWalletProvisioning, {
+      traderId: traderId as Id<"traders">,
+    });
+
+    const trader = await asDeskManager(t).query(api.traders.getById, {
+      traderId: traderId as Id<"traders">,
+    });
+    expect(trader?.walletStep).toBeUndefined();
+    expect(trader?.walletStepTokenId).toBeUndefined();
+  });
+});
+
+describe("wallet provisioning checkpoints", () => {
+  it("markCreating records the paperwork step and clears a stale tokenId", async () => {
+    const t = makeT();
+    const deskManagerId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskManagerId, {
+      name: "Checkpoint Trader",
+      status: "paused",
+      walletStatus: "pending",
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.patch(traderId as Id<"traders">, { walletStepTokenId: 99 });
+    });
+
+    const updatedAt = await t.run(async (ctx) => {
+      const trader = await ctx.db.get(traderId as Id<"traders">);
+      return trader!.updatedAt;
+    });
+
+    const acquired = await t.mutation(internal.traders.markCreating, {
+      traderId: traderId as Id<"traders">,
+      expectedUpdatedAt: updatedAt,
+    });
+    expect(acquired).toBe(true);
+
+    const trader = await t.run(async (ctx) =>
+      ctx.db.get(traderId as Id<"traders">)
+    );
+    expect(trader?.walletStatus).toBe("creating");
+    expect(trader?.walletStep).toBe("paperwork");
+    expect(trader?.walletStepTokenId).toBeUndefined();
+  });
+
+  it("setWalletStep records the step and tokenId while creating", async () => {
+    const t = makeT();
+    const deskManagerId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskManagerId, {
+      name: "Mid Pipeline",
+      status: "paused",
+      walletStatus: "creating",
+    });
+
+    await t.mutation(internal.traders.setWalletStep, {
+      traderId: traderId as Id<"traders">,
+      step: "id_minted",
+      tokenId: 128,
+    });
+
+    const trader = await t.run(async (ctx) =>
+      ctx.db.get(traderId as Id<"traders">)
+    );
+    expect(trader?.walletStep).toBe("id_minted");
+    expect(trader?.walletStepTokenId).toBe(128);
+  });
+
+  it("setWalletStep is a no-op when the wallet is not creating", async () => {
+    const t = makeT();
+    const deskManagerId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskManagerId, {
+      name: "Already Ready",
+      walletStatus: "ready",
+    });
+
+    await t.mutation(internal.traders.setWalletStep, {
+      traderId: traderId as Id<"traders">,
+      step: "seat_registered",
+    });
+
+    const trader = await t.run(async (ctx) =>
+      ctx.db.get(traderId as Id<"traders">)
+    );
+    expect(trader?.walletStep).toBeUndefined();
+  });
+
+  it("getById read model exposes walletStep and walletStepTokenId", async () => {
+    const t = makeT();
+    const deskManagerId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskManagerId, {
+      name: "Read Model",
+      status: "paused",
+      walletStatus: "creating",
+    });
+
+    await t.mutation(internal.traders.setWalletStep, {
+      traderId: traderId as Id<"traders">,
+      step: "seat_registered",
+      tokenId: 55,
+    });
+
+    const trader = await asDeskManager(t).query(api.traders.getById, {
+      traderId: traderId as Id<"traders">,
+    });
+    expect(trader?.walletStep).toBe("seat_registered");
+    expect(trader?.walletStepTokenId).toBe(55);
   });
 });


### PR DESCRIPTION
Replace the binary "Wallet: Ready/Setting up..." datum with a back-office onboarding checklist that advances through provisioning checkpoints (paperwork → trader ID minted → seat registered → floor badge) and pays off with a CRT portrait reveal and stamp when the wallet lands.

Provisioning records cosmetic checkpoints via a new internal setWalletStep mutation (no-op unless still creating, so stale workers can't scribble); createForTrader reports them non-fatally so checkpoint writes never abort the mint/transfer path.