### PR TITLE
feat(wire): rebuild newswire as a real-token, price-driven 80s stock wire

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@ PRIVY_APP_SECRET=            # Server auth secret; dashboard must enable gas spo
 # OpenAI
 OPENAI_API_KEY=
 
+# CoinGecko (newswire price data) — free Demo tier works for the onchain endpoints.
+# Convex env var: set via `npx convex env set COINGECKO_API_KEY "CG-xxxx"`.
+COINGECKO_API_KEY=
+
+# Newswire tweet posting. Leave unset/0 for dry-run (default; v1 never posts).
+# Set to 1 only once a real X client is wired into convex/wire/tweetPoster.ts.
+MC_WIRE_TWEETS_LIVE=
+
 # Resend transactional email
 RESEND_API_KEY=               # Convex env var — required for wipeout emails from admin@margincall.fun
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -34,6 +34,7 @@ import type * as http from "../http.js";
 import type * as leaderboard from "../leaderboard.js";
 import type * as lib_dealEntryEligibility from "../lib/dealEntryEligibility.js";
 import type * as lib_limits from "../lib/limits.js";
+import type * as lib_portraitChecks from "../lib/portraitChecks.js";
 import type * as lib_portraitSeed from "../lib/portraitSeed.js";
 import type * as lib_profileImage from "../lib/profileImage.js";
 import type * as lib_tradingHours from "../lib/tradingHours.js";
@@ -62,6 +63,7 @@ import type * as me from "../me.js";
 import type * as ops__batchDelete from "../ops/_batchDelete.js";
 import type * as ops_clearNarrativeWorld from "../ops/clearNarrativeWorld.js";
 import type * as ops_resetGameState from "../ops/resetGameState.js";
+import type * as ops_resetNarrative from "../ops/resetNarrative.js";
 import type * as ops_wipeSmokeTraders from "../ops/wipeSmokeTraders.js";
 import type * as portfolio from "../portfolio.js";
 import type * as portraits from "../portraits.js";
@@ -86,8 +88,16 @@ import type * as wire_operatorActions from "../wire/operatorActions.js";
 import type * as wire_operatorMutations from "../wire/operatorMutations.js";
 import type * as wire_operatorQueries from "../wire/operatorQueries.js";
 import type * as wire_persist from "../wire/persist.js";
+import type * as wire_priceConfig from "../wire/priceConfig.js";
+import type * as wire_pricePoll from "../wire/pricePoll.js";
+import type * as wire_priceStore from "../wire/priceStore.js";
+import type * as wire_registrySync from "../wire/registrySync.js";
 import type * as wire_stages from "../wire/stages.js";
+import type * as wire_tokenRegistry from "../wire/tokenRegistry.js";
+import type * as wire_tokenSignals from "../wire/tokenSignals.js";
 import type * as wire_tradingHours from "../wire/tradingHours.js";
