### PR TITLE
feat(portraits): v4 two-ink screenprint NFT system

### DIFF
--- a/convex/lib/portraitChecks.ts
+++ b/convex/lib/portraitChecks.ts
@@ -1,0 +1,155 @@
+// Post-generation verification for v4 portraits. Pure module (NOT "use node"):
+// it takes an injected `grader` (and, in the orchestrator, an injected `generate`)
+// so the decision logic is unit-testable with a fake grader — no OpenAI, no
+// network. The real grader lives in convex/portraits.ts.
+//
+// The grader is a QA aid, not the safety gate — the prompt's exclusion block is
+// the actual guardrail. So checks FAIL only on an affirmative negative verdict;
+// a null verdict (grader infra error) is treated as pass (fail-open) so a vision
+// outage can't flip the whole fleet to error.
+
+import {
+  SURFACED_SLOTS,
+  TRAIT_META,
+  type PublicPortraitTraits,
+} from "./portraitSeed";
+
+export type GraderVerdict = {
+  present: boolean | null;
+  confidence?: number;
+  note?: string;
+};
+
+export type Grader = (
+  base64: string,
+  question: string
+) => Promise<GraderVerdict>;
+
+// A clean flat cream border is REQUIRED in v4 (review5). The question is phrased
+// so an affirmative "yes" means the border is defective.
+export const BORDER_QUESTION =
+  "the outer border/edge of this square image has a soft glow, halo, vignette, " +
+  "drop-shadow or bevel around the field — i.e. the border is NOT a clean, flat, " +
+  "crisp edge";
+
+// Trait-visibility questions, keyed by trait id. Ported from scratchpad/grade7.py
+// and re-keyed to the v4 (post-redesign) trait ids. Only rare/legendary values
+// are checked (commons/uncommons are not gated).
+export const RUBRIC: Record<string, string> = {
+  // Expression
+  manic:
+    "the person's mouth is wide open in a big laugh (head-back, teeth showing, eyes wide) — NOT merely a closed smile, smirk, or grin",
+  // Field Ink
+  silver:
+    "the flat background field behind the person is a cool metallic SILVER / grey — not red, blue, teal, gold, ochre, or cream",
+  goldleaf:
+    "the flat background field behind the person is a lustrous metallic GOLD (shiny gold-leaf / foil), clearly gold — not ochre, amber, silver, or cream",
+  // Attire
+  goldthread:
+    "the suit has clearly visible GOLD-colored pinstripes or gold thread accents woven into it",
+  // Vice
+  litcigar:
+    "there is a cigar with a visible curl or wisp of SMOKE rising from it",
+  martini: "the person is holding a stemmed martini / cocktail glass in a hand",
+  cigbouquet:
+    "the person is holding a fistful of MANY lit cigarettes (five or more) fanned out, with multiple glowing tips — clearly more than two",
+  coupe:
+    "the person is holding or raising a wide, shallow champagne COUPE glass overflowing with foam or bubbles",
+  // Field Flourish
+  tickerbold:
+    "the background field has several BOLD pale horizontal ticker-tape bands running across it (not a plain solid field)",
+  confetti:
+    "the background field is filled with FALLING ticker-tape / confetti streamer shapes (busy, not a plain solid field)",
+};
+
+export type CheckResult = { ok: boolean; note?: string };
+
+/** Fails only when the grader affirmatively reports a defective border. */
+export async function checkFlatBorder(
+  grader: Grader,
+  base64: string
+): Promise<CheckResult> {
+  const verdict = await grader(base64, BORDER_QUESTION);
+  if (verdict.present === true) {
+    return { ok: false, note: verdict.note ?? "non-flat border" };
+  }
+  return { ok: true };
+}
+
+/**
+ * For each rare/legendary surfaced trait with a rubric, asks the grader that the
+ * trait is visible. Fails only on an affirmative "not present". `traits === null`
+ * (e.g. a fallback-prompt render) has nothing to verify → passes.
+ */
+export async function checkTraitVisibility(
+  grader: Grader,
+  base64: string,
+  traits: PublicPortraitTraits | null
+): Promise<CheckResult & { missing?: string }> {
+  if (!traits) return { ok: true };
+  for (const slot of SURFACED_SLOTS) {
+    const id = traits[slot.key];
+    const meta = TRAIT_META[slot.key][id];
+    if (!meta) continue;
+    if (meta.tier !== "Rare" && meta.tier !== "Legendary") continue;
+    const question = RUBRIC[id];
+    if (!question) continue;
+    const verdict = await grader(base64, question);
+    if (verdict.present === false) {
+      return { ok: false, missing: id, note: verdict.note ?? `missing ${id}` };
+    }
+  }
+  return { ok: true };
+}
+
+export type AttemptOutcome =
+  | { status: "ready"; base64: string }
+  | { status: "error"; reason: string };
+
+/**
+ * Generate → verify → regenerate up to `maxAttempts`. Never ships a failing tile:
+ * on an affirmative border/trait failure it regenerates; after exhausting all
+ * attempts it returns a distinct error reason from the last failure. Grader
+ * infra-nulls are fail-open (treated as pass by the checks).
+ */
+export async function runPortraitAttempts(opts: {
+  generate: () => Promise<string>;
+  grader: Grader;
+  traits: PublicPortraitTraits | null;
+  maxAttempts?: number;
+}): Promise<AttemptOutcome> {
+  const maxAttempts = opts.maxAttempts ?? 3;
+  let lastReason = "portrait_generation_failed";
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let base64: string;
+    try {
+      base64 = await opts.generate();
+    } catch (err) {
+      lastReason = `generation_error: ${err instanceof Error ? err.message : String(err)}`;
+      continue;
+    }
+    if (!base64) {
+      lastReason = "generation_error: empty image";
+      continue;
+    }
+
+    const border = await checkFlatBorder(opts.grader, base64);
+    if (!border.ok) {
+      lastReason = "failed_border_check";
+      continue;
+    }
+    const visibility = await checkTraitVisibility(
+      opts.grader,
+      base64,
+      opts.traits
+    );
+    if (!visibility.ok) {
+      lastReason = "failed_trait_visibility";
+      continue;
+    }
+    return { status: "ready", base64 };
+  }
+
+  return { status: "error", reason: lastReason };
+}

--- a/convex/lib/portraitSeed.ts
+++ b/convex/lib/portraitSeed.ts
@@ -1,495 +1,363 @@
-export const PORTRAIT_METADATA_VERSION = 3;
+// v4 portrait system — two-ink screenprint noir NFT collection.
+//
+// Pipeline: a random seed is minted at trader creation and stored on the row
+// (convex/traders.ts). All trait derivation is a PURE function of that stored
+// seed — same seed ⇒ same traits ⇒ same prompt, forever. gpt-image-1 renders
+// the composed prompt (no reference/edit conditioning).
+//
+// Sources of truth: scratchpad/review5.html (locked style + pinned hex),
+// review6.html (approved rarity weights/tiers/odds), review7.html (the four
+// Phase-2 redesigned values + the hardened no-text clause). Weights are
+// PERMANENT post-launch — see docs/portrait-rarity-v4.md.
 
-type GenderPresentation = "feminine" | "masculine";
-type GenderPresentationSource =
-  | "inferred-feminine"
-  | "inferred-masculine"
-  | "hashed";
+export const PORTRAIT_METADATA_VERSION = 4;
+
+export type PortraitTier = "Common" | "Uncommon" | "Rare" | "Legendary";
+
+const TIER_RANK: Record<PortraitTier, number> = {
+  Common: 0,
+  Uncommon: 1,
+  Rare: 2,
+  Legendary: 3,
+};
+
+// ─── Surfaced trait slots (the 5 that appear in metadata) ────────────────────
 
 export type PublicPortraitTraits = {
-  archetype: string;
-  scene: string;
-  prop: string;
-  marketMoment: string;
   expression: string;
-  lighting: string;
-  cameraAngle: string;
-  genderPresentation: string;
-  apparentAge: string;
-  appearanceVariant: string;
-  hairstyle: string;
-  clothingStyle: string;
-  accessory: string;
+  fieldInk: string;
+  attire: string;
+  vice: string;
+  fieldFlourish: string;
 };
+
+type SurfacedSlotKey = keyof PublicPortraitTraits;
 
 const PUBLIC_TRAIT_KEYS = [
-  "archetype",
-  "scene",
-  "prop",
-  "marketMoment",
   "expression",
-  "lighting",
-  "cameraAngle",
-  "genderPresentation",
-  "apparentAge",
-  "appearanceVariant",
-  "hairstyle",
-  "clothingStyle",
-  "accessory",
-] as const satisfies readonly (keyof PublicPortraitTraits)[];
+  "fieldInk",
+  "attire",
+  "vice",
+  "fieldFlourish",
+] as const satisfies readonly SurfacedSlotKey[];
 
