### PR TITLE
feat(wire): bar a ticker from leading two drops in a row

### DIFF
--- a/convex/wire/dramaRanker.ts
+++ b/convex/wire/dramaRanker.ts
@@ -166,8 +166,14 @@ function tokenOneLiner(signal: TokenSignal): string {
 export function rankAndSelectLead(input: {
   signals: TokenSignal[];
   events: GameEventCtx[];
+  /**
+   * Slug of the token that led the immediately-previous drop, if any. That
+   * token is barred from leading again this drop so a hot name can't run the
+   * wire two slots in a row; it can still surface as a woven-in quiet stat.
+   */
+  prevLeadTokenSlug?: string | null;
 }): LeadSelection {
-  const { signals, events } = input;
+  const { signals, events, prevLeadTokenSlug } = input;
   const patterns = detectPatterns(events);
 
   // Fold detected trap patterns in as synthetic game events (can win the lead).
@@ -188,7 +194,13 @@ export function rankAndSelectLead(input: {
     .filter((s) => s.ok)
     .map((signal) => ({ signal, score: tokenScore(signal) }))
     .sort((a, b) => b.score - a.score);
-  const topToken = rankedTokens[0] ?? null;
+  // Anti-repeat: exclude the previous drop's lead token from lead contention so
+  // the same ticker never leads two slots running. Falls through to the next
+  // token, a game event, or a quiet tape — whichever ranks next.
+  const leadTokens = prevLeadTokenSlug
+    ? rankedTokens.filter((t) => t.signal.slug !== prevLeadTokenSlug)
+    : rankedTokens;
+  const topToken = leadTokens[0] ?? null;
 
   const gameScoreTop = topGame?.score ?? 0;
   const tokenScoreTop = topToken?.score ?? 0;
@@ -196,7 +208,12 @@ export function rankAndSelectLead(input: {
   // Nothing crosses the bar → quiet tape.
   if (gameScoreTop < LEAD_THRESHOLD && tokenScoreTop < LEAD_THRESHOLD) {
     // Best available real stat to weave in (token routine move or top game stat).
-    const bestRoutineToken = rankedTokens.find((t) => t.score > 0)?.signal;
+    // Prefer a token other than the previous lead; fall back to it only if it is
+    // the sole priced mover.
+    const bestRoutineToken = (
+      leadTokens.find((t) => t.score > 0) ??
+      rankedTokens.find((t) => t.score > 0)
+    )?.signal;
     const realStatOneLiner = bestRoutineToken
       ? tokenOneLiner(bestRoutineToken)
       : topGame && topGame.score > 0

--- a/convex/wire/generator.ts
+++ b/convex/wire/generator.ts
@@ -114,8 +114,10 @@ async function runGenerator(
   const lastWorld = (lastDrop?.worldState ?? {}) as {
     topTraderId?: string;
     quietAngleKey?: string | null;
+    leadTokenSlug?: string | null;
   };
   const prevQuietAngleKey = lastWorld.quietAngleKey ?? null;
+  const prevLeadTokenSlug = lastWorld.leadTokenSlug ?? null;
 
   // Leaderboard #1 change → synthetic game event.
   const events: GameEventCtx[] = [...recentGameEvents];
@@ -176,6 +178,7 @@ async function runGenerator(
     dayPosture: posture,
     slot,
     prevQuietAngleKey,
+    prevLeadTokenSlug,
   });
 
   const arcBySlug = new Map(arcs.map((a) => [a.slug, a]));
@@ -500,6 +503,9 @@ async function runGenerator(
     primaryArcSlug: advance.primaryArcSlug,
     topTraderId: currentTop?.id ?? lastWorld.topTraderId ?? null,
     quietAngleKey: quietSlotAngle?.key ?? advance.quietAngle?.key ?? null,
+    // The token that led this drop; the next drop bars it from leading again.
+    leadTokenSlug:
+      lead.leadKind === "token" ? (lead.tokenLead?.slug ?? null) : null,
     floorTalkTruth: advance.floorTalkClaims.map((c) => ({
       text: c.text,
       isTrue: c.isTrue,

--- a/convex/wire/worldState.ts
+++ b/convex/wire/worldState.ts
@@ -71,6 +71,8 @@ export interface WorldStateAdvanceInput {
   dayPosture: string;
   slot: number;
   prevQuietAngleKey?: string | null;
+  /** Token slug that led the previous drop; barred from leading again. */
+  prevLeadTokenSlug?: string | null;
 }
 
 export interface WorldStateAdvance {
@@ -245,9 +247,10 @@ export function computeWorldStateAdvance(
     dayPosture,
     slot,
     prevQuietAngleKey,
+    prevLeadTokenSlug,
   } = input;
 
-  const lead = rankAndSelectLead({ signals, events });
+  const lead = rankAndSelectLead({ signals, events, prevLeadTokenSlug });
 
   const signalBySlug = new Map(signals.map((s) => [s.slug, s]));
   const companyBySlug = new Map(companies.map((c) => [c.slug, c]));

--- a/tests/convex/wire-drama-ranker.test.ts
+++ b/tests/convex/wire-drama-ranker.test.ts
@@ -77,6 +77,52 @@ describe("dramaRanker: lead selection", () => {
     expect(sel.realStatOneLiner).toBeTruthy();
   });
 
+  it("bars the previous drop's lead token from leading twice in a row", () => {
+    const lfi = sig({
+      slug: "lienfi",
+      symbol: "LFI",
+      move24hPct: 43,
+      classification: "flash",
+    });
+    const kupo = sig({
+      slug: "kupo",
+      symbol: "KUPO",
+      move24hPct: 12,
+      classification: "story",
+    });
+
+    // Without a prior lead, the biggest mover (LFI flash) leads.
+    const first = rankAndSelectLead({ signals: [lfi, kupo], events: [] });
+    expect(first.tokenLead?.symbol).toBe("LFI");
+
+    // Next drop: LFI is barred, so the next-best token (KUPO) leads instead.
+    const second = rankAndSelectLead({
+      signals: [lfi, kupo],
+      events: [],
+      prevLeadTokenSlug: "lienfi",
+    });
+    expect(second.leadKind).toBe("token");
+    expect(second.tokenLead?.symbol).toBe("KUPO");
+  });
+
+  it("falls to a quiet tape when the only mover led the previous drop", () => {
+    const lfi = sig({
+      slug: "lienfi",
+      symbol: "LFI",
+      move24hPct: 43,
+      classification: "flash",
+    });
+    const sel = rankAndSelectLead({
+      signals: [lfi],
+      events: [],
+      prevLeadTokenSlug: "lienfi",
+    });
+    expect(sel.leadKind).toBe("quiet");
+    // The repeat may still be woven in as the quiet stat, but it does not lead.
+    expect(sel.tokenLead).toBeNull();
+    expect(sel.realStatOneLiner).toContain("LFI");
+  });
+
   it("detects a trap-phrase pattern across multiple traders", () => {
     const patterns = detectPatterns([
       ev({


### PR DESCRIPTION
## Problem

Wire lead selection (`rankAndSelectLead`) was stateless — it picked whichever token scored highest, with no memory of the prior drop. While a name stays hot (e.g. LFI/LienFi), it led **every** hourly drop, producing near-identical consecutive posts.

## Fix

Follows the existing `prevQuietAngleKey` anti-repeat pattern: carry the previous drop's lead ticker forward and bar it from leading the next drop.

- **`generator.ts`** — persists `leadTokenSlug` on each drop's `worldState`; reads the prior drop's value back as `prevLeadTokenSlug`. (`worldState` is `v.any()` — no schema change.)
- **`worldState.ts`** — threads `prevLeadTokenSlug` through `computeWorldStateAdvance` into the ranker.
- **`dramaRanker.ts`** — excludes the previous lead token from lead contention. Falls through to the next-best token, a game event, or a quiet tape.

If the repeat is the **sole** mover, the drop goes quiet and the ticker can still be woven in as the quiet stat — but it never headlines twice running.

## Tests

Added two cases to `wire-drama-ranker.test.ts` (barred-repeat → next token leads; sole-mover repeat → quiet). Full suite: 362 passing.

## Deploy note

Convex functions already deployed to prod (`formal-pigeon-323`) via `convex dev --once`; this PR is the git-side reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)