### PR TITLE
feat(wire): guarantee $CASHTAG + @handle in token tweets

### DIFF
--- a/convex/wire/generator.ts
+++ b/convex/wire/generator.ts
@@ -456,6 +456,8 @@ async function runGenerator(
   // ── Tweet: sanitize (strip/reject URLs, ≤280, ensure @handle), then post ──
   const sanitized = sanitizeTweet(validated.tweetVariant, {
     subjectHandle: tweetSubjectHandle,
+    subjectSymbol:
+      lead.leadKind === "token" ? (lead.tokenLead?.symbol ?? null) : null,
   });
   let tweetStatus: string;
   if (!sanitized.ok) {

--- a/convex/wire/tweetVariant.ts
+++ b/convex/wire/tweetVariant.ts
@@ -34,7 +34,7 @@ function hasHandle(text: string, handle: string): boolean {
  */
 export function sanitizeTweet(
   raw: string,
-  opts: { subjectHandle?: string | null } = {}
+  opts: { subjectHandle?: string | null; subjectSymbol?: string | null } = {}
 ): SanitizeResult {
   const issues: string[] = [];
   let text = (raw ?? "").replace(/\s+/g, " ").trim();
@@ -63,6 +63,16 @@ export function sanitizeTweet(
     .trim();
   if (stripped !== text) issues.push("stripped_mention");
   text = stripped;
+
+  // Ensure the subject company's $CASHTAG is present (ticker discoverability).
+  const symbol = opts.subjectSymbol?.trim().toUpperCase();
+  if (symbol && !new RegExp(`\\$${symbol}\\b`, "i").test(text)) {
+    const candidate = `${text} $${symbol}`.trim();
+    if (candidate.length <= TWEET_MAX_CHARS) {
+      text = candidate;
+      issues.push("added_cashtag");
+    }
+  }
 
   // Ensure the subject company's handle is present (distribution mechanic).
   const handle = opts.subjectHandle?.trim();

--- a/tests/convex/wire-tweet-variant.test.ts
+++ b/tests/convex/wire-tweet-variant.test.ts
@@ -52,6 +52,23 @@ describe("sanitizeTweet", () => {
     expect(res.text.match(/@AskSurplus/g)?.length).toBe(1);
   });
 
+  it("injects the subject cashtag when the model omitted it", () => {
+    const res = sanitizeTweet("Basemate ripped 46% and the interns cheered", {
+      subjectHandle: "@basemateagent",
+      subjectSymbol: "BASEMATE",
+    });
+    expect(res.text).toContain("$BASEMATE");
+    expect(res.text).toContain("@basemateagent");
+    expect(res.issues).toContain("added_cashtag");
+  });
+
+  it("does not duplicate a cashtag the model already wrote", () => {
+    const res = sanitizeTweet("$BASEMATE ripped 46%", {
+      subjectSymbol: "BASEMATE",
+    });
+    expect(res.text.match(/\$BASEMATE/gi)?.length).toBe(1);
+  });
+
   it("preserves cashtags", () => {
     const res = sanitizeTweet("Quiet day for $KUPO and $NOOK", {});
     expect(res.text).toContain("$KUPO");


### PR DESCRIPTION
Follow-up to #180 — this commit missed that merge but is **already deployed to production** (Convex `--once` push); this PR just reconciles `main` with what's running.

Guarantees every token-story tweet carries both the subject company's **`$CASHTAG`** and **`@handle`**. Previously the `@handle` was always appended but the `$SYMBOL` cashtag only appeared if the model happened to write it. The sanitizer now injects the cashtag when missing (dedup-safe). Tests updated (10/10 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)