-export const APPARENT_AGES = [
-  { id: "late_20s", prompt: "late 20s" },
-  { id: "mid_30s", prompt: "mid 30s" },
-  { id: "mid_40s", prompt: "mid 40s" },
-  { id: "late_50s", prompt: "late 50s" },
-] as const;
-
-type ApparentAgeId = (typeof APPARENT_AGES)[number]["id"];
-
-export const ARCHETYPES = [
-  {
-    id: "mna_rainmaker",
-    description:
-      "late-night hostile takeover war room, binders, fax paper, brass desk lamp, calm calculating presence",
-    scene: "private deal-room office at midnight, walnut paneling",
-    prop: "open binder of deal docs, brass desk lamp",
-    marketMoment: "mid-deal closing crunch",
-    preferredAgeBuckets: ["mid_30s", "mid_40s"],
-  },
-  {
-    id: "junk_bond_operator",
-    description:
-      "high-yield bond desk strewn with prospectuses, ash in the air, leaning forward over the desk",
-    scene: "high-yield bond desk, paper-stacked horizon",
-    prop: "thick stapled prospectus, half-empty coffee mug",
-    marketMoment: "leveraged-buyout euphoria",
-    preferredAgeBuckets: ["mid_30s", "mid_40s"],
-  },
-  {
-    id: "risk_floor_captain",
-    description:
-      "risk supervision pod overlooking a floor of traders, posture upright and watchful",
-    scene: "risk pod overlooking a busy trading floor",
-    prop: "clipboard with printed risk sheet",
-    marketMoment: "mid-session volatility spike",
-    preferredAgeBuckets: ["mid_40s", "late_50s"],
-  },
-  {
-    id: "crash_day_survivor",
-    description:
-      "chaotic trading floor during a crash, papers in motion, red and green terminal glow, intense expression",
-    scene: "chaotic trading floor mid-crash, papers tumbling",
-    prop: "crumpled order tickets in fist",
-    marketMoment: "black-monday-style crash session",
-    preferredAgeBuckets: ["mid_30s", "mid_40s", "late_50s"],
-  },
-  {
-    id: "commodities_pit_veteran",
-    description:
-      "noisy commodities pit, light trading jacket, paper order slips, crowded floor of arms and hand signals",
-    scene: "open-outcry commodities pit, jackets and hand signals",
-    prop: "bundle of paper order slips",
-    marketMoment: "heating crude / grains squeeze",
-    preferredAgeBuckets: ["mid_40s", "late_50s"],
-  },
-  {
-    id: "execution_desk_closer",
-    description:
-      "execution desk, order tickets, multiple corded phones in the background, aggressive focused posture",
-    scene: "execution desk, banks of corded phones along the wall behind",
-    prop: "order ticket pad mid-write",
-    marketMoment: "block-trade execution rush",
-    preferredAgeBuckets: ["late_20s", "mid_30s", "mid_40s"],
-  },
-  {
-    id: "macro_crisis_analyst",
-    description:
-      "macro research nook with global newspapers, charts, and a small globe, contemplative",
-    scene: "macro research nook, oak desk, world newspapers",
-    prop: "folded Financial Times across the desk",
-    marketMoment: "sovereign-debt crisis briefing",
-    preferredAgeBuckets: ["mid_30s", "mid_40s", "late_50s"],
-  },
-  {
-    id: "boiler_room_salesman",
-    description:
-      "cramped boiler-room sales floor, pitching into a corded phone resting on shoulder, bullpen of identical desks behind",
-    scene: "cramped boiler-room bullpen of desks",
-    prop: "corded phone resting on shoulder",
-    marketMoment: "retail penny-stock pump",
-    preferredAgeBuckets: ["late_20s", "mid_30s"],
-  },
-  {
-    id: "arbitrage_specialist",
-    description:
-      "quiet arbitrage cubicle with two CRTs running abstract glowing market shapes, ruler and pencil notes (text unreadable), focused stare",
-    scene: "quiet arb cubicle, two CRTs side by side",
-    prop: "mechanical pencil and ruler",
-    marketMoment: "merger-spread compression",
-    preferredAgeBuckets: ["late_20s", "mid_30s", "mid_40s"],
-  },
-  {
-    id: "rookie_quant",
-    description:
-      "cramped back-office analytics room, oversized 1980s suit, thick glasses, stacked CRT monitors, abstract unreadable notes",
-    scene: "back-office analytics room, stacked CRTs",
-    prop: "basic four-function calculator",
-    marketMoment: "first big intraday rally",
-    preferredAgeBuckets: ["late_20s"],
-  },
-  {
-    id: "old_school_partner",
-    description:
-      "corner partner office, walnut paneling, antique globe, leather chair, posture relaxed and powerful",
-    scene: "corner partner office, brass-and-walnut detail",
-    prop: "unlit cigar held casually",
-    marketMoment: "quiet partner-track afternoon",
-    preferredAgeBuckets: ["mid_40s", "late_50s"],
-  },
-  {
-    id: "margin_call_escapee",
-    description:
-      "dark office after a catastrophic trade, loosened tie, red warning glow, scattered papers, exhausted expression",
-    scene: "dark office post-blowup, single overhead lamp, red glow",
-    prop: "scattered crumpled paper, tie pulled loose",
-    marketMoment: "post-margin-call wreckage",
-    preferredAgeBuckets: ["mid_30s", "mid_40s", "late_50s"],
-  },
-] as const;
-
-export const EXPRESSIONS = [
-  { id: "calm_calculating", prompt: "calm calculating expression" },
-  { id: "sharp_focused", prompt: "sharp focused gaze" },
-  { id: "tense_alert", prompt: "tense alert posture" },
-  { id: "worn_exhausted", prompt: "worn exhausted look" },
-  { id: "confident_smirk", prompt: "confident smirk" },
-  { id: "predatory_grin", prompt: "predatory grin" },
-  { id: "bewildered_overwhelmed", prompt: "bewildered overwhelmed look" },
-  { id: "cold_detached", prompt: "cold detached stare" },
-] as const;
-
-export const LIGHTING = [
-  { id: "amber_desk_lamp", prompt: "warm amber desk-lamp pool" },
-  {
-    id: "green_crt_glow",
-    prompt: "green CRT terminal glow on one side of face",
-  },
-  {
-    id: "overhead_fluorescent",
-    prompt: "flat overhead fluorescent office light",
-  },
-  { id: "red_warning_glow", prompt: "low red warning-light glow" },
-  { id: "window_dawn", prompt: "cool blue pre-dawn window light" },
-  {
-    id: "high_contrast_noir",
-    prompt: "hard cinematic noir key light, deep shadows",
-  },
-] as const;
-
-export const CAMERA_ANGLES = [
-  {
-    id: "head_and_shoulders_centered",
-    prompt: "head-and-shoulders, centered, eyes to camera",
-  },
-  { id: "three_quarter_left", prompt: "three-quarter angle from camera left" },
-  {
-    id: "three_quarter_right",
-    prompt: "three-quarter angle from camera right",
-  },
-  { id: "slight_low_angle", prompt: "slight low angle, heroic framing" },
-  { id: "slight_high_angle", prompt: "slight high angle, watchful framing" },
-] as const;
-
-export const GENDER_PRESENTATIONS = [
-  { id: "feminine", prompt: "woman, feminine presentation" },
-  { id: "masculine", prompt: "man, masculine presentation" },
-] as const;
-
-const GENDER_PRESENTATION_BY_ID: Record<
-  GenderPresentation,
-  (typeof GENDER_PRESENTATIONS)[number]
-> = {
-  feminine: GENDER_PRESENTATIONS[0],
-  masculine: GENDER_PRESENTATIONS[1],
+type TraitValue = {
+  id: string;
+  /** Display label — PERMANENT once minted (baked into tokenURI). */
+  label: string;
+  /** Designed odds within the slot, as a percentage (sums to 100 per slot). */
+  weight: number;
+  tier: PortraitTier;
+  /** Prompt fragment describing the trait; `null` = adds nothing to the prompt. */
+  prompt: string | null;
 };
 
-export const APPEARANCE_VARIANTS = [
+// Weights/tiers verbatim from review6; the four redesigned display names +
+// prompt fragments (Gold Leaf, Cigarette Bouquet, Champagne Coupe, Bold Ticker
+// Bands) from review7. Prompt fragments ported from scratchpad/gen9_roster.py.
+
+export const EXPRESSIONS: readonly TraitValue[] = [
   {
-    id: "pale_fair_freckled_light_blond",
-    prompt: "pale fair skin, freckled, light-blond hair",
+    id: "cold",
+    label: "Cold Detached",
+    weight: 32.6,
+    tier: "Common",
+    prompt: "a cold detached stare",
   },
   {
-    id: "fair_auburn_subtle_waves",
-    prompt: "fair skin, auburn hair with subtle waves",
+    id: "sharp",
+    label: "Sharp Focused",
+    weight: 26.2,
+    tier: "Common",
+    prompt: "a sharp focused predatory gaze, brows slightly lowered",
   },
   {
-    id: "fair_dark_brown_sharp_brows",
-    prompt: "fair skin, dark-brown hair, sharp brows",
+    id: "tense",
+    label: "Tense Alert",
+    weight: 22.0,
+    tier: "Common",
+    prompt: "a tense alert wary look",
   },
   {
-    id: "olive_dark_wavy",
-    prompt: "olive-toned skin, dark wavy hair",
+    id: "predatory",
+    label: "Predatory Grin",
+    weight: 12.0,
+    tier: "Uncommon",
+    prompt: "a wide predatory grin, teeth showing, cold eyes",
   },
   {
-    id: "warm_tan_jet_black_straight",
-    prompt: "warm-tan skin, jet-black straight hair",
+    id: "smirk",
+    label: "Confident Smirk",
+    weight: 6.5,
+    tier: "Uncommon",
+    prompt: "a confident one-sided smirk",
   },
   {
-    id: "medium_brown_dark_coiled",
-    prompt: "medium-brown skin, dark coiled hair",
-  },
-  {
-    id: "deep_brown_short_tightly_coiled",
-    prompt: "deep-brown skin, short tightly-coiled hair",
-  },
-  {
-    id: "deep_brown_longer_twisted_coiled",
-    prompt: "deep-brown skin, longer twisted-coiled hair",
-  },
-  {
-    id: "light_tan_almond_sleek_black",
-    prompt: "light-tan skin, almond eyes, sleek black hair",
-  },
-  {
-    id: "medium_tan_almond_pulled_back",
-    prompt: "medium-tan skin, almond eyes, dark hair pulled back",
-  },
-  {
-    id: "ruddy_fair_salt_and_pepper",
-    prompt: "ruddy fair skin, salt-and-pepper hair",
-  },
-  {
-    id: "deep_tan_dark_silver_streaks",
-    prompt: "deep-tan skin, dark hair with a few silver streaks",
+    id: "manic",
+    label: "Manic Laugh",
+    weight: 0.7,
+    tier: "Rare",
+    prompt:
+      "head tipped back in a manic wide-eyed open-mouthed laugh, teeth bared",
   },
 ] as const;
 
-export const HAIRSTYLES = [
-  { id: "short_business_cut", prompt: "short business cut" },
-  { id: "slicked_back", prompt: "slicked-back hair" },
-  { id: "feathered_layered", prompt: "feathered layered 80s hair" },
-  { id: "power_perm", prompt: "power perm" },
-  { id: "tight_chignon", prompt: "tight low chignon" },
-  { id: "voluminous_blowout", prompt: "voluminous 80s blowout" },
+// Field Ink prompt fragments describe the flat background field + accent ink.
+export const FIELD_INKS: readonly TraitValue[] = [
   {
-    id: "pulled_back_low_pony",
-    prompt: "hair pulled back in a low ponytail",
-  },
-  { id: "side_part_classic", prompt: "classic side part" },
-  { id: "cropped_natural_coil", prompt: "cropped natural coils" },
-  { id: "buzz_cut", prompt: "buzz cut" },
-] as const;
-
-export const CLOTHING_STYLES = [
-  {
-    id: "pinstripe_double_breasted",
-    prompt: "pinstripe double-breasted suit, broad shoulders",
+    id: "vermilion",
+    label: "Vermilion",
+    weight: 24.75,
+    tier: "Common",
+    prompt: "vermilion #DD3B1C",
   },
   {
-    id: "charcoal_three_piece",
-    prompt: "charcoal three-piece suit, vest visible",
-  },
-  { id: "navy_power_suit", prompt: "navy power suit, structured shoulders" },
-  {
-    id: "tan_summer_suit",
-    prompt: "tan summer-weight suit, sleeves slightly pushed",
+    id: "cobalt",
+    label: "Cobalt",
+    weight: 24.75,
+    tier: "Common",
+    prompt: "cobalt #2A4BD0",
   },
   {
-    id: "shirt_sleeves_braces",
-    prompt: "white dress shirt, leather braces, tie loosened",
-  },
-  { id: "burgundy_blazer_silk", prompt: "burgundy blazer over a silk shell" },
-  {
-    id: "grey_skirt_suit",
-    prompt: "grey 80s skirt suit with sharp lapels",
+    id: "ochre",
+    label: "Ochre",
+    weight: 24.75,
+    tier: "Common",
+    prompt: "ochre #C89012",
   },
   {
-    id: "black_dress_blazer",
-    prompt: "black sheath dress under a long-line blazer",
+    id: "teal",
+    label: "Teal",
+    weight: 24.75,
+    tier: "Common",
+    prompt: "teal #147A6E",
   },
   {
-    id: "commodities_trading_jacket",
-    prompt: "brightly colored open-outcry trading jacket",
+    id: "silver",
+    label: "Burnished Silver",
+    weight: 0.5,
+    tier: "Rare",
+    prompt:
+      "a flat cool burnished-silver grey (single flat metallic-grey tone, not a shiny gradient)",
   },
   {
-    id: "rumpled_oxford_no_tie",
-    prompt: "rumpled oxford shirt, no tie, top button open",
+    id: "goldleaf",
+    label: "Gold Leaf",
+    weight: 0.5,
+    tier: "Legendary",
+    prompt:
+      "a lustrous METALLIC GOLD-LEAF field — burnished gold foil with clear sheen and darker gold shading, unmistakably shiny gold, NOT flat ochre/amber (this legendary breaks the flat-field rule)",
   },
 ] as const;
 
-export const ACCESSORIES = [
-  { id: "tortoiseshell_glasses", prompt: "tortoiseshell glasses" },
-  { id: "aviator_glasses", prompt: "aviator-frame glasses" },
-  { id: "gold_signet_ring", prompt: "gold signet ring on pinky" },
-  { id: "chunky_gold_watch", prompt: "chunky gold wristwatch" },
-  { id: "pearl_studs", prompt: "small pearl stud earrings" },
-  { id: "silk_pocket_square", prompt: "paisley silk pocket square" },
-  { id: "bold_red_lip", prompt: "bold red lipstick" },
-  { id: "gold_chain_thin", prompt: "thin gold chain visible at collar" },
-  { id: "silk_scarf_neck", prompt: "silk scarf knotted at the neck" },
-  { id: "no_accessory", prompt: "no notable accessory" },
+/** Deep-skin mints are constrained to warm inks (review5 locked rule). */
+const WARM_INK_IDS = new Set(["vermilion", "ochre", "goldleaf"]);
+
+export const ATTIRE: readonly TraitValue[] = [
+  {
+    id: "business",
+    label: "Business Suit",
+    weight: 42.0,
+    tier: "Common",
+    prompt: "a plain business suit with lapels and tie",
+  },
+  {
+    id: "braces",
+    label: "Shirt-sleeves & Braces",
+    weight: 20.0,
+    tier: "Common",
+    prompt: "a dress shirt and tie with bold suspenders/braces",
+  },
+  {
+    id: "jacket",
+    label: "Trading Jacket",
+    weight: 16.0,
+    tier: "Common",
+    prompt:
+      "a floor-trader's jacket rendered in the accent ink (not a second color) over a cream shirt and tie",
+  },
+  {
+    id: "tuxedo",
+    label: "Tuxedo",
+    weight: 10.0,
+    tier: "Uncommon",
+    prompt: "a black tuxedo with bow tie and wing collar",
+  },
+  {
+    id: "fur",
+    label: "Fur-Collar Overcoat",
+    weight: 11.0,
+    tier: "Uncommon",
+    prompt: "an opulent fur-collared overcoat over a suit",
+  },
+  {
+    id: "goldthread",
+    label: "Gold-Threaded Power Suit",
+    weight: 1.0,
+    tier: "Rare",
+    prompt:
+      "a power suit with bold gold-thread pinstripes woven through the fabric",
+  },
 ] as const;
 
-const FEMININE_NAMES = new Set([
-  "hayley",
-  "hailey",
-  "haylee",
-  "sarah",
-  "sara",
-  "emily",
-  "emma",
-  "jessica",
-  "amanda",
-  "olivia",
-  "michelle",
-  "rachel",
-  "laura",
-  "jennifer",
-  "amy",
-  "stephanie",
-  "nicole",
-  "elizabeth",
-  "megan",
-  "ashley",
-  "brittany",
-  "heather",
-  "christina",
-  "kimberly",
-  "rebecca",
-  "kelly",
-  "tiffany",
-  "danielle",
-  "melissa",
-  "lauren",
-  "katherine",
-  "kate",
-  "katie",
-  "catherine",
-  "caroline",
-  "claire",
-  "sophie",
-  "sophia",
-  "ava",
-  "isabella",
-  "mia",
-  "abigail",
-  "grace",
-  "ella",
-  "chloe",
-  "lily",
-  "zoe",
-  "hannah",
-  "natalie",
-  "victoria",
-  "julia",
-  "anna",
-  "maria",
-  "diane",
-  "linda",
-  "barbara",
-  "susan",
-  "karen",
-  "nancy",
-  "betty",
-]);
+export const VICES: readonly TraitValue[] = [
+  { id: "none", label: "None", weight: 79.9, tier: "Common", prompt: null },
+  {
+    id: "unlitcig",
+    label: "Unlit Cigarette",
+    weight: 11.0,
+    tier: "Uncommon",
+    prompt: "an unlit cigarette held at the lips, no smoke",
+  },
+  {
+    id: "cigar",
+    label: "Cigar",
+    weight: 7.0,
+    tier: "Uncommon",
+    prompt: "a fat cigar clenched in the teeth, no smoke",
+  },
+  {
+    id: "litcigar",
+    label: "Lit Cigar",
+    weight: 1.0,
+    tier: "Rare",
+    prompt: "a lit cigar at the lips with a curl of cream smoke rising",
+  },
+  {
+    id: "martini",
+    label: "Martini",
+    weight: 0.6,
+    tier: "Rare",
+    prompt: "one hand raised holding a stemmed martini glass",
+  },
+  {
+    id: "cigbouquet",
+    label: "Cigarette Bouquet",
+    weight: 0.3,
+    tier: "Legendary",
+    prompt:
+      "a ridiculous fistful of five or more lit cigarettes fanned at the mouth, every tip glowing, smoke rising",
+  },
+  {
+    id: "coupe",
+    label: "Champagne Coupe",
+    weight: 0.2,
+    tier: "Legendary",
+    prompt:
+      "raising a wide champagne coupe overflowing with foam and bubbles spilling over the rim, in a toast",
+  },
+] as const;
 
-const MASCULINE_NAMES = new Set([
-  "david",
-  "michael",
-  "mike",
-  "marcus",
-  "james",
-  "jim",
-  "robert",
-  "rob",
-  "anthony",
-  "tony",
-  "thomas",
-  "tom",
-  "john",
-  "daniel",
-  "dan",
-  "matthew",
-  "matt",
-  "christopher",
-  "chris",
-  "andrew",
-  "andy",
-  "joshua",
-  "josh",
-  "ryan",
-  "brandon",
-  "jason",
-  "justin",
-  "william",
-  "will",
-  "liam",
-  "noah",
-  "ethan",
-  "mason",
-  "logan",
-  "lucas",
-  "jackson",
-  "henry",
-  "sebastian",
-  "jacob",
-  "jack",
-  "aiden",
-  "owen",
-  "benjamin",
-  "ben",
-  "samuel",
-  "joseph",
-  "joe",
-  "kevin",
-  "brian",
-  "steven",
-  "steve",
-  "timothy",
-  "tim",
-  "richard",
-  "rick",
-  "george",
-  "frank",
-  "peter",
-  "paul",
-  "mark",
-  "scott",
-  "gary",
-  "gregory",
-  "edward",
-  "ed",
-  "charles",
-  "charlie",
-  "donald",
-  "ronald",
-  "kenneth",
-  "ken",
-]);
+export const FIELD_FLOURISHES: readonly TraitValue[] = [
+  {
+    id: "plain",
+    label: "Plain Field",
+    weight: 85.4,
+    tier: "Common",
+    prompt: null,
+  },
+  {
+    id: "halftone",
+    label: "Halftone Dot Wash",
+    weight: 12.0,
+    tier: "Uncommon",
+    prompt: "a subtle halftone dot texture across the flat field",
+  },
+  {
+    id: "tickerbold",
+    label: "Bold Ticker Bands",
+    weight: 1.6,
+    tier: "Rare",
+    prompt:
+      "several bold distinct pale horizontal ticker-tape bands running clearly across the flat field (blank shapes)",
+  },
+  {
+    id: "confetti",
+    label: "Confetti Storm",
+    weight: 1.0,
+    tier: "Legendary",
+    prompt:
+      "the flat field filled with falling ticker-tape confetti streamers as bold graphic shapes",
+  },
+] as const;
 
-const EXPLICIT_AMBIGUOUS = new Set([
-  "jordan",
-  "taylor",
-  "morgan",
-  "casey",
-  "alex",
-  "sam",
-  "pat",
-  "jamie",
-  "riley",
-  "avery",
-  "cameron",
-  "skyler",
-  "quinn",
-  "dakota",
-  "reese",
-  "rowan",
-  "blake",
-  "drew",
-  "kai",
-  "sage",
-]);
+/** Ordered slot definitions: derivation category + surfaced key + display label. */
+export const SURFACED_SLOTS = [
+  { key: "expression", label: "Expression", pool: EXPRESSIONS },
+  { key: "fieldInk", label: "Field Ink", pool: FIELD_INKS },
+  { key: "attire", label: "Attire", pool: ATTIRE },
+  { key: "vice", label: "Vice", pool: VICES },
+  { key: "fieldFlourish", label: "Field Flourish", pool: FIELD_FLOURISHES },
+] as const satisfies readonly {
+  key: SurfacedSlotKey;
+  label: string;
+  pool: readonly TraitValue[];
+}[];
+
+/** id → {label, tier, weight} per slot. Single source for metadata + display. */
+export const TRAIT_META: Record<
+  SurfacedSlotKey,
+  Record<string, { label: string; tier: PortraitTier; weight: number }>
+> = Object.fromEntries(
+  SURFACED_SLOTS.map((slot) => [
+    slot.key,
+    Object.fromEntries(
+      slot.pool.map((v) => [
+        v.id,
+        { label: v.label, tier: v.tier, weight: v.weight },
+      ])
+    ),
+  ])
+) as Record<
+  SurfacedSlotKey,
+  Record<string, { label: string; tier: PortraitTier; weight: number }>
+>;
+
+// ─── Seed-only demographic inputs (shape the face, NEVER surfaced) ───────────
+
+type DemographicValue = {
+  id: string;
+  label: string;
+  weight: number;
+  prompt: string;
+};
+
+const SKIN: readonly DemographicValue[] = [
+  {
+    id: "fair",
+    label: "Fair",
+    weight: 40,
+    prompt: "face ~80% cream with hard black shadow shapes; no accent on skin.",
+  },
+  {
+    id: "mid",
+    label: "Mid",
+    weight: 40,
+    prompt:
+      "face ~55% cream, ~45% hard black shadow shapes, a few accent hatch strokes on cheek/jaw.",
+  },
+  {
+    id: "deep",
+    label: "Deep",
+    weight: 20,
+    prompt:
+      "face flat black base + cream highlight planes + the warm accent as midtone; no brown.",
+  },
+] as const;
+
+const GENDERS: readonly DemographicValue[] = [
+  { id: "masculine", label: "Masculine", weight: 55, prompt: "man" },
+  { id: "feminine", label: "Feminine", weight: 45, prompt: "woman" },
+] as const;
+
+const AGES: readonly DemographicValue[] = [
+  { id: "20s", label: "Late 20s", weight: 20, prompt: "late 20s" },
+  { id: "30s", label: "Mid 30s", weight: 30, prompt: "mid 30s" },
+  { id: "40s", label: "Mid 40s", weight: 30, prompt: "mid 40s" },
+  { id: "50s", label: "Late 50s", weight: 20, prompt: "late 50s" },
+] as const;
+
+// ─── Hashing + weighted selection (pure, deterministic) ──────────────────────
 
 export function getPortraitPromptVersion(source: unknown): number {
   if (
@@ -520,17 +388,125 @@ export function pickFrom<T>(pool: readonly T[], hash: number): T {
   return pool[hash % pool.length];
 }
 
-export function inferGenderPresentationFromName(
-  name: string
-): GenderPresentation | "unknown" {
-  if (!name) return "unknown";
-  const first = name.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
-  if (!first) return "unknown";
-  if (EXPLICIT_AMBIGUOUS.has(first)) return "unknown";
-  if (FEMININE_NAMES.has(first)) return "feminine";
-  if (MASCULINE_NAMES.has(first)) return "masculine";
-  return "unknown";
+/**
+ * Deterministic weighted selection. Weights are scaled ×100 to integers (all
+ * table weights are exact at ≤2 decimals) so the walk is pure integer math —
+ * no float drift, identical on every platform. An empty pool falls back to the
+ * provided fallback (deep-skin ink-filter safety); if that is empty too, throws.
+ */
+export function weightedPick<T extends { weight: number }>(
+  pool: readonly T[],
+  hash: number,
+  fallback?: readonly T[]
+): T {
+  const effective = pool.length > 0 ? pool : (fallback ?? []);
+  if (effective.length === 0) {
+    throw new Error("weightedPick: empty pool and no fallback");
+  }
+  const scaled = effective.map((item) => Math.round(item.weight * 100));
+  const total = scaled.reduce((sum, w) => sum + w, 0);
+  if (total <= 0) return effective[0];
+  let r = hash % total;
+  for (let i = 0; i < effective.length; i++) {
+    r -= scaled[i];
+    if (r < 0) return effective[i];
+  }
+  return effective[effective.length - 1];
 }
+
+// ─── Prompt composition (two-ink screenprint noir) ───────────────────────────
+
+// Style + layout ported verbatim from scratchpad/gen9_roster.py.
+const STYLE =
+  "ART DIRECTION — TWO-INK SCREENPRINT NOIR (locked). Saul Bass silkscreen poster: bold hard-edged flat shapes, " +
+  "three tones only — cream #EFE6D0, black #17140F, and one accent ink. No gradients, no soft shading, no hatching to " +
+  "model form; only flat shape blocks + subtle flat ink grain. STRICT PALETTE: all wardrobe, props and accessories use " +
+  "ONLY those three tones — cream, black, and the single accent ink; NEVER introduce a second color anywhere (a jacket, " +
+  "tie, collar or prop is cream, black, or the accent — nothing else). HAIR always a solid black mass; blond/grey/auburn " +
+  "shown only as cream highlight strands, never as a yellow, gold, ochre or brown ink.";
+
+const LAYOUT =
+  "LAYOUT: square. Uniform cream (#EFE6D0) border on the outer ~6%, thin black keyline just inside the field edge, " +
+  "crisp edges — no vignette/glow/bevel. Tight forward head-and-shoulders bust, centered at identical scale: hair near " +
+  "field top, eyes upper-middle, chin ~two-thirds down, shoulders exiting the bottom.";
+
+// Hardened exclusion block (review7 fix for the gold-leaf "1987" leak). This is
+// the exclusion guardrail — it must never be weakened. NOTE: v4 intentionally
+// has a cream border frame (review5), so the old v3 "No border." clause is
+// deliberately dropped; the border is verified flat post-generation instead.
+const EXCLUSIONS =
+  "ABSOLUTELY NO readable text, numerals, letters, dates, years, ticker symbols, denominations, signatures, badges, " +
+  "captions, logos, watermarks or UI anywhere — no '1987', no numbers on lapels or fields. Ticker-tape and confetti are " +
+  "blank graphic shapes only. No modern devices, no cryptocurrency imagery. Keep the dark 1987 Wall Street satire in " +
+  "imagery, never in text. The trader's name and internal seed must not appear visually in the image.";
+
+const INTRO =
+  "Create one square collectible trader-character portrait for the PvP game Margin Call — one entry in a unified " +
+  "NFT collection where art style, palette, ink and composition are IDENTICAL across the set.";
+
+type ComposeInput = {
+  skin: DemographicValue;
+  gender: DemographicValue;
+  age: DemographicValue;
+  expression: TraitValue;
+  fieldInk: TraitValue;
+  attire: TraitValue;
+  vice: TraitValue;
+  fieldFlourish: TraitValue;
+};
+
+// Plain color words per accent, used to bind a colored garment (the trading
+// jacket) to the actual accent so gpt-image-1 can't default it to its own hue.
+const ACCENT_WORD: Record<string, string> = {
+  vermilion: "vermilion red",
+  cobalt: "cobalt blue",
+  ochre: "ochre gold-brown",
+  teal: "teal",
+  silver: "black",
+  goldleaf: "black",
+};
+
+function composePrompt(input: ComposeInput): string {
+  const inkPrompt = input.fieldInk.prompt ?? input.fieldInk.label;
+  // Metallic inks (silver/goldleaf) describe the whole field; flat inks are "a flat X field".
+  const fieldline =
+    input.fieldInk.id === "silver" || input.fieldInk.id === "goldleaf"
+      ? inkPrompt
+      : `a flat ${inkPrompt} field`;
+  const flourPrompt = input.fieldFlourish.prompt;
+  const vicePrompt = input.vice.prompt;
+
+  // The trading jacket has a strong "bright red/orange" prior — bind it to the
+  // exact accent color so the tile never carries a second ink.
+  const attirePrompt =
+    input.attire.id === "jacket"
+      ? `a floor-trader's jacket that is a single flat block of ${ACCENT_WORD[input.fieldInk.id] ?? "the accent color"} — the SAME accent as the field, with no second color — over a cream shirt and black tie`
+      : input.attire.prompt;
+
+  const parts: string[] = [
+    INTRO,
+    STYLE,
+    `${LAYOUT} The background is ${fieldline}.` +
+      (flourPrompt
+        ? ""
+        : " The field is a single flat solid color, no graphics."),
+    `SUBJECT: a ${input.age.prompt} ${input.gender.prompt}. SKIN: ${input.skin.prompt} ` +
+      `EXPRESSION: ${input.expression.prompt}. ATTIRE: ${attirePrompt}.` +
+      (vicePrompt ? "" : " No hands, no held objects, no props."),
+  ];
+  if (vicePrompt) {
+    parts.push(
+      `PROP (this rare/legendary mint breaks the no-prop rule): ${vicePrompt}.`
+    );
+  }
+  if (flourPrompt) {
+    parts.push(`FIELD FLOURISH: ${flourPrompt}.`);
+  }
+  parts.push(EXCLUSIONS);
+  return parts.join("\n\n");
+}
+
+// ─── Public read projection ──────────────────────────────────────────────────
 
 export function readPublicTraits(source: unknown): PublicPortraitTraits | null {
   if (
@@ -544,7 +520,7 @@ export function readPublicTraits(source: unknown): PublicPortraitTraits | null {
   }
 
   const traits = (source as { traits: Record<string, unknown> }).traits;
-  const publicTraits = {} as Record<keyof PublicPortraitTraits, string>;
+  const publicTraits = {} as Record<SurfacedSlotKey, string>;
   for (const key of PUBLIC_TRAIT_KEYS) {
     const value = traits[key];
     if (typeof value !== "string") return null;
@@ -553,129 +529,131 @@ export function readPublicTraits(source: unknown): PublicPortraitTraits | null {
   return publicTraits;
 }
 
-export function composePrompt(traits: {
-  archetype: (typeof ARCHETYPES)[number];
-  expression: (typeof EXPRESSIONS)[number];
-  lighting: (typeof LIGHTING)[number];
-  marketMoment: string;
-  cameraAngle: (typeof CAMERA_ANGLES)[number];
-  genderPresentation: (typeof GENDER_PRESENTATIONS)[number];
-  apparentAge: (typeof APPARENT_AGES)[number];
-  appearanceVariant: (typeof APPEARANCE_VARIANTS)[number];
-  hairstyle: (typeof HAIRSTYLES)[number];
-  clothingStyle: (typeof CLOTHING_STYLES)[number];
-  accessory: (typeof ACCESSORIES)[number];
-}): string {
-  return [
-    "Create a square profile-picture portrait of one fictional 1987 Wall Street trader for the competitive AI trading game Margin Call. The portrait should feel like a collectible rogue-trader character NFT, not a corporate headshot.",
-    [
-      "Character traits:",
-      `- Gender presentation: ${traits.genderPresentation.prompt}`,
-      `- Apparent age: ${traits.apparentAge.prompt}`,
-      `- Visual appearance: ${traits.appearanceVariant.prompt}`,
-      `- Hairstyle: ${traits.hairstyle.prompt}`,
-      `- Clothing: ${traits.clothingStyle.prompt}`,
-      `- Accessory: ${traits.accessory.prompt}`,
-    ].join("\n"),
-    [
-      "Scene:",
-      `- Archetype: ${traits.archetype.description}`,
-      `- Setting: ${traits.archetype.scene}`,
-      `- Main prop: ${traits.archetype.prop}`,
-      `- Expression: ${traits.expression.prompt}`,
-      `- Lighting: ${traits.lighting.prompt}`,
-      `- Market moment: ${traits.marketMoment}`,
-      `- Camera angle: ${traits.cameraAngle.prompt}`,
-    ].join("\n"),
-    "Style:\nHigh-end retro game character art, painterly pixel-art inspired, cinematic 1980s financial thriller, dramatic amber and green CRT lighting, gritty scanline texture, detailed face, distinct silhouette, square crop, upper-body or head-and-shoulders composition.",
-    "Strict exclusions:\nNo readable text anywhere. No captions. No name. No nameplate. No labels. No job titles. No ticker symbols. No numbers. No letters. No logos. No watermarks. No UI text. No readable documents. No readable terminal text. No readable screen text. No modern devices. No cryptocurrency imagery. No border.",
-    "The trader's name and internal seed must not appear visually in the image.",
-  ].join("\n\n");
+// ─── Tier helpers ─────────────────────────────────────────────────────────────
+
+function tierOf(slot: SurfacedSlotKey, id: string): PortraitTier {
+  return TRAIT_META[slot][id]?.tier ?? "Common";
 }
 
+/** Overall mint rarity = the highest tier across the 5 surfaced slots. */
+export function resolveTierFromTraitIds(
+  traits: PublicPortraitTraits
+): PortraitTier {
+  let best: PortraitTier = "Common";
+  for (const key of PUBLIC_TRAIT_KEYS) {
+    const t = tierOf(key, traits[key]);
+    if (TIER_RANK[t] > TIER_RANK[best]) best = t;
+  }
+  return best;
+}
+
+// ─── Derivation entry points ──────────────────────────────────────────────────
+
+type Demographic = { skin: string; gender: string; age: string };
+
+function byId<T extends { id: string }>(pool: readonly T[], id: string): T {
+  return pool.find((v) => v.id === id) ?? pool[0];
+}
+
+/**
+ * Recompose the prompt from already-derived, stored trait + demographic ids.
+ * Used by the reseed path so a version bump can evolve prompt TEXT without ever
+ * re-rolling trait IDENTITY — the inviolable-determinism guarantee.
+ */
+export function composePromptFromStored(
+  traits: PublicPortraitTraits,
+  demographic: Demographic
+): string {
+  return composePrompt({
+    skin: byId(SKIN, demographic.skin),
+    gender: byId(GENDERS, demographic.gender),
+    age: byId(AGES, demographic.age),
+    expression: byId(EXPRESSIONS, traits.expression),
+    fieldInk: byId(FIELD_INKS, traits.fieldInk),
+    attire: byId(ATTIRE, traits.attire),
+    vice: byId(VICES, traits.vice),
+    fieldFlourish: byId(FIELD_FLOURISHES, traits.fieldFlourish),
+  });
+}
+
+/**
+ * Pure derivation from a stored random seed. Only `seed` feeds the hash; name /
+ * mandate / personality are provenance-only (written to imagePromptSource, never
+ * hashed) so traits never change when a trader is renamed or reconfigured.
+ */
 export function buildPortraitSeed(args: {
-  ownerSubject: string;
-  name: string;
-  mandate: unknown;
+  seed: string;
+  name?: string;
+  mandate?: unknown;
   personality?: string;
 }) {
-  const baseHash = stableHash(
-    JSON.stringify({
-      ownerSubject: args.ownerSubject,
-      name: args.name,
-      mandate: args.mandate ?? {},
-      personality: args.personality ?? "",
-      version: PORTRAIT_METADATA_VERSION,
-    })
+  const baseHash = stableHash(args.seed);
+
+  // Demographic (seed-only) — picked from its own categories first.
+  const skin = weightedPick(SKIN, subHash(baseHash, "skin"));
+  const gender = weightedPick(GENDERS, subHash(baseHash, "gender"));
+  const age = weightedPick(AGES, subHash(baseHash, "age"));
+
+  // Surfaced slots — each from an independent category (order-independent).
+  const expression = weightedPick(EXPRESSIONS, subHash(baseHash, "expression"));
+  const inkPool =
+    skin.id === "deep"
+      ? FIELD_INKS.filter((ink) => WARM_INK_IDS.has(ink.id))
+      : FIELD_INKS;
+  const fieldInk = weightedPick(
+    inkPool,
+    subHash(baseHash, "fieldInk"),
+    FIELD_INKS
+  );
+  const attire = weightedPick(ATTIRE, subHash(baseHash, "attire"));
+  const vice = weightedPick(VICES, subHash(baseHash, "vice"));
+  const fieldFlourish = weightedPick(
+    FIELD_FLOURISHES,
+    subHash(baseHash, "fieldFlourish")
   );
 
-  const archetype = pickFrom(ARCHETYPES, subHash(baseHash, "archetype"));
-  const ageOptions = APPARENT_AGES.filter((age) =>
-    (archetype.preferredAgeBuckets as readonly ApparentAgeId[]).includes(age.id)
-  );
-  const apparentAge = pickFrom(ageOptions, subHash(baseHash, "apparentAge"));
-  const inferred = inferGenderPresentationFromName(args.name);
-  const genderPresentation =
-    inferred === "unknown"
-      ? pickFrom(GENDER_PRESENTATIONS, subHash(baseHash, "genderPresentation"))
-      : GENDER_PRESENTATION_BY_ID[inferred];
-  const genderPresentationSource: GenderPresentationSource =
-    inferred === "unknown" ? "hashed" : `inferred-${inferred}`;
-  const expression = pickFrom(EXPRESSIONS, subHash(baseHash, "expression"));
-  const lighting = pickFrom(LIGHTING, subHash(baseHash, "lighting"));
-  const cameraAngle = pickFrom(CAMERA_ANGLES, subHash(baseHash, "cameraAngle"));
-  const appearanceVariant = pickFrom(
-    APPEARANCE_VARIANTS,
-    subHash(baseHash, "appearanceVariant")
-  );
-  const hairstyle = pickFrom(HAIRSTYLES, subHash(baseHash, "hairstyle"));
-  const clothingStyle = pickFrom(
-    CLOTHING_STYLES,
-    subHash(baseHash, "clothingStyle")
-  );
-  const accessory = pickFrom(ACCESSORIES, subHash(baseHash, "accessory"));
-  const imageStyleSeed = `portrait-v${PORTRAIT_METADATA_VERSION}-${baseHash.toString(36)}`;
+  const traits: PublicPortraitTraits = {
+    expression: expression.id,
+    fieldInk: fieldInk.id,
+    attire: attire.id,
+    vice: vice.id,
+    fieldFlourish: fieldFlourish.id,
+  };
+  const tier = resolveTierFromTraitIds(traits);
+  const demographic: Demographic = {
+    skin: skin.id,
+    gender: gender.id,
+    age: age.id,
+  };
+
   const imagePrompt = composePrompt({
-    archetype,
+    skin,
+    gender,
+    age,
     expression,
-    lighting,
-    marketMoment: archetype.marketMoment,
-    cameraAngle,
-    genderPresentation,
-    apparentAge,
-    appearanceVariant,
-    hairstyle,
-    clothingStyle,
-    accessory,
+    fieldInk,
+    attire,
+    vice,
+    fieldFlourish,
   });
+  const imageStyleSeed = `portrait-v${PORTRAIT_METADATA_VERSION}-${baseHash.toString(36)}`;
 
   return {
     imageStatus: "pending" as const,
     imagePrompt,
     imagePromptSource: {
       version: PORTRAIT_METADATA_VERSION,
-      traderName: args.name,
+      seed: args.seed,
+      traderName: args.name ?? null,
       mandateSnapshot: args.mandate ?? {},
       personalitySnapshot: args.personality ?? null,
-      genderPresentationSource,
-      traits: {
-        archetype: archetype.id,
-        scene: archetype.scene,
-        prop: archetype.prop,
-        marketMoment: archetype.marketMoment,
-        expression: expression.id,
-        lighting: lighting.id,
-        cameraAngle: cameraAngle.id,
-        genderPresentation: genderPresentation.id,
-        apparentAge: apparentAge.id,
-        appearanceVariant: appearanceVariant.id,
-        hairstyle: hairstyle.id,
-        clothingStyle: clothingStyle.id,
-        accessory: accessory.id,
-      },
+      demographic,
+      tier,
+      traits,
     },
     imageStyleSeed,
-    imageVariant: archetype.id,
+    // imageVariant now carries the overall rarity tier (v3 stored archetype.id).
+    imageVariant: tier,
     imageRetryCount: 0,
     metadataVersion: PORTRAIT_METADATA_VERSION,
   };

--- a/convex/portraits.ts
+++ b/convex/portraits.ts
@@ -5,9 +5,25 @@ import { v } from "convex/values";
 import { action, internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { assertOperatorSubject } from "./wire/_operatorUtils";
+import { composePromptFromStored, readPublicTraits } from "./lib/portraitSeed";
+import {
+  type Grader,
+  type GraderVerdict,
+  runPortraitAttempts,
+} from "./lib/portraitChecks";
 
-const FALLBACK_PROMPT =
-  "Create a square profile-picture portrait of one fictional 1987 Wall Street trader for a retro trading game. Painterly pixel-art inspired, cinematic 1980s financial thriller, detailed face, head-and-shoulders or upper-body composition. No readable text anywhere. No captions, no name, no nameplate, no labels, no job titles, no ticker symbols, no numbers, no letters, no logos, no watermarks, no UI text, no readable documents, no readable terminal text, no readable screen text, no modern devices, no cryptocurrency imagery, no border.";
+// Baseline COMMON v4 mint in the locked screenprint style — only used if a
+// trader somehow reaches generation without a composed prompt.
+const FALLBACK_PROMPT = composePromptFromStored(
+  {
+    expression: "cold",
+    fieldInk: "cobalt",
+    attire: "business",
+    vice: "none",
+    fieldFlourish: "plain",
+  },
+  { skin: "fair", gender: "masculine", age: "40s" }
+);
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -20,6 +36,70 @@ function requireEnv(name: string): string {
 function decodeBase64Image(value: string): Blob {
   const bytes = Buffer.from(value, "base64");
   return new Blob([bytes], { type: "image/png" });
+}
+
+const GRADER_SYSTEM =
+  "You are a STRICT visual QA grader for an NFT trait pipeline. Judge only what " +
+  "is unambiguously visible. When uncertain, answer false. Reply ONLY with compact JSON.";
+
+/**
+ * Vision QA grader (gpt-4o). Ported from scratchpad/grade7.py. Returns
+ * `{present:null}` on any parse/API failure after its own retries — callers
+ * treat null as fail-open (the prompt exclusion block is the real guardrail;
+ * a vision outage must not error the whole fleet).
+ */
+async function gradeImageTrait(
+  client: OpenAI,
+  base64: string,
+  question: string
+): Promise<GraderVerdict> {
+  const user =
+    `Question: Is it true that ${question}? ` +
+    'Reply exactly: {"present": true|false, "confidence": 0.0-1.0, "note": "<=12 words"}';
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await client.chat.completions.create(
+        {
+          model: "gpt-4o",
+          temperature: 0,
+          max_tokens: 120,
+          messages: [
+            { role: "system", content: GRADER_SYSTEM },
+            {
+              role: "user",
+              content: [
+                { type: "text", text: user },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: `data:image/png;base64,${base64}`,
+                    detail: "high",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        { timeout: 60_000 }
+      );
+      const txt = res.choices?.[0]?.message?.content ?? "";
+      const start = txt.indexOf("{");
+      const end = txt.lastIndexOf("}");
+      if (start === -1 || end === -1) continue;
+      const parsed = JSON.parse(txt.slice(start, end + 1)) as GraderVerdict;
+      if (typeof parsed.present !== "boolean") {
+        return { present: null, note: "unparseable verdict" };
+      }
+      return parsed;
+    } catch {
+      // fall through to retry / null
+    }
+  }
+  return { present: null, note: "grader-error" };
+}
+
+function makeGrader(client: OpenAI): Grader {
+  return (base64, question) => gradeImageTrait(client, base64, question);
 }
 
 export const generateForTrader = internalAction({
@@ -38,24 +118,45 @@ export const generateForTrader = internalAction({
       const apiKey = requireEnv("OPENAI_API_KEY");
       const prompt = trader.imagePrompt ?? FALLBACK_PROMPT;
       const client = new OpenAI({ apiKey });
-      const response = await client.images.generate(
-        {
-          model: "gpt-image-1",
-          prompt,
-          size: "1024x1024",
-          quality: "medium",
-          output_format: "png",
-          n: 1,
-        },
-        { timeout: 90_000 }
-      );
+      const traits = readPublicTraits(trader.imagePromptSource);
 
-      const image = response.data?.[0]?.b64_json;
-      if (!image) {
-        throw new Error("Image generation returned no image data");
+      const generate = async (): Promise<string> => {
+        const response = await client.images.generate(
+          {
+            model: "gpt-image-1",
+            prompt,
+            size: "1024x1024",
+            quality: "high",
+            output_format: "png",
+            n: 1,
+          },
+          { timeout: 120_000 }
+        );
+        const image = response.data?.[0]?.b64_json;
+        if (!image) throw new Error("Image generation returned no image data");
+        return image;
+      };
+
+      // Generate → verify flat border + rare/legendary trait visibility →
+      // regenerate up to 3×. Never ships a failing tile.
+      const outcome = await runPortraitAttempts({
+        generate,
+        grader: makeGrader(client),
+        traits,
+        maxAttempts: 3,
+      });
+
+      if (outcome.status === "error") {
+        await ctx.runMutation(internal.traders.applyPortraitError, {
+          traderId,
+          error: outcome.reason,
+        });
+        return;
       }
 
-      const storageId = await ctx.storage.store(decodeBase64Image(image));
+      const storageId = await ctx.storage.store(
+        decodeBase64Image(outcome.base64)
+      );
       await ctx.runMutation(internal.traders.applyPortraitReady, {
         traderId,
         profileImageStorageId: storageId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -111,6 +111,10 @@ export default defineSchema({
     ),
     imagePrompt: v.optional(v.string()),
     imagePromptSource: v.optional(v.any()),
+    // Random per-trader seed minted once at creation. All portrait traits derive
+    // deterministically from this value (convex/lib/portraitSeed.ts); it is never
+    // regenerated, so a trader's traits are frozen for life.
+    portraitSeed: v.optional(v.string()),
     imageStyleSeed: v.optional(v.string()),
     imageVariant: v.optional(v.string()),
     imageRetryCount: v.optional(v.number()),

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -16,9 +16,12 @@ import {
 import { assertTradingHours } from "./lib/tradingHours";
 import {
   buildPortraitSeed,
+  composePromptFromStored,
   getPortraitPromptVersion,
   PORTRAIT_METADATA_VERSION,
   readPublicTraits,
+  resolveTierFromTraitIds,
+  stableHash,
 } from "./lib/portraitSeed";
 import { walletStepValidator } from "./schema";
 import { TRADER_NAME_REGEX } from "../src/lib/trader-name";
@@ -116,19 +119,36 @@ async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
   };
 }
 
-const ARCHETYPE_LABEL_OVERRIDES: Record<string, string> = {
-  mna_rainmaker: "M&A Rainmaker",
-  old_school_partner: "Old-School Partner",
-};
+/** Read the stored seed-only demographic ({skin,gender,age}) from imagePromptSource. */
+function readStoredDemographic(
+  source: unknown
+): { skin: string; gender: string; age: string } | null {
+  if (
+    typeof source !== "object" ||
+    source === null ||
+    !("demographic" in source)
+  ) {
+    return null;
+  }
+  const d = (source as { demographic: unknown }).demographic;
+  if (typeof d !== "object" || d === null) return null;
+  const { skin, gender, age } = d as Record<string, unknown>;
+  if (
+    typeof skin !== "string" ||
+    typeof gender !== "string" ||
+    typeof age !== "string"
+  ) {
+    return null;
+  }
+  return { skin, gender, age };
+}
 
-function humanizeImageVariant(variant: string | undefined): string {
-  if (!variant) return "Wall Street Operator";
-  if (ARCHETYPE_LABEL_OVERRIDES[variant])
-    return ARCHETYPE_LABEL_OVERRIDES[variant];
-  return variant
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+/**
+ * v4 stores the overall mint rarity tier in `imageVariant` (v3 stored an
+ * archetype id). Surface it as the trader's headline "Rarity".
+ */
+function humanizeRarity(variant: string | undefined): string {
+  return variant && variant.trim() !== "" ? variant : "Common";
 }
 
 function deriveRiskProfile(mandate: unknown): string {
@@ -154,7 +174,7 @@ async function publicTraderBasics(ctx: QueryCtx, trader: Doc<"traders">) {
     name: trader.name,
     status: trader.status,
     portraitStatus: trader.imageStatus ?? "pending",
-    archetype: humanizeImageVariant(trader.imageVariant),
+    rarity: humanizeRarity(trader.imageVariant),
     riskProfile: deriveRiskProfile(trader.mandate),
     tokenId: trader.tokenId ?? null,
     profileImageUrl: await resolveReadyProfileImageUrl(ctx, trader),
@@ -508,8 +528,11 @@ export const createRecord = internalMutation({
 
     const now = Date.now();
     const normalizedMandate = normalizeMandate(args.mandate);
-    const portraitSeed = buildPortraitSeed({
-      ownerSubject,
+    // Mint the immutable per-trader portrait seed once. All traits derive from
+    // it deterministically and it is never regenerated (determinism inviolable).
+    const seed = crypto.randomUUID();
+    const portraitFields = buildPortraitSeed({
+      seed,
       name: trimmedName,
       mandate: normalizedMandate,
       personality: args.personality,
@@ -522,7 +545,8 @@ export const createRecord = internalMutation({
       status: "paused",
       mandate: normalizedMandate,
       personality: args.personality,
-      ...portraitSeed,
+      portraitSeed: seed,
+      ...portraitFields,
       walletStatus: "pending",
       escrowBalanceUsdc: 0,
       createdAt: now,
@@ -768,21 +792,59 @@ export const markPortraitGenerating = internalMutation({
     }
 
     const promptVersion = getPortraitPromptVersion(trader.imagePromptSource);
-    const shouldReseed =
+    // The portrait seed is minted once and never regenerated. Legacy rows (pre-v4)
+    // lack it — mint one now and persist it so derivation is stable from here on.
+    const seed = trader.portraitSeed ?? crypto.randomUUID();
+    const stale =
       !trader.imagePrompt ||
       !trader.imageStyleSeed ||
       promptVersion < PORTRAIT_METADATA_VERSION;
-    const seedPatch = shouldReseed
-      ? buildPortraitSeed({
-          ownerSubject: trader.ownerSubject,
+
+    // Determinism is inviolable: if this row already has derived traits, a version
+    // bump may only evolve the prompt TEXT — never re-roll trait identity. Recompute
+    // the prompt from the stored trait + demographic ids and keep the traits as-is.
+    // Only re-derive from the seed when traits are absent (legacy / first generation).
+    const storedTraits = readPublicTraits(trader.imagePromptSource);
+    const storedDemographic = readStoredDemographic(trader.imagePromptSource);
+
+    let seedPatch: Record<string, unknown> = {};
+    let reseeded = false;
+    if (stale) {
+      reseeded = true;
+      if (storedTraits && storedDemographic) {
+        const imagePrompt = composePromptFromStored(
+          storedTraits,
+          storedDemographic
+        );
+        const tier = resolveTierFromTraitIds(storedTraits);
+        const prevSource =
+          (trader.imagePromptSource as Record<string, unknown> | undefined) ??
+          {};
+        seedPatch = {
+          imagePrompt,
+          imageStyleSeed: `portrait-v${PORTRAIT_METADATA_VERSION}-${stableHash(seed).toString(36)}`,
+          imageVariant: tier,
+          metadataVersion: PORTRAIT_METADATA_VERSION,
+          imagePromptSource: {
+            ...prevSource,
+            version: PORTRAIT_METADATA_VERSION,
+            seed,
+            tier,
+          },
+        };
+      } else {
+        seedPatch = buildPortraitSeed({
+          seed,
           name: trader.name,
           mandate: trader.mandate ?? {},
           personality: trader.personality,
-        })
-      : {};
-    const nextRetryCount = shouldReseed ? 0 : (trader.imageRetryCount ?? 0) + 1;
+        });
+      }
+    }
+    const nextRetryCount = reseeded ? 0 : (trader.imageRetryCount ?? 0) + 1;
     const patch = {
       ...seedPatch,
+      portraitSeed: seed,
       imageStatus: "generating",
       imageLastAttemptAt: Date.now(),
       imageRetryCount: nextRetryCount,

--- a/docs/portrait-rarity-v4.md
+++ b/docs/portrait-rarity-v4.md
@@ -1,0 +1,127 @@
+# Margin Call — Portrait Rarity (v4)
+
+> ⚠️ **Weights are PERMANENT post-launch.** Rarity is baked into `tokenURI` at mint
+> and published as designed odds; it cannot be changed after the collection opens.
+> These numbers ship as-is. Editing a weight, reordering a pool, or renaming a value
+> after launch breaks the published odds and the determinism guarantee.
+
+Art direction: **two-ink screenprint noir** (Saul Bass silkscreen — cream `#EFE6D0`,
+black `#17140F`, one accent ink). Pipeline: a random seed is minted per trader at
+creation, stored on the row, and all traits derive deterministically from it
+(`convex/lib/portraitSeed.ts`). Same seed → same traits → same prompt, forever. The
+prompt is rendered once by `gpt-image-1` (quality high) with no reference/edit
+conditioning, then verified (flat border + rare/legendary trait visibility) and
+regenerated up to 3× before it can ship.
+
+Sources of truth: `review5.html` (locked style + pinned hex), `review6.html`
+(approved weights/tiers/odds), `review7.html` (the four Phase-2 redesigned values +
+the hardened no-text clause).
+
+## Surfaced trait slots (the only attributes in `tokenURI`)
+
+Each slot's weights sum to 100. **Rarity tier of a mint = the highest tier across
+the five slots.** The metadata `attributes` array carries the 5 slots (each with its
+tier + designed odds), plus overall **Rarity** and **Token ID** — nothing else.
+
+### 1 · Expression
+
+| Value           | Weight | Tier     |
+| --------------- | -----: | -------- |
+| Cold Detached   |  32.6% | Common   |
+| Sharp Focused   |  26.2% | Common   |
+| Tense Alert     |  22.0% | Common   |
+| Predatory Grin  |  12.0% | Uncommon |
+| Confident Smirk |   6.5% | Uncommon |
+| Manic Laugh     |   0.7% | Rare     |
+
+### 2 · Field Ink (background + accent)
+
+| Value               | Weight | Tier      |
+| ------------------- | -----: | --------- |
+| Vermilion `#DD3B1C` | 24.75% | Common    |
+| Cobalt `#2A4BD0`    | 24.75% | Common    |
+| Ochre `#C89012`     | 24.75% | Common    |
+| Teal `#147A6E`      | 24.75% | Common    |
+| Burnished Silver    |   0.5% | Rare      |
+| Gold Leaf           |   0.5% | Legendary |
+
+### 3 · Attire
+
+| Value                    | Weight | Tier     |
+| ------------------------ | -----: | -------- |
+| Business Suit            |  42.0% | Common   |
+| Shirt-sleeves & Braces   |  20.0% | Common   |
+| Trading Jacket           |  16.0% | Common   |
+| Fur-Collar Overcoat      |  11.0% | Uncommon |
+| Tuxedo                   |  10.0% | Uncommon |
+| Gold-Threaded Power Suit |   1.0% | Rare     |
+
+### 4 · Vice / Prop (legendaries break the no-prop rule)
+
+| Value             | Weight | Tier      |
+| ----------------- | -----: | --------- |
+| None              |  79.9% | Common    |
+| Unlit Cigarette   |  11.0% | Uncommon  |
+| Cigar             |   7.0% | Uncommon  |
+| Lit Cigar         |   1.0% | Rare      |
+| Martini           |   0.6% | Rare      |
+| Cigarette Bouquet |   0.3% | Legendary |
+| Champagne Coupe   |   0.2% | Legendary |
+
+### 5 · Field Flourish (worked into the flat field)
+
+| Value             | Weight | Tier      |
+| ----------------- | -----: | --------- |
+| Plain Field       |  85.4% | Common    |
+| Halftone Dot Wash |  12.0% | Uncommon  |
+| Bold Ticker Bands |   1.6% | Rare      |
+| Confetti Storm    |   1.0% | Legendary |
+
+## Seed-only inputs (NOT surfaced in metadata)
+
+These shape the face and drive the ink-mapping rule, but are **never** emitted as
+attributes and never leak through any read model (`readPublicTraits` returns only
+the 5 surfaced keys; the demographic is stored on a sibling key).
+
+| Input               | Values (weights)                                    |
+| ------------------- | --------------------------------------------------- |
+| Skin                | Fair 40 · Mid 40 · Deep 20                          |
+| Gender presentation | Masculine 55 · Feminine 45                          |
+| Apparent age        | Late 20s 20 · Mid 30s 30 · Mid 40s 30 · Late 50s 20 |
+
+**Skin → ink rule:** deep-skin mints draw Field Ink only from the warm subset
+(Vermilion, Ochre, Gold Leaf); the accent doubles as the face midtone so deep-brown
+faces render in black + warm-accent + cream with no out-of-palette fourth tone.
+
+## Combinatorics & odds
+
+- **6,048** surfaced-attribute combinations (5 slots).
+- **~2.0% legendary** (`1 − (1−.005)(1−.005)(1−.010) = 1.99%` — Gold Leaf 0.5%,
+  legendary Vice 0.5%, Confetti 1.0%).
+- **~7.2% rare-or-better** (`1 − (.993·.990·.990·.979·.974) = 7.20%`).
+- Rarest possible mint ("The Bonfire": Manic Laugh + Gold-Threaded Power Suit +
+  Champagne Coupe + Gold Leaf + Confetti Storm) ≈ 7 × 10⁻¹² — a theoretical ceiling.
+
+## Legendary stacking policy
+
+**Stacking is allowed — no one-legendary-cap.** Phase 2 rendered 3 maximally-stacked
+mints and all 3 survived composition (still read as one coherent screenprint bust),
+so a single mint may roll multiple legendary values. The compound math above is
+unchanged (no cap applied).
+
+## Phase-2 redesigns (renderability)
+
+Four values were redesigned to pass the ≥90% renderability bar; weights/tiers are
+unchanged, only the visual + display name:
+
+| Original (review6)        | Shipped (review7)        | Why                                                                                     |
+| ------------------------- | ------------------------ | --------------------------------------------------------------------------------------- |
+| Two Lit Cigarettes        | **Cigarette Bouquet**    | exact count of 2 unrenderable/uncheckable; a fistful of 5+ reads as excess              |
+| Champagne Bottle Mid-Pour | **Champagne Coupe**      | the pour arc + hand failed; an overflowing coupe has no fragile arc                     |
+| Faint Ticker-Tape Lines   | **Bold Ticker Bands**    | faint tape washed out at 64px; bold bands read at icon size                             |
+| Solid Gold (flat)         | **Gold Leaf** (metallic) | flat gold was indistinguishable from common Ochre; metallic gold-leaf separates cleanly |
+
+The gold-leaf redesign initially leaked a readable "1987" date; the exclusion block
+was hardened (no numerals / dates / badges) and the leak cleared across the full
+Phase-3 roster. That hardened clause is the `EXCLUSIONS` string in
+`convex/lib/portraitSeed.ts` and must never be weakened.

--- a/src/app/traders/[traderId]/page.tsx
+++ b/src/app/traders/[traderId]/page.tsx
@@ -148,7 +148,7 @@ export function PublicTraderDossier({
                   Token-bound operator
                 </p>
                 <p className="mt-1 text-sm font-bold uppercase tracking-wide text-[var(--t-text)]">
-                  {trader.archetype} / {trader.riskProfile}
+                  {trader.rarity} / {trader.riskProfile}
                 </p>
               </div>
             </div>
@@ -169,7 +169,7 @@ export function PublicTraderDossier({
                   label="Token ID"
                   value={tokenLabel(trader.tokenId)}
                 />
-                <DatumCell label="Archetype" value={trader.archetype} />
+                <DatumCell label="Rarity" value={trader.rarity} />
                 <DatumCell label="Risk" value={trader.riskProfile} />
               </div>
             </section>
@@ -186,7 +186,10 @@ export function PublicTraderDossier({
                     <DatumCell
                       key={key}
                       label={label}
-                      value={humanizePortraitTraitValue(trader.traits![key])}
+                      value={humanizePortraitTraitValue(
+                        key,
+                        trader.traits![key]
+                      )}
                     />
                   ))}
                 </div>

--- a/src/app/traders/[traderId]/page.ui.test.tsx
+++ b/src/app/traders/[traderId]/page.ui.test.tsx
@@ -9,7 +9,7 @@ const BASE_TRADER = {
   status: "active" as const,
   tokenId: 87,
   portraitStatus: "ready" as const,
-  archetype: "Corporate raider",
+  rarity: "Legendary",
   riskProfile: "Aggressive",
   traits: null,
   escrowBalanceUsdc: 125.5,

--- a/src/components/public-trader-dialog.tsx
+++ b/src/components/public-trader-dialog.tsx
@@ -28,10 +28,6 @@ import {
   formatUsdc,
 } from "@/lib/utils";
 
-const NON_ARCHETYPE_TRAIT_ROWS = PUBLIC_PORTRAIT_TRAIT_ROWS.filter(
-  ([key]) => key !== "archetype"
-);
-
 export function PublicTraderDialog({
   traderId,
   open,
@@ -120,7 +116,7 @@ function PublicTraderContent({
                 </span>
               </span>
               <span className="text-[var(--t-divider)]">/</span>
-              <span className="text-[var(--t-text)]">{trader.archetype}</span>
+              <span className="text-[var(--t-text)]">{trader.rarity}</span>
               <span className="text-[var(--t-divider)]">/</span>
               <span>
                 <span className="text-[var(--t-text)]">
@@ -185,7 +181,7 @@ function PublicTraderContent({
               valueClassName={cn("text-2xl sm:text-3xl", escrowTone)}
               accent
             />
-            <HeroStat label="Archetype" value={trader.archetype} />
+            <HeroStat label="Rarity" value={trader.rarity} />
             <HeroStat label="Risk profile" value={trader.riskProfile} />
           </div>
 
@@ -197,11 +193,11 @@ function PublicTraderContent({
                 hintTone="text-[var(--t-green)]"
               />
               <dl className="grid gap-px bg-[var(--t-divider)]/40 sm:grid-cols-2">
-                {NON_ARCHETYPE_TRAIT_ROWS.map(([key, label]) => (
+                {PUBLIC_PORTRAIT_TRAIT_ROWS.map(([key, label]) => (
                   <TraitRow
                     key={key}
                     label={label}
-                    value={humanizePortraitTraitValue(trader.traits![key])}
+                    value={humanizePortraitTraitValue(key, trader.traits![key])}
                   />
                 ))}
               </dl>

--- a/src/lib/__tests__/trader-metadata.test.ts
+++ b/src/lib/__tests__/trader-metadata.test.ts
@@ -18,7 +18,7 @@ describe("trader NFT metadata helpers", () => {
         name: "Gordon Gecko",
         status: "active",
         portraitStatus: "pending",
-        archetype: "Junk Bond Operator",
+        rarity: "Common",
         riskProfile: "Aggressive",
         tokenId: null,
         profileImageUrl: null,
@@ -32,19 +32,24 @@ describe("trader NFT metadata helpers", () => {
       image: "https://margin-call.example/trader-placeholder.png",
       external_url: "https://margin-call.example/traders/trader-1",
     });
-    expect(metadata.attributes.map((attr) => attr.trait_type)).not.toContain(
+    expect(metadata.attributes.map((a) => a.trait_type)).not.toContain(
       "Token ID"
     );
+    // Rarity is always present; demographics/gameplay state are never surfaced.
+    expect(metadata.attributes).toContainEqual({
+      trait_type: "Rarity",
+      value: "Common",
+    });
   });
 
-  it("uses the generated image URL and token ID attribute when ready", () => {
+  it("uses the generated image URL and Token ID attribute when ready", () => {
     const metadata = buildTraderNftMetadata(
       {
         traderId: "trader-2",
         name: "Bud Fox",
         status: "active",
         portraitStatus: "ready",
-        archetype: "Junk Bond Operator",
+        rarity: "Uncommon",
         riskProfile: "Balanced",
         tokenId: 42,
         profileImageUrl: "https://storage.example/portrait.png",
@@ -60,87 +65,75 @@ describe("trader NFT metadata helpers", () => {
     });
   });
 
-  it("humanizes special-case archetype attributes", () => {
-    const metadata = buildTraderNftMetadata(
-      {
-        traderId: "trader-3",
-        name: "Hayley Patel",
-        status: "active",
-        portraitStatus: "ready",
-        archetype: "M&A Rainmaker",
-        riskProfile: "Balanced",
-        tokenId: null,
-        profileImageUrl: "https://storage.example/portrait.png",
-        traits: {
-          archetype: "mna_rainmaker",
-          scene: "private deal-room office at midnight, walnut paneling",
-          prop: "open binder of deal docs, brass desk lamp",
-          marketMoment: "mid-deal closing crunch",
-          expression: "calm_calculating",
-          lighting: "amber_desk_lamp",
-          cameraAngle: "head_and_shoulders_centered",
-          genderPresentation: "feminine",
-          apparentAge: "mid_30s",
-          appearanceVariant: "fair_auburn_subtle_waves",
-          hairstyle: "tight_chignon",
-          clothingStyle: "pinstripe_double_breasted",
-          accessory: "gold_signet_ring",
-        },
-      },
-      "https://margin-call.example"
-    );
-
-    expect(metadata.attributes).toContainEqual({
-      trait_type: "Archetype",
-      value: "M&A Rainmaker",
-    });
-  });
-
-  it("adds public portrait traits to NFT attributes", () => {
+  it("emits the 5 surfaced slots (tier + odds) + Rarity + Token ID, and no demographics", () => {
     const metadata = buildTraderNftMetadata(
       {
         traderId: "trader-4",
-        name: "Jordan Cross",
+        name: "The Bonfire",
         status: "active",
         portraitStatus: "ready",
-        archetype: "Junk Bond Operator",
+        rarity: "Legendary",
         riskProfile: "Aggressive",
-        tokenId: null,
+        tokenId: 7,
         profileImageUrl: "https://storage.example/portrait.png",
         traits: {
-          archetype: "junk_bond_operator",
-          scene: "high-yield bond desk, paper-stacked horizon",
-          prop: "thick stapled prospectus, half-empty coffee mug",
-          marketMoment: "leveraged-buyout euphoria",
-          expression: "sharp_focused",
-          lighting: "green_crt_glow",
-          cameraAngle: "three_quarter_left",
-          genderPresentation: "masculine",
-          apparentAge: "mid_40s",
-          appearanceVariant: "olive_dark_wavy",
-          hairstyle: "slicked_back",
-          clothingStyle: "charcoal_three_piece",
-          accessory: "no_accessory",
+          expression: "sharp",
+          fieldInk: "vermilion",
+          attire: "business",
+          vice: "litcigar",
+          fieldFlourish: "confetti",
         },
       },
       "https://margin-call.example"
     );
 
     expect(metadata.attributes).toEqual([
-      { trait_type: "Status", value: "active" },
-      { trait_type: "Portrait Status", value: "ready" },
-      { trait_type: "Archetype", value: "Junk Bond Operator" },
-      { trait_type: "Risk Profile", value: "Aggressive" },
-      { trait_type: "Gender Presentation", value: "Masculine" },
-      { trait_type: "Apparent Age", value: "Mid 40s" },
-      { trait_type: "Appearance", value: "Olive Dark Wavy" },
-      { trait_type: "Hairstyle", value: "Slicked Back" },
-      { trait_type: "Clothing", value: "Charcoal Three Piece" },
-      { trait_type: "Accessory", value: "No Accessory" },
-      { trait_type: "Expression", value: "Sharp Focused" },
-      { trait_type: "Lighting", value: "Green Crt Glow" },
-      { trait_type: "Camera", value: "Three Quarter Left" },
-      { trait_type: "Market Moment", value: "Leveraged-Buyout Euphoria" },
+      {
+        trait_type: "Expression",
+        value: "Sharp Focused",
+        tier: "Common",
+        designed_odds: "26.2%",
+      },
+      {
+        trait_type: "Field Ink",
+        value: "Vermilion",
+        tier: "Common",
+        designed_odds: "24.75%",
+      },
+      {
+        trait_type: "Attire",
+        value: "Business Suit",
+        tier: "Common",
+        designed_odds: "42%",
+      },
+      {
+        trait_type: "Vice",
+        value: "Lit Cigar",
+        tier: "Rare",
+        designed_odds: "1%",
+      },
+      {
+        trait_type: "Field Flourish",
+        value: "Confetti Storm",
+        tier: "Legendary",
+        designed_odds: "1%",
+      },
+      { trait_type: "Rarity", value: "Legendary" },
+      { trait_type: "Token ID", value: 7 },
     ]);
+
+    const types = metadata.attributes.map((a) => a.trait_type);
+    for (const forbidden of [
+      "Gender Presentation",
+      "Apparent Age",
+      "Appearance",
+      "Skin",
+      "Archetype",
+      "Status",
+      "Portrait Status",
+      "Risk Profile",
+    ]) {
+      expect(types).not.toContain(forbidden);
+    }
   });
 });

--- a/src/lib/portrait-traits.ts
+++ b/src/lib/portrait-traits.ts
@@ -1,44 +1,20 @@
-export type PublicPortraitTraits = {
-  archetype: string;
-  scene: string;
-  prop: string;
-  marketMoment: string;
-  expression: string;
-  lighting: string;
-  cameraAngle: string;
-  genderPresentation: string;
-  apparentAge: string;
-  appearanceVariant: string;
-  hairstyle: string;
-  clothingStyle: string;
-  accessory: string;
-};
+import {
+  type PublicPortraitTraits,
+  SURFACED_SLOTS,
+  TRAIT_META,
+} from "../../convex/lib/portraitSeed";
 
-export const PUBLIC_PORTRAIT_TRAIT_ROWS = [
-  ["archetype", "Archetype"],
-  ["scene", "Scene"],
-  ["prop", "Prop"],
-  ["marketMoment", "Market Moment"],
-  ["expression", "Expression"],
-  ["lighting", "Lighting"],
-  ["cameraAngle", "Camera Angle"],
-  ["genderPresentation", "Gender Presentation"],
-  ["apparentAge", "Apparent Age"],
-  ["appearanceVariant", "Appearance"],
-  ["hairstyle", "Hairstyle"],
-  ["clothingStyle", "Clothing"],
-  ["accessory", "Accessory"],
-] as const satisfies readonly [keyof PublicPortraitTraits, string][];
+export type { PublicPortraitTraits };
 
-export function humanizePortraitTraitValue(value: string): string {
-  const overrides: Record<string, string> = {
-    mna_rainmaker: "M&A Rainmaker",
-  };
-  if (overrides[value]) return overrides[value];
-  return value.replaceAll("_", " ").replace(/\S+/g, (word) =>
-    word
-      .split("-")
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join("-")
-  );
+/** [surfacedKey, display label] rows for the 5 v4 trait slots. */
+export const PUBLIC_PORTRAIT_TRAIT_ROWS = SURFACED_SLOTS.map(
+  (slot) => [slot.key, slot.label] as const
+) as ReadonlyArray<readonly [keyof PublicPortraitTraits, string]>;
+
+/** Human display label for a stored trait id within its slot. */
+export function humanizePortraitTraitValue(
+  slotKey: keyof PublicPortraitTraits,
+  id: string
+): string {
+  return TRAIT_META[slotKey]?.[id]?.label ?? id;
 }

--- a/src/lib/trader-display.ts
+++ b/src/lib/trader-display.ts
@@ -7,7 +7,7 @@ export type PublicTraderProfile = {
   status: "active" | "paused" | "wiped_out";
   tokenId: number | null;
   portraitStatus: "pending" | "generating" | "ready" | "error";
-  archetype: string;
+  rarity: string;
   riskProfile: string;
   traits: PublicPortraitTraits | null;
   escrowBalanceUsdc: number;

--- a/src/lib/trader-metadata.ts
+++ b/src/lib/trader-metadata.ts
@@ -1,7 +1,5 @@
-import {
-  humanizePortraitTraitValue,
-  type PublicPortraitTraits,
-} from "./portrait-traits";
+import { type PublicPortraitTraits } from "./portrait-traits";
+import { SURFACED_SLOTS, TRAIT_META } from "../../convex/lib/portraitSeed";
 
 export type { PublicPortraitTraits };
 
@@ -14,7 +12,7 @@ export type PublicTraderMetadataModel = {
   name: string;
   status: string;
   portraitStatus: string;
-  archetype: string;
+  rarity: string;
   riskProfile: string;
   tokenId: number | null;
   profileImageUrl: string | null;
@@ -54,63 +52,38 @@ export function buildTraderNftMetadata(
     image = buildTraderPlaceholderImageUrl(baseUrl);
   }
 
-  const baseAttributes: Array<{ trait_type: string; value: string | number }> =
-    [
-      { trait_type: "Status", value: trader.status },
-      { trait_type: "Portrait Status", value: trader.portraitStatus },
-      { trait_type: "Archetype", value: trader.archetype },
-      { trait_type: "Risk Profile", value: trader.riskProfile },
-    ];
+  // OpenSea-standard attributes: the 5 surfaced trait slots only (each carrying
+  // its designed odds + rarity tier), plus overall Rarity and Token ID. No
+  // demographics (skin/gender/age are seed-only and never surfaced), no gameplay
+  // state. These values + odds are PERMANENT once minted — see
+  // docs/portrait-rarity-v4.md.
+  type TraitAttribute = {
+    trait_type: string;
+    value: string | number;
+    tier?: string;
+    designed_odds?: string;
+  };
 
-  if (trader.tokenId !== null) {
-    baseAttributes.push({ trait_type: "Token ID", value: trader.tokenId });
+  const attributes: TraitAttribute[] = [];
+
+  if (trader.traits) {
+    for (const slot of SURFACED_SLOTS) {
+      const id = trader.traits[slot.key];
+      const meta = TRAIT_META[slot.key][id];
+      attributes.push({
+        trait_type: slot.label,
+        value: meta?.label ?? id,
+        tier: meta?.tier ?? "Common",
+        designed_odds: `${meta?.weight ?? 0}%`,
+      });
+    }
   }
 
-  const traitAttributes: Array<{ trait_type: string; value: string | number }> =
-    trader.traits
-      ? [
-          {
-            trait_type: "Gender Presentation",
-            value: humanizePortraitTraitValue(trader.traits.genderPresentation),
-          },
-          {
-            trait_type: "Apparent Age",
-            value: humanizePortraitTraitValue(trader.traits.apparentAge),
-          },
-          {
-            trait_type: "Appearance",
-            value: humanizePortraitTraitValue(trader.traits.appearanceVariant),
-          },
-          {
-            trait_type: "Hairstyle",
-            value: humanizePortraitTraitValue(trader.traits.hairstyle),
-          },
-          {
-            trait_type: "Clothing",
-            value: humanizePortraitTraitValue(trader.traits.clothingStyle),
-          },
-          {
-            trait_type: "Accessory",
-            value: humanizePortraitTraitValue(trader.traits.accessory),
-          },
-          {
-            trait_type: "Expression",
-            value: humanizePortraitTraitValue(trader.traits.expression),
-          },
-          {
-            trait_type: "Lighting",
-            value: humanizePortraitTraitValue(trader.traits.lighting),
-          },
-          {
-            trait_type: "Camera",
-            value: humanizePortraitTraitValue(trader.traits.cameraAngle),
-          },
-          {
-            trait_type: "Market Moment",
-            value: humanizePortraitTraitValue(trader.traits.marketMoment),
-          },
-        ]
-      : [];
+  attributes.push({ trait_type: "Rarity", value: trader.rarity });
+
+  if (trader.tokenId !== null) {
+    attributes.push({ trait_type: "Token ID", value: trader.tokenId });
+  }
 
   return {
     name: trader.name,
@@ -118,6 +91,6 @@ export function buildTraderNftMetadata(
       "AI trader identity for Margin Call, a PvP trading game set on 1980s Wall Street.",
     image,
     external_url: buildTraderExternalUrl(baseUrl, trader.traderId),
-    attributes: [...baseAttributes, ...traitAttributes],
+    attributes,
   };
 }

--- a/tests/convex/portraitChecks.test.ts
+++ b/tests/convex/portraitChecks.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BORDER_QUESTION,
+  checkFlatBorder,
+  checkTraitVisibility,
+  RUBRIC,
+  runPortraitAttempts,
+  type Grader,
+} from "../../convex/lib/portraitChecks";
+import type { PublicPortraitTraits } from "../../convex/lib/portraitSeed";
+
+const COMMON: PublicPortraitTraits = {
+  expression: "cold",
+  fieldInk: "vermilion",
+  attire: "business",
+  vice: "none",
+  fieldFlourish: "plain",
+};
+// Vice "litcigar" is Rare → gated by the visibility check.
+const RARE_VICE: PublicPortraitTraits = { ...COMMON, vice: "litcigar" };
+
+// A clean grader: border is flat (present:false to "has glow") and any trait is visible.
+const cleanGrader: Grader = async (_b, q) =>
+  q === BORDER_QUESTION ? { present: false } : { present: true };
+
+describe("portraitChecks — flat border", () => {
+  it("passes when the border is affirmatively clean", async () => {
+    expect(await checkFlatBorder(cleanGrader, "x")).toEqual({ ok: true });
+  });
+  it("fails when the grader affirmatively reports a bad border", async () => {
+    const grader: Grader = async () => ({ present: true, note: "halo" });
+    expect((await checkFlatBorder(grader, "x")).ok).toBe(false);
+  });
+  it("fails open on a grader infra-null", async () => {
+    const grader: Grader = async () => ({ present: null });
+    expect(await checkFlatBorder(grader, "x")).toEqual({ ok: true });
+  });
+});
+
+describe("portraitChecks — trait visibility", () => {
+  it("passes with no traits to verify", async () => {
+    expect(await checkTraitVisibility(cleanGrader, "x", null)).toEqual({
+      ok: true,
+    });
+  });
+  it("does not gate common/uncommon traits even if the grader says absent", async () => {
+    const grader: Grader = async () => ({ present: false });
+    expect(await checkTraitVisibility(grader, "x", COMMON)).toEqual({
+      ok: true,
+    });
+  });
+  it("fails when a rare trait is affirmatively absent", async () => {
+    const grader: Grader = async () => ({ present: false });
+    const res = await checkTraitVisibility(grader, "x", RARE_VICE);
+    expect(res.ok).toBe(false);
+    expect(res.missing).toBe("litcigar");
+  });
+  it("passes when the rare trait is visible", async () => {
+    expect(await checkTraitVisibility(cleanGrader, "x", RARE_VICE)).toEqual({
+      ok: true,
+    });
+  });
+  it("has a rubric entry for every checked rare/legendary id", () => {
+    for (const id of [
+      "manic",
+      "silver",
+      "goldleaf",
+      "goldthread",
+      "litcigar",
+      "martini",
+      "cigbouquet",
+      "coupe",
+      "tickerbold",
+      "confetti",
+    ]) {
+      expect(RUBRIC[id]).toBeTruthy();
+    }
+  });
+});
+
+describe("portraitChecks — runPortraitAttempts", () => {
+  it("returns ready on the first clean attempt", async () => {
+    const generate = vi.fn(async () => "img");
+    const out = await runPortraitAttempts({
+      generate,
+      grader: cleanGrader,
+      traits: COMMON,
+    });
+    expect(out).toEqual({ status: "ready", base64: "img" });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("regenerates after a border failure, then succeeds", async () => {
+    let n = 0;
+    const generate = vi.fn(async () => `img-${++n}`);
+    const grader: Grader = async (b, q) =>
+      q === BORDER_QUESTION ? { present: b === "img-1" } : { present: true };
+    const out = await runPortraitAttempts({ generate, grader, traits: COMMON });
+    expect(out).toEqual({ status: "ready", base64: "img-2" });
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+
+  it("errors with failed_border_check after exhausting attempts", async () => {
+    const generate = vi.fn(async () => "bad");
+    const grader: Grader = async () => ({ present: true });
+    const out = await runPortraitAttempts({
+      generate,
+      grader,
+      traits: COMMON,
+      maxAttempts: 3,
+    });
+    expect(out).toEqual({ status: "error", reason: "failed_border_check" });
+    expect(generate).toHaveBeenCalledTimes(3);
+  });
+
+  it("errors with failed_trait_visibility when a rare trait never appears", async () => {
+    const grader: Grader = async (_b, q) =>
+      q === BORDER_QUESTION ? { present: false } : { present: false };
+    const out = await runPortraitAttempts({
+      generate: async () => "x",
+      grader,
+      traits: RARE_VICE,
+      maxAttempts: 2,
+    });
+    expect(out).toEqual({ status: "error", reason: "failed_trait_visibility" });
+  });
+
+  it("fails open: a grader outage never blocks the tile", async () => {
+    const grader: Grader = async () => ({ present: null });
+    const out = await runPortraitAttempts({
+      generate: async () => "y",
+      grader,
+      traits: RARE_VICE,
+    });
+    expect(out).toEqual({ status: "ready", base64: "y" });
+  });
+
+  it("surfaces a generation_error reason when generation keeps throwing", async () => {
+    const generate = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const out = await runPortraitAttempts({
+      generate,
+      grader: cleanGrader,
+      traits: COMMON,
+      maxAttempts: 2,
+    });
+    expect(out.status).toBe("error");
+    if (out.status === "error")
+      expect(out.reason).toContain("generation_error");
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/convex/portraitSeed.test.ts
+++ b/tests/convex/portraitSeed.test.ts
@@ -1,212 +1,195 @@
 import { describe, expect, it } from "vitest";
 import {
-  ARCHETYPES,
-  PORTRAIT_METADATA_VERSION,
   buildPortraitSeed,
-  inferGenderPresentationFromName,
+  composePromptFromStored,
+  FIELD_INKS,
+  PORTRAIT_METADATA_VERSION,
   readPublicTraits,
+  resolveTierFromTraitIds,
+  SURFACED_SLOTS,
+  TRAIT_META,
 } from "../../convex/lib/portraitSeed";
 
-const baseArgs = {
-  ownerSubject: "did:privy:owner",
-  mandate: { bankroll_pct: 25, max_entry_cost_usdc: 100 },
-  personality: "Aggressive credit trader",
-};
-
-const TRAIT_KEYS = [
-  "archetype",
-  "scene",
-  "prop",
-  "marketMoment",
+const SURFACED_KEYS = [
+  "attire",
   "expression",
-  "lighting",
-  "cameraAngle",
-  "genderPresentation",
-  "apparentAge",
-  "appearanceVariant",
-  "hairstyle",
-  "clothingStyle",
-  "accessory",
-] as const;
+  "fieldFlourish",
+  "fieldInk",
+  "vice",
+];
+const WARM_INKS = new Set(["vermilion", "ochre", "goldleaf"]);
 
-function seedFor(name: string, ownerSubject = baseArgs.ownerSubject) {
-  return buildPortraitSeed({ ...baseArgs, ownerSubject, name });
+function seedFor(
+  seed: string,
+  over: Partial<{ name: string; mandate: unknown; personality: string }> = {}
+) {
+  return buildPortraitSeed({
+    seed,
+    name: over.name ?? "Bud Fox",
+    mandate: over.mandate ?? { bankroll_pct: 25 },
+    personality: over.personality ?? "Aggressive credit trader",
+  });
 }
 
-function traitsFrom(seed: ReturnType<typeof buildPortraitSeed>) {
-  return seed.imagePromptSource.traits;
-}
+const traitsOf = (s: ReturnType<typeof buildPortraitSeed>) =>
+  s.imagePromptSource.traits;
 
-describe("portrait seed v3", () => {
-  it("is deterministic for identical inputs", () => {
-    const first = seedFor("Bud Fox");
-    const second = seedFor("Bud Fox");
-
-    expect(first.imagePrompt).toBe(second.imagePrompt);
-    expect(first.imageStyleSeed).toBe(second.imageStyleSeed);
-    expect(first.imageVariant).toBe(second.imageVariant);
-    expect(traitsFrom(first)).toEqual(traitsFrom(second));
+describe("portrait seed v4", () => {
+  it("is deterministic for an identical seed", () => {
+    const a = seedFor("seed-alpha");
+    const b = seedFor("seed-alpha");
+    expect(a.imagePrompt).toBe(b.imagePrompt);
+    expect(a.imageStyleSeed).toBe(b.imageStyleSeed);
+    expect(a.imageVariant).toBe(b.imageVariant);
+    expect(traitsOf(a)).toEqual(traitsOf(b));
   });
 
-  it("diversifies traits across distinct names", () => {
-    const seeds = Array.from({ length: 50 }, (_, index) =>
-      seedFor(`Trader ${index}`)
-    );
-
-    expect(
-      new Set(seeds.map((s) => traitsFrom(s).archetype)).size
-    ).toBeGreaterThanOrEqual(8);
-    expect(
-      new Set(seeds.map((s) => traitsFrom(s).appearanceVariant)).size
-    ).toBeGreaterThanOrEqual(5);
-    expect(
-      new Set(seeds.map((s) => traitsFrom(s).clothingStyle)).size
-    ).toBeGreaterThanOrEqual(4);
+  it("traits are a pure function of the seed — name/mandate/personality never affect them", () => {
+    const a = seedFor("seed-frozen", {
+      name: "Gordon",
+      mandate: { bankroll_pct: 5 },
+      personality: "cautious",
+    });
+    const b = seedFor("seed-frozen", {
+      name: "Completely Different",
+      mandate: { bankroll_pct: 99 },
+      personality: "reckless",
+    });
+    expect(traitsOf(a)).toEqual(traitsOf(b));
+    expect(a.imagePrompt).toBe(b.imagePrompt);
+    // provenance fields still reflect the caller's inputs
+    expect(a.imagePromptSource.traderName).toBe("Gordon");
+    expect(b.imagePromptSource.traderName).toBe("Completely Different");
   });
 
-  it("uses feminine name inference for curated names", () => {
-    for (const name of ["Hayley", "Hailey"]) {
-      const seed = seedFor(name);
-      expect(seed.imagePromptSource.traits.genderPresentation).toBe("feminine");
-      expect(seed.imagePromptSource.genderPresentationSource).toBe(
-        "inferred-feminine"
-      );
-    }
+  it("recomputing the prompt from stored trait ids is stable (version-bump inviolability)", () => {
+    const seed = seedFor("seed-recompute");
+    const traits = traitsOf(seed);
+    const demographic = seed.imagePromptSource.demographic;
+    const recomposed = composePromptFromStored(traits, demographic);
+    expect(recomposed).toBe(seed.imagePrompt);
+    expect(resolveTierFromTraitIds(traits)).toBe(seed.imageVariant);
   });
 
-  it("uses a deterministic hash fallback for ambiguous names", () => {
-    const first = seedFor("Jordan");
-    const second = seedFor("Jordan");
-
-    expect(first.imagePromptSource.genderPresentationSource).toBe("hashed");
-    expect(["feminine", "masculine"]).toContain(
-      first.imagePromptSource.traits.genderPresentation
-    );
-    expect(first.imagePromptSource.traits.genderPresentation).toBe(
-      second.imagePromptSource.traits.genderPresentation
-    );
+  it("stamps v4 metadata and a seed-derived style seed", () => {
+    const seed = seedFor("seed-meta");
+    expect(seed.metadataVersion).toBe(PORTRAIT_METADATA_VERSION);
+    expect(PORTRAIT_METADATA_VERSION).toBe(4);
+    expect(seed.imagePromptSource.version).toBe(4);
+    expect(seed.imageStyleSeed).toMatch(/^portrait-v4-/);
+    expect(seed.imagePromptSource.seed).toBe("seed-meta");
   });
 
-  it("never includes the raw first name in the prompt", () => {
-    const names = [
+  it("surfaces exactly the 5 trait slots and never leaks demographics", () => {
+    const seed = seedFor("seed-public");
+    const publicTraits = readPublicTraits(seed.imagePromptSource);
+    expect(publicTraits).not.toBeNull();
+    expect(Object.keys(publicTraits!).sort()).toEqual(SURFACED_KEYS);
+    // seed-only demographic is stored on a sibling key, never in the public projection
+    expect(publicTraits).not.toHaveProperty("skin");
+    expect(publicTraits).not.toHaveProperty("gender");
+    expect(publicTraits).not.toHaveProperty("age");
+    expect(seed.imagePromptSource.demographic).toMatchObject({
+      skin: expect.any(String),
+      gender: expect.any(String),
+      age: expect.any(String),
+    });
+  });
+
+  it("never renders the trader name into the prompt", () => {
+    for (const name of [
       "Hayley",
       "David",
-      "Marcus",
-      "Olivia",
       "Gordon",
-      "Bud",
       "Jordan",
-      "Taylor",
       "Sarah",
-      "Michael",
-      "Emily",
-      "Anthony",
-      "Laura",
-      "Ryan",
-      "Diane",
-      "Frank",
-      "Sophie",
-      "Peter",
-      "Ava",
       "Kenneth",
-    ];
-
-    for (const name of names) {
-      const prompt = seedFor(name).imagePrompt;
+    ]) {
+      const prompt = seedFor(`seed-${name}`, { name }).imagePrompt;
       expect(new RegExp(`\\b${name}\\b`, "i").test(prompt)).toBe(false);
     }
   });
 
-  it("includes the strict exclusions and final safety sentence", () => {
-    const prompt = seedFor("Hayley").imagePrompt.toLowerCase();
-
+  it("keeps the hardened exclusion block (never weakened)", () => {
+    const prompt = seedFor("seed-exclude").imagePrompt.toLowerCase();
     for (const phrase of [
       "no readable text",
-      "no captions",
-      "no name",
-      "no nameplate",
-      "no labels",
-      "no job titles",
-      "no ticker symbols",
-      "no numbers",
-      "no letters",
-      "no logos",
-      "no watermarks",
-      "no ui text",
-      "no readable documents",
-      "no readable terminal text",
-      "no readable screen text",
+      "numerals",
+      "letters",
+      "dates",
+      "ticker symbols",
+      "logos",
+      "watermarks",
       "no modern devices",
       "no cryptocurrency imagery",
-      "no border",
+      "no '1987'",
       "the trader's name and internal seed must not appear visually in the image.",
     ]) {
       expect(prompt).toContain(phrase);
     }
   });
 
-  it("stores provenance and all derived trait keys", () => {
-    const seed = seedFor("Hayley Patel");
-
-    expect(seed.imagePromptSource.version).toBe(PORTRAIT_METADATA_VERSION);
-    expect(seed.imagePromptSource.traderName).toBe("Hayley Patel");
-    expect(seed.imagePromptSource.mandateSnapshot).toEqual(baseArgs.mandate);
-    expect(seed.imagePromptSource.personalitySnapshot).toBe(
-      baseArgs.personality
-    );
-    expect(seed.imagePromptSource.genderPresentationSource).toBe(
-      "inferred-feminine"
-    );
-    expect(Object.keys(seed.imagePromptSource.traits).sort()).toEqual(
-      [...TRAIT_KEYS].sort()
-    );
+  it("constrains deep-skin mints to warm inks", () => {
+    let deepCount = 0;
+    for (let i = 0; i < 3000; i++) {
+      const seed = seedFor(`deep-scan-${i}`);
+      if (seed.imagePromptSource.demographic.skin === "deep") {
+        deepCount++;
+        expect(WARM_INKS.has(traitsOf(seed).fieldInk)).toBe(true);
+      }
+    }
+    expect(deepCount).toBeGreaterThan(0); // sanity: we actually saw deep-skin mints
   });
 
-  it("projects only the public trait map", () => {
-    const seed = seedFor("Gordon Gecko");
-    const publicShape = {
-      name: "Gordon Gecko",
-      traits: readPublicTraits(seed.imagePromptSource),
-    };
-
-    expect(publicShape.traits).not.toBeNull();
-    expect(Object.keys(publicShape.traits!).sort()).toEqual(
-      [...TRAIT_KEYS].sort()
-    );
-    expect(publicShape).not.toHaveProperty("traderName");
-    expect(publicShape).not.toHaveProperty("mandateSnapshot");
-    expect(publicShape).not.toHaveProperty("personalitySnapshot");
-    expect(publicShape).not.toHaveProperty("genderPresentationSource");
-    expect(publicShape).not.toHaveProperty("imagePrompt");
-    expect(publicShape).not.toHaveProperty("imageStyleSeed");
+  it("weighted distribution roughly matches the designed odds", () => {
+    const N = 4000;
+    let none = 0;
+    let rareOrBetter = 0;
+    const tierRank = { Common: 0, Uncommon: 1, Rare: 2, Legendary: 3 } as const;
+    for (let i = 0; i < N; i++) {
+      const traits = traitsOf(seedFor(`dist-${i}`));
+      if (traits.vice === "none") none++;
+      const tier = resolveTierFromTraitIds(traits);
+      if (tierRank[tier] >= tierRank.Rare) rareOrBetter++;
+    }
+    // Vice "None" is designed at 79.9%
+    expect(none / N).toBeGreaterThan(0.72);
+    expect(none / N).toBeLessThan(0.87);
+    // Rare-or-better is designed at ~7.2%
+    expect(rareOrBetter / N).toBeGreaterThan(0.03);
+    expect(rareOrBetter / N).toBeLessThan(0.13);
   });
 
-  it("has sane archetype distribution over 200 deterministic names", () => {
-    const counts = new Map<string, number>();
-
-    for (let index = 0; index < 200; index += 1) {
-      const archetype = traitsFrom(
-        seedFor(`Trader ${index}`, `did:privy:owner-${index}`)
-      ).archetype;
-      counts.set(archetype, (counts.get(archetype) ?? 0) + 1);
+  it("every common trait value is reachable over many seeds", () => {
+    const seen: Record<string, Set<string>> = Object.fromEntries(
+      SURFACED_SLOTS.map((s) => [s.key, new Set<string>()])
+    );
+    for (let i = 0; i < 4000; i++) {
+      const traits = traitsOf(seedFor(`reach-${i}`));
+      for (const slot of SURFACED_SLOTS) seen[slot.key].add(traits[slot.key]);
     }
-
-    for (const archetype of ARCHETYPES) {
-      expect(counts.get(archetype.id) ?? 0).toBeGreaterThan(0);
-    }
-    for (const count of counts.values()) {
-      expect(count / 200).toBeLessThanOrEqual(0.25);
+    for (const slot of SURFACED_SLOTS) {
+      for (const value of slot.pool) {
+        if (value.tier === "Common") {
+          // deep-only ink exclusion never removes a common ink, so all commons appear
+          expect(seen[slot.key].has(value.id)).toBe(true);
+        }
+      }
     }
   });
 
-  it.each([
-    ["Hayley", "feminine"],
-    ["Hayley Patel", "feminine"],
-    ["Jordan", "unknown"],
-    ["DAVID", "masculine"],
-    ["", "unknown"],
-    ["Zxqwer", "unknown"],
-  ] as const)("infers %s as %s", (name, expected) => {
-    expect(inferGenderPresentationFromName(name)).toBe(expected);
+  it("TRAIT_META covers every value in every slot", () => {
+    for (const slot of SURFACED_SLOTS) {
+      for (const value of slot.pool) {
+        expect(TRAIT_META[slot.key][value.id]).toEqual({
+          label: value.label,
+          tier: value.tier,
+          weight: value.weight,
+        });
+      }
+    }
+    // sanity: gold leaf is the legendary ink, silver the rare one
+    expect(FIELD_INKS.find((i) => i.id === "goldleaf")?.tier).toBe("Legendary");
+    expect(FIELD_INKS.find((i) => i.id === "silver")?.tier).toBe("Rare");
   });
 });

--- a/tests/convex/x402-auth.test.ts
+++ b/tests/convex/x402-auth.test.ts
@@ -533,37 +533,42 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
     const trader = await t.run(async (ctx) => ctx.db.get(traderId as never));
     expect(trader?.imageStatus).toBe("pending");
     expect(trader?.imageRetryCount).toBe(0);
-    expect(trader?.metadataVersion).toBe(3);
-    expect(trader?.imagePrompt).toContain("1987 Wall Street trader");
-    expect(trader?.imagePrompt).not.toContain("Portrait");
-    expect(trader?.imagePrompt).not.toContain("equity_salesman");
-    expect(trader?.imagePrompt).toContain("No readable text");
-    expect(trader?.imagePrompt).toContain("No captions");
-    expect(trader?.imagePrompt).toContain("No labels");
-    expect(trader?.imageStyleSeed).toMatch(/^portrait-v3-/);
-    expect(trader?.imageVariant).toEqual(expect.any(String));
+    expect(trader?.metadataVersion).toBe(4);
+    expect(trader?.portraitSeed).toEqual(expect.any(String));
+    expect(trader?.imagePrompt).toContain("TWO-INK SCREENPRINT NOIR");
+    expect(trader?.imagePrompt).toContain("1987 Wall Street satire");
+    expect(trader?.imagePrompt).not.toContain("Portrait"); // trader name never leaks
+    expect(trader?.imagePrompt).toContain("readable text");
+    expect(trader?.imagePrompt).toContain("No modern devices");
+    expect(trader?.imagePrompt).toContain(
+      "The trader's name and internal seed must not appear visually in the image."
+    );
+    expect(trader?.imageStyleSeed).toMatch(/^portrait-v4-/);
+    // imageVariant now holds the overall rarity tier.
+    expect(["Common", "Uncommon", "Rare", "Legendary"]).toContain(
+      trader?.imageVariant
+    );
     expect(trader?.imagePromptSource).toMatchObject({
-      version: 3,
+      version: 4,
+      seed: trader?.portraitSeed,
       traderName: "Portrait",
       mandateSnapshot: mandate,
       personalitySnapshot: "Aggressive merger arbitrage specialist",
-      genderPresentationSource: expect.any(String),
+      demographic: {
+        skin: expect.any(String),
+        gender: expect.any(String),
+        age: expect.any(String),
+      },
       traits: expect.objectContaining({
-        archetype: expect.any(String),
-        scene: expect.any(String),
-        prop: expect.any(String),
-        marketMoment: expect.any(String),
         expression: expect.any(String),
-        lighting: expect.any(String),
-        cameraAngle: expect.any(String),
-        genderPresentation: expect.any(String),
-        apparentAge: expect.any(String),
-        appearanceVariant: expect.any(String),
-        hairstyle: expect.any(String),
-        clothingStyle: expect.any(String),
-        accessory: expect.any(String),
+        fieldInk: expect.any(String),
+        attire: expect.any(String),
+        vice: expect.any(String),
+        fieldFlourish: expect.any(String),
       }),
     });
+    // demographics are seed-only — never surfaced in the public trait projection
+    expect(trader?.imagePromptSource.traits).not.toHaveProperty("gender");
     expect(trader?.walletStatus).toBe("pending");
   });
 
@@ -644,7 +649,7 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
       name: "Public Metadata Trader",
       status: "active",
       portraitStatus: "pending",
-      archetype: "Wall Street Operator",
+      rarity: "Common",
       riskProfile: "Conservative",
       tokenId: null,
       profileImageUrl: null,
@@ -675,7 +680,7 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
         mandate: { bankroll_pct: 75 },
         profileImageStorageId: storageId,
         imageStatus: "ready",
-        imageVariant: "junk_bond_operator",
+        imageVariant: "Rare",
         walletStatus: "ready",
         escrowBalanceUsdc: 1000,
         tokenId: 99,
@@ -692,7 +697,7 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
       traderId,
       name: "Ready Portrait Trader",
       portraitStatus: "ready",
-      archetype: "Junk Bond Operator",
+      rarity: "Rare",
       riskProfile: "Aggressive",
       tokenId: 99,
     });
@@ -737,7 +742,7 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
       status: "active",
       tokenId: null,
       portraitStatus: "pending",
-      archetype: "Wall Street Operator",
+      rarity: "Common",
       riskProfile: "Balanced",
       escrowBalanceUsdc: 250,
       profileImageUrl: null,
@@ -781,7 +786,7 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
         personality: "Do not expose this full personality text.",
         profileImageStorageId: storageId,
         imageStatus: "ready",
-        imageVariant: "execution_desk",
+        imageVariant: "Legendary",
         imagePrompt: "Private prompt",
         imagePromptSource: { private: true },
         walletStatus: "ready",
@@ -802,7 +807,7 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
       traderId,
       name: "Ready Public Trader",
       portraitStatus: "ready",
-      archetype: "Execution Desk",
+      rarity: "Legendary",
       riskProfile: "Aggressive",
       escrowBalanceUsdc: 1200,
       tokenId: 77,


### PR DESCRIPTION
## What

Replaces the name-derived "cinematic film-still" trader portraits with a seed-driven **v4 two-ink screenprint noir** NFT collection.

**Pipeline:** random seed minted per trader at creation → stored on `traders.portraitSeed` → deterministic weighted trait derivation → screenprint prompt → single `gpt-image-1` (quality **high**) → post-generation verification (regenerate ≤3×, never ship a failing tile). No reference/edit conditioning.

## Traits
- **5 surfaced slots** (in `tokenURI`): Expression, Field Ink, Attire, Vice, Field Flourish — weighted so ~7% rare-or-better, ~2% legendary. Legendary stacking allowed (survived Phase-2 composition).
- **3 seed-only demographics** (skin/gender/age): shape the face, **never surfaced** in any read model or metadata.
- All name-based gender inference deleted.

## Key properties
- **Determinism is inviolable.** Only the seed feeds the hash; name/mandate/personality are provenance-only. Version bumps recompute only the *prompt* from stored trait ids — trait identity never re-rolls.
- **Verification.** Flat-border + rare/legendary trait-visibility checks via a gpt-4o grader; grader infra-errors fail open (the prompt's hardened exclusion block is the real guardrail).
- **Metadata.** `tokenURI.attributes` = 5 surfaced slots (each with tier + designed odds) + Rarity + Token ID. No demographics.

## Files
- `convex/lib/portraitSeed.ts` — trait tables, weighted selection, `composePrompt`, `PORTRAIT_METADATA_VERSION=4`
- `convex/lib/portraitChecks.ts` (new) — injectable grader + checks + attempt loop (unit-tested with a fake grader)
- `convex/portraits.ts` — gpt-4o grader + regenerate loop
- `convex/traders.ts` + `convex/schema.ts` — `portraitSeed` field, seed lifecycle, `archetype`→`rarity`
- `src/lib/{portrait-traits,trader-metadata,trader-display}.ts` + profile page + dialog — 5-slot metadata/UI, `archetype`→`rarity`
- `docs/portrait-rarity-v4.md` — permanent-weights rarity spec

## Rollout note
The Convex functions are deployed separately (`convex dev --once`) and the 10 live traders are being backfilled. **Merge promptly** — the Convex read-model field rename (`archetype`→`rarity`) is coupled to this frontend, so the live metadata route + profile pages need this deploy to stay in sync.

## Testing
- 484 vitest tests pass (rewrote seed/metadata/UI suites; added `portraitChecks.test.ts`)
- `tsc --noEmit` clean, `pnpm lint` 0 errors, `pnpm build` compiles
- Verified end-to-end: 17 v4 renders (incl. forced-legendary) through the real derivation + check loop; independent art-direction review passed after a two-ink jacket fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)