### PR TITLE
feat(ui): surface persona traits + rarity, tier-styled

### DIFF
--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -114,6 +114,7 @@ async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
     imageStatus: trader.imageStatus,
     profileImageUrl: await resolveTraderProfileImageUrl(ctx, trader),
     traits: readPublicTraits(trader.imagePromptSource),
+    rarity: humanizeRarity(trader.imageVariant),
     createdAt: trader.createdAt,
     updatedAt: trader.updatedAt,
   };

--- a/src/app/traders/[traderId]/page.tsx
+++ b/src/app/traders/[traderId]/page.tsx
@@ -5,10 +5,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
 import { TRADER_PLACEHOLDER_IMAGE_PATH } from "@/lib/trader-metadata";
-import {
-  PUBLIC_PORTRAIT_TRAIT_ROWS,
-  humanizePortraitTraitValue,
-} from "@/lib/portrait-traits";
+import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
 import { DatumCell } from "@/components/datum-cell";
 import { EmptyState } from "@/components/empty-state";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
@@ -143,15 +140,27 @@ export function PublicTraderDossier({
                   </div>
                 ) : null}
               </div>
-              <div className="border-t border-[var(--t-divider)] bg-[#070b09]/85 px-4 py-3">
+              <div className="flex items-center justify-between gap-3 border-t border-[var(--t-divider)] bg-[#070b09]/85 px-4 py-3">
                 <p className="text-[10px] uppercase tracking-[0.2em] text-[var(--t-muted)]">
                   Token-bound operator
                 </p>
-                <p className="mt-1 text-sm font-bold uppercase tracking-wide text-[var(--t-text)]">
-                  {trader.rarity} / {trader.riskProfile}
-                </p>
+                <RarityBadge rarity={trader.rarity} />
               </div>
             </div>
+
+            {trader.traits ? (
+              <div className="terminal-panel mt-5 overflow-hidden">
+                <div className="border-b border-[var(--t-divider)] bg-[var(--t-surface)]/70 px-4 py-2.5">
+                  <h2 className="text-[11px] font-bold uppercase tracking-[0.24em] text-[var(--t-amber)]">
+                    Persona traits
+                  </h2>
+                </div>
+                <PersonaTraits
+                  traits={trader.traits}
+                  className="sm:grid-cols-1"
+                />
+              </div>
+            ) : null}
           </div>
 
           <div className="grid min-w-0 content-start gap-5">
@@ -169,32 +178,13 @@ export function PublicTraderDossier({
                   label="Token ID"
                   value={tokenLabel(trader.tokenId)}
                 />
-                <DatumCell label="Rarity" value={trader.rarity} />
+                <DatumCell
+                  label="Rarity"
+                  value={<RarityBadge rarity={trader.rarity} />}
+                />
                 <DatumCell label="Risk" value={trader.riskProfile} />
               </div>
             </section>
-
-            {trader.traits ? (
-              <section className="terminal-panel p-4 sm:p-5">
-                <div className="mb-4 border-b border-[var(--t-divider)] pb-3">
-                  <h2 className="font-[family-name:var(--font-plex-sans)] text-xl font-black uppercase tracking-wide text-[var(--t-amber)]">
-                    Traits
-                  </h2>
-                </div>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {PUBLIC_PORTRAIT_TRAIT_ROWS.map(([key, label]) => (
-                    <DatumCell
-                      key={key}
-                      label={label}
-                      value={humanizePortraitTraitValue(
-                        key,
-                        trader.traits![key]
-                      )}
-                    />
-                  ))}
-                </div>
-              </section>
-            ) : null}
 
             <section className="terminal-panel min-h-0 p-4 sm:p-5">
               <div className="mb-4 border-b border-[var(--t-divider)] pb-3">

--- a/src/app/traders/[traderId]/page.ui.test.tsx
+++ b/src/app/traders/[traderId]/page.ui.test.tsx
@@ -48,4 +48,26 @@ describe("PublicTraderDossier", () => {
     );
     expect(html).toContain("generating");
   });
+
+  it("surfaces persona traits + a tier-styled rarity when traits are present", () => {
+    const html = renderToStaticMarkup(
+      <PublicTraderDossier
+        trader={{
+          ...BASE_TRADER,
+          rarity: "Legendary",
+          traits: {
+            expression: "cold",
+            fieldInk: "goldleaf", // Legendary
+            attire: "business",
+            vice: "none",
+            fieldFlourish: "plain",
+          },
+        }}
+      />
+    );
+
+    expect(html).toContain("Persona traits");
+    expect(html).toContain("Gold Leaf"); // legendary field ink label
+    expect(html).toContain('data-tier="Legendary"'); // tier styling hook
+  });
 });

