### PR TITLE
feat(deal): skip redundant approvals + granular create-deal progress

### DIFF
--- a/src/components/wire/create-deal-dialog.tsx
+++ b/src/components/wire/create-deal-dialog.tsx
@@ -19,8 +19,11 @@ import { MarketClosedButton } from "@/components/market-closed-button";
 import type { Id } from "../../../convex/_generated/dataModel";
 
 const STEP_LABELS: Record<string, string> = {
+  checking: "CHECKING WALLET & ALLOWANCE...",
   approving: "APPROVING USDC SPEND...",
+  confirmingApproval: "CONFIRMING APPROVAL ON-CHAIN...",
   creating: "CREATING DEAL ON-CHAIN...",
+  confirmingCreate: "CONFIRMING DEAL ON-CHAIN...",
   syncing: "SYNCING DEAL TO DATABASE...",
   done: "DEAL CREATED SUCCESSFULLY",
 };
@@ -39,11 +42,23 @@ const STAGE_LABELS: Record<DialogState, string> = {
   creating: "Send",
 };
 
-function createDealProgressWidth(step: string): "33%" | "66%" | "90%" | "100%" {
-  if (step === "approving") return "33%";
-  if (step === "creating") return "66%";
-  if (step === "syncing") return "90%";
-  return "100%";
+function createDealProgressWidth(step: string): string {
+  switch (step) {
+    case "checking":
+      return "12%";
+    case "approving":
+      return "28%";
+    case "confirmingApproval":
+      return "48%";
+    case "creating":
+      return "66%";
+    case "confirmingCreate":
+      return "86%";
+    case "syncing":
+      return "95%";
+    default:
+      return "100%";
+  }
 }
 
 function StageIndicator({

--- a/src/hooks/use-create-deal.ts
+++ b/src/hooks/use-create-deal.ts
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { erc20Abi, parseUnits, decodeEventLog } from "viem";
+import { erc20Abi, parseUnits, decodeEventLog, maxUint256 } from "viem";
 import { useMutation } from "convex/react";
+import { usePrivy } from "@privy-io/react-auth";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useSponsoredContractWrite } from "@/hooks/use-sponsored-contract-write";
+import { getEmbeddedEvmWalletAddress } from "@/lib/privy/wallet";
 import { syncDeskWalletBalance } from "@/lib/api";
 import {
   ESCROW_ADDRESS,
@@ -19,7 +21,15 @@ import {
   MARKET_CLOSED_MESSAGE,
 } from "../../convex/lib/tradingHours";
 
-type CreateDealStep = "idle" | "approving" | "creating" | "syncing" | "done";
+type CreateDealStep =
+  | "idle"
+  | "checking"
+  | "approving"
+  | "confirmingApproval"
+  | "creating"
+  | "confirmingCreate"
+  | "syncing"
+  | "done";
 
 interface CreateDealState {
   step: CreateDealStep;
@@ -33,6 +43,8 @@ interface CreateDealState {
 export function useCreateDeal() {
   const [state, setState] = useState<CreateDealState>({ step: "idle" });
   const writeSponsoredContract = useSponsoredContractWrite();
+  const { user } = usePrivy();
+  const walletAddress = getEmbeddedEvmWalletAddress(user) ?? undefined;
 
   const recordOnChainCreation = useMutation(api.deals.recordOnChainCreation);
 
@@ -50,7 +62,7 @@ export function useCreateDeal() {
         throw error;
       }
 
-      setState({ step: "approving" });
+      setState({ step: "checking" });
 
       try {
         await syncDeskWalletBalance("Fund your wallet before creating a deal");
@@ -58,19 +70,43 @@ export function useCreateDeal() {
         const potAmountRaw = parseUnits(potAmountUsdc.toString(), 6);
         const entryCostRaw = parseUnits(entryCostUsdc.toString(), 6);
 
-        const approveHash = await writeSponsoredContract({
-          address: USDC_SEPOLIA_ADDRESS,
-          abi: erc20Abi,
-          functionName: "approve",
-          args: [ESCROW_ADDRESS, potAmountRaw],
-          chainId: CONTRACTS_CHAIN_ID,
-        });
-
-        setState((s) => ({ ...s, approveHash }));
-
         const publicClient = makePublicClient();
 
-        await publicClient.waitForTransactionReceipt({ hash: approveHash });
+        // Skip the approve tx entirely when the desk wallet already has a
+        // standing allowance that covers this pot. We approve maxUint256 (USDC
+        // treats it as infinite), so only the first deal ever needs an approval.
+        let hasSufficientAllowance = false;
+        if (walletAddress) {
+          try {
+            const allowance = await publicClient.readContract({
+              address: USDC_SEPOLIA_ADDRESS,
+              abi: erc20Abi,
+              functionName: "allowance",
+              args: [walletAddress, ESCROW_ADDRESS],
+            });
+            hasSufficientAllowance = allowance >= potAmountRaw;
+          } catch {
+            // Fall back to approving if the allowance read fails.
+            hasSufficientAllowance = false;
+          }
+        }
+
+        let approveHash: `0x${string}` | undefined;
+        if (!hasSufficientAllowance) {
+          setState((s) => ({ ...s, step: "approving" }));
+
+          approveHash = await writeSponsoredContract({
+            address: USDC_SEPOLIA_ADDRESS,
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [ESCROW_ADDRESS, maxUint256],
+            chainId: CONTRACTS_CHAIN_ID,
+          });
+
+          setState((s) => ({ ...s, approveHash, step: "confirmingApproval" }));
+
+          await publicClient.waitForTransactionReceipt({ hash: approveHash });
+        }
 
         setState((s) => ({ ...s, step: "creating" }));
 
@@ -82,7 +118,7 @@ export function useCreateDeal() {
           chainId: CONTRACTS_CHAIN_ID,
         });
 
-        setState((s) => ({ ...s, createHash }));
+        setState((s) => ({ ...s, createHash, step: "confirmingCreate" }));
 
         const createTxReceipt = await publicClient.waitForTransactionReceipt({
           hash: createHash,
@@ -140,7 +176,7 @@ export function useCreateDeal() {
         throw err;
       }
     },
-    [writeSponsoredContract, recordOnChainCreation]
+    [writeSponsoredContract, recordOnChainCreation, walletAddress]
   );
 
   const reset = useCallback(() => {

--- a/src/lib/contracts/client.ts
+++ b/src/lib/contracts/client.ts
@@ -8,6 +8,9 @@ function buildPublicClient() {
   return createPublicClient({
     chain: CONTRACTS_CHAIN,
     transport: http(baseSepoliaRpcUrl),
+    // Base blocks land in ~2s; poll faster than viem's 4s default so receipt
+    // waits between the approve and createDeal txs resolve promptly.
+    pollingInterval: 1_000,
   });
 }
 


### PR DESCRIPTION
## Problem
Creating a deal fired an exact-pot USDC `approve` before **every** deal (the escrow's `createDeal` consumes the full allowance), then froze the UI on "APPROVING USDC SPEND..." at 33% for the entire approve receipt wait — the "long wait between the two transactions" with no visible progress.

## Changes
**Faster**
- Read the current USDC→escrow allowance first; **skip the approve tx** when it already covers the pot. Approve `maxUint256` when we do approve (USDC treats it as infinite), so only the *first* deal a wallet creates needs an approval — repeat deals drop a whole tx + receipt wait.
- Lower RPC `pollingInterval` 4s → 1s (`client.ts`); Base blocks land in ~2s.

**Better feedback**
- Split the frozen `approving` step into `checking → approving → confirmingApproval → creating → confirmingCreate → syncing`, each with its own label and progress width, so the bar advances while each tx mines.

## Files
- `src/hooks/use-create-deal.ts`
- `src/components/wire/create-deal-dialog.tsx`
- `src/lib/contracts/client.ts`

## Note
The agent/MCP path already batches approve+createDeal into one `send_calls`. Moving the UI to EIP-5792 batched calls (one confirmation, no intermediate wait) is a larger follow-up left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)