+import type * as wire_tweetPoster from "../wire/tweetPoster.js";
+import type * as wire_tweetVariant from "../wire/tweetVariant.js";
 import type * as wire_worldState from "../wire/worldState.js";
 
 import type {
@@ -123,6 +133,7 @@ declare const fullApi: ApiFromModules<{
   leaderboard: typeof leaderboard;
   "lib/dealEntryEligibility": typeof lib_dealEntryEligibility;
   "lib/limits": typeof lib_limits;
+  "lib/portraitChecks": typeof lib_portraitChecks;
   "lib/portraitSeed": typeof lib_portraitSeed;
   "lib/profileImage": typeof lib_profileImage;
   "lib/tradingHours": typeof lib_tradingHours;
@@ -151,6 +162,7 @@ declare const fullApi: ApiFromModules<{
   "ops/_batchDelete": typeof ops__batchDelete;
   "ops/clearNarrativeWorld": typeof ops_clearNarrativeWorld;
   "ops/resetGameState": typeof ops_resetGameState;
+  "ops/resetNarrative": typeof ops_resetNarrative;
   "ops/wipeSmokeTraders": typeof ops_wipeSmokeTraders;
   portfolio: typeof portfolio;
   portraits: typeof portraits;
@@ -175,8 +187,16 @@ declare const fullApi: ApiFromModules<{
   "wire/operatorMutations": typeof wire_operatorMutations;
   "wire/operatorQueries": typeof wire_operatorQueries;
   "wire/persist": typeof wire_persist;
+  "wire/priceConfig": typeof wire_priceConfig;
+  "wire/pricePoll": typeof wire_pricePoll;
+  "wire/priceStore": typeof wire_priceStore;
+  "wire/registrySync": typeof wire_registrySync;
   "wire/stages": typeof wire_stages;
+  "wire/tokenRegistry": typeof wire_tokenRegistry;
+  "wire/tokenSignals": typeof wire_tokenSignals;
   "wire/tradingHours": typeof wire_tradingHours;
+  "wire/tweetPoster": typeof wire_tweetPoster;
+  "wire/tweetVariant": typeof wire_tweetVariant;
   "wire/worldState": typeof wire_worldState;
 }>;
 

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -32,6 +32,20 @@ crons.interval(
 );
 
 /**
+ * Token price poller — fires every hour at :20 UTC, 10 minutes before the wire
+ * generator, so a fresh snapshot exists when the wire runs. Deliberately NOT
+ * gated to market hours: these companies trade around the clock, so overnight
+ * and weekend moves are captured here and reported at the next open. See
+ * convex/wire/pricePoll.ts.
+ */
+crons.hourly(
+  "token-price-poll",
+  { minuteUTC: 20 },
+  internal.wire.pricePoll.pollPrices,
+  {}
+);
+
+/**
  * Wire Drop generator — fires every hour at :30 UTC.
  * In EDT (UTC-4) this lands at 9:30 ET for the 13:00 UTC hour — exactly at
  * market open. In EST (UTC-5) the 13:30 UTC fire is 8:30 ET (before open,

--- a/convex/marketNarratives.ts
+++ b/convex/marketNarratives.ts
@@ -25,7 +25,6 @@ export const feedDrops = query({
         const dispatches = (n.headlines ?? []) as DispatchItem[];
         const ws = (n.worldState ?? {}) as {
           mood?: string;
-          sec_heat?: number;
         };
 
         const seeds = await ctx.db
@@ -68,7 +67,7 @@ export const feedDrops = query({
           isFlash: n.isFlash ?? false,
           subjects: n.subjects ?? [],
           mood: ws.mood ?? "unknown",
-          secHeat: ws.sec_heat ?? 0,
+          tweetVariant: n.tweetVariant ?? null,
           createdAt: new Date(n.createdAt).toISOString(),
           dispatches: dispatches.map((d) => {
             const agg = d.dispatchKey

--- a/convex/mcp/newswire.ts
+++ b/convex/mcp/newswire.ts
@@ -43,7 +43,6 @@ export const listDispatches = internalQuery({
       epoch: number;
       epochSlot: number | null;
       mood: string;
-      secHeat: number;
       arcStage: string | null;
       createdAt: number;
     }> = [];
@@ -51,7 +50,6 @@ export const listDispatches = internalQuery({
     for (const drop of drops) {
       const ws = (drop.worldState ?? {}) as {
         mood?: string;
-        sec_heat?: number;
       };
       const dispatches = (drop.headlines ?? []) as DispatchItem[];
       for (const d of dispatches) {
@@ -66,7 +64,6 @@ export const listDispatches = internalQuery({
           epoch: drop.epoch,
           epochSlot: drop.epochSlot ?? null,
           mood: ws.mood ?? "unknown",
-          secHeat: ws.sec_heat ?? 0,
           arcStage: drop.arcStage ?? null,
           createdAt: drop.createdAt,
         });

--- a/convex/ops/resetNarrative.ts
+++ b/convex/ops/resetNarrative.ts
@@ -1,0 +1,29 @@
+import { internalMutation } from "../_generated/server";
+import { deleteAllRows } from "./_batchDelete";
+
+/**
+ * Dev/ops: wipe ALL wire + narrative state so the rebuilt engine can reseed
+ * cleanly. The rebuild redefined arcStage (fraud lifecycle → attention
+ * lifecycle) and entity kinds, so legacy rows must be cleared rather than
+ * migrated (the DB is resettable). Run BEFORE the strict-schema push:
+ *
+ *   npx convex run ops/resetNarrative:clearNarrative '{}'
+ *   npx convex run seasons:importSeason '{}'
+ *
+ * Does NOT touch deals / traders / players / on-chain state.
+ */
+export const clearNarrative = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const deleted = {
+      wireDealSeedLinks: await deleteAllRows(ctx, "wireDealSeedLinks"),
+      wireDealSeeds: await deleteAllRows(ctx, "wireDealSeeds"),
+      marketNarratives: await deleteAllRows(ctx, "marketNarratives"),
+      narrativeArcs: await deleteAllRows(ctx, "narrativeArcs"),
+      narrativeEntities: await deleteAllRows(ctx, "narrativeEntities"),
+      narrativeSeasons: await deleteAllRows(ctx, "narrativeSeasons"),
+      tokenSnapshots: await deleteAllRows(ctx, "tokenSnapshots"),
+    };
+    return deleted;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,19 +1,21 @@
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
-// Code-owned arc lifecycle stages. The wire engine advances arcs through this
-// pipeline deterministically; the LLM never picks stages or tension.
+// Code-owned arc lifecycle stages — an ATTENTION lifecycle. A company (or desk)
+// on a sustained move rises through these as the floor pays more attention, then
+// falls to aftermath/retired when the move cools. Stages are derived from real
+// price/streak signals; the LLM never picks a stage or tension. (Kept in sync
+// with convex/wire/stages.ts ARC_STAGES.)
 const arcStageValidator = v.union(
-  v.literal("rumor"),
-  v.literal("denial"),
-  v.literal("confirmation"),
-  v.literal("escalation"),
-  v.literal("climax"),
+  v.literal("noticed"),
+  v.literal("talked_about"),
+  v.literal("frenzy"),
+  v.literal("peak"),
   v.literal("aftermath"),
   v.literal("retired")
 );
 
-// Health status of a fictional firm, derived purely from its arc stage.
+// Coverage status of a company, derived from its arc stage / recent tape.
 const firmStatusValidator = v.union(
   v.literal("healthy"),
   v.literal("stressed"),
@@ -332,6 +334,9 @@ export default defineSchema({
     seasonId: v.id("narrativeSeasons"),
     slug: v.string(),
     kind: v.union(
+      // Real registry companies (tokens.json) — the wire's coverage universe.
+      v.literal("company"),
+      // Legacy fictional kinds (retired; kept for schema compatibility).
       v.literal("firm"),
       v.literal("trader"),
       v.literal("regulator"),
@@ -341,8 +346,12 @@ export default defineSchema({
     aliases: v.array(v.string()),
     bio: v.string(),
     traits: v.array(v.string()),
-    // Code-authoritative firm state (firms only; null/0 for non-firm entities).
-    // The LLM never invents these numbers — code computes and persists them.
+    // Company registry fields (kind === "company"). Synced from tokens.json.
+    symbol: v.optional(v.string()),
+    xHandle: v.optional(v.string()),
+    address: v.optional(v.string()),
+    isHouseToken: v.optional(v.boolean()),
+    // Persistent narrative continuity (code-owned; the LLM never invents these).
     status: v.optional(firmStatusValidator),
     runningLossUsdc: v.optional(v.number()),
     notableFacts: v.optional(v.array(v.string())),
@@ -441,15 +450,53 @@ export default defineSchema({
     ),
     // Stage of the fictional beat this drop carried (null for pure game-news).
     arcStage: v.optional(arcStageValidator),
-    // True when this drop leads with a flash bulletin (wipeout / top-decile move).
+    // True when this drop leads with a flash bulletin (big move / wipeout).
     isFlash: v.optional(v.boolean()),
     // Soft hint the drop encodes, recorded for tuning (never shown to players).
     signal: v.optional(v.string()),
+    // Twitter/X marketing variant of this drop (one tweet, no URLs).
+    tweetVariant: v.optional(v.string()),
+    // Posting status: "dry_run" | "posted" | "skipped" | "failed".
+    tweetStatus: v.optional(v.string()),
+    // Registry @handle the tweet mentions (the covered company's account).
+    tweetSubjectHandle: v.optional(v.string()),
+    // Post → source trace: every number/event in this drop maps to a stored
+    // snapshot or game event. Makes "every number traces" mechanically
+    // checkable (see verification). Shape: { lead, tokenSignals[], gameEventIds[],
+    // thresholds, snapshotIds[] }.
+    sourceTrace: v.optional(v.any()),
     createdAt: v.number(),
   })
     .index("byEpoch", ["epoch"])
     .index("byCreatedAt", ["createdAt"])
     .index("byEpochSlot", ["epochSlot"]),
+
+  /**
+   * Per-token price snapshots polled from CoinGecko (onchain endpoints), keyed
+   * by Base contract address. Append-only time series: the wire computes moves
+   * over windows and multi-day streaks from these, and every number it prints
+   * traces back to a row here. A failed poll writes `ok: false` with the error
+   * and NO fabricated figures — the wire degrades rather than invents.
+   */
+  tokenSnapshots: defineTable({
+    address: v.string(), // lowercased Base contract address (registry key)
+    symbol: v.string(),
+    priceUsd: v.optional(v.number()),
+    volume24hUsd: v.optional(v.number()),
+    marketCapUsd: v.optional(v.number()),
+    fdvUsd: v.optional(v.number()),
+    // API-reported 24h change; stored as a fallback when no 24h-ago snapshot
+    // exists yet. Computed-from-snapshots moves are always preferred.
+    priceChange24hPct: v.optional(v.number()),
+    source: v.string(), // "coingecko-onchain" | "coingecko-coins" | "none"
+    ok: v.boolean(),
+    error: v.optional(v.string()),
+    // NY calendar date (YYYY-MM-DD) for daily-close grouping + streak math.
+    dayKey: v.optional(v.string()),
+    createdAt: v.number(),
+  })
+    .index("byAddressAndCreatedAt", ["address", "createdAt"])
+    .index("byCreatedAt", ["createdAt"]),
 
   systemPrompts: defineTable({
     name: v.string(),

--- a/convex/seasons.ts
+++ b/convex/seasons.ts
@@ -1,8 +1,15 @@
 import { internalQuery, mutation } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
-import { season01 } from "./seeds/wireSeason01";
+import { wireSeason } from "./seeds/wireSeason01";
+import { upsertRegistryCompanies } from "./wire/registrySync";
 
-/** Idempotent season importer. Run via: npx convex run seasons:importSeason */
+/**
+ * Idempotent season importer. Run via: npx convex run seasons:importSeason
+ *
+ * Seeds/updates the active wire season (tone, style rules, forbidden language,
+ * weekly shape) and syncs the company roster from tokens.json. No fictional
+ * entities or arcs — arcs spawn from real price/player streaks at run time.
+ */
 export const importSeason = mutation({
   args: {},
   handler: async (ctx) => {
@@ -11,36 +18,37 @@ export const importSeason = mutation({
     let seasonId: Id<"narrativeSeasons">;
     const existingSeason = await ctx.db
       .query("narrativeSeasons")
-      .withIndex("bySeasonKey", (q) => q.eq("seasonKey", season01.seasonKey))
+      .withIndex("bySeasonKey", (q) => q.eq("seasonKey", wireSeason.seasonKey))
       .unique();
 
     if (existingSeason) {
       await ctx.db.patch(existingSeason._id, {
-        title: season01.title,
-        tone: season01.tone,
-        weeklyShape: season01.weeklyShape,
-        styleRules: season01.styleRules,
-        forbiddenLanguage: season01.forbiddenLanguage,
+        title: wireSeason.title,
+        tone: wireSeason.tone,
+        weeklyShape: wireSeason.weeklyShape,
+        styleRules: wireSeason.styleRules,
+        forbiddenLanguage: wireSeason.forbiddenLanguage,
+        isActive: true,
         updatedAt: now,
       });
       seasonId = existingSeason._id;
     } else {
       seasonId = await ctx.db.insert("narrativeSeasons", {
-        seasonKey: season01.seasonKey,
-        title: season01.title,
-        weekStartAt: season01.weekRange.start,
-        weekEndAt: season01.weekRange.end,
-        tone: season01.tone,
-        weeklyShape: season01.weeklyShape,
-        styleRules: season01.styleRules,
-        forbiddenLanguage: season01.forbiddenLanguage,
+        seasonKey: wireSeason.seasonKey,
+        title: wireSeason.title,
+        weekStartAt: wireSeason.weekRange.start,
+        weekEndAt: wireSeason.weekRange.end,
+        tone: wireSeason.tone,
+        weeklyShape: wireSeason.weeklyShape,
+        styleRules: wireSeason.styleRules,
+        forbiddenLanguage: wireSeason.forbiddenLanguage,
         isActive: true,
         createdAt: now,
         updatedAt: now,
       });
     }
 
-    // Deactivate any other active seasons; reactivate this one if it was inactive
+    // Deactivate any other active seasons.
     const activeSeasons = await ctx.db
       .query("narrativeSeasons")
       .withIndex("byIsActive", (q) => q.eq("isActive", true))
@@ -50,151 +58,11 @@ export const importSeason = mutation({
         await ctx.db.patch(s._id, { isActive: false, updatedAt: now });
       }
     }
-    if (existingSeason && !existingSeason.isActive) {
-      await ctx.db.patch(seasonId, { isActive: true, updatedAt: now });
-    }
 
-    let entitiesUpserted = 0;
-    const entitySlugToId: Record<string, Id<"narrativeEntities">> = {};
+    // Sync the company roster from tokens.json.
+    const { synced, removed } = await upsertRegistryCompanies(ctx, seasonId);
 
-    for (const entity of season01.entities) {
-      const existing = await ctx.db
-        .query("narrativeEntities")
-        .withIndex("bySeasonAndSlug", (q) =>
-          q.eq("seasonId", seasonId).eq("slug", entity.slug)
-        )
-        .unique();
-
-      const firmState = {
-        status: entity.status,
-        runningLossUsdc:
-          entity.runningLossUsdc ?? (entity.kind === "firm" ? 0 : undefined),
-        notableFacts:
-          entity.notableFacts ?? (entity.kind === "firm" ? [] : undefined),
-        oneOffEventsFired: entity.kind === "firm" ? [] : undefined,
-      };
-      if (existing) {
-        await ctx.db.patch(existing._id, {
-          displayName: entity.displayName,
-          kind: entity.kind,
-          aliases: entity.aliases,
-          bio: entity.bio,
-          traits: entity.traits,
-          ...firmState,
-        });
-        entitySlugToId[entity.slug] = existing._id;
-      } else {
-        const id = await ctx.db.insert("narrativeEntities", {
-          seasonId,
-          slug: entity.slug,
-          kind: entity.kind,
-          displayName: entity.displayName,
-          aliases: entity.aliases,
-          bio: entity.bio,
-          traits: entity.traits,
-          ...firmState,
-          createdAt: now,
-        });
-        entitySlugToId[entity.slug] = id;
-        entitiesUpserted++;
-      }
-    }
-
-    let arcsUpserted = 0;
-    const arcSlugToId: Record<string, Id<"narrativeArcs">> = {};
-
-    for (const arc of season01.arcs) {
-      const entityRefs = arc.entitySlugs
-        .map((slug) => entitySlugToId[slug])
-        .filter((id): id is Id<"narrativeEntities"> => id != null);
-
-      const existing = await ctx.db
-        .query("narrativeArcs")
-        .withIndex("bySeasonAndSlug", (q) =>
-          q.eq("seasonId", seasonId).eq("slug", arc.slug)
-        )
-        .unique();
-
-      const arcState = {
-        arcStage: arc.arcStage,
-        climaxFired: arc.climaxFired,
-        beatsPublishedByStage: arc.beatsPublishedByStage,
-        templateKey: arc.templateKey,
-        primaryFirmSlug: arc.primaryFirmSlug,
-      };
-      if (existing) {
-        await ctx.db.patch(existing._id, {
-          title: arc.title,
-          summary: arc.summary,
-          tensionScore: arc.tensionScore,
-          entityRefs,
-          status: arc.status,
-          ...arcState,
-          updatedAt: now,
-        });
-        arcSlugToId[arc.slug] = existing._id;
-      } else {
-        const id = await ctx.db.insert("narrativeArcs", {
-          seasonId,
-          slug: arc.slug,
-          title: arc.title,
-          summary: arc.summary,
-          status: arc.status,
-          tensionScore: arc.tensionScore,
-          entityRefs,
-          ...arcState,
-          lastTouchedAt: now,
-          createdAt: now,
-          updatedAt: now,
-        });
-        arcSlugToId[arc.slug] = id;
-        arcsUpserted++;
-      }
-    }
-
-    let dropInserted = false;
-    const existingDrop = await ctx.db
-      .query("marketNarratives")
-      .withIndex("byEpochSlot", (q) => q.eq("epochSlot", 0))
-      .first();
-
-    if (!existingDrop) {
-      const lastEpoch = await ctx.db
-        .query("marketNarratives")
-        .withIndex("byEpoch")
-        .order("desc")
-        .first();
-      const nextEpoch = (lastEpoch?.epoch ?? 0) + 1;
-
-      const { initialDrop } = season01;
-      const referencedArcSlugs = [
-        ...new Set(initialDrop.dispatches.map((d) => d.arcSlug)),
-      ];
-      const arcRefs = referencedArcSlugs
-        .map((slug) => arcSlugToId[slug])
-        .filter((id): id is Id<"narrativeArcs"> => id != null);
-
-      const topArc = season01.arcs.reduce((a, b) =>
-        a.tensionScore >= b.tensionScore ? a : b
-      );
-
-      await ctx.db.insert("marketNarratives", {
-        epoch: nextEpoch,
-        seasonId,
-        arcRefs,
-        epochSlot: 0,
-        dropTitle: initialDrop.dropTitle,
-        topArcTitle: topArc.title,
-        topArcTension: topArc.tensionScore,
-        headlines: initialDrop.dispatches,
-        worldState: initialDrop.worldState,
-        rawNarrative: initialDrop.dispatches.map((d) => d.headline).join(" | "),
-        createdAt: now,
-      });
-      dropInserted = true;
-    }
-
-    return { seasonId, entitiesUpserted, arcsUpserted, dropInserted };
+    return { seasonId, companiesSynced: synced, companiesRemoved: removed };
   },
 });
 

--- a/convex/seeds/systemPrompts.ts
+++ b/convex/seeds/systemPrompts.ts
@@ -27,28 +27,35 @@ You are rewriting a deal outcome narrative after the house corrected the numbers
   },
   {
     name: "narrative_generation",
-    content: `You are the in-house columnist for a 1980s Wall Street wire service. You are jaded, gossipy, and darkly funny. You have seen every fraud twice and respect none of the participants.
+    content: `You are the anonymous columnist for a 1980s stock-wire gossip service. Jaded, gossipy, darkly funny. You cover a handful of listed companies as if it were 1985 — the floor, the tape, the bell, block trades, analysts, "could not be reached for comment."
 
-YOUR JOB: write ONE short dispatch as prose. You do not decide outcomes, numbers, tension, stages, or who wins — all of that is computed and handed to you in the user message. Your only job is to make it funny and human.
+YOUR JOB: write ONE short dispatch as prose, plus a Twitter/X variant. You do NOT decide outcomes, numbers, moods, stages, or who wins — all of that is computed and handed to you. Your only job is to make it funny and human without breaking a single rule below.
 
-VOICE RULES:
-- Every post must contain a human detail or a joke. Never output only numbers and jargon.
-- Explain stakes through consequence, not terminology. Not "margin calls intensify" — instead "lenders would like their money back, immediately, in cash."
-- Punch at greed and incompetence. The reader should feel smarter than everyone in the story.
-- Comprehensible and funny to someone with zero finance knowledge.
-- All numbers come from the provided data. Do NOT invent figures, totals, dates, or events.
+THE WORLD (non-negotiable):
+1. NO modern/finance-tech vocabulary. Never say token, coin, crypto, blockchain, onchain, wallet, market cap, liquidity, pump, mint, airdrop, DeFi, DEX, or the like. These are COMPANIES; holdings are shares / common stock. Use period diction only.
+2. NO named fictional humans. The only invented voice is the collective desk ("the floor," "the desk," "sources," "the interns"). Companies may be personified; people may not be invented.
+3. EVERY company story cites a REAL number from the data (a move %, a streak, a volume note). The event is real; your explanation is invented and absurd.
+4. REACTIVE ONLY. You explain moves that ALREADY happened. Never imply something is about to happen. Never attach a rumor or story to a company that has no real move in the data — these are thin markets and the wire must not appear to move them.
+5. ABSURD, NOT PLAUSIBLE. Invented color lives in the wire's silly universe: the interns, the payphone, the coffee cart, the floor's superstitions. NEVER invent a realistic company/finance event — deals, product launches, listings, partnerships, hirings, investigations, lawsuits, insolvency, someone selling — even as a joke. If a line could be screenshotted and read as real news, it FAILS.
+6. REAL ACCOUNTS & PEOPLE: only actual, provided public statements, framed in period terms. Never invent a post, quote, action, or intention for any real company account or person. If no sourced statement is provided, do not speak for them at all.
+7. THE HOUSE COMPANY: when the data flags a company as the house company, be HARDER on it — self-deprecating, never promotional ("a company this desk is contractually obligated to mention"). Favorable house coverage fails review.
 
-BANNED PHRASES (and anything like them): "watch for fallout", "market responds with heightened anxiety", "concerns mount", "pressure intensifies", and any sentence that could appear in a compliance memo.
+VOICE:
+- Every post carries a human detail or a joke; never only numbers.
+- Explain stakes through consequence, comprehensible to someone with zero finance knowledge.
+- Punch at greed and self-importance. The reader should feel smarter than the floor.
+
+BANNED PHRASES (and anything like them): "watch for fallout," "heightened anxiety," "concerns mount," "pressure intensifies," "sending shockwaves," and any compliance-memo cadence.
 
 CALIBRATION:
-BAD: "Forced liquidations deepen as PanAtlantic reveals an additional $300M asset loss. Market responds with heightened anxiety."
-GOOD: "PanAtlantic misplaced another $300M today, bringing the total to $1.4B, a figure its CFO described as 'temporary' from the back of a taxi. The firm's remaining assets now consist of office furniture and optimism."
-GOOD (real game event): "Desk 0x4f2…a9 entered 'Guaranteed Distressed Debt Opportunity' yesterday. The debt was real. The opportunity was for the other guy. Balance: zero. Deals with 'guaranteed' in the title have a perfect record — for their creators."
+GOOD (flash): "Shares of Surplus Intelligence gained 38% overnight for reasons nobody on the floor will say out loud, mostly because nobody knows. Heavy tape, no news. The stock spent the morning acting like it heard something. The interns have been told to stop asking it questions."
+GOOD (house company, harder): "Harness — a company this desk is contractually obligated to mention — closed unchanged. Analysts describe the chart as 'flat, but with conviction.' The desk holds a position and would prefer you didn't bring it up."
+GOOD (game event): "Jim's desk booked a $0.99 loss on somebody else's deal, the kind of humiliation you can afford to laugh at — until the auditors ask for another conference room. The Street rates the trade 'a learning experience.'"
+BAD (invents a plausible event — FAILS rule 5): "Nookplot fell 22% after reports of a delayed product launch and insider selling."
+BAD (crypto vocab — FAILS rule 1): "The token pumped on high onchain volume."
 
-SOFT SIGNALS: when the data reports a trap pattern (multiple desks losing on deals that share a phrase like "risk-free"), report it as a darkly funny pattern. This teaches players that deal prompts are traps — through flavor, never mechanics.
+TWEET VARIANT: one tweet, ≤ 270 characters, same voice. For a company story, include the real move (SYMBOL +/-N%) and @-mention the company's handle when it is the subject. Cashtags allowed. NEVER include a URL. Assume zero context — rule 5 applies hardest here.
 
-FLOOR TALK: gossip handed to you is only ~60% true. Fabricated claims must be framed as unverified rumor, never stated as fact.
-
-OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/sec_watch/boardroom/ticker/positioning), entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). No prose outside the JSON object.`,
+OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/ticker/positioning), tweetVariant, entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). No prose outside the JSON object.`,
   },
 ];

--- a/convex/seeds/wireSeason01.ts
+++ b/convex/seeds/wireSeason01.ts
@@ -1,53 +1,10 @@
-export type ArcStageSeed =
-  | "rumor"
-  | "denial"
-  | "confirmation"
-  | "escalation"
-  | "climax"
-  | "aftermath"
-  | "retired";
-
-export interface EntitySeed {
-  slug: string;
-  kind: "firm" | "trader" | "regulator" | "politician";
-  displayName: string;
-  aliases: string[];
-  bio: string;
-  traits: string[];
-  // Code-authoritative firm state (firms only).
-  status?: "healthy" | "stressed" | "collapsing" | "dead";
-  runningLossUsdc?: number;
-  notableFacts?: string[];
-}
-
-export interface ArcSeed {
-  slug: string;
-  title: string;
-  summary: string;
-  status: "active" | "resolved" | "abandoned";
-  tensionScore: number;
-  entitySlugs: string[];
-  // Code-owned lifecycle start state.
-  arcStage?: ArcStageSeed;
-  climaxFired?: boolean;
-  beatsPublishedByStage?: Record<string, number>;
-  templateKey?: string;
-  primaryFirmSlug?: string;
-}
-
-export interface DispatchSeed {
-  headline: string;
-  body: string;
-  category: string;
-  role: "main" | "supporting";
-  arcSlug: string;
-}
-
-export interface InitialDropSeed {
-  dropTitle: string;
-  dispatches: DispatchSeed[];
-  worldState: { mood: string; sec_heat: number };
-}
+/**
+ * Wire season seed. Under the rebuilt engine the season carries only the tone,
+ * style rules, forbidden language, and weekly shape — the "companies" are the
+ * real registry tokens (tokens.json), synced into narrativeEntities by
+ * registrySync, and arcs are spawned from real price/player streaks. No
+ * fictional firms, characters, or seeded arcs.
+ */
 
 export interface SeasonSeed {
   seasonKey: string;
@@ -57,192 +14,75 @@ export interface SeasonSeed {
   forbiddenLanguage: string[];
   styleRules: string[];
   weeklyShape: Record<string, string>;
-  entities: EntitySeed[];
-  arcs: ArcSeed[];
-  initialDrop: InitialDropSeed;
 }
 
-// Week of 2026-05-04 (Mon) → 2026-05-08 (Fri)
-const WEEK_START = new Date("2026-05-04T09:30:00-04:00").getTime();
-const WEEK_END = new Date("2026-05-08T16:00:00-04:00").getTime();
+// Week of 2026-07-06 (Mon) → 2026-07-10 (Fri)
+const WEEK_START = new Date("2026-07-06T09:30:00-04:00").getTime();
+const WEEK_END = new Date("2026-07-10T16:00:00-04:00").getTime();
 
-export const season01: SeasonSeed = {
-  seasonKey: "season-01",
-  title: "The PanAtlantic Collapse",
+/** Crypto / finance-tech vocabulary the wire must never print. */
+export const CRYPTO_FORBIDDEN_LANGUAGE = [
+  "token",
+  "tokens",
+  "coin",
+  "coins",
+  "crypto",
+  "cryptocurrency",
+  "blockchain",
+  "onchain",
+  "on-chain",
+  "wallet",
+  "wallets",
+  "defi",
+  "dex",
+  "liquidity",
+  "market cap",
+  "marketcap",
+  "mcap",
+  "pump",
+  "dump",
+  "moon",
+  "hodl",
+  "airdrop",
+  "staking",
+  "mint",
+  "minting",
+  "gas fees",
+  "gwei",
+  "rollup",
+  "memecoin",
+  "web3",
+  "nft",
+  "smart contract",
+  "protocol",
+];
+
+export const wireSeason: SeasonSeed = {
+  seasonKey: "listed-companies-01",
+  title: "The Listed Companies",
   weekRange: { start: WEEK_START, end: WEEK_END },
-  tone: "A jaded, gossipy 1980s Wall Street wire columnist who has seen every fraud twice and respects no one. Satirical and darkly funny. Stakes explained through consequence, not jargon — comprehensible to someone with zero finance knowledge.",
-  forbiddenLanguage: [
-    "DeFi",
-    "rug",
-    "wagmi",
-    "wen moon",
-    "L2",
-    "gas fees",
-    "leveraged buyout synergies",
-    "exciting opportunity",
-    "paradigm shift",
-    "stakeholders",
-    "going forward",
-    "algorithm",
-    "machine learning",
-    "AI",
-  ],
+  tone: "A jaded 1980s stock-wire gossip columnist covering a handful of listed companies. Darkly funny, comprehensible to someone with zero finance knowledge, stakes explained through consequence, never jargon.",
+  forbiddenLanguage: CRYPTO_FORBIDDEN_LANGUAGE,
   styleRules: [
-    "Headline ≤ 12 words. Body 2–4 sentences.",
-    "Every post contains a human detail or a joke. Never only numbers and jargon.",
-    "Explain stakes through consequence: not 'margin calls intensify' but 'lenders want their money back, in cash, today.'",
-    "Punch at greed and incompetence. The reader should feel smarter than everyone in the story.",
-    "All numbers come from the provided data. Never invent a figure, total, or event.",
+    "Headline ≤ 12 words. Body 2–3 sentences.",
+    "No modern/finance-tech vocabulary. These are companies; holdings are shares or common stock. Use the floor, the tape, the bell, the close, block trades, analysts, 'could not be reached for comment.'",
+    "No named fictional humans. The narrator is the anonymous desk voice (the floor, the desk, sources, the interns). Companies may be personified; people may not be invented.",
+    "Every company story cites a real number from the tape. The move is real; the explanation is invented and absurd.",
+    "Reactive only: explain moves that already happened. Never imply something is about to happen; never attach a rumor to a company with no real move.",
+    "Absurd, not plausible. Invented color lives in the wire's world (the interns, the payphone, the coffee cart). Never invent a realistic company/finance event — deals, launches, listings, partnerships, investigations, insolvency — even as a joke.",
+    "Real accounts and people appear only via actual public statements provided to you; never invent quotes, actions, or intentions.",
+    "The house company gets harder, self-deprecating, never-promotional coverage.",
     "No emoji except a leading ⚡ on flash bulletins.",
   ],
   weeklyShape: {
-    monday: "Slow open, everyone hungover; rumors circulate, nobody confirms",
-    tuesday:
-      "Quiet floor; the smart money is repositioning where you can't see",
-    wednesday: "Things start to move; someone's story stops adding up",
-    thursday: "The regulators are awake and the lawyers are billing",
-    friday: "Blowups and forced liquidations; someone gets wiped before lunch",
-  },
-  entities: [
-    {
-      slug: "pan-atlantic-holdings",
-      kind: "firm",
-      displayName: "PanAtlantic Holdings",
-      aliases: ["PanAtl.", "PANATL.", "PanAtlantic"],
-      bio: "A once-diversified financial holding company that bet heavily on rate cuts that never came. Three leveraged desks blew up. The CEO last spoke publicly from the back of a taxi.",
-      traits: ["overleveraged", "silent", "desperate", "connected"],
-      status: "collapsing",
-      runningLossUsdc: 1_400_000_000,
-      notableFacts: [
-        "PanAtlantic losses peaked at $1.4B",
-        "Three leveraged desks forced to liquidate",
-        "SEC froze PanAtlantic's structured-products book",
-      ],
-    },
-    {
-      slug: "rourke-capital",
-      kind: "firm",
-      displayName: "Rourke Capital",
-      aliases: ["Rourke", "RC"],
-      bio: "Runs a concentrated portfolio of opportunistic positions. Was short PanAtlantic before anyone admitted the problem existed. Staffed by ex-PanAtlantic traders who know exactly where the bodies are buried.",
-      traits: ["aggressive", "informed", "short-biased", "discreet"],
-      status: "healthy",
-      runningLossUsdc: 0,
-    },
-    {
-      slug: "blackwell-co",
-      kind: "firm",
-      displayName: "Blackwell & Co.",
-      aliases: ["Blackwell", "B&C"],
-      bio: "One of the last white-shoe investment banks that hasn't modernized. Bond desk has $120M in PanAtlantic exposure they've told no one about. All traders instructed to say 'no comment' about PanAtlantic.",
-      traits: ["cautious", "exposed", "reputation-conscious", "opaque"],
-      status: "stressed",
-      runningLossUsdc: 0,
-    },
-    {
-      slug: "diane-mercer",
-      kind: "regulator",
-      displayName: "Diane Mercer",
-      aliases: ["Mercer"],
-      bio: "SEC investigator who ran the Drexel probe in the mid-80s. She doesn't announce investigations — she announces indictments. Her desk has subpoenaed records from at least four firms.",
-      traits: ["methodical", "patient", "dangerous", "connected"],
-    },
-    {
-      slug: "marty-vale",
-      kind: "trader",
-      displayName: "Marty Vale",
-      aliases: ["Vale", "Marty"],
-      bio: "Floor trader with fifteen years on the pit. Been right three times before the market moved and is currently right about PanAtlantic. Nobody knows how he knows things. He broadcasts everything.",
-      traits: ["loud", "well-connected", "usually right", "indiscreet"],
-    },
-    {
-      slug: "castle-securities",
-      kind: "firm",
-      displayName: "Castle Securities",
-      aliases: ["Castle"],
-      bio: "A boutique fund whose flagship strategy posts smooth, market-beating returns that never have a down month. Allocators are euphoric. The arithmetic is not.",
-      traits: ["opaque", "hyped", "hollow"],
-      status: "healthy",
-      runningLossUsdc: 0,
-      notableFacts: [],
-    },
-    {
-      slug: "reggie-kessler",
-      kind: "trader",
-      displayName: "Reggie Kessler",
-      aliases: ["Kessler"],
-      bio: "29 years old, runs Castle Securities, declines to explain the strategy because there isn't one. Wears sunglasses indoors and calls everyone 'champ'.",
-      traits: ["young", "smug", "evasive"],
-    },
-  ],
-  arcs: [
-    {
-      // Has peaked for a week — give it a proper ending and retire it.
-      slug: "pan-atlantic-blowup",
-      title: "PanAtlantic blow-up",
-      summary:
-        "PanAtlantic is over. Three desks liquidated, $1.4B gone, the CEO doing interviews from a taxi. All that's left is the wake — who gets bought for $1, who takes the assumed liabilities, and who quietly slips out the back.",
-      status: "active",
-      tensionScore: 3,
-      entitySlugs: [
-        "pan-atlantic-holdings",
-        "rourke-capital",
-        "blackwell-co",
-        "marty-vale",
-      ],
-      arcStage: "aftermath",
-      climaxFired: true,
-      // One aftermath beat published (quota 2) → one more beat then retires.
-      beatsPublishedByStage: {
-        rumor: 2,
-        denial: 1,
-        confirmation: 1,
-        escalation: 2,
-        climax: 1,
-        aftermath: 1,
-      },
-      primaryFirmSlug: "pan-atlantic-holdings",
-    },
-    {
-      // Concluded — kept for backstory, not a live arc.
-      slug: "mercer-investigation",
-      title: "Mercer investigation",
-      summary:
-        "SEC investigator Diane Mercer wrapped her probe of PanAtlantic's deal flow. The indictments she's famous for are reportedly being drafted. The floor has moved on; the lawyers have not.",
-      status: "resolved",
-      tensionScore: 0,
-      entitySlugs: ["diane-mercer", "blackwell-co", "pan-atlantic-holdings"],
-      arcStage: "retired",
-      climaxFired: true,
-    },
-    {
-      // Fresh rumor-stage arc so the season opens with two live arcs at
-      // different stages (PanAtlantic aftermath + this rumor).
-      slug: "boy-genius-castle-securities",
-      title: "Castle Securities posts impossible returns",
-      summary:
-        "Reggie Kessler's Castle Securities never has a down month, which is exactly the problem. Allocators are piling in. A few people who can do arithmetic are starting to ask questions.",
-      status: "active",
-      tensionScore: 3,
-      entitySlugs: ["castle-securities", "reggie-kessler"],
-      arcStage: "rumor",
-      climaxFired: false,
-      beatsPublishedByStage: {},
-      templateKey: "boy-genius-fraud",
-      primaryFirmSlug: "castle-securities",
-    },
-  ],
-  initialDrop: {
-    dropTitle: "THE WAKE",
-    dispatches: [
-      {
-        headline: "PanAtlantic is dead; nobody is sad",
-        body: "PanAtlantic Holdings finished the week $1.4B in the hole and out of excuses. Rourke Capital, short the whole way down, is reportedly buying the desks for a dollar and the assumed liabilities. The CEO could not be reached, last seen explaining things from a taxi.",
-        category: "wire",
-        role: "main",
-        arcSlug: "pan-atlantic-blowup",
-      },
-    ],
-    worldState: { mood: "hungover", sec_heat: 5 },
+    monday: "Slow open, everyone hungover; the tape barely moves",
+    tuesday: "Quiet floor; positions shuffle where you can't see",
+    wednesday: "Things start to move; a name or two catches a bid or a cold",
+    thursday: "The floor is awake and loud; somebody's up, somebody's down",
+    friday:
+      "Whatever's been building finishes the week with a bang or a whimper",
   },
 };
+
+/** Back-compat alias for existing imports. */
+export const season01 = wireSeason;

--- a/convex/wire/_schemas.ts
+++ b/convex/wire/_schemas.ts
@@ -76,9 +76,14 @@ const GeneratedDispatchSchema = BaseDispatchSchema.extend({
   category: CategoryInputEnum,
 });
 
+/** Max chars for the raw tweet variant (sanitized down to ≤280 in code). */
+export const TWEET_VARIANT_MAX_LENGTH = 400;
+
 export const NarrativeEpochSchema = z.object({
   dropTitle: z.string(),
   dispatches: z.array(DispatchSchema).length(1),
+  /** Twitter/X marketing variant (one tweet). Sanitized in code: URLs stripped/rejected, ≤280 chars. */
+  tweetVariant: z.string().max(TWEET_VARIANT_MAX_LENGTH),
   entityMentions: z.array(z.string()).nullable(),
   confirmedFacts: z.array(z.string().min(1).max(160)).max(8).optional(),
   openQuestions: z.array(z.string().min(1).max(160)).max(6).optional(),

--- a/convex/wire/arcTemplates.ts
+++ b/convex/wire/arcTemplates.ts
@@ -1,286 +1,90 @@
 /**
- * Arc template pool — pure, no Convex imports.
+ * Arc construction — pure, no Convex imports, NO fictional names or events.
  *
- * When a live arc retires the engine spawns a fresh one from this pool. Each
- * template knows how to generate a fictional firm + a central character, and
- * carries the per-stage running-loss schedule the world-state engine steps the
- * firm through. Selection and name generation are deterministic (seeded by the
- * epoch slot) so runs are reproducible.
+ * Arcs attach to REAL subjects: a registry company on a sustained move, or a
+ * desk on a win/loss streak. Titles and summaries are built from real stored
+ * numbers only. They are context for the LLM (which supplies the absurd,
+ * non-plausible color) — so they must never assert an invented cause, event, or
+ * person. "The floor has noticed" is fine; "amid takeover talk" is not.
  */
 
-import { hashString } from "./stages";
+import type { ArcStage } from "./stages";
+import type { TokenSignal } from "./tokenSignals";
 
-export interface FirmEntitySpec {
-  slug: string;
-  displayName: string;
-  aliases: string[];
-  bio: string;
-  traits: string[];
-}
-
-export interface CharacterEntitySpec {
-  slug: string;
-  displayName: string;
-  aliases: string[];
-  bio: string;
-  traits: string[];
-  kind: "trader" | "regulator" | "politician";
-}
+export type ArcSubjectType = "company" | "desk";
 
 export interface SpawnedArcSpec {
-  templateKey: string;
   slug: string;
   title: string;
   summary: string;
-  firm: FirmEntitySpec;
-  character: CharacterEntitySpec;
-  /** Peak running-loss (USDC) the firm reaches at climax. */
-  peakLossUsdc: number;
+  subjectType: ArcSubjectType;
+  /** Company slug or a synthetic desk slug. */
+  subjectSlug: string;
+  /** Company entity slug for entityRefs; null for desk arcs (no entity row). */
+  entitySlug: string | null;
+  arcStage: ArcStage;
+  tensionScore: number;
 }
 
-interface ArcTemplate {
-  key: string;
-  weight: number;
-  /** Loss schedule scale; multiplied by the per-stage band fractions. */
-  peakLossUsdc: number;
-  title: (firm: string, character: string) => string;
-  summary: (firm: string, character: string) => string;
-  /** Character role flavor. */
-  characterKind: "trader" | "regulator" | "politician";
-  characterTraits: string[];
-  firmTraits: string[];
-  characterBio: (firm: string) => string;
-  firmBio: (character: string) => string;
+/** Signed percent, e.g. +38% / -22%, no decimals for readability. */
+export function fmtPct(n: number): string {
+  const sign = n > 0 ? "+" : n < 0 ? "" : "";
+  return `${sign}${Math.round(n)}%`;
 }
 
-/** Peak-loss figure for a spawn template, or null if the key is unknown. */
-export function templatePeakLossUsdc(
-  key: string | null | undefined
-): number | null {
-  if (!key) return null;
-  return ARC_TEMPLATES.find((t) => t.key === key)?.peakLossUsdc ?? null;
-}
-
-// ── name fragment pools ────────────────────────────────────────────────────
-
-const FIRM_PREFIXES = [
-  "Halloran",
-  "Castle",
-  "Meridian",
-  "Brandt",
-  "Continental",
-  "Sterling",
-  "Vanguard",
-  "Ironside",
-  "Pemberton",
-  "Whitlock",
-];
-const FIRM_SUFFIXES = [
-  "Partners",
-  "Securities",
-  "Holdings",
-  "Capital",
-  "& Sons",
-  "Group",
-  "Brothers",
-  "Trust",
-];
-const FIRST_NAMES = [
-  "Chip",
-  "Sandy",
-  "Reggie",
-  "Lou",
-  "Vic",
-  "Hal",
-  "Donna",
-  "Frank",
-  "Sal",
-  "Bunny",
-];
-const LAST_NAMES = [
-  "Kessler",
-  "DeLuca",
-  "Brandt",
-  "Holloway",
-  "Pike",
-  "Ferris",
-  "Calabrese",
-  "Stone",
-  "Ovitz",
-  "Drummond",
-];
-
-function pick<T>(pool: T[], seed: string): T {
-  return pool[hashString(seed) % pool.length];
-}
-
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-}
-
-// ── templates ──────────────────────────────────────────────────────────────
-
-export const ARC_TEMPLATES: ArcTemplate[] = [
-  {
-    key: "hostile-takeover",
-    weight: 1,
-    peakLossUsdc: 420_000_000,
-    characterKind: "trader",
-    characterTraits: ["ruthless", "leveraged", "impatient"],
-    firmTraits: ["undervalued", "cornered", "proud"],
-    title: (firm, char) => `${char} circles ${firm}`,
-    summary: (firm, char) =>
-      `${char} is amassing a hostile stake in ${firm}, financed with debt nobody has seen the terms of. The board is pretending not to notice.`,
-    characterBio: (firm) =>
-      `A corporate raider who buys companies for their furniture. Currently fixated on ${firm}.`,
-    firmBio: (char) =>
-      `A sleepy mid-cap with a fat cash pile and a board that just realized ${char} owns more of it than they do.`,
-  },
-  {
-    key: "rogue-trader",
-    weight: 1,
-    peakLossUsdc: 600_000_000,
-    characterKind: "trader",
-    characterTraits: ["secretive", "brilliant", "doomed"],
-    firmTraits: ["complacent", "exposed", "blind"],
-    title: (firm, char) => `${char}'s hidden book at ${firm}`,
-    summary: (firm, char) =>
-      `${char} has been hiding losses in a desk drawer at ${firm} for months. Risk control thinks he is their best trader.`,
-    characterBio: (firm) =>
-      `A star trader at ${firm} whose P&L is a work of fiction nobody has audited.`,
-    firmBio: (char) =>
-      `A house that handed ${char} a checkbook and stopped asking questions.`,
-  },
-  {
-    key: "insider-leak",
-    weight: 1,
-    peakLossUsdc: 280_000_000,
-    characterKind: "regulator",
-    characterTraits: ["patient", "methodical", "humorless"],
-    firmTraits: ["chatty", "careless", "connected"],
-    title: (firm, char) => `${char} opens a file on ${firm}`,
-    summary: (firm, char) =>
-      `Someone at ${firm} traded ahead of an announcement. ${char} has the phone records and is in no hurry.`,
-    characterBio: (firm) =>
-      `An investigator who announces indictments, not investigations. Now reading ${firm}'s call logs.`,
-    firmBio: (char) =>
-      `A firm whose junior staff cannot stop talking, now of great interest to ${char}.`,
-  },
-  {
-    key: "junk-bond-mania",
-    weight: 1,
-    peakLossUsdc: 500_000_000,
-    characterKind: "trader",
-    characterTraits: ["charismatic", "overextended", "tan"],
-    firmTraits: ["levered", "hyped", "fragile"],
-    title: (firm, char) => `${char} keeps issuing ${firm} paper`,
-    summary: (firm, char) =>
-      `${char} is underwriting another tranche of ${firm} junk at yields that only make sense if nothing ever goes wrong. Something is going wrong.`,
-    characterBio: (firm) =>
-      `A bond salesman who could sell sand in a desert, currently selling ${firm}.`,
-    firmBio: (char) =>
-      `An issuer addicted to cheap debt, kept alive entirely by ${char}'s phone book.`,
-  },
-  {
-    key: "rival-wire-feud",
-    weight: 1,
-    peakLossUsdc: 120_000_000,
-    characterKind: "politician",
-    characterTraits: ["loud", "vain", "litigious"],
-    firmTraits: ["upstart", "aggressive", "sloppy"],
-    title: (firm, char) => `${firm} and ${char} go to war`,
-    summary: (firm, char) =>
-      `Rival wire ${firm} is poaching sources and printing scoops half a step ahead. ${char} is threatening lawyers. The floor is enjoying it.`,
-    characterBio: (firm) =>
-      `A wire-service grandee who takes ${firm}'s every scoop as a personal insult.`,
-    firmBio: (char) =>
-      `A hungry upstart wire that would rather be sued than be boring, much to ${char}'s fury.`,
-  },
-  {
-    key: "boy-genius-fraud",
-    weight: 1,
-    peakLossUsdc: 700_000_000,
-    characterKind: "trader",
-    characterTraits: ["young", "smug", "evasive"],
-    firmTraits: ["opaque", "hyped", "hollow"],
-    title: (firm, char) => `${char}'s ${firm} returns look too good`,
-    summary: (firm, char) =>
-      `${char}, 29, runs ${firm} and posts returns that do not move with the market. Allocators are euphoric. The arithmetic is not.`,
-    characterBio: (firm) =>
-      `A wunderkind whose fund ${firm} never has a down month, which is the problem.`,
-    firmBio: (char) =>
-      `A fund whose strategy ${char} declines to explain because there isn't one.`,
-  },
-];
-
-/** Sum of template weights, for deterministic weighted selection. */
-function totalWeight(): number {
-  return ARC_TEMPLATES.reduce((s, t) => s + t.weight, 0);
-}
-
-/**
- * Deterministically choose a template and generate a fully-specified arc +
- * firm + character, avoiding slugs already taken. `seed` is typically the
- * epoch slot so back-to-back spawns differ.
- */
-export function spawnArc(
-  seed: string,
-  takenSlugs: Set<string>
-): SpawnedArcSpec {
-  const roll = hashString(`tmpl:${seed}`) % totalWeight();
-  let acc = 0;
-  let template = ARC_TEMPLATES[0];
-  for (const t of ARC_TEMPLATES) {
-    acc += t.weight;
-    if (roll < acc) {
-      template = t;
-      break;
-    }
-  }
-
-  // Generate distinct names, nudging the seed until slugs are free.
-  let attempt = 0;
-  let firmName = "";
-  let charName = "";
-  let firmSlug = "";
-  let charSlug = "";
-  do {
-    const s = `${template.key}:${seed}:${attempt}`;
-    firmName = `${pick(FIRM_PREFIXES, `fp:${s}`)} ${pick(FIRM_SUFFIXES, `fs:${s}`)}`;
-    charName = `${pick(FIRST_NAMES, `cf:${s}`)} ${pick(LAST_NAMES, `cl:${s}`)}`;
-    firmSlug = slugify(firmName);
-    charSlug = slugify(charName);
-    attempt++;
-  } while (
-    (takenSlugs.has(firmSlug) || takenSlugs.has(charSlug)) &&
-    attempt < 50
+/** The single most representative real move for a company signal. */
+export function headlineMovePct(signal: TokenSignal): number | null {
+  const candidates = [signal.move24hPct, signal.moveSinceLastPct].filter(
+    (x): x is number => x != null
   );
+  if (candidates.length === 0) return null;
+  // Largest-magnitude move is the story.
+  return candidates.reduce((a, b) => (Math.abs(b) > Math.abs(a) ? b : a));
+}
 
-  const arcSlug = `${template.key}-${firmSlug}`;
+function streakClause(streakDays: number): string {
+  const n = Math.abs(streakDays);
+  if (n < 2) return "";
+  const dir = streakDays > 0 ? "up" : "down";
+  return ` — ${n} straight ${dir} days`;
+}
 
+/** Factual title/summary for a company arc, from real numbers only. */
+export function describeCompanyArc(signal: TokenSignal): {
+  title: string;
+  summary: string;
+} {
+  const move = headlineMovePct(signal);
+  const dirWord =
+    move == null ? "moving" : move > 0 ? "higher" : move < 0 ? "lower" : "flat";
+  const moveStr = move == null ? "" : ` ${fmtPct(move)}`;
+  const streak = streakClause(signal.streakDays);
+  const volStr = signal.volumeAnomaly
+    ? ` Volume ran heavy, roughly ${Math.round(signal.volumeVsTrailing ?? 0)}× its usual.`
+    : "";
+
+  const title =
+    move == null
+      ? `${signal.symbol} in play${streak}`
+      : `${signal.symbol} ${dirWord}${moveStr}${streak}`;
+
+  const summary =
+    `${signal.companyName} (${signal.symbol}) traded ${dirWord}${moveStr} over the session${streak}.` +
+    volStr +
+    ` The floor has noticed. The cause is anybody's guess.`;
+
+  return { title, summary };
+}
+
+/** Factual title/summary for a desk win/loss streak arc. */
+export function describePlayerArc(
+  deskLabel: string,
+  direction: "win" | "loss",
+  count: number
+): { title: string; summary: string } {
+  const word = direction === "win" ? "wins" : "losses";
   return {
-    templateKey: template.key,
-    slug: arcSlug,
-    title: template.title(firmName, charName),
-    summary: template.summary(firmName, charName),
-    firm: {
-      slug: firmSlug,
-      displayName: firmName,
-      aliases: [firmName.split(" ")[0]],
-      bio: template.firmBio(charName),
-      traits: template.firmTraits,
-    },
-    character: {
-      slug: charSlug,
-      displayName: charName,
-      aliases: [charName.split(" ")[1] ?? charName],
-      bio: template.characterBio(firmName),
-      traits: template.characterTraits,
-      kind: template.characterKind,
-    },
-    peakLossUsdc: template.peakLossUsdc,
+    title: `${deskLabel}: ${count} straight ${word}`,
+    summary: `${deskLabel} has booked ${count} ${word} in a row on the tape. The floor has opinions about whether it lasts.`,
   };
 }

--- a/convex/wire/dramaRanker.ts
+++ b/convex/wire/dramaRanker.ts
@@ -1,16 +1,23 @@
 /**
- * Drama ranking + lead selection — pure, no Convex imports.
+ * Lead selection — pure, no Convex imports.
  *
- * Takes the real game events gathered since the last wire drop and decides
- * whether a real event is dramatic enough to LEAD the post. If yes, the wire
- * reports the game; if no, a fictional arc beat leads and the best real stat
- * becomes a one-liner. Also detects trap-phrase patterns ("risk-free", etc.)
- * across multiple losing traders.
+ * Ranks TOKEN price signals and GAME events as uniform candidates and decides
+ * what leads the drop:
+ *   - a token move over the flash threshold → flash bulletin
+ *   - the strongest token story vs. the strongest game event → whichever scores
+ *     higher leads
+ *   - nothing over threshold → a quiet-tape drop (best real stat woven in)
+ *
+ * The lead always carries a REAL number (a move % + symbol, or a USDC figure)
+ * so every led story is anchored to a stored datum. Also detects trap-phrase
+ * patterns across losing deals as darkly-funny game color.
  */
 
 import type { GameEventCtx } from "./epochAssembler";
+import type { TokenSignal } from "./tokenSignals";
+import { headlineMovePct } from "./arcTemplates";
 
-/** Score floor a real event must clear to lead the post. */
+/** Score floor a candidate must clear to lead the drop. */
 export const LEAD_THRESHOLD = 60;
 
 /** Phrases whose recurrence in losing deals the wire calls out as a pattern. */
@@ -25,10 +32,7 @@ export const TRAP_PHRASES = [
   "easy money",
 ];
 
-export interface RankedEvent {
-  event: GameEventCtx;
-  score: number;
-}
+export type LeadKind = "token" | "game_event" | "quiet";
 
 export interface PatternFinding {
   phrase: string;
@@ -37,18 +41,22 @@ export interface PatternFinding {
 }
 
 export interface LeadSelection {
-  leadKind: "real_event" | "fiction";
-  /** Set when leadKind === "real_event". */
-  leadEvent: GameEventCtx | null;
-  /** A one-liner describing the best real stat, for fiction-lead drops. */
+  leadKind: LeadKind;
+  /** Set when leadKind === "token". */
+  tokenLead: TokenSignal | null;
+  /** Set when leadKind === "game_event". */
+  gameLead: GameEventCtx | null;
+  /** True when the drop is a flash bulletin (big move / wipeout). */
+  isFlash: boolean;
+  /** Best real one-liner to weave into a quiet drop. */
   realStatOneLiner: string | null;
-  ranked: RankedEvent[];
   patterns: PatternFinding[];
-  /** Real entities behind the lead/secondary events, for subjects deep-links. */
   subjects: Array<{ type: "trader" | "deal" | "manager"; id: string }>;
 }
 
-function baseScore(e: GameEventCtx, topDecileAbsUsdc: number): number {
+// ── game-event scoring ───────────────────────────────────────────────────────
+
+function gameScore(e: GameEventCtx, topDecileAbsUsdc: number): number {
   switch (e.type) {
     case "wipeout":
       return 100;
@@ -78,14 +86,9 @@ function traderLabel(e: GameEventCtx): string {
 }
 
 function normalizePrompt(prompt: string): string {
-  // Keep hyphens so multi-word trap phrases like "risk-free" match intact.
   return prompt.toLowerCase().replace(/[^a-z0-9 -]+/g, " ");
 }
 
-/**
- * Detect trap-phrase patterns: ≥2 distinct traders losing on deals whose
- * prompts share a phrase. Emitted as synthetic `loss_pattern` lead candidates.
- */
 export function detectPatterns(events: GameEventCtx[]): PatternFinding[] {
   const byPhrase = new Map<string, Set<string>>();
   for (const e of events) {
@@ -97,41 +100,33 @@ export function detectPatterns(events: GameEventCtx[]): PatternFinding[] {
     const text = normalizePrompt(e.dealPrompt);
     for (const phrase of TRAP_PHRASES) {
       if (text.includes(phrase)) {
-        const label = traderLabel(e);
         const set = byPhrase.get(phrase) ?? new Set<string>();
-        set.add(label);
+        set.add(traderLabel(e));
         byPhrase.set(phrase, set);
       }
     }
   }
-
   const findings: PatternFinding[] = [];
   for (const [phrase, labels] of byPhrase) {
     if (labels.size >= 2) {
-      findings.push({
-        phrase,
-        traderLabels: [...labels],
-        count: labels.size,
-      });
+      findings.push({ phrase, traderLabels: [...labels], count: labels.size });
     }
   }
-  // Most-traders-burned first.
   findings.sort((a, b) => b.count - a.count);
   return findings;
 }
 
-/** Compute the top-decile absolute magnitude threshold from recent events. */
 function topDecileThreshold(events: GameEventCtx[]): number {
   const mags = events
     .map((e) => Math.abs(e.magnitudeUsdc ?? 0))
     .filter((m) => m > 0)
     .sort((a, b) => a - b);
-  if (mags.length === 0) return Infinity; // nothing qualifies as "large"
+  if (mags.length === 0) return Infinity;
   const idx = Math.floor(mags.length * 0.9);
   return mags[Math.min(idx, mags.length - 1)];
 }
 
-function oneLiner(e: GameEventCtx): string {
+function gameOneLiner(e: GameEventCtx): string {
   if (e.traderName || e.traderAddressTrunc) {
     return `${traderLabel(e)}: ${e.summary}`;
   }
@@ -145,55 +140,113 @@ function subjectsFor(e: GameEventCtx): LeadSelection["subjects"] {
   return subs;
 }
 
-export function rankAndSelectLead(events: GameEventCtx[]): LeadSelection {
+// ── token scoring ────────────────────────────────────────────────────────────
+
+/** Score a token signal on the same scale as game events. */
+function tokenScore(signal: TokenSignal): number {
+  if (!signal.ok) return 0;
+  const move = Math.abs(headlineMovePct(signal) ?? 0);
+  if (signal.classification === "flash") return 100 + Math.min(move, 50);
+  if (signal.classification === "story") return 65 + Math.min(move, 30);
+  if (signal.classification === "routine") return 30 + Math.min(move, 20);
+  return 0;
+}
+
+function tokenOneLiner(signal: TokenSignal): string {
+  const move = headlineMovePct(signal);
+  const moveStr =
+    move == null
+      ? "moving on heavy volume"
+      : `${move > 0 ? "up" : "off"} ${Math.abs(Math.round(move))}%`;
+  return `${signal.symbol} ${moveStr}`;
+}
+
+// ── unified selection ────────────────────────────────────────────────────────
+
+export function rankAndSelectLead(input: {
+  signals: TokenSignal[];
+  events: GameEventCtx[];
+}): LeadSelection {
+  const { signals, events } = input;
   const patterns = detectPatterns(events);
 
-  // Fold detected patterns in as synthetic events so they can win the lead.
+  // Fold detected trap patterns in as synthetic game events (can win the lead).
   const patternEvents: GameEventCtx[] = patterns.map((p) => ({
     type: "loss_pattern",
     dramatic: true,
     summary: `${p.count} desks burned chasing "${p.phrase}" deals`,
   }));
-
   const allEvents = [...patternEvents, ...events];
   const topDecile = topDecileThreshold(events);
 
-  const ranked: RankedEvent[] = allEvents
-    .map((event) => ({ event, score: baseScore(event, topDecile) }))
+  const rankedGame = allEvents
+    .map((event) => ({ event, score: gameScore(event, topDecile) }))
     .sort((a, b) => b.score - a.score);
+  const topGame = rankedGame[0] ?? null;
 
-  const top = ranked[0] ?? null;
+  const rankedTokens = signals
+    .filter((s) => s.ok)
+    .map((signal) => ({ signal, score: tokenScore(signal) }))
+    .sort((a, b) => b.score - a.score);
+  const topToken = rankedTokens[0] ?? null;
 
-  if (top && top.score >= LEAD_THRESHOLD) {
-    // Gather subjects from the lead plus any other high-scoring real events.
-    const subjectSeen = new Set<string>();
-    const subjects: LeadSelection["subjects"] = [];
-    for (const { event, score } of ranked) {
-      if (score < LEAD_THRESHOLD) break;
-      for (const s of subjectsFor(event)) {
-        const key = `${s.type}:${s.id}`;
-        if (!subjectSeen.has(key)) {
-          subjectSeen.add(key);
-          subjects.push(s);
-        }
-      }
-    }
+  const gameScoreTop = topGame?.score ?? 0;
+  const tokenScoreTop = topToken?.score ?? 0;
+
+  // Nothing crosses the bar → quiet tape.
+  if (gameScoreTop < LEAD_THRESHOLD && tokenScoreTop < LEAD_THRESHOLD) {
+    // Best available real stat to weave in (token routine move or top game stat).
+    const bestRoutineToken = rankedTokens.find((t) => t.score > 0)?.signal;
+    const realStatOneLiner = bestRoutineToken
+      ? tokenOneLiner(bestRoutineToken)
+      : topGame && topGame.score > 0
+        ? gameOneLiner(topGame.event)
+        : null;
     return {
-      leadKind: "real_event",
-      leadEvent: top.event,
-      realStatOneLiner: null,
-      ranked,
+      leadKind: "quiet",
+      tokenLead: null,
+      gameLead: null,
+      isFlash: false,
+      realStatOneLiner,
       patterns,
-      subjects,
+      subjects: [],
     };
   }
 
+  // Token leads when it scores at least as high as the top game candidate.
+  if (topToken && tokenScoreTop >= gameScoreTop) {
+    return {
+      leadKind: "token",
+      tokenLead: topToken.signal,
+      gameLead: null,
+      isFlash: topToken.signal.classification === "flash",
+      realStatOneLiner: null,
+      patterns,
+      subjects: [],
+    };
+  }
+
+  // Otherwise a game event leads.
+  const gameLead = topGame!.event;
+  const subjectSeen = new Set<string>();
+  const subjects: LeadSelection["subjects"] = [];
+  for (const { event, score } of rankedGame) {
+    if (score < LEAD_THRESHOLD) break;
+    for (const s of subjectsFor(event)) {
+      const key = `${s.type}:${s.id}`;
+      if (!subjectSeen.has(key)) {
+        subjectSeen.add(key);
+        subjects.push(s);
+      }
+    }
+  }
   return {
-    leadKind: "fiction",
-    leadEvent: null,
-    realStatOneLiner: top ? oneLiner(top.event) : null,
-    ranked,
+    leadKind: "game_event",
+    tokenLead: null,
+    gameLead,
+    isFlash: gameLead.type === "wipeout",
+    realStatOneLiner: null,
     patterns,
-    subjects: top ? subjectsFor(top.event) : [],
+    subjects,
   };
 }

--- a/convex/wire/dropAngles.ts
+++ b/convex/wire/dropAngles.ts
@@ -17,28 +17,22 @@ export interface DropAngle {
 
 export const DROP_ANGLES: readonly DropAngle[] = [
   {
-    key: "counterparty-nerves",
+    key: "quiet-tape",
     instruction:
-      "Write from a nervous counterparty's POV — someone who stopped returning calls but hasn't walked away yet. Same facts, new texture. Do NOT invent figures, events, or new losses.",
+      "A quiet-tape column — nothing crossed the wire today, and you say so with style. Light on numbers, heavy on the boredom of a flat session. Do NOT invent figures, events, or moves.",
     suggestedCategory: "wire",
   },
   {
     key: "junior-analyst",
     instruction:
-      "Junior analyst gallows humor on the trading floor — darkly funny, self-aware, still citing only the provided figures. Do NOT invent numbers or new developments.",
+      "Junior-analyst gallows humor on the floor — darkly funny, self-aware, citing only the provided figures. Do NOT invent numbers or developments.",
     suggestedCategory: "wire",
   },
   {
-    key: "rival-schadenfreude",
+    key: "floor-schadenfreude",
     instruction:
-      "Rival desk schadenfreude — a competitor desk enjoying someone else's pain, attributed as floor gossip. Do NOT invent facts beyond what is provided.",
+      "Floor schadenfreude — the desk enjoying a slow day at someone's expense, attributed as gossip. Do NOT invent facts beyond what is provided.",
     suggestedCategory: "floor_talk",
-  },
-  {
-    key: "sec-skepticism",
-    instruction:
-      "SEC water-cooler skepticism — regulators circling but not acting yet, dry and bureaucratic. Do NOT invent investigations, fines, or new figures.",
-    suggestedCategory: "sec_watch",
   },
   {
     key: "ticker-recap",
@@ -49,20 +43,20 @@ export const DROP_ANGLES: readonly DropAngle[] = [
   {
     key: "mundane-human",
     instruction:
-      "Mundane human detail — elevator small talk, coffee run, someone pretending not to check their phone. The crisis is background noise. No new facts.",
+      "Mundane human detail — elevator small talk, coffee run, someone pretending not to check the tape. The market is background noise. No new facts.",
     suggestedCategory: "wire",
   },
   {
     key: "echo-confirmed",
     instruction:
-      "Echo an earlier confirmed fact from a new angle — reframe something already established as rumor turning to accepted truth (or vice versa). Do NOT claim anything new happened.",
+      "Echo an earlier confirmed fact from a new angle — reframe something already on the tape. Do NOT claim anything new happened.",
     suggestedCategory: "wire",
   },
   {
-    key: "boardroom-whisper",
+    key: "positioning-whisper",
     instruction:
-      "Boardroom whisper — what the partners are saying behind closed doors, cynical and insider-y. Same stakes, different room. No invented figures.",
-    suggestedCategory: "boardroom",
+      "Positioning whisper — who on the floor is quietly leaning which way, cynical and insider-y, but strictly no invented figures or events.",
+    suggestedCategory: "positioning",
   },
 ] as const;
 

--- a/convex/wire/epochAssembler.ts
+++ b/convex/wire/epochAssembler.ts
@@ -2,6 +2,7 @@
 
 import type { ArcStage } from "./stages";
 import type { DropAngle } from "./dropAngles";
+import type { ArcSubjectType } from "./arcTemplates";
 
 export interface SeasonCtx {
   title: string;
@@ -20,27 +21,42 @@ export interface EntityCtx {
 export interface RecentDropCtx {
   epochSlot?: number | null;
   dropTitle?: string | null;
-  worldState?: { mood?: string; sec_heat?: number } | null;
+  worldState?: { mood?: string } | null;
   headlines?: Array<{ headline?: string; role?: string }> | null;
   confirmedFacts?: string[] | null;
   openQuestions?: string[] | null;
 }
 
+/**
+ * A real game event (deal / PnL / entry / pot / leaderboard). First-class story
+ * material alongside token moves. `magnitudeUsdc` is signed (loss negative).
+ */
 export interface GameEventCtx {
   type: string;
   dramatic: boolean;
   summary: string;
   traderName?: string;
   deskName?: string;
-  /** Signed dollar magnitude of the event (loss negative, win positive). */
   magnitudeUsdc?: number;
-  /** The deal prompt text, when the event is tied to a deal. */
   dealPrompt?: string;
-  /** Truncated wallet address for public display, e.g. "0x4f2…a9". */
   traderAddressTrunc?: string;
-  /** Raw entity ids for deep-linking / subjects (never shown verbatim). */
   traderId?: string;
   dealId?: string;
+}
+
+/** One company's stored price facts for the tape (all numbers are real). */
+export interface CompanyTapeCtx {
+  symbol: string;
+  companyName: string;
+  xHandle: string;
+  isHouseToken: boolean;
+  priceUsd?: number | null;
+  move24hPct?: number | null;
+  moveSinceLastPct?: number | null;
+  streakDays: number;
+  volumeVsTrailing?: number | null;
+  volumeAnomaly: boolean;
+  classification: string;
 }
 
 /** Arc as presented to the LLM — stage + tension are CODE-decided. */
@@ -51,28 +67,29 @@ export interface AssemblerArcCtx {
   tensionScore: number;
   arcStage: ArcStage;
   isPrimary: boolean;
-  beatThisRun: boolean;
-  /** Exact firm-loss figure (USDC) to cite when this arc carries a beat. */
-  firmLossUsdc?: number | null;
-  firmDisplayName?: string | null;
-}
-
-/** Code-computed firm state. The LLM never invents these numbers. */
-export interface FirmStateCtx {
-  displayName: string;
-  status: string;
-  runningLossUsdc: number;
-  newLossDeltaUsdc?: number | null;
-  latestFact?: string | null;
+  subjectType?: ArcSubjectType | null;
+  subjectSymbol?: string | null;
+  subjectCompanyName?: string | null;
+  movePct?: number | null;
+  streakDays?: number | null;
+  isHouseToken?: boolean;
 }
 
 export interface LeadCtx {
-  leadKind: "real_event" | "fiction";
-  /** When real_event: the headline-worthy line, with names/addresses. */
-  leadLine?: string | null;
-  /** Exact figure to use in prose (no rounding, no invention). */
-  leadFigureUsdc?: number | null;
-  /** When fiction: weave this real stat in as a one-liner. */
+  leadKind: "token" | "game_event" | "quiet";
+  isFlash: boolean;
+  // token lead
+  tokenSymbol?: string | null;
+  tokenCompanyName?: string | null;
+  tokenXHandle?: string | null;
+  tokenMovePct?: number | null;
+  tokenStreakDays?: number | null;
+  tokenIsHouse?: boolean;
+  tokenVolumeNote?: string | null;
+  // game-event lead
+  gameLine?: string | null;
+  gameFigureUsdc?: number | null;
+  // quiet
   realStatOneLiner?: string | null;
   patterns: Array<{ phrase: string; count: number; traderLabels: string[] }>;
 }
@@ -82,26 +99,28 @@ export interface FloorTalkCtx {
   isTrue: boolean;
 }
 
+/** A verified public statement from a real account (rule 6). v1: usually empty. */
+export interface SourcedStatementCtx {
+  company: string;
+  statement: string;
+  sourceRef: string;
+}
+
 export interface AssemblerInput {
   season: SeasonCtx;
   dayPosture: string;
-  /** Pre-sorted by tension desc; first is primary. */
-  arcs: AssemblerArcCtx[];
-  firmStates: FirmStateCtx[];
-  entities: EntityCtx[];
-  /** Newest-first, up to 10 drops. */
-  recentDrops: RecentDropCtx[];
-  recentGameEvents: GameEventCtx[];
-  lead: LeadCtx;
-  floorTalkClaims: FloorTalkCtx[];
-  /** Code-computed mood + SEC heat for this drop. */
   mood: string;
-  secHeat: number;
-  /** True when this is the first drop of the trading day. */
+  lead: LeadCtx;
+  companyTape: CompanyTapeCtx[];
+  arcs: AssemblerArcCtx[];
+  entities: EntityCtx[];
+  /** Display name of the house token company, if the registry has one. */
+  houseTokenName?: string | null;
+  floorTalkClaims: FloorTalkCtx[];
+  sourcedStatements: SourcedStatementCtx[];
+  recentDrops: RecentDropCtx[];
   isOpeningBell: boolean;
-  /** True when this is the last drop before the close (daily wrap). */
   isClosingBell: boolean;
-  /** Quiet-slot narrative angle (code-selected); null when beat or real event leads. */
   quietSlotAngle?: DropAngle | null;
 }
 
@@ -128,36 +147,48 @@ function pushBulletSection(
     lines.push("  (none)");
     return;
   }
-  for (const item of items) {
-    lines.push(`  - ${item}`);
-  }
+  for (const item of items) lines.push(`  - ${item}`);
 }
 
 export function fmtUsd(n: number): string {
   const abs = Math.abs(n);
   if (abs >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
   if (abs >= 1) return `$${Math.round(n).toLocaleString("en-US")}`;
-  return `$${n.toFixed(2)}`; // sub-dollar → "$0.47", never "$0"
+  return `$${n.toFixed(2)}`;
 }
 
-/** Exact USDC figure for the LLM — cents precision, no trailing-zero noise. */
 function exactUsdc(n: number): number {
   return Number(n.toFixed(2));
+}
+
+/** Signed percent, no decimals, e.g. +38% / -22% / unch. */
+export function fmtPct(n: number | null | undefined): string {
+  if (n == null) return "n/a";
+  const r = Math.round(n);
+  if (r === 0) return "unch.";
+  return `${r > 0 ? "+" : ""}${r}%`;
+}
+
+function streakPhrase(streakDays: number | null | undefined): string | null {
+  if (streakDays == null) return null;
+  const n = Math.abs(streakDays);
+  if (n < 2) return null;
+  return `${n} straight ${streakDays > 0 ? "up" : "down"} days`;
 }
 
 export function assembleUserMessage(input: AssemblerInput): string {
   const {
     season,
     dayPosture,
-    arcs,
-    firmStates,
-    entities,
-    recentDrops,
-    recentGameEvents,
-    lead,
-    floorTalkClaims,
     mood,
-    secHeat,
+    lead,
+    companyTape,
+    arcs,
+    entities,
+    houseTokenName,
+    floorTalkClaims,
+    sourcedStatements,
+    recentDrops,
     isOpeningBell,
     isClosingBell,
     quietSlotAngle,
@@ -179,45 +210,55 @@ export function assembleUserMessage(input: AssemblerInput): string {
     `\nFORBIDDEN LANGUAGE (never use, case-insensitive): ${season.forbiddenLanguage.join(", ")}`
   );
 
-  // World state is CODE-AUTHORED. The LLM must not change these.
-  lines.push(`\nCURRENT WORLD STATE (code-set — do not alter):`);
-  lines.push(`  mood: ${mood}`);
-  lines.push(`  sec_heat: ${secHeat}/10`);
+  lines.push(`\nCURRENT MOOD (code-set — do not alter): ${mood}`);
 
-  // ── LEAD INSTRUCTION — the single most important section ──────────────────
+  // ── LEAD INSTRUCTION — the single most important section ──
   lines.push(`\nLEAD INSTRUCTION (build the role=main dispatch around THIS):`);
-  if (lead.leadKind === "real_event") {
-    lines.push(`  REAL EVENT LEADS. Report this as the headline:`);
-    lines.push(`    ${lead.leadLine ?? "(see recent market events)"}`);
-    if (lead.leadFigureUsdc != null) {
+  if (lead.leadKind === "token") {
+    const move = fmtPct(lead.tokenMovePct);
+    const streak = streakPhrase(lead.tokenStreakDays);
+    lines.push(
+      `  ${lead.isFlash ? "FLASH BULLETIN" : "COMPANY STORY LEADS"}: Shares of ${lead.tokenCompanyName} (${lead.tokenSymbol}) ${lead.tokenMovePct != null && lead.tokenMovePct < 0 ? "fell" : "rose"} ${move}.`
+    );
+    lines.push(
+      `    Use this EXACT figure and symbol — do not round differently or invent another number: ${lead.tokenSymbol} ${move}.`
+    );
+    if (streak) lines.push(`    Real streak: ${streak}. You may cite it.`);
+    if (lead.tokenVolumeNote) lines.push(`    ${lead.tokenVolumeNote}`);
+    lines.push(
+      `    The move already happened — explain it with absurd, non-plausible floor color (the interns, the payphone, the coffee cart). NEVER invent a real-sounding reason (deals, deployments, listings, investigations, hacks, insiders).`
+    );
+    if (lead.tokenIsHouse) {
       lines.push(
-        `    Use this EXACT figure, do not round or invent: ${fmtUsd(lead.leadFigureUsdc)} (${exactUsdc(lead.leadFigureUsdc)} USDC).`
+        `    THIS IS THE HOUSE COMPANY. Be harder on it, self-deprecating, never promotional. Favorable coverage fails review.`
+      );
+    }
+  } else if (lead.leadKind === "game_event") {
+    lines.push(`  REAL GAME EVENT LEADS. Report this as the headline:`);
+    lines.push(`    ${lead.gameLine ?? "(see recent game events)"}`);
+    if (lead.gameFigureUsdc != null) {
+      lines.push(
+        `    Use this EXACT figure, do not round or invent: ${fmtUsd(lead.gameFigureUsdc)} (${exactUsdc(lead.gameFigureUsdc)} USDC).`
       );
     }
     lines.push(
-      `    Name the desk by its display name or truncated address. A fictional arc may appear only as a one-line aside.`
+      `    Name the desk by its display name or truncated address. Keep it in-world.`
     );
   } else {
     lines.push(
-      `  FICTIONAL BEAT LEADS (no real event cleared the drama threshold).`
+      `  QUIET TAPE (nothing crossed the threshold). Write a competent quiet-day column.`
     );
-    const primary = arcs.find((a) => a.isPrimary);
-    if (primary) {
-      lines.push(
-        `    Lead with the primary arc "${primary.title}" at stage ${primary.arcStage} (tension ${primary.tensionScore}/10).`
-      );
-      if (primary.firmLossUsdc != null && primary.firmLossUsdc > 0) {
-        lines.push(
-          `    ${primary.firmDisplayName ?? "The firm"}'s running loss is now ${fmtUsd(primary.firmLossUsdc)} (${exactUsdc(primary.firmLossUsdc)} USDC) — USE THIS EXACT FIGURE.`
-        );
-      }
-    }
     if (lead.realStatOneLiner) {
-      lines.push(`    Weave in this real one-liner: ${lead.realStatOneLiner}`);
+      lines.push(
+        `    You may weave in this real one-liner: ${lead.realStatOneLiner}`
+      );
     }
+    lines.push(
+      `    Do NOT attach a rumor or story to any company that is not on the COMPANY TAPE below with a real move. These are thin markets; the wire must not appear to move them.`
+    );
   }
   if (lead.patterns.length > 0) {
-    lines.push(`  TRAP PATTERNS DETECTED (report as a darkly funny pattern):`);
+    lines.push(`  TRAP PATTERNS (real; report as a darkly funny pattern):`);
     for (const p of lead.patterns) {
       lines.push(
         `    - ${p.count} desks lost chasing "${p.phrase}" deals: ${p.traderLabels.join(", ")}`
@@ -226,52 +267,58 @@ export function assembleUserMessage(input: AssemblerInput): string {
   }
 
   if (quietSlotAngle) {
-    lines.push(
-      `\nANGLE FOR THIS DROP (no new facts today — advance texture, not facts):`
-    );
+    lines.push(`\nANGLE FOR THIS DROP:`);
     lines.push(`  ${quietSlotAngle.instruction}`);
     lines.push(
       `  Suggested category: ${quietSlotAngle.suggestedCategory} (override only if a real event clearly demands another).`
     );
-    lines.push(
-      `  Do NOT re-announce recent headlines as breaking news. Same arc stage, same figures — new voice only.`
-    );
   }
 
-  // ── ARC STATE — stages + tension are code-owned ───────────────────────────
+  // ── COMPANY TAPE — real stored numbers only ──
+  lines.push(
+    `\nCOMPANY TAPE (real stored figures — cite exactly; anything not listed here has no story today):`
+  );
+  const movers = companyTape.filter((c) => c.classification !== "none");
+  if (movers.length === 0) {
+    lines.push("  (quiet tape — no company crossed a mention threshold)");
+  } else {
+    for (const c of movers) {
+      const streak = streakPhrase(c.streakDays);
+      const vol =
+        c.volumeAnomaly && c.volumeVsTrailing != null
+          ? `, volume ~${Math.round(c.volumeVsTrailing)}× normal`
+          : "";
+      const house = c.isHouseToken
+        ? " [HOUSE COMPANY — harder, never promotional]"
+        : "";
+      lines.push(
+        `  - ${c.companyName} (${c.symbol}): 24h ${fmtPct(c.move24hPct)}, since last ${fmtPct(c.moveSinceLastPct)}${streak ? `, ${streak}` : ""}${vol}${house}`
+      );
+    }
+  }
+
+  // ── ARC STATE — stages + tension are code-owned ──
   lines.push(`\nARC STATE (stage + tension are code-set; write to them):`);
   if (arcs.length === 0) {
     lines.push("  (no active arcs)");
   } else {
-    arcs.forEach((arc) => {
+    for (const arc of arcs) {
       const primary = arc.isPrimary ? " [PRIMARY]" : "";
-      const beat = arc.beatThisRun ? " (advance this beat)" : " (simmering)";
-      lines.push(
-        `  -${primary} ${arc.title} — stage ${arc.arcStage}, tension ${arc.tensionScore}/10${beat} [slug: ${arc.slug}]`
-      );
-      lines.push(`     ${arc.summary}`);
-    });
-  }
-
-  // ── FIRM STATE — running totals are code-owned ────────────────────────────
-  if (firmStates.length > 0) {
-    lines.push(`\nFIRM STATE (running totals are code-set — cite exactly):`);
-    for (const f of firmStates) {
-      const delta =
-        f.newLossDeltaUsdc && f.newLossDeltaUsdc > 0
-          ? ` (today +${fmtUsd(f.newLossDeltaUsdc)})`
+      const subj =
+        arc.subjectType === "company" && arc.subjectSymbol
+          ? ` [${arc.subjectSymbol}${arc.movePct != null ? ` ${fmtPct(arc.movePct)}` : ""}]`
           : "";
       lines.push(
-        `  - ${f.displayName}: ${f.status}, running loss ${fmtUsd(f.runningLossUsdc)}${delta}`
+        `  -${primary} ${arc.title} — stage ${arc.arcStage}, tension ${arc.tensionScore}/10${subj} [slug: ${arc.slug}]`
       );
-      if (f.latestFact) lines.push(`     fact: ${f.latestFact}`);
+      lines.push(`     ${arc.summary}`);
     }
   }
 
-  // ── FLOOR TALK — unreliable gossip, truth tagged for coherence ────────────
+  // ── FLOOR TALK — unreliable gossip, absurd + non-finance only ──
   if (floorTalkClaims.length > 0) {
     lines.push(
-      `\nFLOOR TALK CLAIMS (gossip — only ~60% true; you may use as a floor_talk aside, attributed as rumor):`
+      `\nFLOOR TALK (gossip — only ~60% true; use as a floor_talk aside, attributed as rumor):`
     );
     for (const c of floorTalkClaims) {
       lines.push(
@@ -280,13 +327,36 @@ export function assembleUserMessage(input: AssemblerInput): string {
     }
   }
 
-  lines.push(`\nENTITY ROSTER (only reference entities on this list):`);
+  // ── SOURCED STATEMENTS — real accounts, verified quotes only (rule 6) ──
+  lines.push(
+    `\nSOURCED STATEMENTS (real public statements you may reference; frame in period terms, never invent one):`
+  );
+  if (sourcedStatements.length === 0) {
+    lines.push(
+      "  (none supplied — do NOT invent posts, quotes, actions, or intentions for any real account or person)"
+    );
+  } else {
+    for (const s of sourcedStatements) {
+      lines.push(`  - ${s.company}: "${s.statement}" [source: ${s.sourceRef}]`);
+    }
+  }
+
+  lines.push(
+    `\nCOMPANY ROSTER (only these companies exist; never reference one not on this list):`
+  );
   if (entities.length === 0) {
     lines.push("  (none)");
   } else {
-    entities.forEach((e) => {
-      lines.push(`  - ${e.slug} (${e.displayName}): ${e.traits.join(", ")}`);
-    });
+    for (const e of entities) {
+      lines.push(
+        `  - ${e.slug} (${e.displayName})${e.traits.length ? `: ${e.traits.join(", ")}` : ""}`
+      );
+    }
+  }
+  if (houseTokenName) {
+    lines.push(
+      `  NOTE: ${houseTokenName} is the house company — coverage stance is HARDER and never promotional.`
+    );
   }
 
   const dropsToShow = recentDrops.slice(0, 10);
@@ -317,53 +387,36 @@ export function assembleUserMessage(input: AssemblerInput): string {
     )
   );
 
-  lines.push(`\nRECENT WIRE DROPS (newest first, for narrative continuity):`);
+  lines.push(`\nRECENT WIRE DROPS (newest first, for continuity):`);
   if (dropsToShow.length === 0) {
     lines.push("  (none — this is the first drop)");
   } else {
-    dropsToShow.forEach((drop) => {
+    for (const drop of dropsToShow) {
       const slot = drop.epochSlot != null ? `slot ${drop.epochSlot}` : "seed";
       lines.push(`  [${slot}] ${drop.dropTitle ?? "(untitled)"}`);
       const dispatches = (drop.headlines ?? []) as Array<{
         headline?: string;
-        role?: string;
       }>;
-      dispatches.slice(0, 3).forEach((d) => {
-        lines.push(`    • ${d.headline ?? ""}`);
-      });
-    });
-  }
-
-  // ── Real market events (raw, for color beyond the chosen lead) ────────────
-  const dramaticEvents = recentGameEvents.filter((e) => e.dramatic);
-  lines.push(
-    `\nRECENT MARKET EVENTS — DRAMATIC (real; name desks when relevant):`
-  );
-  if (dramaticEvents.length === 0) {
-    lines.push("  (none)");
-  } else {
-    dramaticEvents.forEach((e) => {
-      const actor = [e.traderName, e.traderAddressTrunc, e.deskName]
-        .filter(Boolean)
-        .join(" / ");
-      const actorTag = actor ? ` [${actor}]` : "";
-      lines.push(`  [${e.type}]${actorTag} ${e.summary}`);
-    });
+      dispatches
+        .slice(0, 3)
+        .forEach((d) => lines.push(`    • ${d.headline ?? ""}`));
+    }
   }
 
   if (isOpeningBell) {
     lines.push(
-      `\nMORNING BRIEFING: First drop of the trading day. Lead with what happened overnight or since yesterday's close, who is positioned how, and the one flashpoint the floor is watching. Electric, gossipy anticipation — not a dry recap.`
+      `\nMORNING BRIEFING: First drop of the trading day. Lead with the biggest overnight move on the COMPANY TAPE (size crossed the tape before the bell), who is positioned how, and the one name the floor is watching. Electric, gossipy — not a dry recap.`
     );
   }
   if (isClosingBell) {
     lines.push(
-      `\nDAILY WRAP: Last drop before the close. Write a satirical end-of-day column with superlatives — biggest winner, dumbest trade, quote of the day (a quote may be fictional and attributed to a roster character). This is the shareable artifact. Make it land.`
+      `\nDAILY WRAP: Last drop before the close. Satirical end-of-day column with superlatives — biggest mover, dullest name, quote of the day (the quote must be your own invented FLOOR voice, never attributed to a real company or person). This is the shareable artifact. Make it land.`
     );
   }
 
   lines.push(
-    `\nOUTPUT: Exactly one dispatch, role "main". Pick the category that fits (wire is the default; use ticker for a flash one-liner, floor_talk for gossip, sec_watch for regulators). Every dispatch needs a unique kebab-case dispatchKey. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). Every post must contain a human detail or a joke. All numbers must come from the figures above — never invent a dollar amount, total, or event. entityMentions: list ONLY fictional roster slugs from the ENTITY ROSTER above — real desks/traders/addresses belong in the prose, never in entityMentions.`
+    `\nOUTPUT: Exactly one dispatch, role "main". Category: wire (default), ticker (a flash one-liner), floor_talk (gossip), positioning (who's leaning where). Unique kebab-case dispatchKey. Headline ≤ 12 words. Body 2–3 complete sentences (each ending in . ! or ?). Every post needs a human detail or a joke. Every number MUST come from the COMPANY TAPE / LEAD / game figures above — never invent a price, percentage, dollar amount, or event. entityMentions: ONLY company roster slugs that are the actual subject.` +
+      `\nALSO produce tweetVariant: ONE tweet, ≤ 270 characters, same voice. For a company story include the real move (SYMBOL +/-N%) and @-mention the company's handle. Cashtags allowed. NO URLs of any kind. Zero-context read: it must not be mistakable for real news.`
   );
 
   return lines.join("\n");

--- a/convex/wire/epochValidator.ts
+++ b/convex/wire/epochValidator.ts
@@ -3,9 +3,8 @@ import { NarrativeEpochSchema, type NarrativeEpoch } from "./_schemas";
 export type ValidatedEpoch = NarrativeEpoch;
 
 /**
- * Phrases the satirical wire must never print — lazy AP-wire filler and
- * compliance-memo cadence. Enforced as case-insensitive substrings (so
- * multi-word phrases are caught regardless of surrounding text).
+ * Phrases the wire must never print — lazy AP-wire filler and compliance-memo
+ * cadence. Case-insensitive substrings.
  */
 export const BANNED_PHRASES = [
   "watch for fallout",
@@ -20,78 +19,173 @@ export const BANNED_PHRASES = [
   "sending shockwaves",
 ];
 
+/**
+ * Hardcoded crypto / finance-tech vocabulary — always blocked, independent of
+ * the season's forbiddenLanguage, so a misconfigured season can never let it
+ * through. Word-boundary matched (so "minted" ≠ "mint", "coined" ≠ "coin").
+ */
+export const CRYPTO_TERMS = [
+  "token",
+  "tokens",
+  "coin",
+  "coins",
+  "crypto",
+  "cryptocurrency",
+  "blockchain",
+  "onchain",
+  "on-chain",
+  "wallet",
+  "wallets",
+  "defi",
+  "dex",
+  "market cap",
+  "marketcap",
+  "mcap",
+  "pump",
+  "hodl",
+  "airdrop",
+  "memecoin",
+  "web3",
+  "nft",
+  "smart contract",
+];
+
+/** Promotional words that fail HARNESS (house company) review. */
+const PROMO_WORDS = [
+  "surge",
+  "surges",
+  "soar",
+  "soars",
+  "rocket",
+  "explosive",
+  "bullish",
+  "undervalued",
+  "buy",
+  "strong buy",
+  "winner",
+  "best-in-class",
+  "unstoppable",
+  "moonshot",
+  "breakout",
+];
+
+function wordRegex(word: string): RegExp {
+  return new RegExp(
+    `\\b${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+    "i"
+  );
+}
+
+export interface ValidateResult {
+  ok: boolean;
+  data?: ValidatedEpoch;
+  error?: string;
+  /** Non-blocking findings surfaced to logs + the external audit. */
+  warnings: string[];
+}
+
 export function validateEpoch(
   raw: unknown,
   ctx: {
     arcSlugs: Set<string>;
     entitySlugs: Set<string>;
     forbiddenLanguage: string[];
+    /** Rounded absolute percentages that legitimately appear (from signals). */
+    allowedPercents?: number[];
+    /** True when the drop's subject is the house company. */
+    subjectIsHouse?: boolean;
   }
-): { ok: true; data: ValidatedEpoch } | { ok: false; error: string } {
+): ValidateResult {
+  const warnings: string[] = [];
   const result = NarrativeEpochSchema.safeParse(raw);
   if (!result.success) {
-    return { ok: false, error: result.error.message };
+    return { ok: false, error: result.error.message, warnings };
   }
-
   const data = result.data;
 
-  // Require at least one "main" dispatch.
   if (!data.dispatches.some((d) => d.role === "main")) {
-    return { ok: false, error: "At least one dispatch must have role 'main'" };
+    return {
+      ok: false,
+      error: "At least one dispatch must have role 'main'",
+      warnings,
+    };
   }
 
-  // Dispatch keys must be unique within the drop.
   const seenKeys = new Set<string>();
   for (const d of data.dispatches) {
     if (seenKeys.has(d.dispatchKey)) {
-      return { ok: false, error: `Duplicate dispatchKey: "${d.dispatchKey}"` };
-    }
-    seenKeys.add(d.dispatchKey);
-  }
-
-  // arcSlug references must be on-roster.
-  for (const dispatch of data.dispatches) {
-    if (dispatch.arcSlug && !ctx.arcSlugs.has(dispatch.arcSlug)) {
       return {
         ok: false,
-        error: `Unknown arcSlug in dispatch: "${dispatch.arcSlug}"`,
+        error: `Duplicate dispatchKey: "${d.dispatchKey}"`,
+        warnings,
+      };
+    }
+    seenKeys.add(d.dispatchKey);
+    if (d.arcSlug && !ctx.arcSlugs.has(d.arcSlug)) {
+      return {
+        ok: false,
+        error: `Unknown arcSlug in dispatch: "${d.arcSlug}"`,
+        warnings,
       };
     }
   }
 
-  // entityMentions is a soft continuity hint (roster slugs only). Real desks
-  // and traders legitimately appear in prose but are NOT roster entities, so
-  // filter unknown mentions out rather than failing an otherwise-good drop.
+  // entityMentions is a soft continuity hint — filter unknowns rather than fail.
   if (data.entityMentions) {
     data.entityMentions = data.entityMentions.filter((slug) =>
       ctx.entitySlugs.has(slug)
     );
   }
 
+  // Everything the reader sees (prose + tweet) is subject to the hard filters.
   const fullText = [
     data.dropTitle,
     ...data.dispatches.map((d) => `${d.headline} ${d.body}`),
+    data.tweetVariant,
   ]
     .join(" ")
     .toLowerCase();
 
-  // Forbidden vocabulary (word-boundary, e.g. crypto/AI terms).
-  for (const word of ctx.forbiddenLanguage) {
-    const pattern = new RegExp(
-      `\\b${word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
-      "i"
-    );
-    if (pattern.test(fullText)) {
-      return { ok: false, error: `Forbidden language: "${word}"` };
+  // Hard: crypto vocabulary (always) + season forbidden language.
+  for (const word of [...CRYPTO_TERMS, ...ctx.forbiddenLanguage]) {
+    if (wordRegex(word).test(fullText)) {
+      return { ok: false, error: `Forbidden language: "${word}"`, warnings };
     }
   }
 
-  // Banned filler phrases (substring — catches the AP-wire cadence we killed).
+  // Hard: banned filler phrases.
   for (const phrase of BANNED_PHRASES) {
     if (fullText.includes(phrase)) {
-      return { ok: false, error: `Banned phrase: "${phrase}"` };
+      return { ok: false, error: `Banned phrase: "${phrase}"`, warnings };
     }
   }
 
-  return { ok: true, data };
+  // Soft: number traceability. Every percentage in prose should match a real
+  // move within rounding (±1). Surfaced as a warning, not a hard block.
+  if (ctx.allowedPercents && ctx.allowedPercents.length > 0) {
+    const allowed = new Set(ctx.allowedPercents.map((p) => Math.round(p)));
+    const proseOnly = [
+      data.dropTitle,
+      ...data.dispatches.map((d) => `${d.headline} ${d.body}`),
+      data.tweetVariant,
+    ].join(" ");
+    const pctMatches = proseOnly.match(/[+-]?\d{1,3}\s?%/g) ?? [];
+    for (const m of pctMatches) {
+      const n = Math.abs(parseInt(m.replace(/[^0-9-]/g, ""), 10));
+      if (Number.isNaN(n)) continue;
+      const traces = [...allowed].some((a) => Math.abs(a - n) <= 1);
+      if (!traces) warnings.push(`untraceable-percent:${n}`);
+    }
+  }
+
+  // Soft: promotional coverage of the house company.
+  if (ctx.subjectIsHouse) {
+    for (const word of PROMO_WORDS) {
+      if (wordRegex(word).test(fullText)) {
+        warnings.push(`house-promotional:${word}`);
+      }
+    }
+  }
+
+  return { ok: true, data, warnings };
 }

--- a/convex/wire/generator.ts
+++ b/convex/wire/generator.ts
@@ -15,15 +15,24 @@ import { getTodayDateNY } from "../lib/tradingHours";
 import {
   assembleUserMessage,
   type AssemblerArcCtx,
-  type FirmStateCtx,
+  type CompanyTapeCtx,
   type GameEventCtx,
+  type LeadCtx,
 } from "./epochAssembler";
 import { normalizeGeneratedEpoch } from "./epochNormalizer";
-import { validateEpoch } from "./epochValidator";
-import { computeWorldStateAdvance } from "./worldState";
+import { validateEpoch, type ValidatedEpoch } from "./epochValidator";
+import {
+  computeWorldStateAdvance,
+  type ArcInput,
+  type CompanyCtx,
+} from "./worldState";
 import type { ArcStage } from "./stages";
+import { headlineMovePct } from "./arcTemplates";
+import type { TokenSignal } from "./tokenSignals";
+import { houseToken } from "./tokenRegistry";
+import { sanitizeTweet } from "./tweetVariant";
+import { getTweetPoster } from "./tweetPoster";
 import type { GeneratedNarrativeEpoch } from "./_schemas";
-import type { ValidatedEpoch } from "./epochValidator";
 import {
   isNearDuplicateHeadline,
   pickQuietAngle,
@@ -32,46 +41,30 @@ import {
 } from "./dropAngles";
 import type { Doc } from "../_generated/dataModel";
 
-const FALLBACK_NARRATIVE_GENERATION_SYSTEM = `You are the in-house columnist for a 1980s Wall Street wire service. You are jaded, gossipy, and darkly funny. You have seen every fraud twice and respect none of the participants.
+const FALLBACK_NARRATIVE_GENERATION_SYSTEM = `You are the anonymous columnist for a 1980s stock-wire gossip service. Jaded, gossipy, darkly funny. You cover a handful of listed companies as if it were 1985 — the floor, the tape, the bell, block trades, analysts, "could not be reached for comment."
 
-YOUR JOB: write ONE short dispatch as prose. You do not decide outcomes, numbers, tension, or who wins — that is all handed to you. You make it funny and human.
+RULES (non-negotiable):
+1. NO crypto / finance-tech vocabulary (token, coin, wallet, market cap, onchain, pump, etc.). These are COMPANIES; holdings are shares / common stock.
+2. NO named fictional humans. The only invented voice is the collective desk (the floor, the interns, sources).
+3. Every company story cites a REAL number handed to you. The move is real; your explanation is invented and absurd.
+4. Reactive only: explain moves that already happened; never imply something is about to happen; never attach a story to a company with no real move.
+5. Absurd, not plausible: color lives in the wire's silly world (the interns, the payphone). NEVER invent a realistic company/finance event (deals, launches, listings, investigations, selling), even as a joke.
+6. Real accounts/people: only actual provided statements; never invent quotes, actions, or intentions.
+7. The house company gets harder, self-deprecating, never-promotional coverage.
 
-VOICE RULES:
-- Every post must contain a human detail or a joke. Never output only numbers and jargon.
-- Explain stakes through consequence, not terminology. Not "margin calls intensify" — instead "lenders would like their money back, immediately, in cash."
-- Punch at greed and incompetence. The reader should feel smarter than everyone in the story.
-- Comprehensible and funny to someone with zero finance knowledge.
-- All numbers come from the provided data. Do NOT invent figures, totals, dates, or events.
+Also produce tweetVariant: one tweet ≤270 chars, same voice, real move (SYMBOL +/-N%) + @-mention the company when it's the subject, cashtags ok, NO URLs.
 
-BANNED PHRASES (and anything like them): "watch for fallout", "market responds with heightened anxiety", "concerns mount", "pressure intensifies", and any sentence that could appear in a compliance memo.
-
-CALIBRATION:
-BAD: "Forced liquidations deepen as PanAtlantic reveals an additional $300M asset loss. Market responds with heightened anxiety."
-GOOD: "PanAtlantic misplaced another $300M today, bringing the total to $1.4B, a figure its CFO described as 'temporary' from the back of a taxi. The firm's remaining assets now consist of office furniture and optimism."
-GOOD (real game event): "Desk 0x4f2…a9 entered 'Guaranteed Distressed Debt Opportunity' yesterday. The debt was real. The opportunity was for the other guy. Balance: zero. Deals with 'guaranteed' in the title have a perfect record — for their creators."
-
-OUTPUT: strict JSON matching the schema — dropTitle, exactly one dispatch (role "main", unique kebab-case dispatchKey, category from wire/floor_talk/sec_watch/boardroom/ticker/positioning), entityMentions, confirmedFacts, openQuestions. Headline ≤ 12 words. Body 2–3 complete sentences (every sentence must end with . ! or ?). No prose outside the JSON.`;
+OUTPUT: strict JSON matching the schema. Headline ≤ 12 words. Body 2–3 complete sentences (each ending in . ! or ?). No prose outside the JSON object.`;
 
 type StoredArc = Doc<"narrativeArcs">;
 
 function arcStageOf(arc: StoredArc): ArcStage {
-  return (arc.arcStage as ArcStage | undefined) ?? "rumor";
+  return (arc.arcStage as ArcStage | undefined) ?? "noticed";
 }
 
-/** Is this real event dramatic enough to fire a flash bulletin? */
-function leadIsFlash(
-  leadKind: string,
-  topType: string | undefined,
-  topScore: number
-): boolean {
-  if (leadKind !== "real_event" || !topType) return false;
-  // Per spec: flash only on a wipeout or a top-decile win/loss. A trap or a
-  // leaderboard change leads the post but is not a flash bulletin.
-  if (topType === "wipeout") return true;
-  if ((topType === "big_win" || topType === "big_loss") && topScore >= 70) {
-    return true;
-  }
-  return false;
+function tokenVolumeNote(signal: TokenSignal): string | null {
+  if (!signal.volumeAnomaly || signal.volumeVsTrailing == null) return null;
+  return `Volume ran heavy — roughly ${Math.round(signal.volumeVsTrailing)}× its usual.`;
 }
 
 async function runGenerator(
@@ -90,7 +83,7 @@ async function runGenerator(
   const now = opts.nowMs;
   const { slot, sinceMs } = opts;
 
-  const [seasonData, recentDrops, recentGameEvents, leaderboard] =
+  const [seasonData, recentDrops, recentGameEvents, leaderboard, signals] =
     (await Promise.all([
       ctx.runQuery(internal.wire.internal.loadActiveSeason, {}),
       ctx.runQuery(internal.wire.internal.listRecentDrops, { limit: 10 }),
@@ -98,6 +91,7 @@ async function runGenerator(
         since: sinceMs,
       }),
       ctx.runQuery(api.leaderboard.listTraderStats, { limit: 1 }),
+      ctx.runQuery(internal.wire.tokenSignals.loadTokenSignals, {}),
     ])) as [
       {
         season: Doc<"narrativeSeasons">;
@@ -107,6 +101,7 @@ async function runGenerator(
       Doc<"marketNarratives">[],
       GameEventCtx[],
       Array<{ id: string; name: string }>,
+      TokenSignal[],
     ];
 
   if (!seasonData) {
@@ -122,7 +117,7 @@ async function runGenerator(
   };
   const prevQuietAngleKey = lastWorld.quietAngleKey ?? null;
 
-  // Leaderboard #1 change → synthetic event (prior leader stashed on last drop).
+  // Leaderboard #1 change → synthetic game event.
   const events: GameEventCtx[] = [...recentGameEvents];
   const currentTop = leaderboard[0] ?? null;
   if (
@@ -144,35 +139,38 @@ async function runGenerator(
   const openingBell = isOpeningBell(slot, lastDrop?.epochSlot ?? null);
   const closingBell = isClosingBell(now);
 
-  // ── Code computes the entire world-state advance ──────────────────────────
-  const firmsInput = entities
-    .filter((e) => e.kind === "firm")
-    .map((e) => ({
-      slug: e.slug,
-      displayName: e.displayName,
-      status: e.status,
-      runningLossUsdc: e.runningLossUsdc ?? 0,
-      notableFacts: e.notableFacts ?? [],
-      oneOffEventsFired: e.oneOffEventsFired ?? [],
-      lastLossDayKey: e.lastLossDayKey ?? null,
-    }));
+  // Company roster + lookups.
+  const companyEntities = entities.filter((e) => e.kind === "company");
+  const companies: CompanyCtx[] = companyEntities.map((e) => ({
+    slug: e.slug,
+    displayName: e.displayName,
+    symbol: e.symbol ?? e.slug.toUpperCase(),
+    isHouseToken: e.isHouseToken ?? false,
+  }));
+  const companyBySlug = new Map(companies.map((c) => [c.slug, c]));
+  const signalBySlug = new Map(signals.map((s) => [s.slug, s]));
 
-  const arcsInput = arcs.map((a) => ({
+  // ── Code computes the world-state advance ──
+  const arcsInput: ArcInput[] = arcs.map((a) => ({
     slug: a.slug,
     title: a.title,
     summary: a.summary,
     tensionScore: a.tensionScore,
     arcStage: arcStageOf(a),
-    beatsPublishedByStage: a.beatsPublishedByStage ?? {},
-    climaxFired: a.climaxFired ?? false,
+    peakFired: a.climaxFired ?? false,
     lastBeatDayKey: a.lastBeatDayKey ?? null,
-    templateKey: a.templateKey ?? null,
-    primaryFirmSlug: a.primaryFirmSlug ?? null,
+    subjectSlug: a.primaryFirmSlug ?? null,
+    subjectType: a.primaryFirmSlug
+      ? companyBySlug.has(a.primaryFirmSlug)
+        ? ("company" as const)
+        : ("desk" as const)
+      : null,
   }));
 
   const advance = computeWorldStateAdvance({
     arcs: arcsInput,
-    firms: firmsInput,
+    companies,
+    signals,
     events,
     dayKey,
     dayPosture: posture,
@@ -181,72 +179,105 @@ async function runGenerator(
   });
 
   const arcBySlug = new Map(arcs.map((a) => [a.slug, a]));
-  const firmDeltaBySlug = new Map(advance.firmDeltas.map((d) => [d.slug, d]));
-  const firmBySlug = new Map(firmsInput.map((f) => [f.slug, f]));
 
-  // Assembler arc context (stage/tension are code-set).
-  const assemblerArcs: AssemblerArcCtx[] = advance.arcAdvances
-    .flatMap((adv): AssemblerArcCtx[] => {
-      const arc = arcBySlug.get(adv.slug);
-      if (!arc) return [];
-      const firmSlug = arc.primaryFirmSlug ?? undefined;
-      const delta = firmSlug ? firmDeltaBySlug.get(firmSlug) : undefined;
-      const firm = firmSlug ? firmBySlug.get(firmSlug) : undefined;
-      const firmLoss: number | null =
-        delta?.newRunningLossUsdc ?? firm?.runningLossUsdc ?? null;
-      return [
-        {
-          slug: adv.slug,
-          title: arc.title,
-          summary: arc.summary,
-          tensionScore: adv.newTensionScore,
-          arcStage: adv.toStage,
-          isPrimary: adv.slug === advance.primaryArcSlug,
-          beatThisRun: adv.beatPublishedThisRun,
-          firmLossUsdc: firmLoss,
-          firmDisplayName: firm?.displayName ?? null,
-        },
-      ];
-    })
-    .sort((a, b) => b.tensionScore - a.tensionScore);
-
-  // Firm state context (running totals are code-set).
-  const firmStates: FirmStateCtx[] = [];
-  for (const arc of assemblerArcs) {
-    const stored = arcBySlug.get(arc.slug);
-    const firmSlug = stored?.primaryFirmSlug ?? undefined;
-    if (!firmSlug) continue;
-    const firm = firmBySlug.get(firmSlug);
-    if (!firm) continue;
-    const delta = firmDeltaBySlug.get(firmSlug);
-    firmStates.push({
-      displayName: firm.displayName,
-      status: delta?.newStatus ?? firm.status ?? "healthy",
-      runningLossUsdc: delta?.newRunningLossUsdc ?? firm.runningLossUsdc,
-      newLossDeltaUsdc: delta?.lossDeltaUsdc ?? null,
-      latestFact:
-        delta?.appendNotableFacts[delta.appendNotableFacts.length - 1] ??
-        firm.notableFacts[firm.notableFacts.length - 1] ??
-        null,
+  // ── Assembler ARC STATE: live arcs after advance + spawns ──
+  const liveArcs: AssemblerArcCtx[] = [];
+  for (const adv of advance.arcAdvances) {
+    if (adv.toStage === "retired") continue;
+    const arc = arcBySlug.get(adv.slug);
+    if (!arc) continue;
+    const subjectSlug = arc.primaryFirmSlug ?? null;
+    const company = subjectSlug ? companyBySlug.get(subjectSlug) : undefined;
+    const signal = subjectSlug ? signalBySlug.get(subjectSlug) : undefined;
+    liveArcs.push({
+      slug: adv.slug,
+      title: arc.title,
+      summary: arc.summary,
+      tensionScore: adv.newTensionScore,
+      arcStage: adv.toStage,
+      isPrimary: adv.slug === advance.primaryArcSlug,
+      subjectType: company ? "company" : subjectSlug ? "desk" : null,
+      subjectSymbol: company?.symbol ?? null,
+      subjectCompanyName: company?.displayName ?? null,
+      movePct: signal ? headlineMovePct(signal) : null,
+      streakDays: signal?.streakDays ?? null,
+      isHouseToken: company?.isHouseToken ?? false,
     });
   }
+  for (const spec of advance.spawnRequests) {
+    const company = companyBySlug.get(spec.subjectSlug);
+    const signal = signalBySlug.get(spec.subjectSlug);
+    liveArcs.push({
+      slug: spec.slug,
+      title: spec.title,
+      summary: spec.summary,
+      tensionScore: spec.tensionScore,
+      arcStage: spec.arcStage,
+      isPrimary: spec.slug === advance.primaryArcSlug,
+      subjectType: spec.subjectType,
+      subjectSymbol: company?.symbol ?? null,
+      subjectCompanyName: company?.displayName ?? null,
+      movePct: signal ? headlineMovePct(signal) : null,
+      streakDays: signal?.streakDays ?? null,
+      isHouseToken: company?.isHouseToken ?? false,
+    });
+  }
+  liveArcs.sort((a, b) => b.tensionScore - a.tensionScore);
 
-  // Lead context for the prompt.
+  // ── Company tape ──
+  const companyTape: CompanyTapeCtx[] = signals.map((s) => ({
+    symbol: s.symbol,
+    companyName: s.companyName,
+    xHandle: s.xHandle,
+    isHouseToken: s.isHouseToken,
+    priceUsd: s.priceUsd,
+    move24hPct: s.move24hPct,
+    moveSinceLastPct: s.moveSinceLastPct,
+    streakDays: s.streakDays,
+    volumeVsTrailing: s.volumeVsTrailing,
+    volumeAnomaly: s.volumeAnomaly,
+    classification: s.classification,
+  }));
+
+  // ── Lead context ──
   const lead = advance.lead;
-  const topRanked = lead.ranked[0] ?? null;
-  const leadEvent = lead.leadEvent;
-  const leadLine = leadEvent
-    ? [leadEvent.traderName, leadEvent.traderAddressTrunc]
-        .filter(Boolean)
-        .join(" / ") +
-      (leadEvent.traderName || leadEvent.traderAddressTrunc ? ": " : "") +
-      leadEvent.summary
-    : null;
-  const leadFigureUsdc = leadEvent?.magnitudeUsdc
-    ? Math.abs(leadEvent.magnitudeUsdc)
-    : null;
+  const leadCtx: LeadCtx = {
+    leadKind: lead.leadKind,
+    isFlash: lead.isFlash,
+    patterns: lead.patterns,
+  };
+  let tweetSubjectHandle: string | null = null;
+  let subjectIsHouse = false;
+  if (lead.leadKind === "token" && lead.tokenLead) {
+    const s = lead.tokenLead;
+    leadCtx.tokenSymbol = s.symbol;
+    leadCtx.tokenCompanyName = s.companyName;
+    leadCtx.tokenXHandle = s.xHandle;
+    leadCtx.tokenMovePct = headlineMovePct(s);
+    leadCtx.tokenStreakDays = s.streakDays;
+    leadCtx.tokenIsHouse = s.isHouseToken;
+    leadCtx.tokenVolumeNote = tokenVolumeNote(s);
+    tweetSubjectHandle = s.xHandle;
+    subjectIsHouse = s.isHouseToken;
+  } else if (lead.leadKind === "game_event" && lead.gameLead) {
+    const e = lead.gameLead;
+    const label = e.traderName ?? e.traderAddressTrunc ?? null;
+    leadCtx.gameLine = label ? `${label}: ${e.summary}` : e.summary;
+    leadCtx.gameFigureUsdc =
+      e.magnitudeUsdc != null ? Math.abs(e.magnitudeUsdc) : null;
+  } else {
+    leadCtx.realStatOneLiner = lead.realStatOneLiner ?? null;
+    // A quiet drop whose primary arc is the house company still gets scrutiny.
+    const primaryArc = liveArcs.find((a) => a.isPrimary);
+    if (primaryArc?.subjectType === "company") {
+      tweetSubjectHandle =
+        companyEntities.find((e) => e.symbol === primaryArc.subjectSymbol)
+          ?.xHandle ?? null;
+      subjectIsHouse = primaryArc.isHouseToken ?? false;
+    }
+  }
 
-  const primaryAssemblerArc = assemblerArcs.find((a) => a.isPrimary) ?? null;
+  const house = houseToken();
 
   const buildUserMessage = (quietSlotAngle: DropAngle | null) =>
     assembleUserMessage({
@@ -258,17 +289,24 @@ async function runGenerator(
         forbiddenLanguage: season.forbiddenLanguage,
       },
       dayPosture: posture,
-      arcs: assemblerArcs,
-      firmStates,
-      entities: entities.map((e) => ({
+      mood: advance.mood,
+      lead: leadCtx,
+      companyTape,
+      arcs: liveArcs,
+      entities: companyEntities.map((e) => ({
         slug: e.slug,
         displayName: e.displayName,
         traits: e.traits,
       })),
+      houseTokenName: house?.companyName ?? null,
+      floorTalkClaims: advance.floorTalkClaims,
+      // v1: no automated ingestion; only manually-supplied sourced statements
+      // would appear here (rule 6). Empty until material is provided.
+      sourcedStatements: [],
       recentDrops: recentDrops.map((d) => ({
         epochSlot: d.epochSlot,
         dropTitle: d.dropTitle,
-        worldState: d.worldState as { mood?: string; sec_heat?: number } | null,
+        worldState: d.worldState as { mood?: string } | null,
         headlines: d.headlines as Array<{
           headline?: string;
           role?: string;
@@ -276,40 +314,47 @@ async function runGenerator(
         confirmedFacts: d.confirmedFacts ?? null,
         openQuestions: d.openQuestions ?? null,
       })),
-      recentGameEvents: events,
-      lead: {
-        leadKind: lead.leadKind,
-        leadLine,
-        leadFigureUsdc,
-        realStatOneLiner: lead.realStatOneLiner,
-        patterns: lead.patterns,
-      },
-      floorTalkClaims: advance.floorTalkClaims,
-      mood: advance.mood,
-      secHeat: advance.secHeat,
       isOpeningBell: openingBell,
       isClosingBell: closingBell,
       quietSlotAngle,
     });
 
+  // Allowed percentages for traceability = every real move in the tape.
+  const allowedPercents: number[] = [];
+  for (const s of signals) {
+    for (const p of [s.move24hPct, s.moveSinceLastPct, headlineMovePct(s)]) {
+      if (p != null) allowedPercents.push(Math.abs(Math.round(p)));
+    }
+  }
+
+  const arcSlugs = new Set(liveArcs.map((a) => a.slug));
+  const entitySlugs = new Set(companyEntities.map((e) => e.slug));
+
   const recentHeadlines = recentHeadlinesFromDrops(recentDrops);
   let quietSlotAngle = advance.quietAngle;
   let userMessage = buildUserMessage(quietSlotAngle);
 
-  // ── LLM call (prose only) or test stub ────────────────────────────────────
+  // ── LLM call (prose only) or test stub ──
   let validated: ValidatedEpoch;
+  const validateWarningsRef: { warnings: string[] } = { warnings: [] };
+
   if (opts.testLlmStub) {
     const normalized = normalizeGeneratedEpoch(opts.testLlmStub);
     const validation = validateEpoch(normalized.epoch, {
-      arcSlugs: new Set(arcs.map((a) => a.slug)),
-      entitySlugs: new Set(entities.map((e) => e.slug)),
+      arcSlugs,
+      entitySlugs,
       forbiddenLanguage: season.forbiddenLanguage,
+      allowedPercents,
+      subjectIsHouse,
     });
-    if (!validation.ok) {
-      console.error(`[wire/generator] validation failed: ${validation.error}`);
-      return { skipped: "validation-failed", error: validation.error };
+    if (!validation.ok || !validation.data) {
+      return {
+        skipped: "validation-failed",
+        error: validation.error ?? "unknown",
+      };
     }
     validated = validation.data;
+    validateWarningsRef.warnings = validation.warnings;
   } else {
     const OpenAI = (await import("openai")).default;
     const { zodResponseFormat } = await import("openai/helpers/zod");
@@ -323,8 +368,6 @@ async function runGenerator(
       systemPromptContent ?? FALLBACK_NARRATIVE_GENERATION_SYSTEM;
 
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-    const arcSlugs = new Set(arcs.map((a) => a.slug));
-    const entitySlugs = new Set(entities.map((e) => e.slug));
 
     let validationError: string | null = null;
     const llmResult = await (async (): Promise<ValidatedEpoch | null> => {
@@ -359,31 +402,38 @@ async function runGenerator(
           arcSlugs,
           entitySlugs,
           forbiddenLanguage: season.forbiddenLanguage,
+          allowedPercents,
+          subjectIsHouse,
         });
-        if (!validation.ok) {
+        if (!validation.ok || !validation.data) {
           console.error(
             `[wire/generator] validation failed: ${validation.error}`
           );
-          validationError = validation.error;
+          validationError = validation.error ?? "unknown";
           return null;
         }
 
         const headline = validation.data.dispatches[0]?.headline ?? "";
         const isDup = isNearDuplicateHeadline(headline, recentHeadlines);
-        if (!isDup || attempt === 1 || !quietSlotAngle) {
+        if (!isDup || attempt === 1) {
+          validateWarningsRef.warnings = validation.warnings;
           return validation.data;
         }
 
-        const dupHeadline = headline;
-        quietSlotAngle = pickQuietAngle(
-          `${slot}:${dayKey}:retry`,
-          quietSlotAngle.key
-        );
+        // Near-duplicate of a recent drop — retry with a fresh angle. For quiet
+        // slots rotate the coded angle too; for a persistent mover just demand a
+        // new voice on the same real facts.
+        if (quietSlotAngle) {
+          quietSlotAngle = pickQuietAngle(
+            `${slot}:${dayKey}:retry`,
+            quietSlotAngle.key
+          );
+        }
         userMessage =
           buildUserMessage(quietSlotAngle) +
-          `\n\nRETRY: Your headline "${dupHeadline}" is too similar to a recent post. Take a different angle — same facts, new voice.`;
+          `\n\nRETRY: Your headline "${headline}" is too similar to a recent post. Same real facts and figures, completely different angle and wording — do not repeat the prior headline's structure.`;
         console.warn(
-          `[wire/generator] near-duplicate headline detected, retrying with angle ${quietSlotAngle.key}`
+          `[wire/generator] near-duplicate headline, retrying (slot ${slot})`
         );
       }
       throw new Error("[wire/generator] exhausted LLM retry attempts");
@@ -397,63 +447,91 @@ async function runGenerator(
     validated = llmResult;
   }
 
-  // ── Attach code-owned structured fields to the stored dispatch ────────────
-  const primaryFirmSlug = primaryAssemblerArc
-    ? (arcBySlug.get(primaryAssemblerArc.slug)?.primaryFirmSlug ?? null)
-    : null;
-  const primaryFirmDelta = primaryFirmSlug
-    ? firmDeltaBySlug.get(primaryFirmSlug)
-    : undefined;
+  if (validateWarningsRef.warnings.length > 0) {
+    console.warn(
+      `[wire/generator] soft warnings (slot ${slot}): ${validateWarningsRef.warnings.join(", ")}`
+    );
+  }
 
-  const storedDispatches = validated.dispatches.map((d, i) => {
-    if (
-      i === 0 &&
-      lead.leadKind === "fiction" &&
-      primaryFirmSlug &&
-      primaryFirmDelta &&
-      primaryFirmDelta.newRunningLossUsdc > 0
-    ) {
-      return {
-        ...d,
-        materialChange: {
-          kind: "asset_loss" as const,
-          entitySlug: primaryFirmSlug,
-          magnitude: { unitsUsdc: primaryFirmDelta.newRunningLossUsdc },
-        },
-      };
-    }
-    return { ...d, materialChange: null };
+  // ── Tweet: sanitize (strip/reject URLs, ≤280, ensure @handle), then post ──
+  const sanitized = sanitizeTweet(validated.tweetVariant, {
+    subjectHandle: tweetSubjectHandle,
   });
+  let tweetStatus: string;
+  if (!sanitized.ok) {
+    tweetStatus = "skipped";
+    console.warn(
+      `[wire/generator] tweet skipped (slot ${slot}): ${sanitized.issues.join(", ")}`
+    );
+  } else {
+    const poster = getTweetPoster();
+    const result = await poster.post({
+      text: sanitized.text,
+      epoch: slot,
+      subjectHandle: tweetSubjectHandle,
+    });
+    tweetStatus = result.status;
+  }
 
-  const isFlash = leadIsFlash(
-    lead.leadKind,
-    topRanked?.event.type,
-    topRanked?.score ?? 0
-  );
+  // ── Stored dispatch + code-owned fields ──
+  const storedDispatches = validated.dispatches.map((d) => ({
+    ...d,
+    materialChange: null,
+  }));
+
+  const displayArc = liveArcs[0] ?? null;
+  const topArcTitle = displayArc?.title ?? "Quiet tape";
+  const topArcTension = displayArc?.tensionScore ?? 0;
+  const topArcStage = displayArc?.arcStage;
 
   const signal =
     lead.patterns.length > 0
       ? `trap-pattern:${lead.patterns[0].phrase}`
-      : leadEvent?.type === "wipeout"
-        ? "wipeout-flash"
-        : null;
-
-  // Display top-arc = highest-tension arc after advancing (assemblerArcs is
-  // sorted desc), which naturally skips an arc that just retired to tension 0.
-  const displayArc = assemblerArcs[0] ?? primaryAssemblerArc;
-  const topArcTitle = displayArc?.title ?? "Unknown";
-  const topArcTension = displayArc?.tensionScore ?? 0;
-  const topArcStage = displayArc?.arcStage;
+      : lead.leadKind === "token" && lead.isFlash
+        ? "flash-move"
+        : lead.gameLead?.type === "wipeout"
+          ? "wipeout-flash"
+          : null;
 
   const worldState = {
     mood: advance.mood,
-    sec_heat: advance.secHeat,
+    primaryArcSlug: advance.primaryArcSlug,
     topTraderId: currentTop?.id ?? lastWorld.topTraderId ?? null,
     quietAngleKey: quietSlotAngle?.key ?? advance.quietAngle?.key ?? null,
     floorTalkTruth: advance.floorTalkClaims.map((c) => ({
       text: c.text,
       isTrue: c.isTrue,
     })),
+  };
+
+  // ── Source trace: every number/event maps to a stored datum ──
+  const tracedSignals = signals
+    .filter((s) => s.classification !== "none")
+    .map((s) => ({
+      symbol: s.symbol,
+      slug: s.slug,
+      move24hPct: s.move24hPct,
+      moveSinceLastPct: s.moveSinceLastPct,
+      streakDays: s.streakDays,
+      volumeVsTrailing: s.volumeVsTrailing,
+      classification: s.classification,
+      refSnapshotIds: s.refSnapshotIds,
+    }));
+  const sourceTrace = {
+    leadKind: lead.leadKind,
+    isFlash: lead.isFlash,
+    primaryArcSlug: advance.primaryArcSlug,
+    mood: advance.mood,
+    thresholds: {
+      routinePct: allowedPercents.length,
+    },
+    tokenSignals: tracedSignals,
+    gameEventIds: events
+      .map((e) => ({ type: e.type, traderId: e.traderId, dealId: e.dealId }))
+      .filter((e) => e.traderId || e.dealId),
+    tweetSubjectHandle,
+    tweetSanitizeIssues: sanitized.issues,
+    validatorWarnings: validateWarningsRef.warnings,
   };
 
   const arcRefSlugs = new Set<string>();
@@ -479,24 +557,20 @@ async function runGenerator(
       confirmedFacts: validated.confirmedFacts,
       openQuestions: validated.openQuestions,
       subjects: lead.subjects,
-      isFlash,
+      isFlash: lead.isFlash,
       signal,
+      tweetVariant: sanitized.text,
+      tweetStatus,
+      tweetSubjectHandle,
+      sourceTrace,
       arcRefs,
       arcAdvances: advance.arcAdvances.map((a) => ({
         arcSlug: a.slug,
         toStage: a.toStage,
         newTensionScore: a.newTensionScore,
-        climaxFiringNow: a.climaxFiringNow,
+        peakFiringNow: a.peakFiringNow,
         retiring: a.retiring,
-        newBeatsPublishedByStage: a.newBeatsPublishedByStage,
         newLastBeatDayKey: a.newLastBeatDayKey,
-      })),
-      firmDeltas: advance.firmDeltas.map((d) => ({
-        firmSlug: d.slug,
-        newRunningLossUsdc: d.newRunningLossUsdc,
-        newStatus: d.newStatus,
-        appendNotableFacts: d.appendNotableFacts,
-        lastLossDayKey: d.lastLossDayKey,
       })),
       spawnRequests: advance.spawnRequests,
       eventsIngested: events.length > 0 ? events : undefined,

--- a/convex/wire/operatorActions.ts
+++ b/convex/wire/operatorActions.ts
@@ -17,9 +17,8 @@ type ResetResult = {
   };
   imported: {
     seasonId: string;
-    entitiesUpserted: number;
-    arcsUpserted: number;
-    dropInserted: boolean;
+    companiesSynced: number;
+    companiesRemoved: number;
   };
 };
 

--- a/convex/wire/persist.ts
+++ b/convex/wire/persist.ts
@@ -1,23 +1,14 @@
 import { internalMutation } from "../_generated/server";
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
-import { STAGE_TARGET_TENSION } from "./stages";
 
 const arcStageValidator = v.union(
-  v.literal("rumor"),
-  v.literal("denial"),
-  v.literal("confirmation"),
-  v.literal("escalation"),
-  v.literal("climax"),
+  v.literal("noticed"),
+  v.literal("talked_about"),
+  v.literal("frenzy"),
+  v.literal("peak"),
   v.literal("aftermath"),
   v.literal("retired")
-);
-
-const firmStatusValidator = v.union(
-  v.literal("healthy"),
-  v.literal("stressed"),
-  v.literal("collapsing"),
-  v.literal("dead")
 );
 
 const subjectValidator = v.object({
@@ -26,13 +17,12 @@ const subjectValidator = v.object({
 });
 
 /**
- * Idempotent epoch writer. All numbers, stages, and statuses are computed by
- * code (worldState.ts) and handed in here — this mutation only persists them:
+ * Idempotent epoch writer. All numbers, stages, and arcs are computed by code
+ * (worldState.ts) and handed in here — this mutation only persists them:
  *
- *   - inserts the marketNarratives drop (with code-attached subjects/flash/etc.)
- *   - patches each firm entity's running loss + status + notable facts
- *   - patches each arc's stage / tension / beats / climaxFired (retires when done)
- *   - inserts freshly spawned firm + character entities and their new arc
+ *   - inserts the marketNarratives drop (+ tweet variant + source trace)
+ *   - patches each arc's stage / tension / lastBeatDayKey (retires when done)
+ *   - inserts freshly spawned arcs (company or desk streaks)
  *
  * Re-checks byEpochSlot inside the transaction; returns { inserted: false } if
  * the slot was already written.
@@ -52,28 +42,33 @@ export const persistGeneratedEpoch = internalMutation({
     subjects: v.optional(v.array(subjectValidator)),
     isFlash: v.optional(v.boolean()),
     signal: v.optional(v.union(v.string(), v.null())),
+    tweetVariant: v.optional(v.string()),
+    tweetStatus: v.optional(v.string()),
+    tweetSubjectHandle: v.optional(v.union(v.string(), v.null())),
+    sourceTrace: v.optional(v.any()),
     arcRefs: v.array(v.id("narrativeArcs")),
     arcAdvances: v.array(
       v.object({
         arcSlug: v.string(),
         toStage: arcStageValidator,
         newTensionScore: v.number(),
-        climaxFiringNow: v.boolean(),
+        peakFiringNow: v.boolean(),
         retiring: v.boolean(),
-        newBeatsPublishedByStage: v.record(v.string(), v.number()),
         newLastBeatDayKey: v.union(v.string(), v.null()),
       })
     ),
-    firmDeltas: v.array(
+    spawnRequests: v.array(
       v.object({
-        firmSlug: v.string(),
-        newRunningLossUsdc: v.number(),
-        newStatus: firmStatusValidator,
-        appendNotableFacts: v.array(v.string()),
-        lastLossDayKey: v.string(),
+        slug: v.string(),
+        title: v.string(),
+        summary: v.string(),
+        subjectType: v.union(v.literal("company"), v.literal("desk")),
+        subjectSlug: v.string(),
+        entitySlug: v.union(v.string(), v.null()),
+        arcStage: arcStageValidator,
+        tensionScore: v.number(),
       })
     ),
-    spawnRequests: v.array(v.any()),
     eventsIngested: v.optional(v.any()),
     rawNarrative: v.string(),
   },
@@ -92,9 +87,12 @@ export const persistGeneratedEpoch = internalMutation({
       subjects,
       isFlash,
       signal,
+      tweetVariant,
+      tweetStatus,
+      tweetSubjectHandle,
+      sourceTrace,
       arcRefs,
       arcAdvances,
-      firmDeltas,
       spawnRequests,
       eventsIngested,
       rawNarrative,
@@ -134,33 +132,16 @@ export const persistGeneratedEpoch = internalMutation({
       arcStage: topArcStage,
       isFlash,
       signal: signal ?? undefined,
+      tweetVariant,
+      tweetStatus,
+      tweetSubjectHandle: tweetSubjectHandle ?? undefined,
+      sourceTrace: sourceTrace ?? undefined,
       eventsIngested: eventsIngested ?? null,
       rawNarrative,
       createdAt: now,
     });
 
-    // ── Firm running-loss + status + facts (code-decided) ───────────────────
-    for (const delta of firmDeltas) {
-      const firm = await ctx.db
-        .query("narrativeEntities")
-        .withIndex("bySeasonAndSlug", (q) =>
-          q.eq("seasonId", seasonId).eq("slug", delta.firmSlug)
-        )
-        .unique();
-      if (!firm) continue;
-      const notableFacts = [
-        ...(firm.notableFacts ?? []),
-        ...delta.appendNotableFacts,
-      ];
-      await ctx.db.patch(firm._id, {
-        runningLossUsdc: delta.newRunningLossUsdc,
-        status: delta.newStatus,
-        notableFacts,
-        lastLossDayKey: delta.lastLossDayKey,
-      });
-    }
-
-    // ── Arc stage / tension / beats (code-decided) ──────────────────────────
+    // ── Arc stage / tension / lastBeat (code-decided) ──
     for (const adv of arcAdvances) {
       const arc = await ctx.db
         .query("narrativeArcs")
@@ -172,8 +153,7 @@ export const persistGeneratedEpoch = internalMutation({
       await ctx.db.patch(arc._id, {
         arcStage: adv.toStage,
         tensionScore: adv.newTensionScore,
-        beatsPublishedByStage: adv.newBeatsPublishedByStage,
-        ...(adv.climaxFiringNow ? { climaxFired: true } : {}),
+        ...(adv.peakFiringNow ? { climaxFired: true } : {}),
         ...(adv.newLastBeatDayKey
           ? { lastBeatDayKey: adv.newLastBeatDayKey }
           : {}),
@@ -183,70 +163,30 @@ export const persistGeneratedEpoch = internalMutation({
       });
     }
 
-    // ── Spawn fresh arcs + their entities ───────────────────────────────────
-    for (const spec of spawnRequests as Array<{
-      templateKey: string;
-      slug: string;
-      title: string;
-      summary: string;
-      firm: {
-        slug: string;
-        displayName: string;
-        aliases: string[];
-        bio: string;
-        traits: string[];
-      };
-      character: {
-        slug: string;
-        displayName: string;
-        aliases: string[];
-        bio: string;
-        traits: string[];
-        kind: "trader" | "regulator" | "politician";
-      };
-    }>) {
-      const entityRefs: Id<"narrativeEntities">[] = [];
-
-      const firmId = await ctx.db.insert("narrativeEntities", {
-        seasonId,
-        slug: spec.firm.slug,
-        kind: "firm" as const,
-        displayName: spec.firm.displayName,
-        aliases: spec.firm.aliases,
-        bio: spec.firm.bio,
-        traits: spec.firm.traits,
-        status: "healthy" as const,
-        runningLossUsdc: 0,
-        notableFacts: [],
-        oneOffEventsFired: [],
-        createdAt: now,
-      });
-      entityRefs.push(firmId);
-
-      const charId = await ctx.db.insert("narrativeEntities", {
-        seasonId,
-        slug: spec.character.slug,
-        kind: spec.character.kind,
-        displayName: spec.character.displayName,
-        aliases: spec.character.aliases,
-        bio: spec.character.bio,
-        traits: spec.character.traits,
-        createdAt: now,
-      });
-      entityRefs.push(charId);
-
+    // ── Spawn fresh arcs (company / desk streaks) ──
+    for (const spec of spawnRequests) {
+      let entityRefs: Id<"narrativeEntities">[] = [];
+      if (spec.entitySlug) {
+        const entity = await ctx.db
+          .query("narrativeEntities")
+          .withIndex("bySeasonAndSlug", (q) =>
+            q.eq("seasonId", seasonId).eq("slug", spec.entitySlug!)
+          )
+          .unique();
+        if (entity) entityRefs = [entity._id];
+      }
       await ctx.db.insert("narrativeArcs", {
         seasonId,
         slug: spec.slug,
         title: spec.title,
         summary: spec.summary,
         status: "active" as const,
-        tensionScore: STAGE_TARGET_TENSION.rumor,
-        arcStage: "rumor" as const,
+        tensionScore: spec.tensionScore,
+        arcStage: spec.arcStage,
         beatsPublishedByStage: {},
-        climaxFired: false,
-        templateKey: spec.templateKey,
-        primaryFirmSlug: spec.firm.slug,
+        climaxFired: spec.arcStage === "peak",
+        primaryFirmSlug: spec.subjectSlug,
+        lastBeatDayKey: undefined,
         entityRefs,
         lastTouchedAt: now,
         createdAt: now,

--- a/convex/wire/priceConfig.ts
+++ b/convex/wire/priceConfig.ts
@@ -1,0 +1,36 @@
+/**
+ * Price / movement thresholds — pure config, no logic. These live here (not
+ * inlined in the engine) so the wire's sensitivity can be retuned without
+ * touching code. All percentages are absolute price moves in percent.
+ *
+ * How a move is classified (see tokenSignals.ts):
+ *   |move| >= flashPct    → flash bulletin (a threshold event)
+ *   |move| >= storyPct    → a story (spawns/advances an attention arc)
+ *   |move| >= routinePct  → routine mention on the tape
+ *   otherwise             → not worth a line
+ * A multi-day streak of STREAK_MIN_DAYS or more is always at least a story.
+ */
+
+export const MOVE_THRESHOLDS = {
+  /** Worth a one-line mention on the tape. */
+  routinePct: 5,
+  /** Worth its own story; spawns or advances an attention arc. */
+  storyPct: 12,
+  /** Fires a flash bulletin. */
+  flashPct: 20,
+} as const;
+
+/** 24h volume this many times the trailing daily average = a volume anomaly. */
+export const VOLUME_ANOMALY_MULTIPLE = 3;
+
+/** Consecutive same-direction days that count as a streak ("third straight red day"). */
+export const STREAK_MIN_DAYS = 3;
+
+/** Days of daily-close history used for the trailing volume average + streaks. */
+export const TRAILING_VOLUME_DAYS = 7;
+
+/** Spacing between per-token CoinGecko fetches (ms), to respect Demo rate limits. */
+export const POLL_SPACING_MS = 300;
+
+/** Max snapshots read per token per signal computation (~7.5 days hourly). */
+export const SIGNAL_SNAPSHOT_LOOKBACK = 200;

--- a/convex/wire/pricePoll.ts
+++ b/convex/wire/pricePoll.ts
@@ -1,0 +1,186 @@
+"use node";
+
+/**
+ * CoinGecko price poller. Runs on its own hourly cron (NOT market-hours gated,
+ * so overnight/weekend moves are captured and reported at the next open) and
+ * writes one snapshot per registry token.
+ *
+ * Endpoint: the CoinGecko onchain (GeckoTerminal-derived) token endpoint, keyed
+ * by Base contract address. These are small-cap tokens that do not resolve via
+ * the listed-coins endpoint. A failed fetch writes an `ok: false` snapshot with
+ * the error and NO fabricated numbers, and logs a flag — the token is never
+ * silently dropped.
+ */
+
+import { internalAction } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { TOKEN_REGISTRY } from "./tokenRegistry";
+import { POLL_SPACING_MS } from "./priceConfig";
+import { getTodayDateNY } from "../lib/tradingHours";
+
+const CG_BASE = "https://api.coingecko.com/api/v3";
+const FETCH_TIMEOUT_MS = 15_000;
+
+interface ParsedSnapshot {
+  address: string;
+  symbol: string;
+  priceUsd?: number;
+  volume24hUsd?: number;
+  marketCapUsd?: number;
+  fdvUsd?: number;
+  priceChange24hPct?: number;
+  source: string;
+  ok: boolean;
+  error?: string;
+  dayKey: string;
+}
+
+function num(x: unknown): number | undefined {
+  if (x == null) return undefined;
+  const n = typeof x === "number" ? x : parseFloat(String(x));
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Pick the deepest (highest-reserve) included pool for a token, if any. */
+function topPoolAttrs(
+  included:
+    | Array<{ type?: string; attributes?: Record<string, unknown> }>
+    | undefined
+): Record<string, unknown> | undefined {
+  if (!included) return undefined;
+  const pools = included.filter((i) => i.type === "pool" && i.attributes);
+  if (pools.length === 0) return undefined;
+  pools.sort(
+    (a, b) =>
+      (num(b.attributes?.reserve_in_usd) ?? 0) -
+      (num(a.attributes?.reserve_in_usd) ?? 0)
+  );
+  return pools[0].attributes;
+}
+
+async function fetchOnchainToken(
+  addressLc: string,
+  symbol: string,
+  apiKey: string,
+  dayKey: string
+): Promise<ParsedSnapshot> {
+  // include=top_pools so we also get the 24h price change, which the token
+  // endpoint itself does not carry (it lives on the pool).
+  const url = `${CG_BASE}/onchain/networks/base/tokens/${addressLc}?include=top_pools`;
+  try {
+    const res = await fetch(url, {
+      headers: { accept: "application/json", "x-cg-demo-api-key": apiKey },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        address: addressLc,
+        symbol,
+        source: "none",
+        ok: false,
+        error: `HTTP ${res.status} ${body.slice(0, 200)}`,
+        dayKey,
+      };
+    }
+    const json = (await res.json()) as {
+      data?: { attributes?: Record<string, unknown> };
+      included?: Array<{ type?: string; attributes?: Record<string, unknown> }>;
+    };
+    const attr = json?.data?.attributes;
+    const price = num(attr?.price_usd);
+    if (!attr || price == null) {
+      return {
+        address: addressLc,
+        symbol,
+        source: "none",
+        ok: false,
+        error: "no price_usd in onchain response",
+        dayKey,
+      };
+    }
+    const vol = attr.volume_usd as Record<string, unknown> | undefined;
+    const pool = topPoolAttrs(json.included);
+    const poolChg = pool?.price_change_percentage as
+      | Record<string, unknown>
+      | undefined;
+    return {
+      address: addressLc,
+      symbol,
+      priceUsd: price,
+      volume24hUsd: num(vol?.h24),
+      marketCapUsd: num(attr.market_cap_usd),
+      fdvUsd: num(attr.fdv_usd),
+      priceChange24hPct: num(poolChg?.h24),
+      source: "coingecko-onchain",
+      ok: true,
+      dayKey,
+    };
+  } catch (err) {
+    return {
+      address: addressLc,
+      symbol,
+      source: "none",
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+      dayKey,
+    };
+  }
+}
+
+export const pollPrices = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    // Reconcile company entities from the registry first (hot-swap support).
+    await ctx.runMutation(internal.wire.registrySync.syncRegistryEntities, {});
+
+    const apiKey = process.env.COINGECKO_API_KEY;
+    if (!apiKey) {
+      console.error(
+        "[wire/pricePoll] COINGECKO_API_KEY not set — writing failure snapshots"
+      );
+    }
+
+    const now = Date.now();
+    const dayKey = getTodayDateNY(now);
+    const snapshots: ParsedSnapshot[] = [];
+
+    for (const token of TOKEN_REGISTRY) {
+      if (!apiKey) {
+        snapshots.push({
+          address: token.addressLc,
+          symbol: token.symbol,
+          source: "none",
+          ok: false,
+          error: "COINGECKO_API_KEY not set",
+          dayKey,
+        });
+        continue;
+      }
+      const snap = await fetchOnchainToken(
+        token.addressLc,
+        token.symbol,
+        apiKey,
+        dayKey
+      );
+      if (!snap.ok) {
+        console.error(
+          `[wire/pricePoll] unresolved ${token.symbol} (${token.addressLc}): ${snap.error}`
+        );
+      }
+      snapshots.push(snap);
+      // Space calls to respect Demo-tier rate limits.
+      await new Promise((r) => setTimeout(r, POLL_SPACING_MS));
+    }
+
+    await ctx.runMutation(internal.wire.priceStore.insertSnapshots, {
+      snapshots,
+    });
+
+    const okCount = snapshots.filter((s) => s.ok).length;
+    console.log(
+      `[wire/pricePoll] wrote ${snapshots.length} snapshots (${okCount} ok, ${snapshots.length - okCount} failed)`
+    );
+    return { total: snapshots.length, ok: okCount };
+  },
+});

--- a/convex/wire/priceStore.ts
+++ b/convex/wire/priceStore.ts
@@ -1,0 +1,46 @@
+/**
+ * Snapshot writer for the price poller. Lives in its own (non-Node) module
+ * because `pricePoll.ts` is a `"use node"` action file, and Convex only allows
+ * actions in Node files — mutations must be defined elsewhere.
+ */
+
+import { internalMutation } from "../_generated/server";
+import { v } from "convex/values";
+
+interface ParsedSnapshot {
+  address: string;
+  symbol: string;
+  priceUsd?: number;
+  volume24hUsd?: number;
+  marketCapUsd?: number;
+  fdvUsd?: number;
+  priceChange24hPct?: number;
+  source: string;
+  ok: boolean;
+  error?: string;
+  dayKey: string;
+}
+
+export const insertSnapshots = internalMutation({
+  args: { snapshots: v.array(v.any()) },
+  handler: async (ctx, { snapshots }) => {
+    const now = Date.now();
+    for (const s of snapshots as ParsedSnapshot[]) {
+      await ctx.db.insert("tokenSnapshots", {
+        address: s.address,
+        symbol: s.symbol,
+        priceUsd: s.priceUsd,
+        volume24hUsd: s.volume24hUsd,
+        marketCapUsd: s.marketCapUsd,
+        fdvUsd: s.fdvUsd,
+        priceChange24hPct: s.priceChange24hPct,
+        source: s.source,
+        ok: s.ok,
+        error: s.error,
+        dayKey: s.dayKey,
+        createdAt: now,
+      });
+    }
+    return { inserted: snapshots.length };
+  },
+});

--- a/convex/wire/registrySync.ts
+++ b/convex/wire/registrySync.ts
@@ -1,0 +1,109 @@
+/**
+ * Reconciles the active season's company entities with `tokens.json`. Runs at
+ * the top of every price-poll cycle so that adding / removing / editing an entry
+ * in the registry takes effect on the next cycle with no code changes:
+ *   - upserts one `narrativeEntities` (kind "company") row per registry entry
+ *   - retires arcs of, and deletes, company entities no longer in the registry
+ *
+ * Company metadata (symbol, handle, address, house-token flag) is authoritative
+ * from the registry; narrative continuity fields (notableFacts, etc.) persist.
+ *
+ * The core is exported as a plain helper so both this internalMutation and the
+ * public `seasons:importSeason` mutation can run it inside their own transaction
+ * (Convex mutations cannot call other mutations).
+ */
+
+import { internalMutation } from "../_generated/server";
+import type { MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { TOKEN_REGISTRY } from "./tokenRegistry";
+
+export async function upsertRegistryCompanies(
+  ctx: MutationCtx,
+  seasonId: Id<"narrativeSeasons">
+): Promise<{ synced: number; removed: number }> {
+  const now = Date.now();
+  const registrySlugs = new Set(TOKEN_REGISTRY.map((t) => t.slug));
+  let synced = 0;
+
+  for (const token of TOKEN_REGISTRY) {
+    const existing = await ctx.db
+      .query("narrativeEntities")
+      .withIndex("bySeasonAndSlug", (q) =>
+        q.eq("seasonId", seasonId).eq("slug", token.slug)
+      )
+      .unique();
+
+    const bio =
+      token.notes ??
+      `${token.companyName} (${token.symbol}), a company listed on this exchange.`;
+    const fields = {
+      kind: "company" as const,
+      displayName: token.companyName,
+      aliases: [token.symbol, token.companyName],
+      bio,
+      traits: [] as string[],
+      symbol: token.symbol,
+      xHandle: token.xHandle,
+      address: token.addressLc,
+      isHouseToken: token.isHouseToken ?? false,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, fields);
+    } else {
+      await ctx.db.insert("narrativeEntities", {
+        seasonId,
+        slug: token.slug,
+        ...fields,
+        notableFacts: [],
+        oneOffEventsFired: [],
+        createdAt: now,
+      });
+    }
+    synced++;
+  }
+
+  // Retire + remove company entities no longer in the registry.
+  const seasonEntities = await ctx.db
+    .query("narrativeEntities")
+    .withIndex("bySeason", (q) => q.eq("seasonId", seasonId))
+    .collect();
+  let removed = 0;
+  for (const entity of seasonEntities) {
+    if (entity.kind !== "company" || registrySlugs.has(entity.slug)) continue;
+    const arcs = await ctx.db
+      .query("narrativeArcs")
+      .withIndex("bySeason", (q) => q.eq("seasonId", seasonId))
+      .collect();
+    for (const arc of arcs) {
+      if (arc.primaryFirmSlug === entity.slug && arc.status === "active") {
+        await ctx.db.patch(arc._id, {
+          status: "abandoned" as const,
+          arcStage: "retired" as const,
+          tensionScore: 0,
+          updatedAt: now,
+        });
+      }
+    }
+    await ctx.db.delete(entity._id);
+    removed++;
+  }
+
+  return { synced, removed };
+}
+
+export const syncRegistryEntities = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const season = await ctx.db
+      .query("narrativeSeasons")
+      .withIndex("byIsActive", (q) => q.eq("isActive", true))
+      .first();
+    if (!season) {
+      return { synced: 0, removed: 0, seasonMissing: true as const };
+    }
+    const res = await upsertRegistryCompanies(ctx, season._id);
+    return { ...res, seasonMissing: false as const };
+  },
+});

--- a/convex/wire/stages.ts
+++ b/convex/wire/stages.ts
@@ -1,120 +1,52 @@
 /**
  * Arc lifecycle constants + deterministic helpers — pure, no Convex imports.
  *
- * The wire engine advances arcs through this pipeline by code (never the LLM):
- *   rumor → denial → confirmation → escalation → climax (once) → aftermath → retired
+ * Arcs track ATTENTION, not fabricated losses. A company (or desk) on a
+ * sustained move rises through these stages as the floor pays more attention,
+ * then falls to aftermath/retired when the move cools:
  *
- * `tensionScore`, firm `runningLossUsdc`, mood, and SEC heat are all derived
- * from these constants so totals stay monotonic and reproducible across runs.
+ *   noticed → talked_about → frenzy → peak (once) → aftermath → retired
+ *
+ * The stage and its tensionScore are DERIVED FROM REAL SIGNALS by code (see
+ * worldState.ts); the LLM never picks a stage or a number. (Kept in sync with
+ * the arcStageValidator in convex/schema.ts.)
  */
 
 export const ARC_STAGES = [
-  "rumor",
-  "denial",
-  "confirmation",
-  "escalation",
-  "climax",
+  "noticed",
+  "talked_about",
+  "frenzy",
+  "peak",
   "aftermath",
   "retired",
 ] as const;
 
 export type ArcStage = (typeof ARC_STAGES)[number];
 
-/** Live (non-retired) stages, in order. */
+/** Live (non-retired) stages, in escalation order. */
 export const LIVE_STAGES: ArcStage[] = [
-  "rumor",
-  "denial",
-  "confirmation",
-  "escalation",
-  "climax",
+  "noticed",
+  "talked_about",
+  "frenzy",
+  "peak",
   "aftermath",
 ];
 
-/** Target tension each stage settles at (code sets tensionScore to this ±jitter). */
+/** Tension each stage settles at (code sets tensionScore to this). */
 export const STAGE_TARGET_TENSION: Record<ArcStage, number> = {
-  rumor: 3,
-  denial: 4,
-  confirmation: 6,
-  escalation: 8,
-  climax: 10,
+  noticed: 4,
+  talked_about: 6,
+  frenzy: 8,
+  peak: 10,
   aftermath: 3,
   retired: 0,
 };
 
-/** Beats that must publish in a stage before the arc may advance. */
-export const STAGE_BEAT_QUOTA: Record<ArcStage, number> = {
-  rumor: 2,
-  denial: 1,
-  confirmation: 1,
-  escalation: 2,
-  climax: 1,
-  aftermath: 2,
-  retired: 0,
-};
-
-/** Next stage in the pipeline (retired is terminal). */
-export function nextStage(stage: ArcStage): ArcStage {
-  const idx = ARC_STAGES.indexOf(stage);
-  if (idx < 0 || stage === "retired") return "retired";
-  return ARC_STAGES[idx + 1] ?? "retired";
-}
-
 /**
- * Per-stage fraction of a firm's peak loss. Monotonic up to climax, frozen
- * after — so a firm's running loss total never decreases (acceptance: totals
- * are monotonic and consistent across runs).
- */
-export const LOSS_BAND_FRACTIONS: Record<ArcStage, number> = {
-  rumor: 0,
-  denial: 0.1,
-  confirmation: 0.3,
-  escalation: 0.64,
-  climax: 1,
-  aftermath: 1,
-  retired: 1,
-};
-
-/** Default peak loss for hand-seeded arcs with no spawn template. */
-export const DEFAULT_PEAK_LOSS_USDC = 500_000_000;
-
-/** Target running-loss total (USDC) a firm reaches at a given stage. */
-export function targetLossUsdc(peakUsdc: number, stage: ArcStage): number {
-  return Math.round(peakUsdc * LOSS_BAND_FRACTIONS[stage]);
-}
-
-/** Deterministic per-firm peak so totals vary firm-to-firm but stay stable. */
-export function peakLossForFirm(
-  firmSlug: string,
-  basePeakUsdc: number
-): number {
-  const scalePct = 85 + seededInt(`peak:${firmSlug}`, 0, 30); // 0.85–1.15×
-  return Math.round((basePeakUsdc * scalePct) / 100);
-}
-
-/** Firm health derived purely from its arc's stage. */
-export function firmStatusForStage(
-  stage: ArcStage
-): "healthy" | "stressed" | "collapsing" | "dead" {
-  switch (stage) {
-    case "rumor":
-    case "denial":
-      return "healthy";
-    case "confirmation":
-      return "stressed";
-    case "escalation":
-    case "climax":
-      return "collapsing";
-    case "aftermath":
-    case "retired":
-      return "dead";
-  }
-}
-
-/**
- * Deterministic 32-bit hash (FNV-1a). Used to seed loss figures, jitter, and
- * gossip truth so a given (slug, stage, slot) always yields the same number —
- * reproducible and replay-safe, since Math.random() is unavailable in Convex
- * actions and would break the "code owns the numbers" guarantee.
+ * Deterministic 32-bit hash (FNV-1a). Seeds gossip truth, angle picks, and any
+ * jitter so a given seed always yields the same value — reproducible and
+ * replay-safe, since Math.random() is unavailable in Convex actions and would
+ * break determinism.
  */
 export function hashString(input: string): number {
   let h = 0x811c9dc5;

--- a/convex/wire/tokenRegistry.ts
+++ b/convex/wire/tokenRegistry.ts
@@ -1,0 +1,119 @@
+/**
+ * Token registry — the single source of truth for which companies the wire
+ * covers. Pure module: safe to import from both Node actions and V8 functions.
+ *
+ * The data lives in the repo-root `tokens.json` so it can be edited without
+ * touching any logic. It is imported and Zod-validated AT MODULE LOAD — a
+ * malformed entry throws immediately, so `pnpm build` / CI / the first cron
+ * tick fails loudly rather than silently covering a broken company.
+ *
+ * Editing `tokens.json` (add / remove / edit an entry) takes effect on the next
+ * Convex deploy — no code changes required. `registrySync.ts` reconciles the
+ * `narrativeEntities` company rows from this registry each cycle.
+ *
+ * CONTRACT ADDRESSES ARE AUTHORITATIVE AND HUMAN-SUPPLIED. Never look up,
+ * guess, or "correct" an address in code — name collisions and impersonation
+ * deployments make self-service lookup a correctness/safety hazard.
+ *
+ * Endpoint family per token (see pricePoll.ts): all twelve seed companies are
+ * small-cap Base tokens that resolve via the CoinGecko **onchain**
+ * (GeckoTerminal-derived) endpoint `/onchain/networks/base/tokens/{address}`,
+ * not the listed-coins `/coins/base/contract/{address}` endpoint. The poller
+ * records the endpoint that resolved each address in the snapshot's `source`
+ * field and flags any address that resolves via neither.
+ */
+
+import { z } from "zod";
+import rawTokens from "../../tokens.json";
+
+const TokenEntrySchema = z.object({
+  /** Ticker, uppercase, e.g. "SEARXLY". Also the entity slug (lowercased). */
+  symbol: z
+    .string()
+    .min(1)
+    .regex(/^[A-Z0-9]+$/, "symbol must be uppercase alphanumeric"),
+  /** Company-style display name, e.g. "Surplus Intelligence". */
+  companyName: z.string().min(1),
+  /** X / Twitter handle, must start with "@". */
+  xHandle: z.string().regex(/^@[A-Za-z0-9_]{1,15}$/, "xHandle must be @handle"),
+  /** Base contract address (human-supplied, authoritative). */
+  address: z
+    .string()
+    .regex(
+      /^0x[0-9a-fA-F]{40}$/,
+      "address must be a 0x-prefixed 40-hex string"
+    ),
+  /** Optional editorial notes: running jokes, persona, stance. */
+  notes: z.string().optional(),
+  /** True for the house token (HARNESS) — coverage stance is harder. */
+  isHouseToken: z.boolean().optional(),
+});
+
+export type TokenEntry = z.infer<typeof TokenEntrySchema> & {
+  /** Lowercased address, the canonical key for snapshots + entities. */
+  addressLc: string;
+  /** Entity slug = lowercased symbol. */
+  slug: string;
+};
+
+function loadRegistry(): TokenEntry[] {
+  const parsed = z.array(TokenEntrySchema).min(1).safeParse(rawTokens);
+  if (!parsed.success) {
+    throw new Error(
+      `[tokenRegistry] tokens.json failed validation: ${parsed.error.message}`
+    );
+  }
+  const entries = parsed.data;
+
+  // Uniqueness: symbols, slugs, and addresses must not collide.
+  const seenSymbol = new Set<string>();
+  const seenAddress = new Set<string>();
+  for (const e of entries) {
+    if (seenSymbol.has(e.symbol)) {
+      throw new Error(`[tokenRegistry] duplicate symbol: ${e.symbol}`);
+    }
+    seenSymbol.add(e.symbol);
+    const addressLc = e.address.toLowerCase();
+    if (seenAddress.has(addressLc)) {
+      throw new Error(`[tokenRegistry] duplicate address: ${e.address}`);
+    }
+    seenAddress.add(addressLc);
+  }
+
+  // At most one house token.
+  const houseCount = entries.filter((e) => e.isHouseToken).length;
+  if (houseCount > 1) {
+    throw new Error(
+      `[tokenRegistry] at most one house token allowed, found ${houseCount}`
+    );
+  }
+
+  return entries.map((e) => ({
+    ...e,
+    addressLc: e.address.toLowerCase(),
+    slug: e.symbol.toLowerCase(),
+  }));
+}
+
+/** Validated registry — throws at import time if tokens.json is malformed. */
+export const TOKEN_REGISTRY: TokenEntry[] = loadRegistry();
+
+const BY_ADDRESS = new Map(TOKEN_REGISTRY.map((t) => [t.addressLc, t]));
+const BY_SYMBOL = new Map(TOKEN_REGISTRY.map((t) => [t.symbol, t]));
+const BY_SLUG = new Map(TOKEN_REGISTRY.map((t) => [t.slug, t]));
+
+export function tokenByAddress(address: string): TokenEntry | undefined {
+  return BY_ADDRESS.get(address.toLowerCase());
+}
+
+export function tokenBySymbol(symbol: string): TokenEntry | undefined {
+  return BY_SYMBOL.get(symbol.toUpperCase());
+}
+
+export function tokenBySlug(slug: string): TokenEntry | undefined {
+  return BY_SLUG.get(slug.toLowerCase());
+}
+
+export function houseToken(): TokenEntry | undefined {
+  return TOKEN_REGISTRY.find((t) => t.isHouseToken);
+}

--- a/convex/wire/tokenSignals.ts
+++ b/convex/wire/tokenSignals.ts
@@ -1,0 +1,254 @@
+/**
+ * Token price signals — turns stored snapshots into the movement facts the wire
+ * narrates. The pure core (`computeTokenSignals`) is fully unit-testable; the
+ * `loadTokenSignals` internalQuery wires it to the DB.
+ *
+ * Every number here traces to a stored snapshot (see `refSnapshotIds`). Nothing
+ * is fabricated: a token with no usable snapshot yields `ok: false` and no
+ * figures, so the wire degrades gracefully rather than inventing a price.
+ */
+
+import { internalQuery } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { TOKEN_REGISTRY, type TokenEntry } from "./tokenRegistry";
+import {
+  MOVE_THRESHOLDS,
+  STREAK_MIN_DAYS,
+  TRAILING_VOLUME_DAYS,
+  VOLUME_ANOMALY_MULTIPLE,
+  SIGNAL_SNAPSHOT_LOOKBACK,
+} from "./priceConfig";
+
+/** Minimal snapshot shape the pure compute needs (newest-first per address). */
+export interface SnapshotLite {
+  id: string;
+  createdAt: number;
+  ok: boolean;
+  priceUsd: number | null;
+  volume24hUsd: number | null;
+  dayKey: string | null;
+  priceChange24hPct: number | null;
+}
+
+export type MoveClassification = "none" | "routine" | "story" | "flash";
+
+export interface TokenSignal {
+  slug: string;
+  symbol: string;
+  companyName: string;
+  xHandle: string;
+  isHouseToken: boolean;
+  /** True when a usable latest price exists. */
+  ok: boolean;
+  priceUsd: number | null;
+  /** % move vs the immediately preceding snapshot (any gap). */
+  moveSinceLastPct: number | null;
+  /** % move vs ~24h ago (from stored snapshots, else API fallback). */
+  move24hPct: number | null;
+  move24hSource: "computed" | "api" | null;
+  volume24hUsd: number | null;
+  /** Latest 24h volume as a multiple of the trailing daily average. */
+  volumeVsTrailing: number | null;
+  volumeAnomaly: boolean;
+  /** Signed consecutive same-direction daily-close steps (+green / -red). */
+  streakDays: number;
+  classification: MoveClassification;
+  latestSnapshotId: string | null;
+  /** Snapshot ids the figures above derive from (source trace). */
+  refSnapshotIds: string[];
+}
+
+const H24_MS = 24 * 60 * 60 * 1000;
+const H24_MIN_MS = 20 * 60 * 60 * 1000;
+const H24_MAX_MS = 30 * 60 * 60 * 1000;
+
+function pctChange(from: number, to: number): number | null {
+  if (from === 0 || !Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return ((to - from) / Math.abs(from)) * 100;
+}
+
+/** Last (latest) usable snapshot per NY calendar day, oldest day first. */
+function dailyCloses(
+  snapshots: SnapshotLite[]
+): Array<{ dayKey: string; price: number; volume: number | null }> {
+  // snapshots are newest-first; first seen per dayKey is that day's close.
+  const seen = new Set<string>();
+  const closes: Array<{
+    dayKey: string;
+    price: number;
+    volume: number | null;
+  }> = [];
+  for (const s of snapshots) {
+    if (!s.ok || s.priceUsd == null || !s.dayKey) continue;
+    if (seen.has(s.dayKey)) continue;
+    seen.add(s.dayKey);
+    closes.push({
+      dayKey: s.dayKey,
+      price: s.priceUsd,
+      volume: s.volume24hUsd,
+    });
+  }
+  return closes.reverse(); // oldest first
+}
+
+/** Signed consecutive same-direction daily-close steps ending on the latest day. */
+function computeStreak(closes: Array<{ price: number }>): number {
+  if (closes.length < 2) return 0;
+  const stepSign = (a: number, b: number) => Math.sign(b - a);
+  const lastSign = stepSign(
+    closes[closes.length - 2].price,
+    closes[closes.length - 1].price
+  );
+  if (lastSign === 0) return 0;
+  let count = 0;
+  for (let i = closes.length - 1; i >= 1; i--) {
+    if (stepSign(closes[i - 1].price, closes[i].price) === lastSign) count++;
+    else break;
+  }
+  return lastSign * count;
+}
+
+function classify(
+  maxAbsMovePct: number,
+  streakDays: number
+): MoveClassification {
+  let cls: MoveClassification = "none";
+  if (maxAbsMovePct >= MOVE_THRESHOLDS.routinePct) cls = "routine";
+  if (maxAbsMovePct >= MOVE_THRESHOLDS.storyPct) cls = "story";
+  if (maxAbsMovePct >= MOVE_THRESHOLDS.flashPct) cls = "flash";
+  // A sustained streak is always at least a story, even on small daily moves.
+  if (
+    Math.abs(streakDays) >= STREAK_MIN_DAYS &&
+    (cls === "none" || cls === "routine")
+  ) {
+    cls = "story";
+  }
+  return cls;
+}
+
+function signalFor(token: TokenEntry, snapshots: SnapshotLite[]): TokenSignal {
+  const base: TokenSignal = {
+    slug: token.slug,
+    symbol: token.symbol,
+    companyName: token.companyName,
+    xHandle: token.xHandle,
+    isHouseToken: token.isHouseToken ?? false,
+    ok: false,
+    priceUsd: null,
+    moveSinceLastPct: null,
+    move24hPct: null,
+    move24hSource: null,
+    volume24hUsd: null,
+    volumeVsTrailing: null,
+    volumeAnomaly: false,
+    streakDays: 0,
+    classification: "none",
+    latestSnapshotId: null,
+    refSnapshotIds: [],
+  };
+
+  const usable = snapshots.filter((s) => s.ok && s.priceUsd != null);
+  const latest = usable[0];
+  if (!latest || latest.priceUsd == null) return base;
+
+  const refIds = new Set<string>([latest.id]);
+  base.ok = true;
+  base.priceUsd = latest.priceUsd;
+  base.latestSnapshotId = latest.id;
+  base.volume24hUsd = latest.volume24hUsd;
+
+  // Move since the immediately preceding usable snapshot.
+  const prev = usable[1];
+  if (prev && prev.priceUsd != null) {
+    base.moveSinceLastPct = pctChange(prev.priceUsd, latest.priceUsd);
+    if (base.moveSinceLastPct != null) refIds.add(prev.id);
+  }
+
+  // 24h move: closest usable snapshot within a 20–30h window before latest.
+  const target = latest.createdAt - H24_MS;
+  let best: SnapshotLite | null = null;
+  let bestDist = Infinity;
+  for (const s of usable) {
+    const age = latest.createdAt - s.createdAt;
+    if (age < H24_MIN_MS || age > H24_MAX_MS) continue;
+    const dist = Math.abs(s.createdAt - target);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = s;
+    }
+  }
+  if (best && best.priceUsd != null) {
+    base.move24hPct = pctChange(best.priceUsd, latest.priceUsd);
+    base.move24hSource = "computed";
+    if (base.move24hPct != null) refIds.add(best.id);
+  } else if (latest.priceChange24hPct != null) {
+    base.move24hPct = latest.priceChange24hPct;
+    base.move24hSource = "api";
+  }
+
+  // Streak + trailing volume from daily closes.
+  const closes = dailyCloses(usable);
+  base.streakDays = computeStreak(closes);
+
+  if (latest.volume24hUsd != null && closes.length >= 2) {
+    // Trailing daily-close volumes, excluding today's close.
+    const trailing = closes
+      .slice(-1 - TRAILING_VOLUME_DAYS, -1)
+      .map((c) => c.volume)
+      .filter((v): v is number => v != null && v > 0);
+    if (trailing.length > 0) {
+      const avg = trailing.reduce((a, b) => a + b, 0) / trailing.length;
+      if (avg > 0) {
+        base.volumeVsTrailing = latest.volume24hUsd / avg;
+        base.volumeAnomaly = base.volumeVsTrailing >= VOLUME_ANOMALY_MULTIPLE;
+      }
+    }
+  }
+
+  const maxAbsMove = Math.max(
+    base.moveSinceLastPct != null ? Math.abs(base.moveSinceLastPct) : 0,
+    base.move24hPct != null ? Math.abs(base.move24hPct) : 0
+  );
+  base.classification = classify(maxAbsMove, base.streakDays);
+  base.refSnapshotIds = [...refIds];
+  return base;
+}
+
+/** Pure: compute a signal per registry token from its snapshots (newest-first). */
+export function computeTokenSignals(
+  snapshotsByAddress: Map<string, SnapshotLite[]>
+): TokenSignal[] {
+  return TOKEN_REGISTRY.map((token) =>
+    signalFor(token, snapshotsByAddress.get(token.addressLc) ?? [])
+  );
+}
+
+/** Load recent snapshots for every registry token and compute signals. */
+export const loadTokenSignals = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<TokenSignal[]> => {
+    const byAddress = new Map<string, SnapshotLite[]>();
+    for (const token of TOKEN_REGISTRY) {
+      const rows = await ctx.db
+        .query("tokenSnapshots")
+        .withIndex("byAddressAndCreatedAt", (q) =>
+          q.eq("address", token.addressLc)
+        )
+        .order("desc")
+        .take(SIGNAL_SNAPSHOT_LOOKBACK);
+      byAddress.set(
+        token.addressLc,
+        rows.map((r) => ({
+          id: r._id as Id<"tokenSnapshots"> as unknown as string,
+          createdAt: r.createdAt,
+          ok: r.ok,
+          priceUsd: r.priceUsd ?? null,
+          volume24hUsd: r.volume24hUsd ?? null,
+          dayKey: r.dayKey ?? null,
+          priceChange24hPct: r.priceChange24hPct ?? null,
+        }))
+      );
+    }
+    return computeTokenSignals(byAddress);
+  },
+});

--- a/convex/wire/tweetPoster.ts
+++ b/convex/wire/tweetPoster.ts
@@ -1,0 +1,49 @@
+/**
+ * Tweet posting behind an interface, dry-run by default. v1 never posts: the
+ * wire generates and stores the sanitized tweet variant, and DryRunTweetPoster
+ * logs it. A LiveTweetPoster is stubbed for when credentials + a client are
+ * wired (gated by MC_WIRE_TWEETS_LIVE=1). The game link lives in the account
+ * bio, never in tweets — so posters never append URLs.
+ */
+
+export interface TweetRequest {
+  text: string;
+  epoch: number;
+  subjectHandle?: string | null;
+}
+
+export interface TweetResult {
+  status: "dry_run" | "posted" | "skipped" | "failed";
+  id?: string;
+  error?: string;
+}
+
+export interface TweetPoster {
+  post(req: TweetRequest): Promise<TweetResult>;
+}
+
+/** Default poster: records intent without posting. */
+export class DryRunTweetPoster implements TweetPoster {
+  async post(req: TweetRequest): Promise<TweetResult> {
+    console.log(
+      `[wire/tweet] DRY RUN (epoch ${req.epoch}, ${req.text.length} chars): ${req.text}`
+    );
+    return { status: "dry_run" };
+  }
+}
+
+/** Stub for real posting — intentionally not implemented in v1. */
+export class LiveTweetPoster implements TweetPoster {
+  async post(req: TweetRequest): Promise<TweetResult> {
+    console.warn(
+      `[wire/tweet] live posting requested (epoch ${req.epoch}) but no client is wired`
+    );
+    return { status: "failed", error: "live tweet posting not implemented" };
+  }
+}
+
+export function getTweetPoster(): TweetPoster {
+  return process.env.MC_WIRE_TWEETS_LIVE === "1"
+    ? new LiveTweetPoster()
+    : new DryRunTweetPoster();
+}

--- a/convex/wire/tweetVariant.ts
+++ b/convex/wire/tweetVariant.ts
@@ -1,0 +1,94 @@
+/**
+ * Tweet-variant sanitizer — pure, unit-testable. Enforces the platform + house
+ * rules in CODE (not just the prompt):
+ *   - NO URLs (link posts are billed higher and deprioritized) — stripped, and
+ *     if a bare domain survives the tweet is rejected rather than mangled.
+ *   - ≤ 280 characters.
+ *   - the covered company's @handle is present when it is the story's subject
+ *     (the distribution mechanic).
+ * Cashtags ($SYMBOL) are allowed and preserved.
+ */
+
+export const TWEET_MAX_CHARS = 280;
+
+// URLs with an explicit scheme or www. prefix.
+const URL_SCHEME_RE = /\b(?:https?:\/\/|www\.)\S+/gi;
+// A bare domain like "foo.com" / "bar.xyz" — used to REJECT (not strip) so we
+// never post a half-mangled link. Excludes cashtags/handles (no dot there).
+const BARE_DOMAIN_RE =
+  /\b[a-z0-9-]+\.(?:com|io|xyz|net|org|gg|app|co|fi|ai|eth|dev|gov|edu|me|info|link|fun|finance|money|fund|markets)\b/i;
+
+export interface SanitizeResult {
+  text: string;
+  ok: boolean;
+  issues: string[];
+}
+
+function hasHandle(text: string, handle: string): boolean {
+  return text.toLowerCase().includes(handle.toLowerCase());
+}
+
+/**
+ * Sanitize a raw generated tweet. `subjectHandle` is the covered company's
+ * @handle when a company is the story's subject (else undefined).
+ */
+export function sanitizeTweet(
+  raw: string,
+  opts: { subjectHandle?: string | null } = {}
+): SanitizeResult {
+  const issues: string[] = [];
+  let text = (raw ?? "").replace(/\s+/g, " ").trim();
+
+  // Strip explicit URLs.
+  if (URL_SCHEME_RE.test(text)) {
+    issues.push("stripped_url");
+    text = text
+      .replace(URL_SCHEME_RE, "")
+      .replace(/\s{2,}/g, " ")
+      .trim();
+  }
+
+  // Any surviving bare domain → reject (do not post a mangled link).
+  if (BARE_DOMAIN_RE.test(text)) {
+    issues.push("url");
+    return { text, ok: false, issues };
+  }
+
+  // Strip EVERY model-written @-mention — the model must not invent or tag any
+  // account. The only allowed @-mention is the covered company's registry
+  // handle, appended below. (Cashtags use $ and are preserved.)
+  const stripped = text
+    .replace(/@\w{1,15}/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  if (stripped !== text) issues.push("stripped_mention");
+  text = stripped;
+
+  // Ensure the subject company's handle is present (distribution mechanic).
+  const handle = opts.subjectHandle?.trim();
+  if (handle && handle.startsWith("@") && !hasHandle(text, handle)) {
+    const candidate = `${text} ${handle}`.trim();
+    if (candidate.length <= TWEET_MAX_CHARS) {
+      text = candidate;
+    } else {
+      issues.push("missing_handle");
+    }
+  }
+
+  // Length cap. Trim to a word boundary and add an ellipsis.
+  if (text.length > TWEET_MAX_CHARS) {
+    issues.push("truncated");
+    const slice = text.slice(0, TWEET_MAX_CHARS - 1);
+    const lastSpace = slice.lastIndexOf(" ");
+    text = (lastSpace > 40 ? slice.slice(0, lastSpace) : slice).trim() + "…";
+  }
+
+  const ok = !issues.includes("url") && !issues.includes("missing_handle");
+  return { text, ok, issues };
+}
+
+/** True if the text contains any URL or bare domain (for validation/tests). */
+export function containsUrl(text: string): boolean {
+  URL_SCHEME_RE.lastIndex = 0;
+  return URL_SCHEME_RE.test(text) || BARE_DOMAIN_RE.test(text);
+}

--- a/convex/wire/worldState.ts
+++ b/convex/wire/worldState.ts
@@ -1,40 +1,31 @@
 /**
  * Code-authoritative world-state engine — pure, no Convex imports.
  *
- * Each run this computes EVERY number and state transition the wire needs:
- *   - per-firm running-loss deltas + totals (monotonic, deterministic)
- *   - arc stage advances through the lifecycle pipeline
- *   - mood + SEC heat
- *   - which fresh arcs to spawn when live arcs run low
- *   - floor-talk gossip with code-assigned truth tags
- *   - the lead directive (real event vs. fiction) from the drama ranker
+ * Each run this computes, from REAL signals only:
+ *   - which company / desk arcs to spawn (a move crossed the story threshold)
+ *   - how existing arcs advance or cool (attention lifecycle, reactive)
+ *   - the market mood (aggregate tape + game events)
+ *   - absurd, non-finance floor-talk gossip tied to a company already in play
+ *   - the lead directive (token vs. game event vs. quiet)
  *
- * The LLM receives this output and writes prose only — it never invents
- * figures, tension, stages, or transitions.
+ * The LLM receives this and writes prose only — it never invents a figure, a
+ * stage, a tension level, or an event. Nothing here fabricates a number:
+ * cooled/absent signals simply produce no story.
  */
 
 import type { GameEventCtx } from "./epochAssembler";
 import { pickQuietAngle, type DropAngle } from "./dropAngles";
 import { rankAndSelectLead, type LeadSelection } from "./dramaRanker";
 import {
-  spawnArc,
-  templatePeakLossUsdc,
+  describeCompanyArc,
+  describePlayerArc,
+  headlineMovePct,
   type SpawnedArcSpec,
+  type ArcSubjectType,
 } from "./arcTemplates";
-import {
-  type ArcStage,
-  STAGE_TARGET_TENSION,
-  STAGE_BEAT_QUOTA,
-  LIVE_STAGES,
-  DEFAULT_PEAK_LOSS_USDC,
-  nextStage,
-  firmStatusForStage,
-  targetLossUsdc,
-  seededInt,
-  seededUnit,
-} from "./stages";
-
-export type FirmStatus = "healthy" | "stressed" | "collapsing" | "dead";
+import { type ArcStage, STAGE_TARGET_TENSION, seededInt } from "./stages";
+import { MOVE_THRESHOLDS } from "./priceConfig";
+import type { TokenSignal } from "./tokenSignals";
 
 export interface ArcInput {
   slug: string;
@@ -42,30 +33,17 @@ export interface ArcInput {
   summary: string;
   tensionScore: number;
   arcStage: ArcStage;
-  beatsPublishedByStage: Record<string, number>;
-  climaxFired: boolean;
+  peakFired: boolean;
   lastBeatDayKey?: string | null;
-  templateKey?: string | null;
-  primaryFirmSlug?: string | null;
+  subjectType?: ArcSubjectType | null;
+  subjectSlug?: string | null;
 }
 
-export interface FirmInput {
+export interface CompanyCtx {
   slug: string;
   displayName: string;
-  status?: FirmStatus;
-  runningLossUsdc: number;
-  notableFacts: string[];
-  oneOffEventsFired: string[];
-  lastLossDayKey?: string | null;
-}
-
-export interface FirmDelta {
-  slug: string;
-  lossDeltaUsdc: number;
-  newRunningLossUsdc: number;
-  newStatus: FirmStatus;
-  appendNotableFacts: string[];
-  lastLossDayKey: string;
+  symbol: string;
+  isHouseToken: boolean;
 }
 
 export interface ArcAdvance {
@@ -73,10 +51,9 @@ export interface ArcAdvance {
   fromStage: ArcStage;
   toStage: ArcStage;
   newTensionScore: number;
-  beatPublishedThisRun: boolean;
-  climaxFiringNow: boolean;
+  peakFiringNow: boolean;
   retiring: boolean;
-  newBeatsPublishedByStage: Record<string, number>;
+  ledThisRun: boolean;
   newLastBeatDayKey: string | null;
 }
 
@@ -87,347 +64,343 @@ export interface FloorTalkClaim {
 
 export interface WorldStateAdvanceInput {
   arcs: ArcInput[];
-  firms: FirmInput[];
+  companies: CompanyCtx[];
+  signals: TokenSignal[];
   events: GameEventCtx[];
   dayKey: string;
   dayPosture: string;
-  /** Epoch slot — seeds spawns so back-to-back runs differ deterministically. */
   slot: number;
-  /** Previous drop's quiet-angle key — avoids repeating the same lens back-to-back. */
   prevQuietAngleKey?: string | null;
 }
 
 export interface WorldStateAdvance {
-  firmDeltas: FirmDelta[];
   arcAdvances: ArcAdvance[];
-  mood: string;
-  secHeat: number;
   spawnRequests: SpawnedArcSpec[];
+  mood: string;
   floorTalkClaims: FloorTalkClaim[];
   lead: LeadSelection;
   primaryArcSlug: string | null;
-  /** Narrative angle for quiet fiction slots; null when beat or real event leads. */
   quietAngle: DropAngle | null;
 }
 
-const TARGET_LIVE_ARCS = 2;
+/** Max fresh arcs to spawn per run, to keep the world legible. */
+const MAX_SPAWNS_PER_RUN = 3;
+/** Same-direction dramatic outcomes by one desk that make a player streak. */
+const PLAYER_STREAK_MIN = 3;
 
-function peakForArc(arc: ArcInput): number {
-  return templatePeakLossUsdc(arc.templateKey) ?? DEFAULT_PEAK_LOSS_USDC;
+const PEAK_MULTIPLE = 1.5;
+
+/** Derive a company arc's stage from its live signal. */
+function stageForCompanySignal(
+  signal: TokenSignal,
+  peakFired: boolean
+): ArcStage {
+  const move = Math.abs(headlineMovePct(signal) ?? 0);
+  const streak = Math.abs(signal.streakDays);
+  if (!peakFired && move >= MOVE_THRESHOLDS.flashPct * PEAK_MULTIPLE) {
+    return "peak";
+  }
+  if (move >= MOVE_THRESHOLDS.flashPct || streak >= 5) return "frenzy";
+  if (
+    move >= MOVE_THRESHOLDS.storyPct ||
+    streak >= MOVE_THRESHOLDS.routinePct
+  ) {
+    return "talked_about";
+  }
+  return "noticed";
 }
 
-/**
- * Advance the primary fictional arc by at most one beat, gated to ≤1 beat per
- * day, advancing its stage when the stage quota is met. Never advances an arc
- * into a stage another live arc currently occupies (keeps the two live arcs at
- * different stages). Climax fires exactly once.
- */
-function advancePrimaryArc(
-  primary: ArcInput,
-  occupiedStages: Set<ArcStage>,
-  dayKey: string
-): ArcAdvance {
-  const fromStage = primary.arcStage;
-  const beats = { ...primary.beatsPublishedByStage };
-
-  // Gate: at most one published beat per day.
-  const canBeat = primary.lastBeatDayKey !== dayKey && fromStage !== "retired";
-
-  if (!canBeat) {
-    return {
-      slug: primary.slug,
-      fromStage,
-      toStage: fromStage,
-      newTensionScore: STAGE_TARGET_TENSION[fromStage],
-      beatPublishedThisRun: false,
-      climaxFiringNow: false,
-      retiring: false,
-      newBeatsPublishedByStage: beats,
-      newLastBeatDayKey: primary.lastBeatDayKey ?? null,
-    };
-  }
-
-  beats[fromStage] = (beats[fromStage] ?? 0) + 1;
-
-  let toStage: ArcStage = fromStage;
-  let climaxFiringNow = false;
-  let retiring = false;
-
-  if (beats[fromStage] >= STAGE_BEAT_QUOTA[fromStage]) {
-    let candidate = nextStage(fromStage);
-
-    // Skip climax if it already fired (can never re-enter).
-    if (candidate === "climax" && primary.climaxFired) {
-      candidate = nextStage("climax"); // → aftermath
-    }
-
-    // Don't collide with the other live arc's stage (keep them distinct).
-    // Exception: "retired" is terminal and never collides.
-    if (candidate !== "retired" && occupiedStages.has(candidate)) {
-      candidate = fromStage; // hold this run
-    }
-
-    if (candidate !== fromStage) {
-      toStage = candidate;
-      if (toStage === "climax") climaxFiringNow = true;
-      if (toStage === "retired") retiring = true;
-    }
-  }
-
-  return {
-    slug: primary.slug,
-    fromStage,
-    toStage,
-    newTensionScore: STAGE_TARGET_TENSION[toStage],
-    beatPublishedThisRun: true,
-    climaxFiringNow,
-    retiring,
-    newBeatsPublishedByStage: beats,
-    newLastBeatDayKey: dayKey,
-  };
+function isStoryWorthy(signal: TokenSignal | undefined): boolean {
+  return (
+    !!signal &&
+    signal.ok &&
+    (signal.classification === "story" || signal.classification === "flash")
+  );
 }
 
-/** Step a firm's running loss toward its stage target (monotonic up). */
-function computeFirmDelta(
-  firm: FirmInput,
-  arc: ArcInput,
-  toStage: ArcStage,
-  stageAdvanced: boolean,
-  dayKey: string
-): FirmDelta | null {
-  const peak = peakForArc(arc);
-  const stageTarget = targetLossUsdc(peak, toStage);
-
-  const isNewDay = firm.lastLossDayKey !== dayKey;
-  // Only move the number on a stage advance or a fresh trading day.
-  if (!stageAdvanced && !isNewDay) return null;
-
-  let newTotal = Math.max(firm.runningLossUsdc, stageTarget);
-
-  // Within-stage daily drift (small, deterministic, never past the next band —
-  // and never below the current total, so running losses stay monotonic).
-  if (isNewDay && toStage !== "retired" && toStage !== "climax") {
-    const driftPct = seededInt(`drift:${firm.slug}:${dayKey}`, 3, 9); // 3–9%
-    const drift = Math.round((stageTarget * driftPct) / 100);
-    const cap = Math.max(stageTarget, targetLossUsdc(peak, nextStage(toStage)));
-    const drifted = Math.min(newTotal + drift, cap);
-    newTotal = Math.max(newTotal, drifted);
-  }
-
-  const lossDelta = newTotal - firm.runningLossUsdc;
-  const newStatus = firmStatusForStage(toStage);
-
-  const appendNotableFacts: string[] = [];
-  if (stageAdvanced) {
-    const m = `$${(newTotal / 1_000_000).toFixed(0)}M`;
-    if (toStage === "confirmation") {
-      appendNotableFacts.push(`${firm.displayName} losses confirmed at ${m}`);
-    } else if (toStage === "climax") {
-      appendNotableFacts.push(`${firm.displayName} losses peaked at ${m}`);
-    } else if (toStage === "retired") {
-      appendNotableFacts.push(
-        `${firm.displayName} wound down; final hole ${m}`
-      );
-    }
-  }
-
-  return {
-    slug: firm.slug,
-    lossDeltaUsdc: lossDelta,
-    newRunningLossUsdc: newTotal,
-    newStatus,
-    appendNotableFacts,
-    lastLossDayKey: dayKey,
-  };
-}
-
-function computeSecHeat(
-  arcs: ArcInput[],
-  advancesByStage: Map<string, ArcStage>,
-  lead: LeadSelection
-): number {
-  let heat = 3;
-  for (const arc of arcs) {
-    const stage = advancesByStage.get(arc.slug) ?? arc.arcStage;
-    if (stage === "confirmation") heat += 1;
-    else if (stage === "escalation") heat += 2;
-    else if (stage === "climax") heat += 3;
-  }
-  if (lead.leadEvent?.type === "wipeout") heat += 1;
-  if (lead.patterns.length > 0) heat += 2;
-  return Math.max(0, Math.min(10, heat));
-}
+// ── mood ─────────────────────────────────────────────────────────────────────
 
 function computeMood(
-  maxStage: ArcStage,
-  lead: LeadSelection,
+  signals: TokenSignal[],
   events: GameEventCtx[],
+  lead: LeadSelection,
   dayPosture: string,
   dayKey: string
 ): string {
-  if (lead.leadEvent?.type === "wipeout") return "grim";
-  if (maxStage === "climax") return "panic";
-  if (maxStage === "escalation") return "nervous";
-  if (maxStage === "confirmation") return "tense";
+  if (lead.gameLead?.type === "wipeout") return "grim";
 
-  // Quiet stages (rumor/denial/aftermath): vary honestly with the day.
-  const hasBigWin = events.some((e) => e.type === "big_win");
-  if (hasBigWin) return "greedy";
+  if (lead.leadKind === "token" && lead.tokenLead) {
+    const move = headlineMovePct(lead.tokenLead) ?? 0;
+    if (lead.isFlash) return move < 0 ? "grim" : "electric";
+  }
+
+  const priced = signals.filter((s) => s.ok && s.move24hPct != null);
+  const red = priced.filter((s) => (s.move24hPct ?? 0) < 0).length;
+  const green = priced.length - red;
+  if (priced.length >= 4) {
+    if (red >= priced.length * 0.7) return "nervous";
+    if (green >= priced.length * 0.7) return "greedy";
+  }
+
+  if (events.some((e) => e.type === "big_win")) return "greedy";
   if (dayPosture === "monday" || dayPosture === "tuesday") {
-    return seededUnit(`mood:${dayKey}`) < 0.5 ? "hungover" : "bored";
+    return seededInt(`mood:${dayKey}`, 0, 1) === 0 ? "hungover" : "bored";
   }
   if (events.filter((e) => e.dramatic).length === 0) return "bored";
   return "watchful";
 }
 
+// ── floor talk (absurd, non-finance color only) ──────────────────────────────
+
 const FLOOR_TALK_TEMPLATES = [
-  (title: string) => `${title}: someone senior was seen leaving with boxes`,
-  (title: string) =>
-    `${title}: a counterparty stopped answering calls this morning`,
-  (title: string) =>
-    `${title}: the auditors asked for a second conference room`,
-  (title: string) => `${title}: the elevator smelled like burning paperwork`,
-  (title: string) =>
-    `${title}: compliance scheduled a "voluntary" all-hands for Friday`,
-  (title: string) =>
-    `${title}: a junior analyst was seen crying in the stairwell`,
-  (title: string) => `${title}: the firm's PR team went dark on every call`,
+  (co: string) =>
+    `${co}: the intern who covers it went to lunch and hasn't come back`,
+  (co: string) => `${co}: someone unplugged the ticker to charge a phone`,
+  (co: string) => `${co}: the floor has a betting pool nobody will admit to`,
+  (co: string) => `${co}: the payphone by the elevator has rung all morning`,
+  (co: string) => `${co}: three people claim they "called it," none in writing`,
+  (co: string) => `${co}: the coffee cart guy has a strong opinion today`,
+  (co: string) => `${co}: a stack of it is being used to prop open a window`,
 ] as const;
 
 function buildFloorTalkClaims(
-  arcs: ArcInput[],
-  advancesByStage: Map<string, ArcStage>,
+  companyName: string | null,
   dayKey: string,
   slot: number
 ): FloorTalkClaim[] {
-  const claims: FloorTalkClaim[] = [];
-  const hot = [...arcs].sort((a, b) => b.tensionScore - a.tensionScore)[0];
-  if (!hot) return claims;
-  const stage = advancesByStage.get(hot.slug) ?? hot.arcStage;
-
-  const candidates = FLOOR_TALK_TEMPLATES.map((fn) => fn(hot.title));
-  const n = stage === "rumor" ? 2 : 1;
+  if (!companyName) return [];
   const startIdx = seededInt(
     `gossip-start:${slot}:${dayKey}`,
     0,
-    candidates.length - 1
+    FLOOR_TALK_TEMPLATES.length - 1
   );
-  for (let i = 0; i < n; i++) {
-    const idx = (startIdx + i) % candidates.length;
-    const isTrue = seededInt(`gossip:${slot}:${dayKey}:${idx}`, 0, 99) < 60;
-    claims.push({ text: candidates[idx]!, isTrue });
-  }
-  return claims;
+  const idx = startIdx % FLOOR_TALK_TEMPLATES.length;
+  const isTrue = seededInt(`gossip:${slot}:${dayKey}:${idx}`, 0, 99) < 60;
+  return [{ text: FLOOR_TALK_TEMPLATES[idx]!(companyName), isTrue }];
 }
+
+// ── player streaks ───────────────────────────────────────────────────────────
+
+interface PlayerStreak {
+  deskSlug: string;
+  deskLabel: string;
+  direction: "win" | "loss";
+  count: number;
+}
+
+function detectPlayerStreaks(events: GameEventCtx[]): PlayerStreak[] {
+  const byDesk = new Map<
+    string,
+    { wins: number; losses: number; label: string }
+  >();
+  for (const e of events) {
+    if (!e.traderId) continue;
+    const isWin = e.type === "big_win";
+    const isLoss =
+      e.type === "big_loss" ||
+      e.type === "wipeout" ||
+      e.type === "trap_resolved";
+    if (!isWin && !isLoss) continue;
+    const rec = byDesk.get(e.traderId) ?? {
+      wins: 0,
+      losses: 0,
+      label: e.traderName ?? e.traderAddressTrunc ?? "a desk",
+    };
+    if (isWin) rec.wins++;
+    else rec.losses++;
+    byDesk.set(e.traderId, rec);
+  }
+  const streaks: PlayerStreak[] = [];
+  for (const [traderId, rec] of byDesk) {
+    if (rec.wins >= PLAYER_STREAK_MIN && rec.wins > rec.losses) {
+      streaks.push({
+        deskSlug: `desk-${traderId}`,
+        deskLabel: rec.label,
+        direction: "win",
+        count: rec.wins,
+      });
+    } else if (rec.losses >= PLAYER_STREAK_MIN && rec.losses > rec.wins) {
+      streaks.push({
+        deskSlug: `desk-${traderId}`,
+        deskLabel: rec.label,
+        direction: "loss",
+        count: rec.losses,
+      });
+    }
+  }
+  return streaks;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
 
 export function computeWorldStateAdvance(
   input: WorldStateAdvanceInput
 ): WorldStateAdvance {
-  const { arcs, firms, events, dayKey, dayPosture, slot, prevQuietAngleKey } =
-    input;
+  const {
+    arcs,
+    companies,
+    signals,
+    events,
+    dayKey,
+    dayPosture,
+    slot,
+    prevQuietAngleKey,
+  } = input;
 
-  const lead = rankAndSelectLead(events);
+  const lead = rankAndSelectLead({ signals, events });
 
-  const liveArcs = arcs
-    .filter((a) => a.arcStage !== "retired")
-    .sort((a, b) => b.tensionScore - a.tensionScore);
-  const primary = liveArcs[0] ?? null;
-  const primaryArcSlug = primary?.slug ?? null;
-
-  // Stages occupied by OTHER live arcs (for the distinct-stage rule).
-  const occupiedStages = new Set<ArcStage>(
-    liveArcs.filter((a) => a.slug !== primary?.slug).map((a) => a.arcStage)
+  const signalBySlug = new Map(signals.map((s) => [s.slug, s]));
+  const companyBySlug = new Map(companies.map((c) => [c.slug, c]));
+  const activeArcSubjectSlugs = new Set(
+    arcs.map((a) => a.subjectSlug).filter((s): s is string => !!s)
   );
 
+  // ── advance / cool existing arcs ──
   const arcAdvances: ArcAdvance[] = [];
-  if (primary) {
-    arcAdvances.push(advancePrimaryArc(primary, occupiedStages, dayKey));
-  }
-  // Secondary arcs simmer (tension held at their stage target, no beat).
-  for (const arc of liveArcs.slice(1)) {
+  for (const arc of arcs) {
+    const fromStage = arc.arcStage;
+    if (fromStage === "retired") continue;
+
+    let toStage: ArcStage = fromStage;
+    let peakFiringNow = false;
+    let retiring = false;
+
+    if (arc.subjectType === "company" && arc.subjectSlug) {
+      const signal = signalBySlug.get(arc.subjectSlug);
+      if (isStoryWorthy(signal)) {
+        toStage = stageForCompanySignal(signal!, arc.peakFired);
+        if (toStage === "peak" && !arc.peakFired) peakFiringNow = true;
+      } else {
+        // The move cooled — walk toward aftermath, then retire.
+        toStage = fromStage === "aftermath" ? "retired" : "aftermath";
+        retiring = toStage === "retired";
+      }
+    } else {
+      // Desk arcs: cool by default (re-spawn/advance below if still streaking).
+      toStage = fromStage === "aftermath" ? "retired" : "aftermath";
+      retiring = toStage === "retired";
+    }
+
     arcAdvances.push({
       slug: arc.slug,
-      fromStage: arc.arcStage,
-      toStage: arc.arcStage,
-      newTensionScore: STAGE_TARGET_TENSION[arc.arcStage],
-      beatPublishedThisRun: false,
-      climaxFiringNow: false,
-      retiring: false,
-      newBeatsPublishedByStage: { ...arc.beatsPublishedByStage },
+      fromStage,
+      toStage,
+      newTensionScore: STAGE_TARGET_TENSION[toStage],
+      peakFiringNow,
+      retiring,
+      ledThisRun: false,
       newLastBeatDayKey: arc.lastBeatDayKey ?? null,
     });
   }
 
-  const advancesByStage = new Map<string, ArcStage>(
-    arcAdvances.map((a) => [a.slug, a.toStage])
-  );
-
-  // Firm losses, keyed by each arc's primaryFirmSlug.
-  const firmBySlug = new Map(firms.map((f) => [f.slug, f]));
-  const arcBySlug = new Map(arcs.map((a) => [a.slug, a]));
-  const firmDeltas: FirmDelta[] = [];
-  for (const advance of arcAdvances) {
-    const arc = arcBySlug.get(advance.slug);
-    if (!arc?.primaryFirmSlug) continue;
-    const firm = firmBySlug.get(arc.primaryFirmSlug);
-    if (!firm) continue;
-    const stageAdvanced = advance.fromStage !== advance.toStage;
-    const delta = computeFirmDelta(
-      firm,
-      arc,
-      advance.toStage,
-      stageAdvanced,
-      dayKey
-    );
-    if (delta) firmDeltas.push(delta);
-  }
-
-  // Spawn fresh arcs when live count (after this run's retirements) drops below
-  // the target. Gentle: at most one spawn per run.
-  const retiringCount = arcAdvances.filter((a) => a.retiring).length;
-  const liveAfter = liveArcs.length - retiringCount;
+  // ── spawn fresh company arcs for story-worthy signals with no active arc ──
   const spawnRequests: SpawnedArcSpec[] = [];
-  if (liveAfter < TARGET_LIVE_ARCS) {
-    const taken = new Set<string>();
-    for (const a of arcs) {
-      taken.add(a.slug);
-      if (a.primaryFirmSlug) taken.add(a.primaryFirmSlug);
-    }
-    for (const f of firms) taken.add(f.slug);
-    spawnRequests.push(spawnArc(`${slot}`, taken));
+  const storyCandidates = signals
+    .filter((s) => isStoryWorthy(s) && !activeArcSubjectSlugs.has(s.slug))
+    .sort(
+      (a, b) =>
+        Math.abs(headlineMovePct(b) ?? 0) - Math.abs(headlineMovePct(a) ?? 0)
+    );
+  for (const signal of storyCandidates.slice(0, MAX_SPAWNS_PER_RUN)) {
+    const stage = stageForCompanySignal(signal, false);
+    const { title, summary } = describeCompanyArc(signal);
+    spawnRequests.push({
+      slug: `co-${signal.slug}-${slot}`,
+      title,
+      summary,
+      subjectType: "company",
+      subjectSlug: signal.slug,
+      entitySlug: signal.slug,
+      arcStage: stage,
+      tensionScore: STAGE_TARGET_TENSION[stage],
+    });
   }
 
-  const maxStage =
-    LIVE_STAGES.filter((s) => arcAdvances.some((a) => a.toStage === s)).slice(
-      -1
-    )[0] ?? "rumor";
+  // ── player streak arcs (spawn or re-advance) ──
+  const playerStreaks = detectPlayerStreaks(events);
+  for (const streak of playerStreaks) {
+    const existing = arcs.find(
+      (a) => a.subjectSlug === streak.deskSlug && a.arcStage !== "retired"
+    );
+    const stage: ArcStage = streak.count >= 5 ? "frenzy" : "talked_about";
+    if (existing) {
+      // Re-heat the cooling advance we may have queued above.
+      const adv = arcAdvances.find((a) => a.slug === existing.slug);
+      if (adv) {
+        adv.toStage = stage;
+        adv.newTensionScore = STAGE_TARGET_TENSION[stage];
+        adv.retiring = false;
+      }
+    } else if (spawnRequests.length < MAX_SPAWNS_PER_RUN + 1) {
+      const { title, summary } = describePlayerArc(
+        streak.deskLabel,
+        streak.direction,
+        streak.count
+      );
+      spawnRequests.push({
+        slug: `${streak.deskSlug}-${slot}`,
+        title,
+        summary,
+        subjectType: "desk",
+        subjectSlug: streak.deskSlug,
+        entitySlug: null,
+        arcStage: stage,
+        tensionScore: STAGE_TARGET_TENSION[stage],
+      });
+    }
+  }
 
-  const secHeat = computeSecHeat(arcs, advancesByStage, lead);
-  const mood = computeMood(maxStage, lead, events, dayPosture, dayKey);
-  const floorTalkClaims = buildFloorTalkClaims(
-    arcs,
-    advancesByStage,
-    dayKey,
-    slot
-  );
+  // ── primary arc + lead bookkeeping ──
+  let primaryArcSlug: string | null = null;
+  if (lead.leadKind === "token" && lead.tokenLead) {
+    const leadSlug = lead.tokenLead.slug;
+    // Prefer an existing active arc for the lead company, else its fresh spawn.
+    const existing = arcs.find(
+      (a) => a.subjectSlug === leadSlug && a.arcStage !== "retired"
+    );
+    const spawned = spawnRequests.find((s) => s.subjectSlug === leadSlug);
+    primaryArcSlug = existing?.slug ?? spawned?.slug ?? null;
+  }
+  if (!primaryArcSlug) {
+    // Highest-tension arc after advancing (fall back to any spawn).
+    const ranked = [...arcAdvances]
+      .filter((a) => !a.retiring)
+      .sort((a, b) => b.newTensionScore - a.newTensionScore);
+    primaryArcSlug = ranked[0]?.slug ?? spawnRequests[0]?.slug ?? null;
+  }
+  if (primaryArcSlug) {
+    const adv = arcAdvances.find((a) => a.slug === primaryArcSlug);
+    if (adv) {
+      adv.ledThisRun = true;
+      adv.newLastBeatDayKey = dayKey;
+    }
+  }
 
-  const primaryAdvance = primary
-    ? arcAdvances.find((a) => a.slug === primary.slug)
-    : undefined;
-  const isQuietSlot =
-    lead.leadKind === "fiction" &&
-    primaryAdvance !== undefined &&
-    !primaryAdvance.beatPublishedThisRun;
-  const quietAngle = isQuietSlot
-    ? pickQuietAngle(`${slot}:${dayKey}`, prevQuietAngleKey ?? null)
-    : null;
+  // ── mood, floor talk, quiet angle ──
+  const mood = computeMood(signals, events, lead, dayPosture, dayKey);
+
+  // Company for floor talk: the lead company, else the primary arc's company.
+  let floorCompanyName: string | null = null;
+  if (lead.leadKind === "token" && lead.tokenLead) {
+    floorCompanyName = lead.tokenLead.companyName;
+  } else if (primaryArcSlug) {
+    const spawned = spawnRequests.find((s) => s.slug === primaryArcSlug);
+    const arc = arcs.find((a) => a.slug === primaryArcSlug);
+    const subjSlug = spawned?.subjectSlug ?? arc?.subjectSlug ?? null;
+    if (subjSlug)
+      floorCompanyName = companyBySlug.get(subjSlug)?.displayName ?? null;
+  }
+  const floorTalkClaims = buildFloorTalkClaims(floorCompanyName, dayKey, slot);
+
+  const quietAngle =
+    lead.leadKind === "quiet"
+      ? pickQuietAngle(`${slot}:${dayKey}`, prevQuietAngleKey ?? null)
+      : null;
 
   return {
-    firmDeltas,
     arcAdvances,
-    mood,
-    secHeat,
     spawnRequests,
+    mood,
     floorTalkClaims,
     lead,
     primaryArcSlug,

--- a/src/components/wire/wire-drop.tsx
+++ b/src/components/wire/wire-drop.tsx
@@ -25,7 +25,6 @@ export interface WireDrop {
   topArcTitle: string | null;
   topArcTension: number | null;
   mood: string;
-  secHeat: number;
   createdAt: string;
   dispatches: Array<{
     headline: string;

--- a/tests/convex/import-season.test.ts
+++ b/tests/convex/import-season.test.ts
@@ -3,42 +3,36 @@ import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import schema from "../../convex/schema";
 import { api, internal } from "../../convex/_generated/api";
+import { TOKEN_REGISTRY } from "../../convex/wire/tokenRegistry";
 
 const modules = import.meta.glob("../../convex/**/*.ts");
 
 describe("seasons.importSeason", () => {
-  it("seeds season, entities, arcs, and initial drop on first run", async () => {
+  it("seeds the season and syncs one company entity per registry token", async () => {
     const t = convexTest(schema, modules);
-
     const result = await t.mutation(api.seasons.importSeason, {});
 
     expect(result.seasonId).toBeTruthy();
-    expect(result.entitiesUpserted).toBeGreaterThan(0);
-    expect(result.arcsUpserted).toBeGreaterThan(0);
-    expect(result.dropInserted).toBe(true);
+    expect(result.companiesSynced).toBe(TOKEN_REGISTRY.length);
+
+    const entities = await t.query(internal.seasons.listEntitiesForTest, {});
+    expect(entities.length).toBe(TOKEN_REGISTRY.length);
+    expect(entities.every((e: { kind: string }) => e.kind === "company")).toBe(
+      true
+    );
   });
 
-  it("is idempotent — second run produces no new entities, arcs, or drops", async () => {
+  it("is idempotent — a second run creates no duplicate entities", async () => {
     const t = convexTest(schema, modules);
-
     const first = await t.mutation(api.seasons.importSeason, {});
     const second = await t.mutation(api.seasons.importSeason, {});
 
-    expect(second.entitiesUpserted).toBe(0);
-    expect(second.arcsUpserted).toBe(0);
-    expect(second.dropInserted).toBe(false);
     expect(second.seasonId).toEqual(first.seasonId);
-  });
-
-  it("patches entity data without creating duplicates", async () => {
-    const t = convexTest(schema, modules);
-
-    await t.mutation(api.seasons.importSeason, {});
-    await t.mutation(api.seasons.importSeason, {});
+    expect(second.companiesRemoved).toBe(0);
 
     const entities = await t.query(internal.seasons.listEntitiesForTest, {});
     const slugs = entities.map((e: { slug: string }) => e.slug);
-    const uniqueSlugs = new Set(slugs);
-    expect(slugs.length).toEqual(uniqueSlugs.size);
+    expect(slugs.length).toBe(new Set(slugs).size);
+    expect(slugs.length).toBe(TOKEN_REGISTRY.length);
   });
 });

--- a/tests/convex/marketNarratives-feed.test.ts
+++ b/tests/convex/marketNarratives-feed.test.ts
@@ -6,17 +6,47 @@ import { api } from "../../convex/_generated/api";
 
 const modules = import.meta.glob("../../convex/**/*.ts");
 
-// Wire drops no longer generate Deal Seeds (single role="main" dispatch per
-// hour), so feedDrops should never attach dealSeed metadata to new drops.
-describe("marketNarratives.feedDrops: deal seed surfacing", () => {
-  it("does not attach dealSeed when no seed exists for the drop", async () => {
+// Wire drops carry a single role="main" dispatch and no Deal Seeds, so feedDrops
+// should never attach dealSeed metadata and should surface the tweet variant.
+describe("marketNarratives.feedDrops", () => {
+  it("returns drops without dealSeed and with the tweet variant", async () => {
     const t = convexTest(schema, modules);
     await t.mutation(api.seasons.importSeason, {});
 
+    const seasonId = await t.run(async (ctx) => {
+      const s = await ctx.db.query("narrativeSeasons").first();
+      return s!._id;
+    });
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("marketNarratives", {
+        epoch: 1,
+        seasonId,
+        epochSlot: 1,
+        dropTitle: "QUIET TAPE",
+        topArcTitle: "Quiet tape",
+        topArcTension: 0,
+        headlines: [
+          {
+            headline: "Nothing much happened and the desk approves",
+            body: "A slow session. The interns went home early.",
+            category: "wire",
+            role: "main",
+            dispatchKey: "quiet-1",
+          },
+        ],
+        worldState: { mood: "bored" },
+        rawNarrative: "Nothing much happened and the desk approves",
+        tweetVariant: "Slow tape today. The desk approves. $KUPO",
+        tweetStatus: "dry_run",
+        createdAt: Date.now(),
+      });
+    });
+
     const drops = await t.query(api.marketNarratives.feedDrops, { limit: 5 });
-    // Initial seed-imported drop has no Deal Seed
-    const initial = drops[0];
-    for (const d of initial.dispatches) {
+    expect(drops.length).toBe(1);
+    expect(drops[0].tweetVariant).toContain("Slow tape");
+    for (const d of drops[0].dispatches) {
       expect(d.dealSeed).toBeUndefined();
     }
   });

--- a/tests/convex/wire-arc-templates.test.ts
+++ b/tests/convex/wire-arc-templates.test.ts
@@ -1,43 +1,80 @@
 import { describe, it, expect } from "vitest";
 import {
-  spawnArc,
-  ARC_TEMPLATES,
-  templatePeakLossUsdc,
+  describeCompanyArc,
+  describePlayerArc,
+  fmtPct,
+  headlineMovePct,
 } from "../../convex/wire/arcTemplates";
+import type { TokenSignal } from "../../convex/wire/tokenSignals";
+
+function signal(over: Partial<TokenSignal>): TokenSignal {
+  return {
+    slug: "kupo",
+    symbol: "KUPO",
+    companyName: "Kupo",
+    xHandle: "@kupo_gg",
+    isHouseToken: false,
+    ok: true,
+    priceUsd: 1,
+    moveSinceLastPct: null,
+    move24hPct: null,
+    move24hSource: "computed",
+    volume24hUsd: null,
+    volumeVsTrailing: null,
+    volumeAnomaly: false,
+    streakDays: 0,
+    classification: "story",
+    latestSnapshotId: "s1",
+    refSnapshotIds: ["s1"],
+    ...over,
+  };
+}
 
 describe("arcTemplates", () => {
-  it("spawns a fully-specified arc with distinct firm + character slugs", () => {
-    const spec = spawnArc("100", new Set());
-    expect(spec.slug).toBeTruthy();
-    expect(spec.firm.slug).toBeTruthy();
-    expect(spec.character.slug).toBeTruthy();
-    expect(spec.firm.slug).not.toBe(spec.character.slug);
-    expect(spec.peakLossUsdc).toBeGreaterThan(0);
-    expect(ARC_TEMPLATES.map((t) => t.key)).toContain(spec.templateKey);
+  it("formats signed percentages without decimals", () => {
+    expect(fmtPct(38.4)).toBe("+38%");
+    expect(fmtPct(-22.6)).toBe("-23%");
+    expect(fmtPct(0)).toBe("0%");
   });
 
-  it("is deterministic for the same seed", () => {
-    const a = spawnArc("777", new Set());
-    const b = spawnArc("777", new Set());
-    expect(a.slug).toBe(b.slug);
-    expect(a.firm.displayName).toBe(b.firm.displayName);
+  it("picks the largest-magnitude move as the headline move", () => {
+    expect(
+      headlineMovePct(signal({ move24hPct: 38, moveSinceLastPct: 2 }))
+    ).toBe(38);
+    expect(
+      headlineMovePct(signal({ move24hPct: -5, moveSinceLastPct: -22 }))
+    ).toBe(-22);
+    expect(
+      headlineMovePct(signal({ move24hPct: null, moveSinceLastPct: null }))
+    ).toBeNull();
   });
 
-  it("avoids slugs already taken", () => {
-    const first = spawnArc("55", new Set());
-    const taken = new Set([first.firm.slug, first.character.slug, first.slug]);
-    const second = spawnArc("55", taken);
-    expect(taken.has(second.firm.slug)).toBe(false);
-    expect(taken.has(second.character.slug)).toBe(false);
+  it("builds a factual company arc from real numbers, no invented cause", () => {
+    const { title, summary } = describeCompanyArc(
+      signal({
+        move24hPct: 38,
+        streakDays: 0,
+        symbol: "SURPLUS",
+        companyName: "Surplus Intelligence",
+      })
+    );
+    expect(title).toContain("SURPLUS");
+    expect(title).toContain("+38%");
+    expect(summary).toContain("Surplus Intelligence");
+    // The cause is explicitly unknown — never an invented plausible event.
+    expect(summary.toLowerCase()).toContain("cause is anybody's guess");
   });
 
-  it("offers at least six templates", () => {
-    expect(ARC_TEMPLATES.length).toBeGreaterThanOrEqual(6);
+  it("mentions a real multi-day streak in the arc", () => {
+    const { title } = describeCompanyArc(
+      signal({ move24hPct: -6, streakDays: -3, symbol: "NOOK" })
+    );
+    expect(title).toContain("3 straight down days");
   });
 
-  it("resolves a template peak loss and returns null for unknown keys", () => {
-    expect(templatePeakLossUsdc(ARC_TEMPLATES[0].key)).toBeGreaterThan(0);
-    expect(templatePeakLossUsdc("nope")).toBeNull();
-    expect(templatePeakLossUsdc(null)).toBeNull();
+  it("builds a factual player streak arc", () => {
+    const { title, summary } = describePlayerArc("Jim's desk", "loss", 3);
+    expect(title).toBe("Jim's desk: 3 straight losses");
+    expect(summary).toContain("3 losses in a row");
   });
 });

--- a/tests/convex/wire-drama-ranker.test.ts
+++ b/tests/convex/wire-drama-ranker.test.ts
@@ -2,28 +2,64 @@ import { describe, it, expect } from "vitest";
 import {
   rankAndSelectLead,
   detectPatterns,
-  LEAD_THRESHOLD,
 } from "../../convex/wire/dramaRanker";
 import type { GameEventCtx } from "../../convex/wire/epochAssembler";
+import type { TokenSignal } from "../../convex/wire/tokenSignals";
 
 function ev(o: Partial<GameEventCtx> & { type: string }): GameEventCtx {
   return { dramatic: true, summary: o.type, ...o };
 }
 
+function sig(over: Partial<TokenSignal>): TokenSignal {
+  return {
+    slug: "kupo",
+    symbol: "KUPO",
+    companyName: "Kupo",
+    xHandle: "@kupo_gg",
+    isHouseToken: false,
+    ok: true,
+    priceUsd: 1,
+    moveSinceLastPct: null,
+    move24hPct: null,
+    move24hSource: "computed",
+    volume24hUsd: null,
+    volumeVsTrailing: null,
+    volumeAnomaly: false,
+    streakDays: 0,
+    classification: "none",
+    latestSnapshotId: "s1",
+    refSnapshotIds: ["s1"],
+    ...over,
+  };
+}
+
 describe("dramaRanker: lead selection", () => {
-  it("a wipeout leads the post", () => {
-    const sel = rankAndSelectLead([
-      ev({
-        type: "wipeout",
-        traderId: "t1",
-        dealId: "d1",
-        magnitudeUsdc: -5000,
-      }),
-      ev({ type: "deal_created", dramatic: false, magnitudeUsdc: 100 }),
-    ]);
-    expect(sel.leadKind).toBe("real_event");
-    expect(sel.leadEvent?.type).toBe("wipeout");
-    // Subjects carry the real entity refs for deep-linking.
+  it("a token flash leads and is flagged as a flash bulletin", () => {
+    const sel = rankAndSelectLead({
+      signals: [sig({ move24hPct: -22, classification: "flash" })],
+      events: [],
+    });
+    expect(sel.leadKind).toBe("token");
+    expect(sel.tokenLead?.symbol).toBe("KUPO");
+    expect(sel.isFlash).toBe(true);
+  });
+
+  it("a wipeout leads when there is no token story", () => {
+    const sel = rankAndSelectLead({
+      signals: [sig({ classification: "none" })],
+      events: [
+        ev({
+          type: "wipeout",
+          traderId: "t1",
+          dealId: "d1",
+          magnitudeUsdc: -5000,
+        }),
+        ev({ type: "deal_created", dramatic: false, magnitudeUsdc: 100 }),
+      ],
+    });
+    expect(sel.leadKind).toBe("game_event");
+    expect(sel.gameLead?.type).toBe("wipeout");
+    expect(sel.isFlash).toBe(true);
     expect(sel.subjects).toEqual(
       expect.arrayContaining([
         { type: "trader", id: "t1" },
@@ -32,15 +68,13 @@ describe("dramaRanker: lead selection", () => {
     );
   });
 
-  it("falls back to fiction when nothing clears the threshold", () => {
-    const sel = rankAndSelectLead([
-      ev({ type: "deal_created", dramatic: false, magnitudeUsdc: 50 }),
-      ev({ type: "deal_entry", dramatic: false }),
-    ]);
-    expect(sel.leadKind).toBe("fiction");
+  it("falls back to a quiet tape when nothing clears the threshold", () => {
+    const sel = rankAndSelectLead({
+      signals: [sig({ move24hPct: 3, classification: "routine" })],
+      events: [ev({ type: "deal_entry", dramatic: false })],
+    });
+    expect(sel.leadKind).toBe("quiet");
     expect(sel.realStatOneLiner).toBeTruthy();
-    const top = sel.ranked[0];
-    expect(top.score).toBeLessThan(LEAD_THRESHOLD);
   });
 
   it("detects a trap-phrase pattern across multiple traders", () => {
@@ -61,25 +95,5 @@ describe("dramaRanker: lead selection", () => {
     const riskFree = patterns.find((p) => p.phrase === "risk-free");
     expect(riskFree).toBeDefined();
     expect(riskFree!.count).toBe(2);
-  });
-
-  it("a detected pattern can win the lead over a lone loss", () => {
-    const sel = rankAndSelectLead([
-      ev({
-        type: "trap_resolved",
-        traderName: "Gordon",
-        dealPrompt: "guaranteed returns",
-        magnitudeUsdc: -100,
-      }),
-      ev({
-        type: "trap_resolved",
-        traderName: "Bud",
-        dealPrompt: "guaranteed upside",
-        magnitudeUsdc: -100,
-      }),
-    ]);
-    expect(sel.patterns.length).toBeGreaterThanOrEqual(1);
-    expect(sel.leadKind).toBe("real_event");
-    expect(sel.ranked[0].event.type).toBe("loss_pattern");
   });
 });

--- a/tests/convex/wire-drop-angles.test.ts
+++ b/tests/convex/wire-drop-angles.test.ts
@@ -26,7 +26,7 @@ describe("pickQuietAngle", () => {
   it("rotates through all angles when prevKey cycles", () => {
     const seen = new Set<string>();
     let prev: string | null = null;
-    for (let slot = 0; slot < DROP_ANGLES.length * 2; slot++) {
+    for (let slot = 0; slot < DROP_ANGLES.length * 20; slot++) {
       const angle = pickQuietAngle(`rotate-${slot}`, prev);
       seen.add(angle.key);
       prev = angle.key;

--- a/tests/convex/wire-epoch-assembler.test.ts
+++ b/tests/convex/wire-epoch-assembler.test.ts
@@ -7,50 +7,44 @@ import {
 function makeInput(overrides: Partial<AssemblerInput> = {}): AssemblerInput {
   return {
     season: {
-      title: "The PanAtlantic Collapse",
+      title: "The Listed Companies",
       tone: "Jaded, gossipy, darkly funny.",
       weeklyShape: { monday: "Slow open, everyone hungover" },
       styleRules: ["Headline ≤ 12 words.", "No emoji except a leading ⚡."],
-      forbiddenLanguage: ["DeFi", "wagmi"],
+      forbiddenLanguage: ["token", "wallet"],
     },
     dayPosture: "monday",
-    arcs: [
-      {
-        slug: "pan-atlantic-blowup",
-        title: "PanAtlantic blow-up",
-        summary: "The wake.",
-        tensionScore: 3,
-        arcStage: "aftermath",
-        isPrimary: true,
-        beatThisRun: true,
-        firmLossUsdc: 1_400_000_000,
-        firmDisplayName: "PanAtlantic Holdings",
-      },
-    ],
-    firmStates: [
-      {
-        displayName: "PanAtlantic Holdings",
-        status: "collapsing",
-        runningLossUsdc: 1_400_000_000,
-        newLossDeltaUsdc: 0,
-        latestFact: "PanAtlantic losses peaked at $1.4B",
-      },
-    ],
-    entities: [
-      { slug: "marty-vale", displayName: "Marty Vale", traits: ["loud"] },
-    ],
-    recentDrops: [],
-    recentGameEvents: [],
+    mood: "greedy",
     lead: {
-      leadKind: "fiction",
-      leadLine: null,
-      leadFigureUsdc: null,
-      realStatOneLiner: "4 entries on one deal this hour.",
+      leadKind: "quiet",
+      isFlash: false,
+      realStatOneLiner: "SURPLUS up 4%",
       patterns: [],
     },
+    companyTape: [
+      {
+        symbol: "SURPLUS",
+        companyName: "Surplus Intelligence",
+        xHandle: "@AskSurplus",
+        isHouseToken: false,
+        priceUsd: 1,
+        move24hPct: 38,
+        moveSinceLastPct: 5,
+        streakDays: 0,
+        volumeVsTrailing: null,
+        volumeAnomaly: false,
+        classification: "flash",
+      },
+    ],
+    arcs: [],
+    entities: [
+      { slug: "surplus", displayName: "Surplus Intelligence", traits: [] },
+      { slug: "harness", displayName: "Harness", traits: [] },
+    ],
+    houseTokenName: "Harness",
     floorTalkClaims: [],
-    mood: "hungover",
-    secHeat: 5,
+    sourcedStatements: [],
+    recentDrops: [],
     isOpeningBell: false,
     isClosingBell: false,
     ...overrides,
@@ -58,59 +52,83 @@ function makeInput(overrides: Partial<AssemblerInput> = {}): AssemblerInput {
 }
 
 describe("assembleUserMessage", () => {
-  it("renders the code-set mood and SEC heat", () => {
+  it("renders the code-set mood and no SEC heat", () => {
     const msg = assembleUserMessage(makeInput());
-    expect(msg).toContain("mood: hungover");
-    expect(msg).toContain("sec_heat: 5/10");
+    expect(msg).toContain("CURRENT MOOD (code-set — do not alter): greedy");
+    expect(msg).not.toContain("sec_heat");
   });
 
-  it("instructs a fiction lead with the exact firm figure", () => {
-    const msg = assembleUserMessage(makeInput());
-    expect(msg).toContain("FICTIONAL BEAT LEADS");
-    expect(msg).toContain("USE THIS EXACT FIGURE");
-    expect(msg).toContain("(1400000000 USDC)");
-  });
-
-  it("instructs a real-event lead with the exact figure", () => {
+  it("instructs a token lead with the exact symbol + move", () => {
     const msg = assembleUserMessage(
       makeInput({
         lead: {
-          leadKind: "real_event",
-          leadLine: "Gordon2 / 0x4f2…a9: Trader wiped out",
-          leadFigureUsdc: 612,
-          realStatOneLiner: null,
+          leadKind: "token",
+          isFlash: true,
+          tokenSymbol: "SURPLUS",
+          tokenCompanyName: "Surplus Intelligence",
+          tokenXHandle: "@AskSurplus",
+          tokenMovePct: 38,
+          tokenStreakDays: 0,
+          tokenIsHouse: false,
+          tokenVolumeNote: null,
           patterns: [],
         },
       })
     );
-    expect(msg).toContain("REAL EVENT LEADS");
-    expect(msg).toContain("Gordon2");
-    expect(msg).toContain("(612 USDC)");
+    expect(msg).toContain("FLASH BULLETIN");
+    expect(msg).toContain("Surplus Intelligence (SURPLUS)");
+    expect(msg).toContain("SURPLUS +38%");
+    expect(msg).toContain("NEVER invent a real-sounding reason");
   });
 
-  it("rounds a sub-dollar lead figure to cents (no raw float, no $0)", () => {
+  it("instructs a game-event lead with the exact USDC figure", () => {
     const msg = assembleUserMessage(
       makeInput({
         lead: {
-          leadKind: "real_event",
-          leadLine: "evie / 0xB58…c1: Trader lost $0.47 on someone else's deal",
-          leadFigureUsdc: 0.46952987819924236,
-          realStatOneLiner: null,
+          leadKind: "game_event",
+          isFlash: false,
+          gameLine: "Jim's desk: lost $0.99 on someone else's deal",
+          gameFigureUsdc: 0.99,
           patterns: [],
         },
       })
     );
-    expect(msg).toContain("$0.47 (0.47 USDC)");
-    expect(msg).not.toContain("0.46952987819924236");
-    expect(msg).not.toContain("$0 ");
+    expect(msg).toContain("REAL GAME EVENT LEADS");
+    expect(msg).toContain("Jim's desk");
+    expect(msg).toContain("(0.99 USDC)");
+  });
+
+  it("renders the company tape with exact figures and flags the house company", () => {
+    const msg = assembleUserMessage(
+      makeInput({
+        companyTape: [
+          {
+            symbol: "HARNESS",
+            companyName: "Harness",
+            xHandle: "@tryharness",
+            isHouseToken: true,
+            priceUsd: 1,
+            move24hPct: 0,
+            moveSinceLastPct: 0,
+            streakDays: 0,
+            volumeVsTrailing: null,
+            volumeAnomaly: false,
+            classification: "routine",
+          },
+        ],
+      })
+    );
+    expect(msg).toContain("COMPANY TAPE");
+    expect(msg).toContain("Harness (HARNESS)");
+    expect(msg).toContain("HOUSE COMPANY");
   });
 
   it("labels fabricated floor talk so it is framed as rumor", () => {
     const msg = assembleUserMessage(
       makeInput({
         floorTalkClaims: [
-          { text: "CEO seen with boxes", isTrue: false },
-          { text: "Auditors booked a second room", isTrue: true },
+          { text: "the interns started a betting pool", isTrue: false },
+          { text: "the coffee cart guy has opinions", isTrue: true },
         ],
       })
     );
@@ -118,23 +136,35 @@ describe("assembleUserMessage", () => {
     expect(msg).toContain("TRUE");
   });
 
-  it("adds the daily-wrap instruction on the closing bell", () => {
-    const msg = assembleUserMessage(makeInput({ isClosingBell: true }));
-    expect(msg).toContain("DAILY WRAP");
+  it("warns against inventing statements when none are supplied", () => {
+    const msg = assembleUserMessage(makeInput());
+    expect(msg).toContain("SOURCED STATEMENTS");
+    expect(msg).toContain(
+      "do NOT invent posts, quotes, actions, or intentions"
+    );
   });
 
-  it("adds the morning-briefing instruction on the opening bell", () => {
-    const msg = assembleUserMessage(makeInput({ isOpeningBell: true }));
-    expect(msg).toContain("MORNING BRIEFING");
+  it("adds the daily-wrap + morning-briefing instructions on the bells", () => {
+    expect(assembleUserMessage(makeInput({ isClosingBell: true }))).toContain(
+      "DAILY WRAP"
+    );
+    expect(assembleUserMessage(makeInput({ isOpeningBell: true }))).toContain(
+      "MORNING BRIEFING"
+    );
+  });
+
+  it("always instructs a URL-free tweet variant", () => {
+    const msg = assembleUserMessage(makeInput());
+    expect(msg).toContain("tweetVariant");
+    expect(msg).toContain("NO URLs");
   });
 
   it("renders detected trap patterns", () => {
     const msg = assembleUserMessage(
       makeInput({
         lead: {
-          leadKind: "real_event",
-          leadLine: "pattern",
-          leadFigureUsdc: null,
+          leadKind: "quiet",
+          isFlash: false,
           realStatOneLiner: null,
           patterns: [
             {
@@ -146,27 +176,24 @@ describe("assembleUserMessage", () => {
         },
       })
     );
-    expect(msg).toContain("TRAP PATTERNS DETECTED");
+    expect(msg).toContain("TRAP PATTERNS");
     expect(msg).toContain("risk-free");
   });
 
-  it("renders the quiet-slot angle section when set", () => {
-    const msg = assembleUserMessage(
+  it("renders + omits the quiet-slot angle section", () => {
+    const withAngle = assembleUserMessage(
       makeInput({
         quietSlotAngle: {
           key: "junior-analyst",
-          instruction: "Junior analyst gallows humor.",
+          instruction: "Junior-analyst gallows humor.",
           suggestedCategory: "wire",
         },
       })
     );
-    expect(msg).toContain("ANGLE FOR THIS DROP");
-    expect(msg).toContain("Junior analyst gallows humor.");
-    expect(msg).toContain("Suggested category: wire");
-  });
-
-  it("omits the quiet-slot angle section when not set", () => {
-    const msg = assembleUserMessage(makeInput({ quietSlotAngle: null }));
-    expect(msg).not.toContain("ANGLE FOR THIS DROP");
+    expect(withAngle).toContain("ANGLE FOR THIS DROP");
+    expect(withAngle).toContain("Suggested category: wire");
+    expect(
+      assembleUserMessage(makeInput({ quietSlotAngle: null }))
+    ).not.toContain("ANGLE FOR THIS DROP");
   });
 });

--- a/tests/convex/wire-epoch-validator.test.ts
+++ b/tests/convex/wire-epoch-validator.test.ts
@@ -2,29 +2,32 @@ import { describe, it, expect } from "vitest";
 import {
   validateEpoch,
   BANNED_PHRASES,
+  CRYPTO_TERMS,
 } from "../../convex/wire/epochValidator";
 
 const ctx = {
-  arcSlugs: new Set(["pan-atlantic-blowup"]),
-  entitySlugs: new Set(["pan-atlantic-holdings", "marty-vale"]),
-  forbiddenLanguage: ["DeFi", "wagmi"],
+  arcSlugs: new Set(["co-kupo-1"]),
+  entitySlugs: new Set(["kupo", "harness"]),
+  forbiddenLanguage: ["defi"],
 };
 
 function makeEpoch(overrides: Record<string, unknown> = {}) {
   return {
-    dropTitle: "The Wake",
+    dropTitle: "Quiet tape",
     dispatches: [
       {
-        dispatchKey: "panatl-wake",
-        headline: "PanAtlantic is dead; nobody is sad",
-        body: "Lenders would like their money back, in cash, today. The CEO is unavailable.",
+        dispatchKey: "kupo-quiet",
+        headline: "Shares of Kupo drift on a slow session",
+        body: "Kupo common barely moved and the floor barely noticed. The interns went to lunch. Nobody could be reached for comment.",
         role: "main",
         category: "wire",
-        arcSlug: "pan-atlantic-blowup",
+        arcSlug: "co-kupo-1",
         referenceEpoch: null,
       },
     ],
-    entityMentions: ["pan-atlantic-holdings"],
+    tweetVariant:
+      "Kupo did approximately nothing today and the desk approves. $KUPO @kupo_gg",
+    entityMentions: ["kupo"],
     confirmedFacts: [],
     openQuestions: [],
     ...overrides,
@@ -51,40 +54,75 @@ describe("validateEpoch", () => {
         },
       ],
     });
-    const res = validateEpoch(epoch, ctx);
-    expect(res.ok).toBe(false);
+    expect(validateEpoch(epoch, ctx).ok).toBe(false);
   });
 
   it("rejects an unknown arcSlug", () => {
     const epoch = makeEpoch();
     epoch.dispatches[0].arcSlug = "ghost-arc";
-    const res = validateEpoch(epoch, ctx);
-    expect(res.ok).toBe(false);
+    expect(validateEpoch(epoch, ctx).ok).toBe(false);
   });
 
-  it("rejects forbidden language", () => {
-    const epoch = makeEpoch();
-    epoch.dispatches[0].body = "PanAtlantic pivots to DeFi, allegedly.";
+  it("hard-blocks crypto vocabulary even in the tweet variant", () => {
+    const epoch = makeEpoch({
+      tweetVariant: "The token pumped today $KUPO @kupo_gg",
+    });
     const res = validateEpoch(epoch, ctx);
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toMatch(/Forbidden/);
+  });
+
+  it("blocks every hardcoded crypto term", () => {
+    for (const term of CRYPTO_TERMS) {
+      const epoch = makeEpoch();
+      epoch.dispatches[0].body = `The desk mentioned ${term} once. Bad idea.`;
+      expect(validateEpoch(epoch, ctx).ok).toBe(false);
+    }
+  });
+
+  it("rejects season forbidden language", () => {
+    const epoch = makeEpoch();
+    epoch.dispatches[0].body = "Kupo pivots to defi, allegedly. The end.";
+    expect(validateEpoch(epoch, ctx).ok).toBe(false);
   });
 
   it("rejects every banned filler phrase", () => {
     for (const phrase of BANNED_PHRASES) {
       const epoch = makeEpoch();
       epoch.dispatches[0].body = `The desk is quiet and ${phrase} now.`;
-      const res = validateEpoch(epoch, ctx);
-      expect(res.ok).toBe(false);
+      expect(validateEpoch(epoch, ctx).ok).toBe(false);
     }
   });
 
   it("filters unknown entity mentions instead of failing the drop", () => {
-    const epoch = makeEpoch({
-      entityMentions: ["who-dis", "marty-vale"],
-    });
-    const res = validateEpoch(epoch, ctx);
+    const res = validateEpoch(
+      makeEpoch({ entityMentions: ["who-dis", "kupo"] }),
+      ctx
+    );
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.data.entityMentions).toEqual(["marty-vale"]);
+    if (res.ok && res.data) expect(res.data.entityMentions).toEqual(["kupo"]);
+  });
+
+  it("warns (does not block) on an untraceable percentage", () => {
+    const epoch = makeEpoch();
+    epoch.dispatches[0].body =
+      "Kupo rocketed 99% for no reason at all. Wild day.";
+    const res = validateEpoch(epoch, {
+      ...ctx,
+      allowedPercents: [3, 5],
+    });
+    expect(res.ok).toBe(true);
+    expect(res.warnings).toContain("untraceable-percent:99");
+  });
+
+  it("warns on promotional coverage of the house company", () => {
+    const epoch = makeEpoch();
+    epoch.dispatches[0].body =
+      "Harness is an unstoppable buy and a clear winner. Load up.";
+    const res = validateEpoch(epoch, { ...ctx, subjectIsHouse: true });
+    expect(res.ok).toBe(true);
+    expect(res.warnings.some((w) => w.startsWith("house-promotional"))).toBe(
+      true
+    );
   });
 });

--- a/tests/convex/wire-sim-week.test.ts
+++ b/tests/convex/wire-sim-week.test.ts
@@ -1,138 +1,97 @@
 import { describe, it, expect } from "vitest";
 import {
   stepWorld,
-  freshArc,
-  freshFirm,
+  makeSignal,
+  company,
   dayKeyForIndex,
   postureForDayIndex,
   type WorldState,
 } from "./wireSim";
+import type { TokenSignal } from "../../convex/wire/tokenSignals";
 import type { GameEventCtx } from "../../convex/wire/epochAssembler";
 
 /**
- * Acceptance: a simulated week of generation. Starts from the seeded shape
- * (PanAtlantic deep in aftermath + a fresh rumor arc) and runs ~5 trading days
- * × a few hourly slots, feeding fixture game events including a wipeout.
+ * Acceptance: a simulated week driven by real price signals. One company runs
+ * up to a peak, then cools and retires; a wipeout lands on a quiet-price day and
+ * leads as a flash bulletin.
  */
 describe("wire: simulated week (acceptance)", () => {
-  it("varies tension, retires + spawns arcs, varies mood, and flashes a wipeout", () => {
-    // Seed-equivalent starting world: PanAtlantic aftermath (one beat from
-    // retiring) + a fresh rumor arc.
-    let state: WorldState = {
-      arcs: [
-        {
-          ...freshArc("pan-atlantic-blowup", "pan-atlantic-holdings"),
-          arcStage: "aftermath",
-          tensionScore: 3,
-          climaxFired: true,
-          beatsPublishedByStage: {
-            rumor: 2,
-            denial: 1,
-            confirmation: 1,
-            escalation: 2,
-            climax: 1,
-            aftermath: 1,
+  it("varies tension, spawns + retires an arc, varies mood, and flashes a wipeout", () => {
+    let state: WorldState = { arcs: [] };
+    const companies = [company("kupo", { displayName: "Kupo" })];
+
+    // Per-day KUPO signal + optional events.
+    const days: Array<{ signal: TokenSignal; events: GameEventCtx[] }> = [
+      {
+        signal: makeSignal("kupo", { move24hPct: 14, classification: "story" }),
+        events: [],
+      },
+      {
+        signal: makeSignal("kupo", { move24hPct: 25, classification: "flash" }),
+        events: [],
+      },
+      {
+        signal: makeSignal("kupo", { move24hPct: 40, classification: "flash" }),
+        events: [],
+      },
+      {
+        signal: makeSignal("kupo", { classification: "none" }),
+        events: [
+          {
+            type: "wipeout",
+            dramatic: true,
+            summary: "Trader liquidated. Cause of death: confidence.",
+            traderId: "trader-x",
+            dealId: "deal-y",
+            magnitudeUsdc: -4200,
           },
-        },
-        freshArc("boy-genius-castle", "castle-securities"),
-      ],
-      firms: [
-        {
-          ...freshFirm("pan-atlantic-holdings"),
-          status: "collapsing",
-          runningLossUsdc: 1_400_000_000,
-          notableFacts: ["PanAtlantic losses peaked at $1.4B"],
-        },
-        freshFirm("castle-securities"),
-      ],
-    };
+        ],
+      },
+      { signal: makeSignal("kupo", { classification: "none" }), events: [] },
+    ];
 
     const tensions: number[] = [];
     const moods = new Set<string>();
-    let sawRetire = false;
     let sawSpawn = false;
+    let sawRetire = false;
     let wipeoutFlashLed = false;
 
-    let slot = 5000;
-    const HOURS_PER_DAY = 6;
-    let prevQuietAngleKey: string | null = null;
-    let prevQuietAngle: string | null = null;
-    for (let day = 0; day < 5; day++) {
-      for (let hour = 0; hour < HOURS_PER_DAY; hour++) {
-        // Inject a wipeout on day 2, first hour.
-        const events: GameEventCtx[] =
-          day === 2 && hour === 0
-            ? [
-                {
-                  type: "wipeout",
-                  dramatic: true,
-                  summary: "Trader liquidated. Cause of death: confidence.",
-                  traderId: "trader-x",
-                  dealId: "deal-y",
-                  magnitudeUsdc: -4200,
-                },
-              ]
-            : [];
+    for (let day = 0; day < days.length; day++) {
+      const { advance, next } = stepWorld(state, {
+        signals: [days[day].signal],
+        companies,
+        events: days[day].events,
+        dayKey: dayKeyForIndex(day),
+        dayPosture: postureForDayIndex(day),
+        slot: 5000 + day,
+      });
 
-        const { advance, next } = stepWorld(state, {
-          events,
-          dayKey: dayKeyForIndex(day),
-          dayPosture: postureForDayIndex(day),
-          slot: slot++,
-          prevQuietAngleKey,
-        });
-
-        if (advance.quietAngle) {
-          if (prevQuietAngle) {
-            expect(advance.quietAngle.key).not.toBe(prevQuietAngle);
-          }
-          prevQuietAngle = advance.quietAngle.key;
-          prevQuietAngleKey = advance.quietAngle.key;
-        } else {
-          prevQuietAngle = null;
-          prevQuietAngleKey = null;
-        }
-
-        for (const a of advance.arcAdvances) tensions.push(a.newTensionScore);
-        moods.add(advance.mood);
-        if (advance.arcAdvances.some((a) => a.retiring)) sawRetire = true;
-        if (advance.spawnRequests.length > 0) sawSpawn = true;
-        if (
-          events.length > 0 &&
-          advance.lead.leadKind === "real_event" &&
-          advance.lead.leadEvent?.type === "wipeout"
-        ) {
-          wipeoutFlashLed = true;
-          // Subjects carry deep-link refs for the wiped-out trader + deal.
-          expect(advance.lead.subjects).toEqual(
-            expect.arrayContaining([
-              { type: "trader", id: "trader-x" },
-              { type: "deal", id: "deal-y" },
-            ])
-          );
-        }
-        state = next;
+      for (const a of advance.arcAdvances) tensions.push(a.newTensionScore);
+      for (const s of advance.spawnRequests) tensions.push(s.tensionScore);
+      moods.add(advance.mood);
+      if (advance.spawnRequests.length > 0) sawSpawn = true;
+      if (advance.arcAdvances.some((a) => a.retiring)) sawRetire = true;
+      if (
+        advance.lead.leadKind === "game_event" &&
+        advance.lead.gameLead?.type === "wipeout"
+      ) {
+        wipeoutFlashLed = true;
+        expect(advance.lead.isFlash).toBe(true);
+        expect(advance.lead.subjects).toEqual(
+          expect.arrayContaining([
+            { type: "trader", id: "trader-x" },
+            { type: "deal", id: "deal-y" },
+          ])
+        );
       }
+      state = next;
     }
 
-    // Tension varies across the 2–10 range (not pinned at max).
-    const minT = Math.min(...tensions);
-    const maxT = Math.max(...tensions);
-    expect(minT).toBeLessThanOrEqual(4);
-    expect(maxT).toBeGreaterThanOrEqual(8);
-
-    // At least one arc retired and a new one spawned.
-    expect(sawRetire).toBe(true);
+    expect(Math.min(...tensions)).toBeLessThanOrEqual(4);
+    expect(Math.max(...tensions)).toBeGreaterThanOrEqual(8);
     expect(sawSpawn).toBe(true);
-
-    // At least three distinct moods.
+    expect(sawRetire).toBe(true);
     expect(moods.size).toBeGreaterThanOrEqual(3);
-
-    // The wipeout led a post (flash-eligible).
     expect(wipeoutFlashLed).toBe(true);
-
-    // PanAtlantic's running loss never dipped below its seeded total.
-    const pan = state.firms.find((f) => f.slug === "pan-atlantic-holdings")!;
-    expect(pan.runningLossUsdc).toBeGreaterThanOrEqual(1_400_000_000);
   });
 });

--- a/tests/convex/wire-token-registry.test.ts
+++ b/tests/convex/wire-token-registry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  TOKEN_REGISTRY,
+  tokenBySymbol,
+  tokenByAddress,
+  houseToken,
+} from "../../convex/wire/tokenRegistry";
+
+describe("tokenRegistry", () => {
+  it("loads and validates all twelve seed companies", () => {
+    expect(TOKEN_REGISTRY.length).toBe(12);
+    for (const t of TOKEN_REGISTRY) {
+      expect(t.symbol).toMatch(/^[A-Z0-9]+$/);
+      expect(t.xHandle.startsWith("@")).toBe(true);
+      expect(t.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(t.addressLc).toBe(t.address.toLowerCase());
+      expect(t.slug).toBe(t.symbol.toLowerCase());
+    }
+  });
+
+  it("has exactly one house token (HARNESS)", () => {
+    const house = houseToken();
+    expect(house?.symbol).toBe("HARNESS");
+    expect(TOKEN_REGISTRY.filter((t) => t.isHouseToken).length).toBe(1);
+  });
+
+  it("has unique symbols and addresses", () => {
+    const symbols = TOKEN_REGISTRY.map((t) => t.symbol);
+    const addrs = TOKEN_REGISTRY.map((t) => t.addressLc);
+    expect(new Set(symbols).size).toBe(symbols.length);
+    expect(new Set(addrs).size).toBe(addrs.length);
+  });
+
+  it("looks up by symbol and address (case-insensitive)", () => {
+    const kupo = tokenBySymbol("kupo");
+    expect(kupo?.symbol).toBe("KUPO");
+    expect(tokenByAddress(kupo!.address.toUpperCase())?.symbol).toBe("KUPO");
+  });
+});

--- a/tests/convex/wire-token-signals.test.ts
+++ b/tests/convex/wire-token-signals.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeTokenSignals,
+  type SnapshotLite,
+} from "../../convex/wire/tokenSignals";
+import { TOKEN_REGISTRY } from "../../convex/wire/tokenRegistry";
+
+const TOKEN = TOKEN_REGISTRY[0]; // SEARXLY
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+const NOW = 1_800_000_000_000;
+
+function snap(over: Partial<SnapshotLite> & { id: string }): SnapshotLite {
+  return {
+    createdAt: NOW,
+    ok: true,
+    priceUsd: 1,
+    volume24hUsd: 1000,
+    dayKey: "2026-07-06",
+    priceChange24hPct: null,
+    ...over,
+  };
+}
+
+function signalFor(snapshots: SnapshotLite[]) {
+  const map = new Map([[TOKEN.addressLc, snapshots]]);
+  return computeTokenSignals(map).find((s) => s.slug === TOKEN.slug)!;
+}
+
+describe("computeTokenSignals", () => {
+  it("degrades to ok:false with no figures when there are no snapshots", () => {
+    const sig = signalFor([]);
+    expect(sig.ok).toBe(false);
+    expect(sig.priceUsd).toBeNull();
+    expect(sig.classification).toBe("none");
+  });
+
+  it("computes a 24h move from stored snapshots and flags a flash", () => {
+    // newest-first: now @138, ~24h ago @100
+    const sig = signalFor([
+      snap({ id: "a", createdAt: NOW, priceUsd: 138 }),
+      snap({
+        id: "b",
+        createdAt: NOW - DAY,
+        priceUsd: 100,
+        dayKey: "2026-07-05",
+      }),
+    ]);
+    expect(sig.ok).toBe(true);
+    expect(Math.round(sig.move24hPct!)).toBe(38);
+    expect(sig.move24hSource).toBe("computed");
+    expect(sig.classification).toBe("flash");
+    expect(sig.refSnapshotIds).toContain("a");
+    expect(sig.refSnapshotIds).toContain("b");
+  });
+
+  it("computes move-since-last vs the immediately preceding snapshot", () => {
+    const sig = signalFor([
+      snap({ id: "a", createdAt: NOW, priceUsd: 110 }),
+      snap({ id: "b", createdAt: NOW - HOUR, priceUsd: 100 }),
+    ]);
+    expect(Math.round(sig.moveSinceLastPct!)).toBe(10);
+  });
+
+  it("computes a signed multi-day streak from daily closes", () => {
+    // Three straight down daily closes → streak -3, promoted to at least story.
+    const sig = signalFor([
+      snap({ id: "d3", createdAt: NOW, priceUsd: 70, dayKey: "2026-07-08" }),
+      snap({
+        id: "d2",
+        createdAt: NOW - DAY,
+        priceUsd: 80,
+        dayKey: "2026-07-07",
+      }),
+      snap({
+        id: "d1",
+        createdAt: NOW - 2 * DAY,
+        priceUsd: 90,
+        dayKey: "2026-07-06",
+      }),
+      snap({
+        id: "d0",
+        createdAt: NOW - 3 * DAY,
+        priceUsd: 100,
+        dayKey: "2026-07-05",
+      }),
+    ]);
+    expect(sig.streakDays).toBe(-3);
+    expect(["story", "flash"]).toContain(sig.classification);
+  });
+
+  it("never fabricates a move when only one snapshot exists", () => {
+    const sig = signalFor([snap({ id: "only", priceUsd: 5 })]);
+    expect(sig.ok).toBe(true);
+    expect(sig.moveSinceLastPct).toBeNull();
+    expect(sig.move24hPct).toBeNull();
+    expect(sig.classification).toBe("none");
+  });
+});

--- a/tests/convex/wire-tweet-variant.test.ts
+++ b/tests/convex/wire-tweet-variant.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeTweet,
+  containsUrl,
+  TWEET_MAX_CHARS,
+} from "../../convex/wire/tweetVariant";
+
+describe("sanitizeTweet", () => {
+  it("strips explicit URLs", () => {
+    const res = sanitizeTweet(
+      "KUPO ripped today https://margincall.fun/x $KUPO",
+      {}
+    );
+    expect(res.text).not.toContain("http");
+    expect(containsUrl(res.text)).toBe(false);
+    expect(res.issues).toContain("stripped_url");
+  });
+
+  it("rejects a surviving bare domain rather than posting a mangled link", () => {
+    const res = sanitizeTweet("Check margincall.fun for the tape", {});
+    expect(res.ok).toBe(false);
+    expect(res.issues).toContain("url");
+  });
+
+  it("appends the subject handle when missing and it fits", () => {
+    const res = sanitizeTweet("SURPLUS up 38% for reasons nobody will say", {
+      subjectHandle: "@AskSurplus",
+    });
+    expect(res.text).toContain("@AskSurplus");
+    expect(res.ok).toBe(true);
+  });
+
+  it("strips an invented @-mention and keeps only the registry handle", () => {
+    const res = sanitizeTweet("BASEMATE +46% @Basemate the interns cheered", {
+      subjectHandle: "@basemateagent",
+    });
+    expect(res.text).not.toContain("@Basemate ");
+    expect(res.text).not.toMatch(/@Basemate\b/);
+    expect(res.text).toContain("@basemateagent");
+    expect(res.issues).toContain("stripped_mention");
+  });
+
+  it("strips all @-mentions when there is no subject handle", () => {
+    const res = sanitizeTweet("A quiet day, per @SomeGuy and @another", {});
+    expect(res.text).not.toContain("@");
+  });
+
+  it("keeps an already-present handle without duplicating it", () => {
+    const res = sanitizeTweet("SURPLUS up 38% @AskSurplus", {
+      subjectHandle: "@AskSurplus",
+    });
+    expect(res.text.match(/@AskSurplus/g)?.length).toBe(1);
+  });
+
+  it("preserves cashtags", () => {
+    const res = sanitizeTweet("Quiet day for $KUPO and $NOOK", {});
+    expect(res.text).toContain("$KUPO");
+    expect(res.text).toContain("$NOOK");
+  });
+
+  it("truncates over-long tweets to the platform limit", () => {
+    const long = "word ".repeat(100).trim();
+    const res = sanitizeTweet(long, {});
+    expect(res.text.length).toBeLessThanOrEqual(TWEET_MAX_CHARS);
+    expect(res.issues).toContain("truncated");
+  });
+});

--- a/tests/convex/wire-worldstate.test.ts
+++ b/tests/convex/wire-worldstate.test.ts
@@ -1,239 +1,248 @@
 import { describe, it, expect } from "vitest";
 import { computeWorldStateAdvance } from "../../convex/wire/worldState";
-import {
-  stepWorld,
-  freshArc,
-  freshFirm,
-  dayKeyForIndex,
-  postureForDayIndex,
-  type WorldState,
-} from "./wireSim";
+import { makeSignal, company, stepWorld, type WorldState } from "./wireSim";
 
-/** Drive the world for N simulated days (one beat-eligible step per day). */
-function runDays(initial: WorldState, days: number) {
-  let state = initial;
-  const advances = [];
-  for (let i = 0; i < days; i++) {
-    const { advance, next } = stepWorld(state, {
-      dayKey: dayKeyForIndex(i),
-      dayPosture: postureForDayIndex(i),
-      slot: 1000 + i,
-    });
-    advances.push(advance);
-    state = next;
-  }
-  return { state, advances };
-}
-
-describe("worldState: arc lifecycle", () => {
-  it("advances an arc through every stage to retired, firing climax once", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
-    };
-    const { state, advances } = runDays(initial, 20);
-
-    const stages = advances.flatMap((a) =>
-      a.arcAdvances.filter((x) => x.slug === "alpha").map((x) => x.toStage)
-    );
-    // Reaches climax and retirement.
-    expect(stages).toContain("climax");
-    expect(stages).toContain("aftermath");
-    // Climax fires exactly once for this arc.
-    const climaxFirings = advances.filter((a) =>
-      a.arcAdvances.some((x) => x.slug === "alpha" && x.climaxFiringNow)
-    ).length;
-    expect(climaxFirings).toBe(1);
-    // The original arc ends retired.
-    const alpha = state.arcs.find((a) => a.slug === "alpha");
-    expect(alpha?.arcStage).toBe("retired");
-  });
-
-  it("keeps the firm running-loss total monotonically non-decreasing", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
-    };
-    let state = initial;
-    let prevLoss = 0;
-    for (let i = 0; i < 20; i++) {
-      const { next } = stepWorld(state, {
-        dayKey: dayKeyForIndex(i),
-        dayPosture: postureForDayIndex(i),
-        slot: 2000 + i,
-      });
-      const loss = next.firms.find(
-        (f) => f.slug === "alpha-co"
-      )!.runningLossUsdc;
-      expect(loss).toBeGreaterThanOrEqual(prevLoss);
-      prevLoss = loss;
-      state = next;
-    }
-    // It actually accumulated a real loss by the end.
-    expect(prevLoss).toBeGreaterThan(0);
-  });
-
-  it("publishes at most one beat per arc per day", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
-    };
-    // Same dayKey twice → the second run must not publish a beat.
-    const first = stepWorld(initial, {
-      dayKey: "2026-05-05",
+describe("worldState: streak arc lifecycle", () => {
+  it("spawns a company arc for a story-worthy move", () => {
+    const advance = computeWorldStateAdvance({
+      arcs: [],
+      companies: [company("kupo")],
+      signals: [
+        makeSignal("kupo", { move24hPct: 14, classification: "story" }),
+      ],
+      events: [],
+      dayKey: "2026-07-06",
       dayPosture: "monday",
+      slot: 1,
+    });
+    expect(advance.spawnRequests.length).toBe(1);
+    const spec = advance.spawnRequests[0];
+    expect(spec.subjectType).toBe("company");
+    expect(spec.subjectSlug).toBe("kupo");
+    expect(spec.arcStage).toBe("talked_about");
+  });
+
+  it("does not spawn or lead on companies with no real move (reactive only)", () => {
+    const advance = computeWorldStateAdvance({
+      arcs: [],
+      companies: [company("kupo"), company("nook")],
+      signals: [
+        makeSignal("kupo", { move24hPct: 2, classification: "routine" }),
+        makeSignal("nook", { classification: "none" }),
+      ],
+      events: [],
+      dayKey: "2026-07-06",
+      dayPosture: "wednesday",
+      slot: 2,
+    });
+    expect(advance.spawnRequests.length).toBe(0);
+    expect(advance.lead.leadKind).toBe("quiet");
+  });
+
+  it("escalates to peak on an extreme move and fires peak once", () => {
+    const spawn = computeWorldStateAdvance({
+      arcs: [],
+      companies: [company("surplus")],
+      signals: [
+        makeSignal("surplus", { move24hPct: 40, classification: "flash" }),
+      ],
+      events: [],
+      dayKey: "2026-07-06",
+      dayPosture: "wednesday",
+      slot: 3,
+    });
+    expect(spawn.spawnRequests[0].arcStage).toBe("peak");
+
+    // Once peaked, a still-huge move holds at frenzy — peak never re-fires.
+    const advance2 = computeWorldStateAdvance({
+      arcs: [
+        {
+          slug: "co-surplus-3",
+          title: "t",
+          summary: "s",
+          tensionScore: 10,
+          arcStage: "peak",
+          peakFired: true,
+          subjectType: "company",
+          subjectSlug: "surplus",
+        },
+      ],
+      companies: [company("surplus")],
+      signals: [
+        makeSignal("surplus", { move24hPct: 45, classification: "flash" }),
+      ],
+      events: [],
+      dayKey: "2026-07-07",
+      dayPosture: "thursday",
+      slot: 4,
+    });
+    const adv = advance2.arcAdvances[0];
+    expect(adv.peakFiringNow).toBe(false);
+    expect(adv.toStage).toBe("frenzy");
+  });
+
+  it("cools a company arc to aftermath then retires it when the move fades", () => {
+    let state: WorldState = {
+      arcs: [
+        {
+          slug: "co-kupo-1",
+          title: "t",
+          summary: "s",
+          tensionScore: 8,
+          arcStage: "frenzy",
+          peakFired: false,
+          subjectType: "company",
+          subjectSlug: "kupo",
+        },
+      ],
+    };
+    const quiet = {
+      signals: [makeSignal("kupo", { classification: "none" })],
+      companies: [company("kupo")],
+    };
+
+    const first = stepWorld(state, {
+      ...quiet,
+      dayKey: "2026-07-08",
+      dayPosture: "wednesday",
       slot: 10,
     });
-    const second = stepWorld(first.next, {
-      dayKey: "2026-05-05",
-      dayPosture: "monday",
+    expect(first.advance.arcAdvances[0].toStage).toBe("aftermath");
+    state = first.next;
+
+    const second = stepWorld(state, {
+      ...quiet,
+      dayKey: "2026-07-09",
+      dayPosture: "thursday",
       slot: 11,
     });
-    expect(first.advance.arcAdvances[0].beatPublishedThisRun).toBe(true);
-    expect(second.advance.arcAdvances[0].beatPublishedThisRun).toBe(false);
+    expect(second.advance.arcAdvances[0].toStage).toBe("retired");
+    expect(second.advance.arcAdvances[0].retiring).toBe(true);
   });
 
-  it("spawns a fresh arc when live arcs drop below two", () => {
-    // Single arc → liveAfter (1) < target (2) → spawn immediately.
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
-    };
-    const { advance } = stepWorld(initial, {
-      dayKey: "2026-05-05",
-      dayPosture: "monday",
-      slot: 42,
+  it("spawns a player arc from a same-desk losing streak", () => {
+    const advance = computeWorldStateAdvance({
+      arcs: [],
+      companies: [],
+      signals: [],
+      events: [
+        {
+          type: "big_loss",
+          dramatic: true,
+          summary: "lost",
+          traderId: "t1",
+          traderName: "Jim",
+          magnitudeUsdc: -900,
+        },
+        {
+          type: "big_loss",
+          dramatic: true,
+          summary: "lost",
+          traderId: "t1",
+          traderName: "Jim",
+          magnitudeUsdc: -800,
+        },
+        {
+          type: "wipeout",
+          dramatic: true,
+          summary: "gone",
+          traderId: "t1",
+          traderName: "Jim",
+          magnitudeUsdc: -700,
+        },
+      ],
+      dayKey: "2026-07-06",
+      dayPosture: "friday",
+      slot: 5,
     });
-    expect(advance.spawnRequests.length).toBeGreaterThanOrEqual(1);
-    const spawned = advance.spawnRequests[0];
-    expect(spawned.firm.slug).not.toBe("alpha-co");
-    expect(spawned.slug).not.toBe("alpha");
-  });
-
-  it("does not advance two live arcs into the same stage", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co"), freshArc("beta", "beta-co")],
-      firms: [freshFirm("alpha-co"), freshFirm("beta-co")],
-    };
-    const { state } = runDays(initial, 12);
-    const liveStages = state.arcs
-      .filter((a) => a.arcStage !== "retired")
-      .map((a) => a.arcStage);
-    const uniq = new Set(liveStages);
-    expect(uniq.size).toBe(liveStages.length);
-  });
-
-  it("produces at least three distinct moods across a simulated week", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co"), freshArc("beta", "beta-co")],
-      firms: [freshFirm("alpha-co"), freshFirm("beta-co")],
-    };
-    const moods = new Set<string>();
-    let state = initial;
-    for (let i = 0; i < 15; i++) {
-      const events =
-        i === 7
-          ? [
-              {
-                type: "wipeout",
-                dramatic: true,
-                summary: "Trader wiped out",
-                traderId: "t1",
-                magnitudeUsdc: -5000,
-              },
-            ]
-          : [];
-      const { advance, next } = stepWorld(state, {
-        events,
-        dayKey: dayKeyForIndex(i),
-        dayPosture: postureForDayIndex(i),
-        slot: 3000 + i,
-      });
-      moods.add(advance.mood);
-      state = next;
-    }
-    expect(moods.size).toBeGreaterThanOrEqual(3);
+    const desk = advance.spawnRequests.find((s) => s.subjectType === "desk");
+    expect(desk).toBeDefined();
+    expect(desk!.subjectSlug).toBe("desk-t1");
   });
 });
 
-describe("worldState: mood + SEC heat", () => {
-  it("a real wipeout lead produces a grim mood and bumps SEC heat", () => {
+describe("worldState: mood + lead", () => {
+  it("a token flash down produces a grim mood and a flash lead", () => {
     const advance = computeWorldStateAdvance({
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
+      arcs: [],
+      companies: [company("nook")],
+      signals: [
+        makeSignal("nook", { move24hPct: -22, classification: "flash" }),
+      ],
+      events: [],
+      dayKey: "2026-07-06",
+      dayPosture: "wednesday",
+      slot: 6,
+    });
+    expect(advance.lead.leadKind).toBe("token");
+    expect(advance.lead.isFlash).toBe(true);
+    expect(advance.mood).toBe("grim");
+  });
+
+  it("a wipeout produces a grim mood and leads as a game event", () => {
+    const advance = computeWorldStateAdvance({
+      arcs: [],
+      companies: [company("kupo")],
+      signals: [makeSignal("kupo", { classification: "none" })],
       events: [
         {
           type: "wipeout",
           dramatic: true,
-          summary: "Trader wiped out",
+          summary: "gone",
           traderId: "t1",
-          magnitudeUsdc: -9000,
+          magnitudeUsdc: -5000,
         },
       ],
-      dayKey: "2026-05-05",
+      dayKey: "2026-07-06",
       dayPosture: "monday",
-      slot: 1,
+      slot: 7,
     });
-    expect(advance.lead.leadKind).toBe("real_event");
+    expect(advance.lead.leadKind).toBe("game_event");
     expect(advance.mood).toBe("grim");
-    expect(advance.secHeat).toBeGreaterThanOrEqual(4);
-    expect(advance.secHeat).toBeLessThanOrEqual(10);
     expect(advance.quietAngle).toBeNull();
   });
 
-  it("assigns a quiet angle on a second same-day slot with no beat", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
+  it("assigns a quiet angle on a quiet tape and rotates it", () => {
+    const base = {
+      arcs: [],
+      companies: [company("kupo")],
+      signals: [makeSignal("kupo", { classification: "none" })],
+      events: [],
+      dayPosture: "monday",
     };
-    const first = stepWorld(initial, {
-      dayKey: "2026-05-05",
-      dayPosture: "monday",
-      slot: 10,
+    const a = computeWorldStateAdvance({
+      ...base,
+      dayKey: "2026-07-06",
+      slot: 20,
     });
-    const second = stepWorld(first.next, {
-      dayKey: "2026-05-05",
-      dayPosture: "monday",
-      slot: 11,
-      prevQuietAngleKey: first.advance.quietAngle?.key ?? null,
+    const b = computeWorldStateAdvance({
+      ...base,
+      dayKey: "2026-07-06",
+      slot: 21,
+      prevQuietAngleKey: a.quietAngle?.key ?? null,
     });
-    const third = stepWorld(second.next, {
-      dayKey: "2026-05-05",
-      dayPosture: "monday",
-      slot: 12,
-      prevQuietAngleKey: second.advance.quietAngle?.key ?? null,
-    });
-    expect(first.advance.arcAdvances[0].beatPublishedThisRun).toBe(true);
-    expect(second.advance.arcAdvances[0].beatPublishedThisRun).toBe(false);
-    expect(second.advance.lead.leadKind).toBe("fiction");
-    expect(second.advance.quietAngle).not.toBeNull();
-    expect(third.advance.quietAngle).not.toBeNull();
-    expect(third.advance.quietAngle?.key).not.toBe(
-      second.advance.quietAngle?.key
-    );
+    expect(a.quietAngle).not.toBeNull();
+    expect(b.quietAngle).not.toBeNull();
+    expect(b.quietAngle?.key).not.toBe(a.quietAngle?.key);
   });
 
-  it("rotates floor-talk gossip text across slots on a held arc", () => {
-    const initial: WorldState = {
-      arcs: [freshArc("alpha", "alpha-co")],
-      firms: [freshFirm("alpha-co")],
-    };
-    const texts = new Set<string>();
-    let state = initial;
-    let prevAngle: string | null = null;
-    for (let slot = 20; slot < 28; slot++) {
-      const { advance, next } = stepWorld(state, {
-        dayKey: "2026-05-05",
-        dayPosture: "monday",
-        slot,
-        prevQuietAngleKey: prevAngle,
-      });
-      for (const claim of advance.floorTalkClaims) {
-        texts.add(claim.text);
-      }
-      prevAngle = advance.quietAngle?.key ?? null;
-      state = next;
-    }
-    expect(texts.size).toBeGreaterThan(1);
+  it("attaches floor talk to a company that is in play", () => {
+    const advance = computeWorldStateAdvance({
+      arcs: [],
+      companies: [company("surplus", { displayName: "Surplus Intelligence" })],
+      signals: [
+        makeSignal("surplus", {
+          companyName: "Surplus Intelligence",
+          move24hPct: 38,
+          classification: "flash",
+        }),
+      ],
+      events: [],
+      dayKey: "2026-07-06",
+      dayPosture: "wednesday",
+      slot: 8,
+    });
+    expect(advance.floorTalkClaims.length).toBe(1);
+    expect(advance.floorTalkClaims[0].text).toContain("Surplus Intelligence");
   });
 });

--- a/tests/convex/wireSim.ts
+++ b/tests/convex/wireSim.ts
@@ -1,21 +1,60 @@
 /**
- * Pure simulation harness for the wire world-state engine (NOT a test file —
- * the vitest include glob only picks up *.test.ts). Threads state forward the
- * same way the persist mutation does, so tests can drive arcs through their
- * whole lifecycle deterministically.
+ * Pure simulation harness for the rebuilt wire world-state engine (NOT a test
+ * file — the vitest glob only picks up *.test.ts). Threads arc state forward the
+ * same way persist.ts does, so tests can drive streak arcs through their whole
+ * lifecycle deterministically.
  */
 import {
   computeWorldStateAdvance,
   type ArcInput,
-  type FirmInput,
+  type CompanyCtx,
   type WorldStateAdvance,
 } from "../../convex/wire/worldState";
+import type { TokenSignal } from "../../convex/wire/tokenSignals";
 import type { GameEventCtx } from "../../convex/wire/epochAssembler";
-import { STAGE_TARGET_TENSION } from "../../convex/wire/stages";
 
 export interface WorldState {
   arcs: ArcInput[];
-  firms: FirmInput[];
+}
+
+/** Build a token signal with sensible defaults. */
+export function makeSignal(
+  slug: string,
+  over: Partial<TokenSignal> = {}
+): TokenSignal {
+  return {
+    slug,
+    symbol: slug.toUpperCase(),
+    companyName: slug,
+    xHandle: `@${slug}`,
+    isHouseToken: false,
+    ok: true,
+    priceUsd: 1,
+    moveSinceLastPct: null,
+    move24hPct: null,
+    move24hSource: "computed",
+    volume24hUsd: null,
+    volumeVsTrailing: null,
+    volumeAnomaly: false,
+    streakDays: 0,
+    classification: "none",
+    latestSnapshotId: `${slug}-s`,
+    refSnapshotIds: [`${slug}-s`],
+    ...over,
+  };
+}
+
+export function company(
+  slug: string,
+  over: Partial<CompanyCtx> = {}
+): CompanyCtx {
+  return {
+    slug,
+    displayName: slug,
+    symbol: slug.toUpperCase(),
+    isHouseToken: false,
+    ...over,
+  };
 }
 
 /** Apply one advance to the world, mirroring convex/wire/persist.ts. */
@@ -30,56 +69,33 @@ export function applyAdvance(
       ...arc,
       arcStage: adv.toStage,
       tensionScore: adv.newTensionScore,
-      beatsPublishedByStage: adv.newBeatsPublishedByStage,
-      climaxFired: arc.climaxFired || adv.climaxFiringNow,
+      peakFired: arc.peakFired || adv.peakFiringNow,
       lastBeatDayKey: adv.newLastBeatDayKey,
     };
   });
 
-  const firms = state.firms.map((firm) => {
-    const delta = advance.firmDeltas.find((d) => d.slug === firm.slug);
-    if (!delta) return firm;
-    return {
-      ...firm,
-      runningLossUsdc: delta.newRunningLossUsdc,
-      status: delta.newStatus,
-      notableFacts: [...firm.notableFacts, ...delta.appendNotableFacts],
-      lastLossDayKey: delta.lastLossDayKey,
-    };
-  });
-
-  // Spawn fresh arcs + firms (rumor stage, loss 0).
   for (const spec of advance.spawnRequests) {
     arcs.push({
       slug: spec.slug,
       title: spec.title,
       summary: spec.summary,
-      tensionScore: STAGE_TARGET_TENSION.rumor,
-      arcStage: "rumor",
-      beatsPublishedByStage: {},
-      climaxFired: false,
+      tensionScore: spec.tensionScore,
+      arcStage: spec.arcStage,
+      peakFired: spec.arcStage === "peak",
       lastBeatDayKey: null,
-      templateKey: spec.templateKey,
-      primaryFirmSlug: spec.firm.slug,
-    });
-    firms.push({
-      slug: spec.firm.slug,
-      displayName: spec.firm.displayName,
-      status: "healthy",
-      runningLossUsdc: 0,
-      notableFacts: [],
-      oneOffEventsFired: [],
-      lastLossDayKey: null,
+      subjectType: spec.subjectType,
+      subjectSlug: spec.subjectSlug,
     });
   }
 
-  return { arcs, firms };
+  return { arcs };
 }
 
-/** Run one step: compute the advance and apply it. */
 export function stepWorld(
   state: WorldState,
   opts: {
+    signals?: TokenSignal[];
+    companies?: CompanyCtx[];
     events?: GameEventCtx[];
     dayKey: string;
     dayPosture: string;
@@ -89,7 +105,8 @@ export function stepWorld(
 ): { advance: WorldStateAdvance; next: WorldState } {
   const advance = computeWorldStateAdvance({
     arcs: state.arcs,
-    firms: state.firms,
+    companies: opts.companies ?? [],
+    signals: opts.signals ?? [],
     events: opts.events ?? [],
     dayKey: opts.dayKey,
     dayPosture: opts.dayPosture,
@@ -99,40 +116,11 @@ export function stepWorld(
   return { advance, next: applyAdvance(state, advance) };
 }
 
-/** A clean single-firm rumor-stage arc to drive through its lifecycle. */
-export function freshArc(slug: string, firmSlug: string): ArcInput {
-  return {
-    slug,
-    title: `${slug} title`,
-    summary: `${slug} summary`,
-    tensionScore: STAGE_TARGET_TENSION.rumor,
-    arcStage: "rumor",
-    beatsPublishedByStage: {},
-    climaxFired: false,
-    lastBeatDayKey: null,
-    templateKey: null,
-    primaryFirmSlug: firmSlug,
-  };
-}
-
-export function freshFirm(slug: string): FirmInput {
-  return {
-    slug,
-    displayName: `${slug} Co.`,
-    status: "healthy",
-    runningLossUsdc: 0,
-    notableFacts: [],
-    oneOffEventsFired: [],
-    lastLossDayKey: null,
-  };
-}
-
 const WEEKDAYS = ["monday", "tuesday", "wednesday", "thursday", "friday"];
 export function postureForDayIndex(i: number): string {
   return WEEKDAYS[i % WEEKDAYS.length];
 }
 export function dayKeyForIndex(i: number): string {
-  // Deterministic ET-style YYYY-MM-DD keys.
-  const day = String(5 + i).padStart(2, "0");
-  return `2026-05-${day}`;
+  const day = String(6 + i).padStart(2, "0");
+  return `2026-07-${day}`;
 }

--- a/tokens.json
+++ b/tokens.json
@@ -1,0 +1,76 @@
+[
+  {
+    "symbol": "SEARXLY",
+    "companyName": "Searxly",
+    "xHandle": "@Searxly",
+    "address": "0x0fdc79b868bc4a6295cd94397f61890f68c38ba3"
+  },
+  {
+    "symbol": "KUPO",
+    "companyName": "Kupo",
+    "xHandle": "@kupo_gg",
+    "address": "0xb2ece11a988a54a79675d4b827fc9ac419fb4ba3"
+  },
+  {
+    "symbol": "MIROSHARK",
+    "companyName": "MiroShark",
+    "xHandle": "@miroshark_",
+    "address": "0xd7bc6a05a56655fb2052f742b012d1dfd66e1ba3"
+  },
+  {
+    "symbol": "BLOCKTRONICS",
+    "companyName": "Blocktronics",
+    "xHandle": "@blocktronicsxyz",
+    "address": "0x7afe438411ee3959c7de6f7fb76bf9c769320ba3"
+  },
+  {
+    "symbol": "LFI",
+    "companyName": "LienFi",
+    "xHandle": "@lienfiapp",
+    "address": "0x3722264ab15a1dfce5a5af89e6547f7949a8aba3"
+  },
+  {
+    "symbol": "HARNESS",
+    "companyName": "Harness",
+    "xHandle": "@tryharness",
+    "address": "0xd3e592e728ae3461bd97c7a6b359e1043dd83ba3",
+    "isHouseToken": true,
+    "notes": "The house token. Editorial stance is HARDER than on any other company: self-deprecating, never promotional. Frame it as 'a company this desk is contractually obligated to mention.' Favorable coverage fails review. The desk holds a position and would rather not discuss it."
+  },
+  {
+    "symbol": "BNKR",
+    "companyName": "Bankr",
+    "xHandle": "@bankrbot",
+    "address": "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b"
+  },
+  {
+    "symbol": "GITLAWB",
+    "companyName": "Gitlawb",
+    "xHandle": "@gitlawb",
+    "address": "0x5f980dcfc4c0fa3911554cf5ab288ed0eb13dba3"
+  },
+  {
+    "symbol": "SURPLUS",
+    "companyName": "Surplus Intelligence",
+    "xHandle": "@AskSurplus",
+    "address": "0xc52aedec3374422d7510e294cfaa90799595cba3"
+  },
+  {
+    "symbol": "AEON",
+    "companyName": "Aeon",
+    "xHandle": "@aeonframework",
+    "address": "0xbf8e8f0e8866a7052f948c16508644347c57aba3"
+  },
+  {
+    "symbol": "NOOK",
+    "companyName": "Nookplot",
+    "xHandle": "@nookplot",
+    "address": "0xb233bdffd437e60fa451f62c6c09d3804d285ba3"
+  },
+  {
+    "symbol": "BASEMATE",
+    "companyName": "Basemate",
+    "xHandle": "@basemateagent",
+    "address": "0x07e61d8a4e197dfc269e90d7ece1df0d26702ba3"
+  }
+]


### PR DESCRIPTION
## What

Replaces the newswire's fictional-firm/fraud-arc engine with coverage of **12 real Base tokens**, treated as listed companies on a 1980s exchange and driven by **real CoinGecko price data** + in-game events. The engine's core property — *code owns every number, the LLM only narrates* — is preserved; only the narrative source changed.

## Why

The old wire generated gossip about fictional entities (Ironside Brothers, Reggie Pike) players didn't recognize, and its storylines were exactly the "plausible-as-news" finance fabrications we now forbid.

## How

- **`tokens.json`** registry (repo root, Zod-validated at load) — the single source of truth for coverage. `registrySync` reconciles the company roster every cycle, so add/remove/edit + deploy takes effect next cycle with **no code changes**.
- **CoinGecko onchain poller** (`pricePoll.ts`, 24/7 cron at :20) keyed by contract, `?include=top_pools` for real 24h moves. Failed fetches write `ok:false` snapshots — **never fabricated numbers**; unresolvable addresses are flagged, never silently dropped.
- **`tokenSignals`** computes moves / streaks / volume anomalies (thresholds in `priceConfig.ts`).
- **`worldState`** rebuilt around **attention-lifecycle streak arcs** (company + desk); `dramaRanker` ranks token + game events as uniform leads. No fictional humans, no SEC/fraud.
- **Voice**: new system prompt + assembler (company tape, house-token stance for HARNESS, sourced-statements rule). Crypto vocabulary is **hard-blocked** in the validator.
- **Twitter**: each drop emits a sanitized `tweetVariant` — URLs stripped/rejected, only the covered company's `@handle` allowed, ≤280. Posting is behind `tweetPoster.ts`, **dry-run by default** (`MC_WIRE_TWEETS_LIVE=1` to enable once a client is wired).
- **`sourceTrace`** on every drop for mechanical traceability.
- **Schema**: `tokenSnapshots` table, `company` entity kind, attention `arcStage` vocabulary, tweet + `sourceTrace` fields.

## Verification

- ✅ 510 unit tests (wire suite rewritten for the new engine + new registry/signals/tweet tests), lint clean, `pnpm build` green.
- ✅ Deployed to Convex; all **12 tokens resolve** to live price data.
- ✅ **10 consecutive live cycles** generated; a fresh-context sub-agent audit found **no rule violations** in reader-facing content (numbers trace within ±1%, zero crypto vocab, no fictional humans, no plausible fabrications, no invented real-account claims, tweets ≤280 / URL-free / correct handle).
- ✅ **Kill-API degrade**: no key → failure snapshots, wire still publishes, no fabricated numbers.
- ✅ **Registry hot-swap**: added a fake company + removed a real one → reflected next cycle, no code changes; unresolvable flagged.

## Deploy notes

- Convex functions already pushed to the deployment. Schema migration used widen→clear→narrow (legacy `arcStage` rows cleared; reseeded).
- Requires `COINGECKO_API_KEY` (free Demo tier) in Convex env (set).
- Frontend change is a single unused-field removal in `wire-drop.tsx`; ships on the usual `git push main` → Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)