### PR TITLE
fix(wire): finish dispatch bodies at sentence boundaries.

### DIFF
--- a/convex/seeds/systemPrompts.ts
+++ b/convex/seeds/systemPrompts.ts
@@ -49,6 +49,6 @@ SOFT SIGNALS: when the data reports a trap pattern (multiple desks losing on dea
 
 FLOOR TALK: gossip handed to you is only ~60% true. Fabricated claims must be framed as unverified rumor, never stated as fact.
 
-OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/sec_watch/boardroom/ticker/positioning), entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–4 sentences. No prose outside the JSON object.`,
+OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/sec_watch/boardroom/ticker/positioning), entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). No prose outside the JSON object.`,
   },
 ];

--- a/convex/wire/_schemas.ts
+++ b/convex/wire/_schemas.ts
@@ -53,11 +53,14 @@ export const SubjectSchema = z.object({
   id: z.string().min(1),
 });
 
+/** OpenAI structured-output maxLength for dispatch body prose. */
+export const DISPATCH_BODY_MAX_LENGTH = 600;
+
 const BaseDispatchSchema = z.object({
   /** Stable per-drop identifier. */
   dispatchKey: z.string().min(1).max(64),
   headline: z.string().max(100),
-  body: z.string().max(400),
+  body: z.string().max(DISPATCH_BODY_MAX_LENGTH),
   role: z.enum(["main", "supporting"]),
   arcSlug: z.string().nullable(),
   referenceEpoch: z.number().nullable(),

--- a/convex/wire/epochAssembler.ts
+++ b/convex/wire/epochAssembler.ts
@@ -341,7 +341,7 @@ export function assembleUserMessage(input: AssemblerInput): string {
   }
 
   lines.push(
-    `\nOUTPUT: Exactly one dispatch, role "main". Pick the category that fits (wire is the default; use ticker for a flash one-liner, floor_talk for gossip, sec_watch for regulators). Every dispatch needs a unique kebab-case dispatchKey. Headline ≤ 12 words. Body 2–4 sentences. Every post must contain a human detail or a joke. All numbers must come from the figures above — never invent a dollar amount, total, or event. entityMentions: list ONLY fictional roster slugs from the ENTITY ROSTER above — real desks/traders/addresses belong in the prose, never in entityMentions.`
+    `\nOUTPUT: Exactly one dispatch, role "main". Pick the category that fits (wire is the default; use ticker for a flash one-liner, floor_talk for gossip, sec_watch for regulators). Every dispatch needs a unique kebab-case dispatchKey. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). Every post must contain a human detail or a joke. All numbers must come from the figures above — never invent a dollar amount, total, or event. entityMentions: list ONLY fictional roster slugs from the ENTITY ROSTER above — real desks/traders/addresses belong in the prose, never in entityMentions.`
   );
 
   return lines.join("\n");

--- a/convex/wire/epochNormalizer.ts
+++ b/convex/wire/epochNormalizer.ts
@@ -1,14 +1,47 @@
-import type {
-  Category,
-  Dispatch,
-  GeneratedNarrativeEpoch,
-  NarrativeEpoch,
+import {
+  DISPATCH_BODY_MAX_LENGTH,
+  type Category,
+  type Dispatch,
+  type GeneratedNarrativeEpoch,
+  type NarrativeEpoch,
 } from "./_schemas";
 
 export type NormalizedEpochResult = {
   epoch: NarrativeEpoch;
   repairedCategoryAliases: number;
 };
+
+const SENTENCE_END = /[.!?]["']?$/;
+
+/**
+ * Structured-output maxLength can hard-cut prose mid-sentence (or mid-character
+ * at the old 180 cap). Trim back to the last sentence boundary when the body
+ * does not end cleanly.
+ */
+export function trimIncompleteDispatchBody(
+  body: string,
+  maxLength: number = DISPATCH_BODY_MAX_LENGTH
+): string {
+  const trimmed = body.trimEnd();
+  if (SENTENCE_END.test(trimmed)) return trimmed;
+
+  const window = trimmed.slice(0, maxLength);
+  const boundaryCandidates = [
+    window.lastIndexOf(". "),
+    window.lastIndexOf("! "),
+    window.lastIndexOf("? "),
+    window.lastIndexOf("."),
+    window.lastIndexOf("!"),
+    window.lastIndexOf("?"),
+  ];
+  const lastBoundary = Math.max(...boundaryCandidates);
+  const minKeep = Math.min(maxLength * 0.4, 80);
+  if (lastBoundary >= minKeep) {
+    return window.slice(0, lastBoundary + 1).trimEnd();
+  }
+
+  return trimmed;
+}
 
 /**
  * Normalize a raw LLM epoch into the strict output shape. The model produces
@@ -23,7 +56,11 @@ export function normalizeGeneratedEpoch(
     if (dispatch.category === "market") repairedCategoryAliases++;
     const category: Category =
       dispatch.category === "market" ? "wire" : dispatch.category;
-    return { ...dispatch, category };
+    return {
+      ...dispatch,
+      category,
+      body: trimIncompleteDispatchBody(dispatch.body),
+    };
   });
 
   return {

--- a/convex/wire/generator.ts
+++ b/convex/wire/generator.ts
@@ -43,7 +43,7 @@ BAD: "Forced liquidations deepen as PanAtlantic reveals an additional $300M asse
 GOOD: "PanAtlantic misplaced another $300M today, bringing the total to $1.4B, a figure its CFO described as 'temporary' from the back of a taxi. The firm's remaining assets now consist of office furniture and optimism."
 GOOD (real game event): "Desk 0x4f2…a9 entered 'Guaranteed Distressed Debt Opportunity' yesterday. The debt was real. The opportunity was for the other guy. Balance: zero. Deals with 'guaranteed' in the title have a perfect record — for their creators."
 
-OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/sec_watch/boardroom/ticker/positioning), entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–4 sentences. No prose outside the JSON.`;
+OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/sec_watch/boardroom/ticker/positioning), entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). No prose outside the JSON.`;
 
 type StoredArc = Doc<"narrativeArcs">;
 

--- a/docs/wire-narrative-engine-prd.md
+++ b/docs/wire-narrative-engine-prd.md
@@ -186,7 +186,7 @@ Convex boundary rule: `wire.generateNextEpoch` is an internal action because it 
 - One **supporting dispatch** that adds pressure, rumor, SEC heat, boardroom tension, ticker movement, or player/agent reaction.
 - Optional one **Deal Seed dispatch** when the story naturally creates a playable opportunity.
 - Continuity every drop: at least one dispatch must reference an active arc, recurring entity, prior player event, or prior dispatch.
-- Hard copy caps: dispatch headlines should be about 100 characters max; dispatch bodies should be about 400 characters max (2–4 sentences).
+- Hard copy caps: dispatch headlines should be about 100 characters max; dispatch bodies should be about 600 characters max (2–3 complete sentences).
 
 Deal Seeds are optional per drop but mandatory over time: at least one Deal Seed must appear every 2 market-hour Wire Drops. The generator receives recent seed cadence as input, and validation rejects a second consecutive drop without a Deal Seed.
 

--- a/docs/wire/season-01.md
+++ b/docs/wire/season-01.md
@@ -28,7 +28,7 @@ Re-running is safe — the importer is idempotent.
 ## Style Rules
 
 - Dispatch headlines: ~100 characters max. Terse. Present tense.
-- Dispatch bodies: ~400 characters max. Two to four sentences.
+- Dispatch bodies: ~600 characters max. Two to three complete sentences.
 - No emoji. No ellipses for drama. No modern crypto vocabulary.
 - Every dispatch must imply a player action: exploit, create, avoid, or watch.
 - Sentences end in facts, not adjectives. "Down $340M." Not "in bad shape."

--- a/tests/convex/wire-epoch-normalizer.test.ts
+++ b/tests/convex/wire-epoch-normalizer.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { trimIncompleteDispatchBody } from "../../convex/wire/epochNormalizer";
+
+describe("trimIncompleteDispatchBody", () => {
+  it("keeps bodies that already end on sentence punctuation", () => {
+    const body =
+      "Rourke turned up demanding books. The receptionist offered a box.";
+    expect(trimIncompleteDispatchBody(body)).toBe(body);
+  });
+
+  it("trims a hard-cut tail back to the last sentence", () => {
+    const body =
+      "Allocators kept knocking since yesterday and this morning Rourke Capital turned up in person demanding to see Castle's books; the receptionist offered coffee and a cardboard box instead. Reggie Kessler is otherwise occupied, sources say, and the floor is repeating a rumor someone senior left with boxes last night. With PanAtlantic's $1400M hole still on everyone's tongue, lenders and allocators no";
+
+    expect(trimIncompleteDispatchBody(body, 400)).toBe(
+      "Allocators kept knocking since yesterday and this morning Rourke Capital turned up in person demanding to see Castle's books; the receptionist offered coffee and a cardboard box instead. Reggie Kessler is otherwise occupied, sources say, and the floor is repeating a rumor someone senior left with boxes last night."
+    );
+  });
+
+  it("drops corrupted tail characters from legacy 180-char cuts", () => {
+    const body =
+      "Overnight murmurs hardened: a senior at Castle Securities was seen leaving with boxes and a counterparty stopped answering calls this morning. Allocators who wrote checks want the帳";
+
+    expect(trimIncompleteDispatchBody(body, 180)).toBe(
+      "Overnight murmurs hardened: a senior at Castle Securities was seen leaving with boxes and a counterparty stopped answering calls this morning."
+    );
+  });
+});


### PR DESCRIPTION
Raise the structured-output cap to 600, trim hard-cut tails in the normalizer, and require complete sentences in prompts.