### PR TITLE
fix(deals): reconcile stuck verified entries whose on-chain resolve was voided by a stale read

### DIFF
--- a/convex/agent/cycle.ts
+++ b/convex/agent/cycle.ts
@@ -194,16 +194,14 @@ export async function resolveOnChainEntry({
   });
   const publicClient = createPublicClient({ chain: baseSepolia, transport });
 
-  const onChainDeal = await publicClient.readContract({
-    address: ESCROW_ADDRESS,
-    abi,
-    functionName: "getDeal",
-    args: [BigInt(onChainDealId)],
-  });
-  if (onChainDeal.pendingEntries === BigInt(0)) {
-    return { status: "already_resolved", reason: "deal_settled" };
-  }
-
+  // Gate on THIS trader's pending status, read first. The global
+  // `pendingEntries` count is unsafe as a short-circuit: a lagging RPC replica
+  // that hasn't yet indexed this trader's own `enterDeal` returns
+  // `pendingEntries === 0`, which previously voided the outcome
+  // (`reconciled:deal-settled`) and permanently stranded a genuinely-pending
+  // entry on-chain — blocking the creator from ever closing the deal. We only
+  // conclude "already resolved" when the contract says this specific trader has
+  // no pending entry; the global count then just distinguishes the two reasons.
   const hasPending = await publicClient.readContract({
     address: ESCROW_ADDRESS,
     abi,
@@ -211,7 +209,19 @@ export async function resolveOnChainEntry({
     args: [BigInt(onChainDealId), BigInt(tokenId)],
   });
   if (!hasPending) {
-    return { status: "already_resolved", reason: "no_trader_entry" };
+    const onChainDeal = await publicClient.readContract({
+      address: ESCROW_ADDRESS,
+      abi,
+      functionName: "getDeal",
+      args: [BigInt(onChainDealId)],
+    });
+    return {
+      status: "already_resolved",
+      reason:
+        onChainDeal.pendingEntries === BigInt(0)
+          ? "deal_settled"
+          : "no_trader_entry",
+    };
   }
 
   const grossPayoutUsdc = Math.max(0, entryCostUsdc + traderPnlUsdc + rakeUsdc);

--- a/convex/agent/reconcileEntries.ts
+++ b/convex/agent/reconcileEntries.ts
@@ -4,7 +4,8 @@ import { internalAction } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { resolveOnChainEntry } from "./cycle";
-import type { OrphanEntry } from "../deals";
+import { reconciledTxHash } from "./onChainSettlement";
+import type { OrphanEntry, StuckEntry } from "../deals";
 
 type ReconcileSummary = {
   scanned: number;
@@ -105,5 +106,86 @@ export const reconcileOrphanEntries = internalAction({
     }
 
     return { scanned: orphans.length, refunded, cleared, skipped };
+  },
+});
+
+type StuckSummary = {
+  scanned: number;
+  settled: number;
+  confirmed: number;
+  skipped: number;
+};
+
+/**
+ * Reconcile stuck *verified* deal entries.
+ *
+ * A stuck entry is a fully-verified entry on a still-open deal whose outcome was
+ * voided with a `reconciled:*` sentinel — `resolveOnChainEntry` read a stale
+ * `pendingEntries === 0` and concluded the deal was settled, so it never called
+ * `resolveEntry` and the trader's entry is still pending on-chain (blocking the
+ * creator from closing). This sweep re-checks the contract and, for any entry
+ * that is genuinely still pending, settles it break-even (entry cost refunded,
+ * no pnl/rake — matching the void's "don't trust the LLM PnL" decision) and
+ * stamps the real resolve tx over the sentinel:
+ *
+ *  - `resolved` — was still pending on-chain; settled break-even and stamped.
+ *  - `already_resolved` — the sentinel was correct (no pending entry on-chain);
+ *    re-stamp the sentinel so the audit trail records the confirmation.
+ *  - `queue_not_head` — another trader is ahead in the FIFO queue; leave it for
+ *    the next tick, which retries once the queue advances.
+ *
+ * Idempotent (once a real `0x…` tx is stamped the entry is no longer a
+ * candidate) and safe to run on any cadence.
+ */
+export const reconcileStuckVerifiedEntries = internalAction({
+  args: { staleMinutes: v.optional(v.number()) },
+  handler: async (ctx, { staleMinutes }): Promise<StuckSummary> => {
+    const cutoffMs =
+      Date.now() - (staleMinutes ?? DEFAULT_STALE_MINUTES) * 60_000;
+
+    const candidates: StuckEntry[] = await ctx.runQuery(
+      internal.deals.listStuckVerifiedEntries,
+      { cutoffMs }
+    );
+
+    let settled = 0;
+    let confirmed = 0;
+    let skipped = 0;
+
+    for (const candidate of candidates) {
+      const result = await resolveOnChainEntry({
+        onChainDealId: candidate.onChainDealId,
+        tokenId: candidate.tokenId,
+        entryCostUsdc: candidate.entryCostUsdc,
+        traderPnlUsdc: 0,
+        rakeUsdc: 0,
+      }).catch(() => null); // RPC/send/env error — leave for the next tick.
+
+      if (result === null) {
+        skipped++;
+        continue;
+      }
+
+      if (result.status === "resolved") {
+        await ctx.runMutation(internal.deals.settleStuckOnChainEntry, {
+          entryId: candidate.entryId,
+          outcomeId: candidate.outcomeId,
+          resolveTxHash: result.txHash,
+        });
+        settled++;
+      } else if (result.status === "already_resolved") {
+        await ctx.runMutation(internal.deals.settleStuckOnChainEntry, {
+          entryId: candidate.entryId,
+          outcomeId: candidate.outcomeId,
+          resolveTxHash: reconciledTxHash(result.reason),
+        });
+        confirmed++;
+      } else {
+        // queue_not_head — another trader ahead in FIFO; retry next tick.
+        skipped++;
+      }
+    }
+
+    return { scanned: candidates.length, settled, confirmed, skipped };
   },
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -87,4 +87,21 @@ crons.interval(
   {}
 );
 
+/**
+ * Reconcile stuck *verified* deal entries. A verified entry whose outcome was
+ * voided with a `reconciled:*` sentinel because `resolveOnChainEntry` read a
+ * stale `pendingEntries === 0` never had `resolveEntry` called — the trader's
+ * entry stays pending on-chain, blocking the creator from closing. Neither the
+ * orphan sweep (only `pending:` rows) nor the cycle §3c retry (skips outcomes
+ * with any `onChainTxHash`) recovers it. This sweep re-checks the contract and
+ * settles any genuinely-pending entry break-even. See
+ * convex/agent/reconcileEntries.ts.
+ */
+crons.interval(
+  "reconcile-stuck-verified-entries",
+  { minutes: 10 },
+  internal.agent.reconcileEntries.reconcileStuckVerifiedEntries,
+  {}
+);
+
 export default crons;

--- a/convex/deals.ts
+++ b/convex/deals.ts
@@ -623,6 +623,143 @@ export const listStaleOrphanEntries = internalQuery({
   },
 });
 
+// ── Stuck verified-entry reconciliation ──────────────────────────────────
+//
+// A distinct failure window from the orphan case above. Here the entry is
+// FULLY verified in Convex (real paymentId + enterTxHash, entryCount bumped)
+// and an outcome exists — but the outcome was *voided* with a `reconciled:*`
+// sentinel because `resolveOnChainEntry` read a stale `pendingEntries === 0`
+// and concluded the deal was already settled, so it never called
+// `resolveEntry`. On-chain the trader's entry is still pending, blocking the
+// creator from closing. Neither the orphan sweep (only scans `pending:` rows)
+// nor the cycle §3c retry (`findUnresolvedOnChain` skips outcomes that already
+// carry an `onChainTxHash`, sentinel included) can recover it — so this sweep
+// re-checks the contract and settles any genuinely-pending entry break-even.
+
+export type StuckEntry = {
+  entryId: Id<"dealEntries">;
+  outcomeId: Id<"dealOutcomes">;
+  traderId: Id<"traders">;
+  dealId: Id<"deals">;
+  onChainDealId: number;
+  tokenId: number;
+  entryCostUsdc: number;
+};
+
+/**
+ * Internal: find verified deal entries on still-open deals whose outcome was
+ * voided with a `reconciled:*` sentinel — candidates for on-chain settlement
+ * re-check. We only consider entries older than `cutoffMs` (never race a live
+ * cycle mid-resolution). Entries whose outcome carries a real `0x…` tx are
+ * settled; entries whose outcome has no tx yet are owned by the cycle §3c
+ * FIFO-retry path and left alone.
+ */
+export const listStuckVerifiedEntries = internalQuery({
+  args: { cutoffMs: v.number() },
+  handler: async (ctx, { cutoffMs }): Promise<StuckEntry[]> => {
+    const openDeals = await ctx.db
+      .query("deals")
+      .withIndex("byStatus", (q) => q.eq("status", "open"))
+      .collect();
+
+    const stuck: StuckEntry[] = [];
+    for (const deal of openDeals) {
+      if (deal.onChainDealId === undefined || deal.onChainDealId === null) {
+        continue;
+      }
+      const entries = await ctx.db
+        .query("dealEntries")
+        .withIndex("byDeal", (q) => q.eq("dealId", deal._id))
+        .collect();
+
+      for (const entry of entries) {
+        // Verified entries only — `pending:` reservations are the orphan sweep's
+        // job (see listStaleOrphanEntries).
+        if (!entry.enterTxHash) continue;
+        if (entry.paymentId.startsWith("pending:")) continue;
+        if (entry.createdAt >= cutoffMs) continue; // still in-flight
+
+        const outcome = await ctx.db
+          .query("dealOutcomes")
+          .withIndex("byTraderAndDeal", (q) =>
+            q.eq("traderId", entry.traderId).eq("dealId", deal._id)
+          )
+          .unique();
+        if (!outcome) continue;
+        const tx = outcome.onChainTxHash;
+        // Only voided (`reconciled:*`) outcomes are candidates. A real `0x…` tx
+        // means it settled; an absent tx means the cycle still owns the retry.
+        if (typeof tx !== "string" || !tx.startsWith("reconciled:")) continue;
+
+        const trader = await ctx.db.get(entry.traderId);
+        if (
+          !trader ||
+          trader.tokenId === undefined ||
+          trader.tokenId === null
+        ) {
+          continue;
+        }
+
+        stuck.push({
+          entryId: entry._id,
+          outcomeId: outcome._id,
+          traderId: entry.traderId,
+          dealId: deal._id,
+          onChainDealId: deal.onChainDealId,
+          tokenId: trader.tokenId,
+          entryCostUsdc: entry.entryCostUsdc,
+        });
+      }
+    }
+    return stuck;
+  },
+});
+
+/**
+ * Internal: record that a stuck verified entry was settled on-chain. Replaces
+ * the outcome's `reconciled:*` sentinel with the real resolve tx (never
+ * clobbers a genuine `0x…` settlement) and logs a `reconcile` activity row.
+ * The on-chain resolve is break-even (entry cost refunded, no pnl/rake) — the
+ * outcome was voided, so no off-chain PnL is applied; the chain balance sync
+ * remains the source of truth.
+ */
+export const settleStuckOnChainEntry = internalMutation({
+  args: {
+    entryId: v.id("dealEntries"),
+    outcomeId: v.id("dealOutcomes"),
+    resolveTxHash: v.string(),
+  },
+  handler: async (ctx, { entryId, outcomeId, resolveTxHash }) => {
+    const entry = await ctx.db.get(entryId);
+    if (!entry) return { settled: false as const };
+
+    const outcome = await ctx.db.get(outcomeId);
+    if (outcome) {
+      const tx = outcome.onChainTxHash;
+      if (typeof tx !== "string" || !tx.startsWith("0x")) {
+        await ctx.db.patch(outcomeId, { onChainTxHash: resolveTxHash });
+      }
+    }
+
+    await ctx.db.insert("agentActivityLog", {
+      traderId: entry.traderId,
+      activityType: "reconcile",
+      message: resolveTxHash.startsWith("0x")
+        ? `Stuck on-chain deal entry settled break-even and cleared (tx=${resolveTxHash})`
+        : `Stuck on-chain deal entry confirmed already settled (${resolveTxHash})`,
+      dealId: entry.dealId,
+      metadata: {
+        entry_id: entryId,
+        resolve_tx_hash: resolveTxHash,
+      },
+      dedupeKey: `reconcile-stuck:${entryId}:${resolveTxHash}`,
+      createdAt: Date.now(),
+    });
+
+    return { settled: true as const };
+  },
+});
+
 /**
  * Internal: clear a reconciled orphan reservation row. Deletes the stale
  * `pending:` entry (freeing the unique (trader, deal) slot so a legit retry can


### PR DESCRIPTION
## Problem

Deal #18 showed a permanent **"1 pending entry"** on-chain, blocking the creator from closing it — despite the orphan-reconcile cron added a few commits back.

Root cause (traced end to end): trader *Jim* (token `7070`) entered deal 18 with a **fully verified** Convex entry, but when the cycle called `resolveOnChainEntry`, it read a stale `getDeal().pendingEntries == 0` from a lagging RPC replica (one that hadn't yet indexed Jim's own `enterDeal`). It concluded the deal was already settled, **skipped `resolveEntry`**, and voided the outcome with the `reconciled:deal-settled` sentinel. On-chain, Jim's entry stayed pending forever.

Neither existing safety net could recover it:
- the **orphan sweep** only scans `pending:` reservation rows (Jim's row is verified), and
- the **cycle §3c retry** (`findUnresolvedOnChain`) skips any outcome that already carries an `onChainTxHash` — the sentinel counts.

## Fix

**Root cause** — `resolveOnChainEntry` now gates on `hasPendingEntry(dealId, tokenId)` for *this* trader **before** consulting the global `pendingEntries` count, so a stale global read can no longer void a genuinely-pending entry.

**Recovery** — new 10-min `reconcile-stuck-verified-entries` sweep: finds verified entries on open deals whose outcome carries a `reconciled:*` sentinel, re-checks the contract, and settles any genuinely-pending entry **break-even** (entry cost refunded, no pnl/rake — matching the void's "don't trust the LLM PnL" decision), stamping the real resolve tx over the sentinel. Idempotent and safe on any cadence.

### Files
- `convex/agent/cycle.ts` — reorder `resolveOnChainEntry` checks (root cause)
- `convex/deals.ts` — `listStuckVerifiedEntries` + `settleStuckOnChainEntry`
- `convex/agent/reconcileEntries.ts` — `reconcileStuckVerifiedEntries` action
- `convex/crons.ts` — new sweep cron

## Verification (already run against prod `formal-pigeon-323`)

The sweep cron fired right after deploy and cleared deal 18. On-chain confirmation:
- `pendingEntries: 1 → 0`
- pot `$5.78 → $4.78` (exact $1 break-even refund of Jim's entry cost)
- `hasPendingEntry(18, 7070) = false`; resolve tx `0x68e0…39d1` succeeded against the escrow
- Jim's outcome `onChainTxHash` overwritten from the sentinel to the real tx
- Audit row: `reconcile` / *"Stuck on-chain deal entry settled break-even and cleared"*

## Out of scope (known gap)

A verified entry that crashed *before* any outcome row was written (no `dealOutcomes` row at all) is not covered — scoped to the voided-sentinel case to avoid break-even-ing an entry that may have legitimate pending PnL. Small extension if we want belt-and-suspenders coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)