--- a/src/components/persona-traits.tsx
+++ b/src/components/persona-traits.tsx
@@ -1,0 +1,135 @@
+import { cn } from "@/lib/utils";
+import {
+  PUBLIC_PORTRAIT_TRAIT_ROWS,
+  humanizePortraitTraitValue,
+  type PublicPortraitTraits,
+} from "@/lib/portrait-traits";
+import { TRAIT_META } from "../../convex/lib/portraitSeed";
+
+type Tier = "Common" | "Uncommon" | "Rare" | "Legendary";
+
+// Tier → palette (existing tokens only). Rares/legendaries pop; commons/uncommons
+// stay neutral so the eye lands on what's actually rare. Legendary gets a gold glow.
+const TIER_TONE: Record<
+  Tier,
+  { text: string; badge: string; tag: string | null }
+> = {
+  Common: {
+    text: "text-[var(--t-text)]",
+    badge: "border-[var(--t-divider)] text-[var(--t-muted)]",
+    tag: null,
+  },
+  Uncommon: {
+    text: "text-[var(--t-text)]",
+    badge: "border-[var(--t-green)]/50 text-[var(--t-green)]",
+    tag: null,
+  },
+  Rare: {
+    text: "text-[var(--t-blue)]",
+    badge: "border-[var(--t-blue)]/60 text-[var(--t-blue)]",
+    tag: "RARE",
+  },
+  Legendary: {
+    text: "text-[var(--t-amber-hot)]",
+    badge:
+      "border-[var(--t-amber)]/60 bg-[var(--t-amber)]/[0.06] text-[var(--t-amber-hot)] shadow-[0_0_12px_rgba(235,193,122,0.28)]",
+    tag: "LEG",
+  },
+};
+
+export function normalizeTier(rarity: string): Tier {
+  return (rarity as Tier) in TIER_TONE ? (rarity as Tier) : "Common";
+}
+
+function tierOf(slotKey: keyof PublicPortraitTraits, id: string): Tier {
+  return (TRAIT_META[slotKey]?.[id]?.tier as Tier) ?? "Common";
+}
+
+/** Tier-colored rarity pill. Legendary gets a subtle gold glow. */
+export function RarityBadge({
+  rarity,
+  className,
+}: {
+  rarity: string;
+  className?: string;
+}) {
+  const tier = normalizeTier(rarity);
+  const tone = TIER_TONE[tier];
+  const notable = tier === "Rare" || tier === "Legendary";
+  return (
+    <span
+      data-tier={tier}
+      className={cn(
+        "inline-flex items-center gap-1 border px-2.5 py-1 text-[11px] font-black uppercase tracking-[0.18em]",
+        tone.badge,
+        className
+      )}
+    >
+      {notable ? (
+        <span aria-hidden className="text-[0.7em]">
+          ◆
+        </span>
+      ) : null}
+      {rarity}
+    </span>
+  );
+}
+
+/**
+ * The 5 surfaced portrait traits as a read-only list, tier-colored per value.
+ * Callers should gate on a non-null `traits`.
+ */
+export function PersonaTraits({
+  traits,
+  className,
+}: {
+  traits: PublicPortraitTraits;
+  className?: string;
+}) {
+  return (
+    <dl
+      className={cn(
+        "grid gap-px bg-[var(--t-divider)]/40 sm:grid-cols-2",
+        className
+      )}
+    >
+      {PUBLIC_PORTRAIT_TRAIT_ROWS.map(([key, label]) => {
+        const id = traits[key];
+        const tier = tierOf(key, id);
+        const tone = TIER_TONE[tier];
+        const notable = tier === "Rare" || tier === "Legendary";
+        return (
+          <div
+            key={key}
+            data-tier={notable ? tier : undefined}
+            className="flex min-w-0 items-baseline justify-between gap-3 bg-[#070b09]/85 px-3 py-2 sm:px-4"
+          >
+            <dt className="shrink-0 text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--t-muted)]">
+              {label}
+            </dt>
+            <dd
+              className={cn(
+                "flex min-w-0 items-center justify-end gap-1.5 text-right text-xs font-bold uppercase tracking-[0.12em]",
+                tone.text
+              )}
+            >
+              {notable ? (
+                <span aria-hidden className="shrink-0 text-[0.7em] opacity-80">
+                  ◆
+                </span>
+              ) : null}
+              <span className="truncate">
+                {humanizePortraitTraitValue(key, id)}
+              </span>
+              {tone.tag ? (
+                <span className="shrink-0 border border-current px-1 text-[8px] leading-tight opacity-90">
+                  {tone.tag}
+                </span>
+              ) : null}
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}

--- a/src/components/persona-traits.ui.test.tsx
+++ b/src/components/persona-traits.ui.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PersonaTraits, RarityBadge } from "./persona-traits";
+
+describe("PersonaTraits", () => {
+  it("humanizes every slot and tier-tags rare/legendary values", () => {
+    const html = renderToStaticMarkup(
+      <PersonaTraits
+        traits={{
+          expression: "manic", // Rare
+          fieldInk: "goldleaf", // Legendary
+          attire: "business", // Common
+          vice: "coupe", // Legendary
+          fieldFlourish: "plain", // Common
+        }}
+      />
+    );
+
+    // Humanized labels for every slot
+    for (const label of [
+      "Manic Laugh",
+      "Gold Leaf",
+      "Business Suit",
+      "Champagne Coupe",
+      "Plain Field",
+    ]) {
+      expect(html).toContain(label);
+    }
+
+    // Rare + Legendary rows carry a data-tier; the ◆ marker + tags appear
+    expect(html).toContain('data-tier="Rare"');
+    expect(html).toContain('data-tier="Legendary"');
+    expect(html).toContain("RARE");
+    expect(html).toContain("LEG");
+    expect(html).toContain("◆");
+  });
+
+  it("leaves common/uncommon rows untagged", () => {
+    const html = renderToStaticMarkup(
+      <PersonaTraits
+        traits={{
+          expression: "cold", // Common
+          fieldInk: "vermilion", // Common
+          attire: "tuxedo", // Uncommon
+          vice: "none", // Common
+          fieldFlourish: "plain", // Common
+        }}
+      />
+    );
+    expect(html).not.toContain("data-tier=");
+    expect(html).not.toContain("◆");
+    expect(html).toContain("Tuxedo");
+  });
+});
+
+describe("RarityBadge", () => {
+  it("renders the tier with a data-tier hook", () => {
+    const legendary = renderToStaticMarkup(<RarityBadge rarity="Legendary" />);
+    expect(legendary).toContain("Legendary");
+    expect(legendary).toContain('data-tier="Legendary"');
+    expect(legendary).toContain("◆");
+
+    const common = renderToStaticMarkup(<RarityBadge rarity="Common" />);
+    expect(common).toContain('data-tier="Common"');
+    expect(common).not.toContain("◆");
+  });
+});

--- a/src/components/public-trader-dialog.tsx
+++ b/src/components/public-trader-dialog.tsx
@@ -8,11 +8,8 @@ import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { TraderAvatar } from "@/components/trader-avatar";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
+import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
 import { formatStatus } from "@/lib/format-status";
-import {
-  PUBLIC_PORTRAIT_TRAIT_ROWS,
-  humanizePortraitTraitValue,
-} from "@/lib/portrait-traits";
 import {
   getEscrowTone,
   getPortraitTone,
@@ -116,7 +113,10 @@ function PublicTraderContent({
                 </span>
               </span>
               <span className="text-[var(--t-divider)]">/</span>
-              <span className="text-[var(--t-text)]">{trader.rarity}</span>
+              <RarityBadge
+                rarity={trader.rarity}
+                className="px-1.5 py-0 text-[10px] tracking-[0.16em]"
+              />
               <span className="text-[var(--t-divider)]">/</span>
               <span>
                 <span className="text-[var(--t-text)]">
@@ -171,38 +171,36 @@ function PublicTraderContent({
               />
             </dl>
           </div>
+
+          {trader.traits ? (
+            <div className="terminal-panel mt-5 overflow-hidden">
+              <div className="flex items-center justify-between gap-3 border-b border-[var(--t-divider)] bg-[var(--t-surface)]/70 px-3 py-2 sm:px-4">
+                <h3 className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--t-amber)]">
+                  Persona traits
+                </h3>
+                <RarityBadge
+                  rarity={trader.rarity}
+                  className="px-1.5 py-0.5 text-[9px] tracking-[0.16em]"
+                />
+              </div>
+              <PersonaTraits
+                traits={trader.traits}
+                className="sm:grid-cols-1"
+              />
+            </div>
+          ) : null}
         </section>
 
         <section className="grid min-w-0 content-start gap-5">
-          <div className="grid gap-3 sm:grid-cols-[1.5fr_1fr_1fr]">
+          <div className="grid gap-3 sm:grid-cols-2">
             <HeroStat
               label="Escrow capital"
               value={formatUsdc(trader.escrowBalanceUsdc)}
               valueClassName={cn("text-2xl sm:text-3xl", escrowTone)}
               accent
             />
-            <HeroStat label="Rarity" value={trader.rarity} />
             <HeroStat label="Risk profile" value={trader.riskProfile} />
           </div>
-
-          {trader.traits ? (
-            <div className="terminal-panel overflow-hidden">
-              <SectionHeader
-                label="Persona traits"
-                hint="Read only"
-                hintTone="text-[var(--t-green)]"
-              />
-              <dl className="grid gap-px bg-[var(--t-divider)]/40 sm:grid-cols-2">
-                {PUBLIC_PORTRAIT_TRAIT_ROWS.map(([key, label]) => (
-                  <TraitRow
-                    key={key}
-                    label={label}
-                    value={humanizePortraitTraitValue(key, trader.traits![key])}
-                  />
-                ))}
-              </dl>
-            </div>
-          ) : null}
 
           <div className="terminal-panel overflow-hidden">
             <SectionHeader
@@ -334,19 +332,6 @@ function SectionHeader({
           {hint}
         </span>
       ) : null}
-    </div>
-  );
-}
-
-function TraitRow({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <div className="flex min-w-0 items-baseline justify-between gap-3 bg-[#070b09]/85 px-3 py-2 sm:px-4">
-      <dt className="shrink-0 text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--t-muted)]">
-        {label}
-      </dt>
-      <dd className="min-w-0 truncate text-right text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-text)]">
-        {value}
-      </dd>
     </div>
   );
 }

--- a/src/components/trader-creation-flow.tsx
+++ b/src/components/trader-creation-flow.tsx
@@ -714,6 +714,8 @@ function FundAndActivateStep({
               traderName={traderName}
               imageStatus={trader?.image_status ?? null}
               profileImageUrl={trader?.profile_image_url ?? ""}
+              traits={trader?.traits ?? null}
+              rarity={trader?.rarity ?? "Common"}
             />
           )}
           <DatumCell

--- a/src/components/trader-detail.tsx
+++ b/src/components/trader-detail.tsx
@@ -6,6 +6,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import { useTrader, type Trader, type TraderStatus } from "@/hooks/use-traders";
 import { TraderAvatar } from "@/components/trader-avatar";
 import { DatumCell } from "@/components/datum-cell";
+import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
 import { formatStatus } from "@/lib/format-status";
 import {
   useSepoliaUsdcBalance,
@@ -309,6 +310,24 @@ export function TraderDetailContent({
               />
             </button>
           </div>
+
+          {trader.traits ? (
+            <div className="mt-4 overflow-hidden border border-[var(--t-divider)] bg-[#070b09]">
+              <div className="flex items-center justify-between gap-3 border-b border-[var(--t-divider)] bg-[var(--t-surface)]/70 px-3 py-2">
+                <h3 className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--t-amber)]">
+                  Persona traits
+                </h3>
+                <RarityBadge
+                  rarity={trader.rarity}
+                  className="px-1.5 py-0.5 text-[9px] tracking-[0.16em]"
+                />
+              </div>
+              <PersonaTraits
+                traits={trader.traits}
+                className="sm:grid-cols-1"
+              />
+            </div>
+          ) : null}
         </section>
 
         <section className="grid min-w-0 content-start gap-4">

--- a/src/components/wallet-onboarding-checklist.test.tsx
+++ b/src/components/wallet-onboarding-checklist.test.tsx
@@ -7,6 +7,8 @@ const baseProps = {
   traderName: "Gordon Gekko",
   imageStatus: "generating" as const,
   profileImageUrl: "",
+  traits: null,
+  rarity: "Common",
 };
 
 describe("WalletOnboardingChecklist", () => {
@@ -100,5 +102,51 @@ describe("WalletOnboardingChecklist", () => {
       />
     );
     expect(ready).not.toContain("COMPLIANCE NEVER SLEEPS");
+  });
+
+  it("reveals persona traits + rarity once the portrait is ready", () => {
+    const html = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        imageStatus="ready"
+        walletStatus="ready"
+        walletStep="seat_registered"
+        tokenId={7}
+        rarity="Legendary"
+        traits={{
+          expression: "cold",
+          fieldInk: "vermilion",
+          attire: "business",
+          vice: "none",
+          fieldFlourish: "confetti",
+        }}
+      />
+    );
+
+    expect(html).toContain("Persona revealed");
+    expect(html).toContain("Confetti Storm"); // legendary flourish label
+    expect(html).toContain("Legendary"); // rarity badge
+    expect(html).toContain('data-tier="Legendary"');
+  });
+
+  it("hides the persona reveal while the portrait is still generating", () => {
+    const html = renderToStaticMarkup(
+      <WalletOnboardingChecklist
+        {...baseProps}
+        imageStatus="generating"
+        walletStatus="creating"
+        walletStep="id_minted"
+        tokenId={7}
+        rarity="Legendary"
+        traits={{
+          expression: "cold",
+          fieldInk: "vermilion",
+          attire: "business",
+          vice: "none",
+          fieldFlourish: "confetti",
+        }}
+      />
+    );
+    expect(html).not.toContain("Persona revealed");
   });
 });

--- a/src/components/wallet-onboarding-checklist.tsx
+++ b/src/components/wallet-onboarding-checklist.tsx
@@ -7,6 +7,8 @@ import {
   TraderAvatar,
   type TraderAvatarImageStatus,
 } from "@/components/trader-avatar";
+import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
+import type { PublicPortraitTraits } from "@/lib/portrait-traits";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { useSfx } from "@/hooks/use-sfx";
 import type { Doc } from "../../convex/_generated/dataModel";
@@ -56,6 +58,8 @@ export function WalletOnboardingChecklist({
   traderName,
   imageStatus,
   profileImageUrl,
+  traits,
+  rarity,
 }: {
   walletStatus: WalletStatus;
   walletStep: WalletStep | null;
@@ -63,6 +67,8 @@ export function WalletOnboardingChecklist({
   traderName: string;
   imageStatus: TraderAvatarImageStatus | null;
   profileImageUrl: string;
+  traits: PublicPortraitTraits | null;
+  rarity: string;
 }) {
   const reducedMotion = useReducedMotion();
   const { playStinger } = useSfx();
@@ -194,6 +200,26 @@ export function WalletOnboardingChecklist({
           {FLAVOR_LINES[flavorIdx]}
         </p>
       )}
+
+      {traits && imageStatus === "ready" ? (
+        <div
+          className={cn(
+            "mt-4 border-t border-[var(--t-divider)] pt-3",
+            portraitRevealed && !reducedMotion && "mc-stamp-in"
+          )}
+        >
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <h4 className="text-[10px] font-bold uppercase tracking-[0.24em] text-[var(--t-amber)]">
+              Persona revealed
+            </h4>
+            <RarityBadge
+              rarity={rarity}
+              className="px-1.5 py-0.5 text-[9px] tracking-[0.16em]"
+            />
+          </div>
+          <PersonaTraits traits={traits} className="sm:grid-cols-1" />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/hooks/use-traders.ts
+++ b/src/hooks/use-traders.ts
@@ -4,6 +4,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
+import type { PublicPortraitTraits } from "@/lib/portrait-traits";
 
 type TraderReadModel = Pick<
   Doc<"traders">,
@@ -29,6 +30,8 @@ type TraderReadModel = Pick<
   | "updatedAt"
 > & {
   profileImageUrl: string;
+  traits: PublicPortraitTraits | null;
+  rarity: string;
 };
 
 export type TraderStatus = "active" | "paused" | "wiped_out";
@@ -47,6 +50,8 @@ export interface Trader {
   personality: string | null;
   image_status: TraderReadModel["imageStatus"] | null;
   profile_image_url: string;
+  traits: PublicPortraitTraits | null;
+  rarity: string;
   escrow_balance_usdc: number;
   wallet_status: Doc<"traders">["walletStatus"];
   wallet_error: string | null;
@@ -75,6 +80,8 @@ function mapTrader(doc: TraderReadModel, ownerAddress: string): Trader {
     personality: doc.personality ?? null,
     image_status: doc.imageStatus ?? null,
     profile_image_url: doc.profileImageUrl,
+    traits: doc.traits ?? null,
+    rarity: doc.rarity ?? "Common",
     escrow_balance_usdc: doc.escrowBalanceUsdc ?? 0,
     wallet_status: doc.walletStatus,
     wallet_error: doc.walletError ?? null,


### PR DESCRIPTION
## What

Traits + rarity previously appeared on **no owner-facing surface** and were plain text everywhere. This makes them clear and consistent, with tier-aware styling.

- **Shared `persona-traits.tsx`** — `PersonaTraits` list + `RarityBadge`, tier-colored (Common grey / Uncommon green / Rare blue / Legendary gold+glow), emits `data-tier`. Replaces the per-surface reimplemented rows.
- **Data plumbing** — `rarity` added to the owner read model (`toTraderReadModel`); `traits` + `rarity` added to the client `Trader` type + `mapTrader`.
- **Public dossier modal** — Persona traits moved **under the portrait** + rarity badge (addresses the screenshot feedback).
- **Public profile page** — traits under the portrait, tier-styled rarity.
- **Owner trader detail** — new persistent Persona Traits + Rarity section under the avatar.
- **Post-mint reveal** — a **"PERSONA REVEALED"** block (rarity badge + traits) lands with the portrait reveal in the onboarding checklist, so a minter immediately sees what they rolled.

## Testing
- 490 vitest tests pass (new `persona-traits.ui.test`, plus reveal + dossier trait coverage), `tsc --noEmit` clean, `pnpm lint` 0 errors, `pnpm build` compiles.

## Rollout
The one Convex change is the additive `rarity` field on `toTraderReadModel` (deployed via `convex dev --once`, backward-compatible). Frontend deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)