### PR TITLE
fix(wire): raise dispatch body cap so posts are not cut off mid-sente…

### DIFF
--- a/convex/wire/_schemas.ts
+++ b/convex/wire/_schemas.ts
@@ -57,7 +57,7 @@ const BaseDispatchSchema = z.object({
   /** Stable per-drop identifier. */
   dispatchKey: z.string().min(1).max(64),
   headline: z.string().max(100),
-  body: z.string().max(180),
+  body: z.string().max(400),
   role: z.enum(["main", "supporting"]),
   arcSlug: z.string().nullable(),
   referenceEpoch: z.number().nullable(),

--- a/docs/wire-narrative-engine-prd.md
+++ b/docs/wire-narrative-engine-prd.md
@@ -186,7 +186,7 @@ Convex boundary rule: `wire.generateNextEpoch` is an internal action because it 
 - One **supporting dispatch** that adds pressure, rumor, SEC heat, boardroom tension, ticker movement, or player/agent reaction.
 - Optional one **Deal Seed dispatch** when the story naturally creates a playable opportunity.
 - Continuity every drop: at least one dispatch must reference an active arc, recurring entity, prior player event, or prior dispatch.
-- Hard copy caps: dispatch headlines should be about 100 characters max; dispatch bodies should be about 180 characters max.
+- Hard copy caps: dispatch headlines should be about 100 characters max; dispatch bodies should be about 400 characters max (2–4 sentences).
 
 Deal Seeds are optional per drop but mandatory over time: at least one Deal Seed must appear every 2 market-hour Wire Drops. The generator receives recent seed cadence as input, and validation rejects a second consecutive drop without a Deal Seed.
 

--- a/docs/wire/season-01.md
+++ b/docs/wire/season-01.md
@@ -28,7 +28,7 @@ Re-running is safe — the importer is idempotent.
 ## Style Rules
 
 - Dispatch headlines: ~100 characters max. Terse. Present tense.
-- Dispatch bodies: ~180 characters max. One to three sentences.
+- Dispatch bodies: ~400 characters max. Two to four sentences.
 - No emoji. No ellipses for drama. No modern crypto vocabulary.
 - Every dispatch must imply a player action: exploit, create, avoid, or watch.
 - Sentences end in facts, not adjectives. "Down $340M." Not "in bad shape."


### PR DESCRIPTION
…nce.

The 180-char structured-output limit conflicted with the 2–4 sentence prompt and truncated bodies at generation time.