### PR TITLE
fix(landing): don't auto-open email modal after intro

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -214,9 +214,11 @@ export default function Home() {
     if (!introSeen) {
       return (
         <IntroSequence
-          onComplete={(triggerLogin) => {
+          onComplete={() => {
+            // Land on the roster after the intro instead of popping the email
+            // modal immediately — let the user see the traders first, then
+            // choose "Enter by email" when they're ready.
             setIntroSeen(true);
-            if (triggerLogin) login();
           }}
         />
       );


### PR DESCRIPTION
Completing the intro previously called login() immediately, popping the Privy email capture over the landing roster so users never saw the traders. Land on the roster instead and let users click "Enter by email" when ready.