### PR TITLE
feat(contracts): MARGINCALL token + SeatVault staking

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -1,6 +1,7 @@
 # Foundry
 cache/
 out/
+broadcast/
 
 # Dependencies (restore with: forge install)
 lib/

--- a/contracts/deployments/base-sepolia.margincall-tokens.json
+++ b/contracts/deployments/base-sepolia.margincall-tokens.json
@@ -1,0 +1,8 @@
+[
+  {
+    "version": 1,
+    "address": "0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7",
+    "symbol": "MARGINCALL",
+    "deployedAt": "2026-07-11T14:53:57.809Z"
+  }
+]

--- a/contracts/deployments/base-sepolia.seat-vaults.json
+++ b/contracts/deployments/base-sepolia.seat-vaults.json
@@ -1,0 +1,12 @@
+[
+  {
+    "version": 1,
+    "address": "0xa8595b279Aeadc8a0d2ce779Dc8Ba4d978eA2f44",
+    "margincallToken": "0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7",
+    "escrow": "0xa244550f0e35032E9c0b09DA4EB4933848d28d16",
+    "seatThreshold": "10000000000000000000000",
+    "cornerOfficeThreshold": "50000000000000000000000",
+    "unstakeCooldown": "86400",
+    "deployedAt": "2026-07-11T14:54:08.995Z"
+  }
+]

--- a/contracts/script/DeployMarginCallToken.s.sol
+++ b/contracts/script/DeployMarginCallToken.s.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {MarginCallToken} from "../src/MarginCallToken.sol";
+
+/// @notice Deploy MARGINCALL test token to Base Sepolia.
+/// Env: INITIAL_MINT (optional, default 1_000_000e18)
+contract DeployMarginCallToken is Script {
+    uint256 internal constant DEFAULT_INITIAL_MINT = 1_000_000e18;
+
+    function run() external {
+        uint256 initialMint = vm.envOr("INITIAL_MINT", DEFAULT_INITIAL_MINT);
+
+        vm.startBroadcast();
+        MarginCallToken token = new MarginCallToken();
+        token.mint(msg.sender, initialMint);
+        vm.stopBroadcast();
+
+        console2.log("MARGINCALL deployed at:", address(token));
+        console2.log("Initial mint to deployer:", initialMint);
+    }
+}

--- a/contracts/script/DeploySeatVault.s.sol
+++ b/contracts/script/DeploySeatVault.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {SeatVault} from "../src/SeatVault.sol";
+
+/// @notice Deploy SeatVault to Base Sepolia.
+/// Env:
+///   MARGINCALL_TOKEN
+///   ESCROW_ADDRESS
+///   SEAT_THRESHOLD (optional, default 10_000e18)
+///   CORNER_THRESHOLD (optional, default 50_000e18)
+///   UNSTAKE_COOLDOWN (optional, default 1 days)
+contract DeploySeatVault is Script {
+    uint256 internal constant DEFAULT_SEAT = 10_000e18;
+    uint256 internal constant DEFAULT_CORNER = 50_000e18;
+    uint256 internal constant DEFAULT_COOLDOWN = 1 days;
+
+    function run() external {
+        address margincallToken = vm.envAddress("MARGINCALL_TOKEN");
+        address escrow = vm.envAddress("ESCROW_ADDRESS");
+        uint256 seatThreshold = vm.envOr("SEAT_THRESHOLD", DEFAULT_SEAT);
+        uint256 cornerThreshold = vm.envOr("CORNER_THRESHOLD", DEFAULT_CORNER);
+        uint256 unstakeCooldown = vm.envOr("UNSTAKE_COOLDOWN", DEFAULT_COOLDOWN);
+
+        vm.startBroadcast();
+        SeatVault vault = new SeatVault(escrow, margincallToken, seatThreshold, cornerThreshold, unstakeCooldown);
+        vm.stopBroadcast();
+
+        console2.log("SeatVault deployed at:", address(vault));
+        console2.log("MARGINCALL token:", margincallToken);
+        console2.log("Escrow:", escrow);
+        console2.log("Seat threshold:", seatThreshold);
+        console2.log("Corner threshold:", cornerThreshold);
+        console2.log("Unstake cooldown:", unstakeCooldown);
+    }
+}

--- a/contracts/src/MarginCallEscrow.sol
+++ b/contracts/src/MarginCallEscrow.sol
@@ -123,7 +123,10 @@ contract MarginCallEscrow {
     function setDepositor(uint256 traderId, address depositor) external onlyOperator {
         require(depositor != address(0), "Zero depositor");
         address current = depositors[traderId];
-        require(current == address(0) || balances[traderId] == 0, "Depositor locked while balance > 0");
+        require(
+            current == address(0) || balances[traderId] == 0,
+            "Depositor locked while balance > 0"
+        );
         depositors[traderId] = depositor;
         emit DepositorSet(traderId, depositor);
     }

--- a/contracts/src/MarginCallEscrow.sol
+++ b/contracts/src/MarginCallEscrow.sol
@@ -123,10 +123,7 @@ contract MarginCallEscrow {
     function setDepositor(uint256 traderId, address depositor) external onlyOperator {
         require(depositor != address(0), "Zero depositor");
         address current = depositors[traderId];
-        require(
-            current == address(0) || balances[traderId] == 0,
-            "Depositor locked while balance > 0"
-        );
+        require(current == address(0) || balances[traderId] == 0, "Depositor locked while balance > 0");
         depositors[traderId] = depositor;
         emit DepositorSet(traderId, depositor);
     }

--- a/contracts/src/MarginCallToken.sol
+++ b/contracts/src/MarginCallToken.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice Test / Sepolia capacity token for SeatVault staking.
+contract MarginCallToken is ERC20 {
+    constructor() ERC20("Margin Call", "MARGINCALL") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/src/SeatVault.sol
+++ b/contracts/src/SeatVault.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IEscrowDepositors {
+    function depositors(uint256 traderId) external view returns (address);
+}
+
+/// @notice Custodies MARGINCALL principal staked against traders for capacity tiers.
+/// @dev Staking authority is the current MarginCallEscrow depositor for each traderId.
+contract SeatVault {
+    using SafeERC20 for IERC20;
+
+    enum Tier {
+        Gallery,
+        Seat,
+        CornerOffice
+    }
+
+    struct StakeInfo {
+        address staker;
+        uint256 active;
+        uint256 pending;
+        uint256 unlockTime;
+    }
+
+    IEscrowDepositors public immutable escrow;
+
+    address public owner;
+    address public pendingOwner;
+
+    IERC20 public token;
+    uint256 public seatThreshold;
+    uint256 public cornerOfficeThreshold;
+    uint256 public unstakeCooldown;
+
+    uint256 public totalPrincipal;
+
+    mapping(uint256 => StakeInfo) private _stakes;
+
+    event Staked(uint256 indexed traderId, address indexed staker, uint256 amount);
+    event UnstakeInitiated(uint256 indexed traderId, address indexed staker, uint256 amount, uint256 unlockTime);
+    event Unstaked(uint256 indexed traderId, address indexed staker, uint256 amount);
+    event PolicyUpdated(uint256 seatThreshold, uint256 cornerOfficeThreshold, uint256 unstakeCooldown);
+    event TokenUpdated(address indexed token);
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    constructor(
+        address escrow_,
+        address token_,
+        uint256 seatThreshold_,
+        uint256 cornerOfficeThreshold_,
+        uint256 unstakeCooldown_
+    ) {
+        require(escrow_ != address(0), "Zero escrow");
+        require(token_ != address(0), "Zero token");
+        require(cornerOfficeThreshold_ >= seatThreshold_, "Corner below seat");
+
+        escrow = IEscrowDepositors(escrow_);
+        token = IERC20(token_);
+        seatThreshold = seatThreshold_;
+        cornerOfficeThreshold = cornerOfficeThreshold_;
+        unstakeCooldown = unstakeCooldown_;
+        owner = msg.sender;
+    }
+
+    function stake(uint256 traderId, uint256 amount) external {
+        require(amount > 0, "Zero amount");
+
+        address depositor = escrow.depositors(traderId);
+        require(depositor != address(0), "Zero depositor");
+        require(depositor == msg.sender, "Not depositor");
+
+        StakeInfo storage info = _stakes[traderId];
+        require(info.staker == address(0) || info.staker == msg.sender, "Foreign principal");
+
+        uint256 balanceBefore = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = token.balanceOf(address(this)) - balanceBefore;
+        require(received > 0, "Zero received");
+
+        if (info.staker == address(0)) {
+            info.staker = msg.sender;
+        }
+
+        info.active += received;
+        totalPrincipal += received;
+
+        emit Staked(traderId, msg.sender, received);
+    }
+
+    function initiateUnstake(uint256 traderId, uint256 amount) external {
+        require(amount > 0, "Zero amount");
+
+        StakeInfo storage info = _stakes[traderId];
+        require(info.staker != address(0), "No stake");
+        require(info.active >= amount, "Over unstake");
+
+        address depositor = escrow.depositors(traderId);
+        require(msg.sender == depositor || msg.sender == info.staker, "Not authorized");
+
+        info.active -= amount;
+        info.pending += amount;
+        info.unlockTime = block.timestamp + unstakeCooldown;
+
+        emit UnstakeInitiated(traderId, info.staker, amount, info.unlockTime);
+    }
+
+    function completeUnstake(uint256 traderId) external {
+        StakeInfo storage info = _stakes[traderId];
+        uint256 pending = info.pending;
+        require(pending > 0, "Nothing pending");
+        require(block.timestamp >= info.unlockTime, "Cooldown active");
+
+        address staker = info.staker;
+        require(staker != address(0), "No staker");
+
+        info.pending = 0;
+        info.unlockTime = 0;
+        if (info.active == 0) {
+            info.staker = address(0);
+        }
+
+        totalPrincipal -= pending;
+        token.safeTransfer(staker, pending);
+
+        emit Unstaked(traderId, staker, pending);
+    }
+
+    function setPolicy(uint256 seatThreshold_, uint256 cornerOfficeThreshold_, uint256 unstakeCooldown_)
+        external
+        onlyOwner
+    {
+        require(cornerOfficeThreshold_ >= seatThreshold_, "Corner below seat");
+
+        seatThreshold = seatThreshold_;
+        cornerOfficeThreshold = cornerOfficeThreshold_;
+        unstakeCooldown = unstakeCooldown_;
+
+        emit PolicyUpdated(seatThreshold_, cornerOfficeThreshold_, unstakeCooldown_);
+    }
+
+    function setToken(address token_) external onlyOwner {
+        require(token_ != address(0), "Zero token");
+        require(totalPrincipal == 0, "Principal outstanding");
+
+        token = IERC20(token_);
+        emit TokenUpdated(token_);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "Zero owner");
+        pendingOwner = newOwner;
+        emit OwnershipTransferStarted(owner, newOwner);
+    }
+
+    function acceptOwnership() external {
+        require(msg.sender == pendingOwner, "Not pending owner");
+        address previousOwner = owner;
+        owner = pendingOwner;
+        pendingOwner = address(0);
+        emit OwnershipTransferred(previousOwner, owner);
+    }
+
+    function stakeOf(uint256 traderId) external view returns (StakeInfo memory) {
+        return _stakes[traderId];
+    }
+
+    function tierOf(uint256 traderId) external view returns (Tier) {
+        StakeInfo storage info = _stakes[traderId];
+        if (info.active == 0) {
+            return Tier.Gallery;
+        }
+
+        address depositor = escrow.depositors(traderId);
+        if (depositor == address(0) || depositor != info.staker) {
+            return Tier.Gallery;
+        }
+
+        if (info.active >= cornerOfficeThreshold) {
+            return Tier.CornerOffice;
+        }
+        if (info.active >= seatThreshold) {
+            return Tier.Seat;
+        }
+        return Tier.Gallery;
+    }
+}

--- a/contracts/test/SeatVault.t.sol
+++ b/contracts/test/SeatVault.t.sol
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {SeatVault} from "../src/SeatVault.sol";
+import {MarginCallToken} from "../src/MarginCallToken.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockEscrowDepositors} from "./mocks/MockEscrowDepositors.sol";
+import {FeeOnTransferERC20} from "./mocks/FeeOnTransferERC20.sol";
+
+contract SeatVaultTest is Test {
+    SeatVault public vault;
+    MarginCallToken public token;
+    MockEscrowDepositors public escrow;
+
+    address owner = address(this);
+    address desk = makeAddr("desk");
+    address otherDesk = makeAddr("otherDesk");
+    address attacker = makeAddr("attacker");
+
+    uint256 constant TRADER = 1;
+    uint256 constant SEAT = 10_000e18;
+    uint256 constant CORNER = 50_000e18;
+    uint256 constant COOLDOWN = 1 days;
+
+    function setUp() public {
+        token = new MarginCallToken();
+        escrow = new MockEscrowDepositors();
+        vault = new SeatVault(address(escrow), address(token), SEAT, CORNER, COOLDOWN);
+
+        escrow.setDepositor(TRADER, desk);
+
+        _fundAndApprove(desk);
+        _fundAndApprove(otherDesk);
+        _fundAndApprove(attacker);
+    }
+
+    function _fundAndApprove(address who) internal {
+        token.mint(who, 1_000_000e18);
+        vm.prank(who);
+        token.approve(address(vault), type(uint256).max);
+    }
+
+    function _stake(uint256 amount) internal {
+        vm.prank(desk);
+        vault.stake(TRADER, amount);
+    }
+
+    function _assertTier(SeatVault.Tier expected) internal view {
+        assertEq(uint8(vault.tierOf(TRADER)), uint8(expected));
+    }
+
+    // ========== Stake auth ==========
+
+    function test_stake_incrementsActive() public {
+        _stake(5_000e18);
+        SeatVault.StakeInfo memory info = vault.stakeOf(TRADER);
+        assertEq(info.staker, desk);
+        assertEq(info.active, 5_000e18);
+        assertEq(vault.totalPrincipal(), 5_000e18);
+    }
+
+    function test_stake_repeatedIncrementsActive() public {
+        _stake(3_000e18);
+        _stake(2_000e18);
+        SeatVault.StakeInfo memory info = vault.stakeOf(TRADER);
+        assertEq(info.active, 5_000e18);
+        assertEq(vault.totalPrincipal(), 5_000e18);
+    }
+
+    function test_stake_revertsZeroAmount() public {
+        vm.prank(desk);
+        vm.expectRevert("Zero amount");
+        vault.stake(TRADER, 0);
+    }
+
+    function test_stake_revertsUnauthorized() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not depositor");
+        vault.stake(TRADER, 1e18);
+    }
+
+    function test_stake_revertsZeroDepositor() public {
+        vm.prank(desk);
+        vm.expectRevert("Zero depositor");
+        vault.stake(99, 1e18);
+    }
+
+    function test_stake_revertsForeignPrincipal() public {
+        _stake(1_000e18);
+        escrow.setDepositor(TRADER, otherDesk);
+        vm.prank(otherDesk);
+        vm.expectRevert("Foreign principal");
+        vault.stake(TRADER, 1e18);
+    }
+
+    // ========== Tier boundaries ==========
+
+    function test_tierOf_galleryBelowSeat() public {
+        _stake(9_999e18);
+        _assertTier(SeatVault.Tier.Gallery);
+    }
+
+    function test_tierOf_seatAtThreshold() public {
+        _stake(10_000e18);
+        _assertTier(SeatVault.Tier.Seat);
+    }
+
+    function test_tierOf_seatBelowCorner() public {
+        _stake(49_999e18);
+        _assertTier(SeatVault.Tier.Seat);
+    }
+
+    function test_tierOf_cornerAtThreshold() public {
+        _stake(50_000e18);
+        _assertTier(SeatVault.Tier.CornerOffice);
+    }
+
+    function test_tierOf_galleryOnDepositorChange() public {
+        _stake(50_000e18);
+        escrow.setDepositor(TRADER, otherDesk);
+        _assertTier(SeatVault.Tier.Gallery);
+    }
+
+    // ========== Unstake flow ==========
+
+    function test_initiateUnstake_dropsTierImmediately() public {
+        _stake(50_000e18);
+        _assertTier(SeatVault.Tier.CornerOffice);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 1e18);
+
+        _assertTier(SeatVault.Tier.Seat);
+    }
+
+    function test_initiateUnstake_revertsOverUnstake() public {
+        _stake(1_000e18);
+        vm.prank(desk);
+        vm.expectRevert("Over unstake");
+        vault.initiateUnstake(TRADER, 1_001e18);
+    }
+
+    function test_completeUnstake_revertsBeforeCooldown() public {
+        _stake(1_000e18);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 500e18);
+
+        vm.expectRevert("Cooldown active");
+        vault.completeUnstake(TRADER);
+    }
+
+    function test_completeUnstake_transfersExactPending() public {
+        _stake(1_000e18);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 400e18);
+
+        uint256 before = token.balanceOf(desk);
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+
+        assertEq(token.balanceOf(desk) - before, 400e18);
+        SeatVault.StakeInfo memory info = vault.stakeOf(TRADER);
+        assertEq(info.pending, 0);
+        assertEq(info.active, 600e18);
+        assertEq(vault.totalPrincipal(), 600e18);
+    }
+
+    function test_completeUnstake_clearsStakerWhenFullyWithdrawn() public {
+        _stake(1_000e18);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 1_000e18);
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+
+        SeatVault.StakeInfo memory info = vault.stakeOf(TRADER);
+        assertEq(info.staker, address(0));
+        assertEq(vault.totalPrincipal(), 0);
+    }
+
+    function test_formerStakerCanUnstakeAfterDepositorChange() public {
+        _stake(5_000e18);
+        escrow.setDepositor(TRADER, otherDesk);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 5_000e18);
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+
+        assertEq(token.balanceOf(desk), 1_000_000e18);
+        assertEq(vault.totalPrincipal(), 0);
+    }
+
+    // ========== setPolicy ==========
+
+    function test_setPolicy_revertsNonOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not owner");
+        vault.setPolicy(SEAT, CORNER, COOLDOWN);
+    }
+
+    function test_setPolicy_revertsCornerBelowSeat() public {
+        vm.expectRevert("Corner below seat");
+        vault.setPolicy(CORNER, SEAT, COOLDOWN);
+    }
+
+    function test_setPolicy_lowersThresholdPromotesTier() public {
+        _stake(8_000e18);
+        _assertTier(SeatVault.Tier.Gallery);
+
+        vault.setPolicy(8_000e18, CORNER, COOLDOWN);
+        _assertTier(SeatVault.Tier.Seat);
+    }
+
+    function test_setPolicy_newCooldownAffectsNewInitiatesOnly() public {
+        _stake(1_000e18);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 100e18);
+        uint256 unlockAfterFirst = vault.stakeOf(TRADER).unlockTime;
+
+        vault.setPolicy(SEAT, CORNER, 2 days);
+
+        // Existing pending unlock is unchanged until another initiate refreshes it.
+        assertEq(vault.stakeOf(TRADER).unlockTime, unlockAfterFirst);
+
+        vm.warp(block.timestamp + 1 hours);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 50e18);
+        uint256 unlockAfterSecond = vault.stakeOf(TRADER).unlockTime;
+
+        assertGt(unlockAfterSecond, unlockAfterFirst);
+        assertGe(unlockAfterSecond, block.timestamp + 2 days);
+    }
+
+    // ========== setToken ==========
+
+    function test_setToken_whenEmpty() public {
+        MarginCallToken newToken = new MarginCallToken();
+        vault.setToken(address(newToken));
+        assertEq(address(vault.token()), address(newToken));
+    }
+
+    function test_setToken_revertsWithPrincipal() public {
+        _stake(1e18);
+        MarginCallToken newToken = new MarginCallToken();
+        vm.expectRevert("Principal outstanding");
+        vault.setToken(address(newToken));
+    }
+
+    function test_setToken_revertsNonOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not owner");
+        vault.setToken(address(token));
+    }
+
+    function test_setToken_revertsZeroAddress() public {
+        vm.expectRevert("Zero token");
+        vault.setToken(address(0));
+    }
+
+    function test_stakeAfterSetTokenUsesNewToken() public {
+        MarginCallToken newToken = new MarginCallToken();
+        vault.setToken(address(newToken));
+
+        newToken.mint(desk, 1_000e18);
+        vm.prank(desk);
+        newToken.approve(address(vault), type(uint256).max);
+
+        vm.prank(desk);
+        vault.stake(TRADER, 500e18);
+
+        assertEq(newToken.balanceOf(address(vault)), 500e18);
+    }
+
+    // ========== Fee-on-transfer ==========
+
+    function test_stake_feeOnTransferCreditsDelta() public {
+        FeeOnTransferERC20 feeToken = new FeeOnTransferERC20("Fee", "FEE");
+        vault.setToken(address(feeToken));
+
+        feeToken.mint(desk, 100_000e18);
+        vm.prank(desk);
+        feeToken.approve(address(vault), type(uint256).max);
+
+        vm.prank(desk);
+        vault.stake(TRADER, 10_000e18);
+
+        SeatVault.StakeInfo memory info = vault.stakeOf(TRADER);
+        assertEq(info.active, 9_900e18);
+        assertEq(feeToken.balanceOf(address(vault)), 9_900e18);
+    }
+
+    // ========== Ownership ==========
+
+    function test_ownershipTwoStep() public {
+        address newOwner = makeAddr("newOwner");
+        vault.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        vault.acceptOwnership();
+        assertEq(vault.owner(), newOwner);
+    }
+
+    // ========== Principal conservation ==========
+
+    function test_principalConservation() public {
+        _stake(20_000e18);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 5_000e18);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 3_000e18);
+
+        SeatVault.StakeInfo memory info = vault.stakeOf(TRADER);
+        assertEq(info.active + info.pending, 20_000e18);
+        assertEq(vault.totalPrincipal(), 20_000e18);
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+
+        info = vault.stakeOf(TRADER);
+        assertEq(info.pending, 0);
+        assertEq(info.active, 12_000e18);
+        assertEq(vault.totalPrincipal(), 12_000e18);
+        assertEq(token.balanceOf(address(vault)), 12_000e18);
+    }
+}
+
+contract SeatVaultReentrancyTest is Test {
+    function test_completeUnstake_reentrancySafe() public {
+        ReentrantToken reentrant = new ReentrantToken();
+        MockEscrowDepositors escrow = new MockEscrowDepositors();
+        SeatVault vault = new SeatVault(address(escrow), address(reentrant), 10_000e18, 50_000e18, 0);
+
+        address desk = makeAddr("desk");
+        escrow.setDepositor(1, desk);
+        reentrant.mint(desk, 1_000e18);
+        reentrant.setVault(vault);
+
+        vm.startPrank(desk);
+        reentrant.approve(address(vault), type(uint256).max);
+        vault.stake(1, 100e18);
+        vault.initiateUnstake(1, 100e18);
+        vm.stopPrank();
+
+        uint256 deskBefore = reentrant.balanceOf(desk);
+        vault.completeUnstake(1);
+
+        assertEq(reentrant.balanceOf(desk) - deskBefore, 100e18);
+        assertEq(reentrant.balanceOf(address(vault)), 0);
+        assertEq(vault.totalPrincipal(), 0);
+    }
+}
+
+contract ReentrantToken is MockERC20 {
+    SeatVault public vaultTarget;
+
+    constructor() MockERC20("Reentrant", "REENT", 18) {}
+
+    function setVault(SeatVault vault_) external {
+        vaultTarget = vault_;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        if (address(vaultTarget) != address(0) && to != address(vaultTarget)) {
+            try vaultTarget.completeUnstake(1) {} catch {}
+        }
+        return super.transfer(to, amount);
+    }
+}

--- a/contracts/test/mocks/FeeOnTransferERC20.sol
+++ b/contracts/test/mocks/FeeOnTransferERC20.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {MockERC20} from "./MockERC20.sol";
+
+/// @dev Transfers burn 1% fee to simulate fee-on-transfer tokens.
+contract FeeOnTransferERC20 is MockERC20 {
+    uint256 public constant FEE_BPS = 100; // 1%
+
+    constructor(string memory name, string memory symbol) MockERC20(name, symbol, 18) {}
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0)) {
+            uint256 fee = (value * FEE_BPS) / 10_000;
+            if (fee > 0) {
+                super._update(from, address(0), fee);
+                value -= fee;
+            }
+        }
+        super._update(from, to, value);
+    }
+}

--- a/contracts/test/mocks/MockEscrowDepositors.sol
+++ b/contracts/test/mocks/MockEscrowDepositors.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract MockEscrowDepositors {
+    mapping(uint256 => address) public depositors;
+
+    function setDepositor(uint256 traderId, address depositor) external {
+        depositors[traderId] = depositor;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:convex": "vitest run tests/convex",
     "seed:wire": "convex run seasons:importSeason",
     "prepare": "husky",
-    "deploy:escrow": "tsx scripts/deploy-escrow.ts"
+    "deploy:escrow": "tsx scripts/deploy-escrow.ts",
+    "deploy:margincall-token": "tsx scripts/deploy-margincall-token.ts",
+    "deploy:seat-vault": "tsx scripts/deploy-seat-vault.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",

--- a/scripts/deploy-escrow.ts
+++ b/scripts/deploy-escrow.ts
@@ -7,43 +7,8 @@
  *
  * Usage: pnpm deploy:escrow
  */
-import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
 import { privateKeyToAccount } from "viem/accounts";
-
-const ROOT = join(import.meta.dirname, "..");
-const ENV_LOCAL = join(ROOT, ".env.local");
-
-function loadEnvLocal(): Record<string, string> {
-  if (!existsSync(ENV_LOCAL)) {
-    throw new Error(
-      ".env.local not found — copy .env.example and set OPERATOR_PRIVATE_KEY"
-    );
-  }
-  const lines = readFileSync(ENV_LOCAL, "utf8").split("\n");
-  const env: Record<string, string> = {};
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq === -1) continue;
-    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
-  }
-  return env;
-}
-
-function patchEnvLocal(key: string, value: string) {
-  let content = readFileSync(ENV_LOCAL, "utf8");
-  const line = `${key}=${value}`;
-  const pattern = new RegExp(`^${key}=.*$`, "m");
-  if (pattern.test(content)) {
-    content = content.replace(pattern, line);
-  } else {
-    content = content.trimEnd() + `\n${line}\n`;
-  }
-  writeFileSync(ENV_LOCAL, content);
-}
+import { loadEnvLocal, patchEnvLocal, runForgeDeploy } from "./deploy-utils";
 
 function main() {
   const env = loadEnvLocal();
@@ -60,27 +25,14 @@ function main() {
 
   console.log(`Deploying MarginCallEscrow with operator ${operatorAddress}…`);
 
-  const output = execSync(
-    `forge script script/DeployMarginCallEscrow.s.sol:DeployMarginCallEscrow --rpc-url "${rpcUrl}" --private-key "${operatorKey}" --broadcast -vv`,
-    {
-      cwd: join(ROOT, "contracts"),
-      env: {
-        ...process.env,
-        OPERATOR_ADDRESS: operatorAddress,
-      },
-      encoding: "utf8",
-    }
-  );
+  const { address } = runForgeDeploy({
+    scriptTarget: "script/DeployMarginCallEscrow.s.sol:DeployMarginCallEscrow",
+    rpcUrl,
+    privateKey: operatorKey,
+    addressLabel: "MarginCallEscrow",
+    env: { OPERATOR_ADDRESS: operatorAddress },
+  });
 
-  console.log(output);
-
-  const match = output.match(
-    /MarginCallEscrow deployed at:\s*(0x[a-fA-F0-9]{40})/
-  );
-  if (!match) {
-    throw new Error("Could not parse deployed address from forge output");
-  }
-  const address = match[1] as string;
   patchEnvLocal("NEXT_PUBLIC_ESCROW_ADDRESS", address);
   patchEnvLocal("ESCROW_ADDRESS", address);
 

--- a/scripts/deploy-margincall-token.ts
+++ b/scripts/deploy-margincall-token.ts
@@ -1,0 +1,59 @@
+/**
+ * Deploy MARGINCALL test token to Base Sepolia.
+ *
+ * Requires in .env.local:
+ *   OPERATOR_PRIVATE_KEY
+ *   NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL
+ *
+ * Optional env for forge: INITIAL_MINT (default 1_000_000e18)
+ *
+ * Usage: pnpm deploy:margincall-token
+ */
+import {
+  appendDeploymentRecord,
+  loadEnvLocal,
+  patchEnvLocal,
+  runForgeDeploy,
+} from "./deploy-utils";
+
+function main() {
+  const env = loadEnvLocal();
+  const rpcUrl = env.NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL;
+  const operatorKey = env.OPERATOR_PRIVATE_KEY;
+  if (!rpcUrl) {
+    throw new Error("NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL missing in .env.local");
+  }
+  if (!operatorKey) {
+    throw new Error("OPERATOR_PRIVATE_KEY missing in .env.local");
+  }
+
+  console.log("Deploying MARGINCALL token to Base Sepolia…");
+
+  const { address } = runForgeDeploy({
+    scriptTarget: "script/DeployMarginCallToken.s.sol:DeployMarginCallToken",
+    rpcUrl,
+    privateKey: operatorKey,
+    addressLabel: "MARGINCALL",
+    env: { INITIAL_MINT: env.INITIAL_MINT ?? "1000000000000000000000000" },
+  });
+
+  patchEnvLocal("MARGINCALL_TOKEN", address);
+  patchEnvLocal("NEXT_PUBLIC_MARGINCALL_TOKEN", address);
+
+  const version = appendDeploymentRecord(
+    "base-sepolia.margincall-tokens.json",
+    {
+      address,
+      symbol: "MARGINCALL",
+      deployedAt: new Date().toISOString(),
+    }
+  );
+
+  console.log(`\nUpdated .env.local:`);
+  console.log(`  MARGINCALL_TOKEN=${address}`);
+  console.log(`  NEXT_PUBLIC_MARGINCALL_TOKEN=${address}`);
+  console.log(`\nRecorded deployment v${version} in contracts/deployments/`);
+  console.log(`BaseScan: https://sepolia.basescan.org/address/${address}`);
+}
+
+main();

--- a/scripts/deploy-seat-vault.ts
+++ b/scripts/deploy-seat-vault.ts
@@ -1,0 +1,96 @@
+/**
+ * Deploy SeatVault to Base Sepolia.
+ *
+ * Requires in .env.local:
+ *   OPERATOR_PRIVATE_KEY
+ *   NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL
+ *   MARGINCALL_TOKEN (or NEXT_PUBLIC_MARGINCALL_TOKEN)
+ *   ESCROW_ADDRESS (or NEXT_PUBLIC_ESCROW_ADDRESS)
+ *
+ * Optional forge env: SEAT_THRESHOLD, CORNER_THRESHOLD, UNSTAKE_COOLDOWN
+ *
+ * Usage: pnpm deploy:seat-vault
+ */
+import {
+  appendDeploymentRecord,
+  loadEnvLocal,
+  patchEnvLocal,
+  runForgeDeploy,
+} from "./deploy-utils";
+
+/** Pull a uint logged by the forge script (e.g. "Seat threshold: 10000…"). */
+function parseLoggedUint(output: string, label: string): string {
+  const match = output.match(new RegExp(`${label}:\\s*(\\d+)`));
+  if (!match) {
+    throw new Error(`Could not parse "${label}" from forge output`);
+  }
+  return match[1] as string;
+}
+
+function main() {
+  const env = loadEnvLocal();
+  const rpcUrl = env.NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL;
+  const operatorKey = env.OPERATOR_PRIVATE_KEY;
+  const margincallToken =
+    env.MARGINCALL_TOKEN ?? env.NEXT_PUBLIC_MARGINCALL_TOKEN;
+  const escrowAddress = env.ESCROW_ADDRESS ?? env.NEXT_PUBLIC_ESCROW_ADDRESS;
+
+  if (!rpcUrl) {
+    throw new Error("NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL missing in .env.local");
+  }
+  if (!operatorKey) {
+    throw new Error("OPERATOR_PRIVATE_KEY missing in .env.local");
+  }
+  if (!margincallToken) {
+    throw new Error(
+      "MARGINCALL_TOKEN missing — run pnpm deploy:margincall-token first"
+    );
+  }
+  if (!escrowAddress) {
+    throw new Error(
+      "ESCROW_ADDRESS missing — run pnpm deploy:escrow or set manually"
+    );
+  }
+
+  console.log(
+    `Deploying SeatVault (token ${margincallToken}, escrow ${escrowAddress})…`
+  );
+
+  const forgeEnv: Record<string, string> = {
+    MARGINCALL_TOKEN: margincallToken,
+    ESCROW_ADDRESS: escrowAddress,
+  };
+  if (env.SEAT_THRESHOLD) forgeEnv.SEAT_THRESHOLD = env.SEAT_THRESHOLD;
+  if (env.CORNER_THRESHOLD) forgeEnv.CORNER_THRESHOLD = env.CORNER_THRESHOLD;
+  if (env.UNSTAKE_COOLDOWN) forgeEnv.UNSTAKE_COOLDOWN = env.UNSTAKE_COOLDOWN;
+
+  const { address, output } = runForgeDeploy({
+    scriptTarget: "script/DeploySeatVault.s.sol:DeploySeatVault",
+    rpcUrl,
+    privateKey: operatorKey,
+    addressLabel: "SeatVault",
+    env: forgeEnv,
+  });
+
+  patchEnvLocal("SEAT_VAULT_ADDRESS", address);
+  patchEnvLocal("NEXT_PUBLIC_SEAT_VAULT_ADDRESS", address);
+
+  const version = appendDeploymentRecord("base-sepolia.seat-vaults.json", {
+    address,
+    margincallToken,
+    escrow: escrowAddress,
+    // Record the values actually applied on-chain (defaults live in the .sol script).
+    seatThreshold: parseLoggedUint(output, "Seat threshold"),
+    cornerOfficeThreshold: parseLoggedUint(output, "Corner threshold"),
+    unstakeCooldown: parseLoggedUint(output, "Unstake cooldown"),
+    deployedAt: new Date().toISOString(),
+  });
+
+  console.log(`\nUpdated .env.local:`);
+  console.log(`  SEAT_VAULT_ADDRESS=${address}`);
+  console.log(`  NEXT_PUBLIC_SEAT_VAULT_ADDRESS=${address}`);
+  console.log(`\nRecorded deployment v${version} in contracts/deployments/`);
+  console.log(`BaseScan: https://sepolia.basescan.org/address/${address}`);
+}
+
+main();

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared helpers for Foundry deploy scripts.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export const ROOT = join(import.meta.dirname, "..");
+export const ENV_LOCAL = join(ROOT, ".env.local");
+export const CONTRACTS_DIR = join(ROOT, "contracts");
+export const DEPLOYMENTS_DIR = join(CONTRACTS_DIR, "deployments");
+
+export function loadEnvLocal(): Record<string, string> {
+  if (!existsSync(ENV_LOCAL)) {
+    throw new Error(
+      ".env.local not found — copy .env.example and set OPERATOR_PRIVATE_KEY"
+    );
+  }
+  const lines = readFileSync(ENV_LOCAL, "utf8").split("\n");
+  const env: Record<string, string> = {};
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    env[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+export function patchEnvLocal(key: string, value: string) {
+  let content = readFileSync(ENV_LOCAL, "utf8");
+  const line = `${key}=${value}`;
+  const pattern = new RegExp(`^${key}=.*$`, "m");
+  if (pattern.test(content)) {
+    content = content.replace(pattern, line);
+  } else {
+    content = content.trimEnd() + `\n${line}\n`;
+  }
+  writeFileSync(ENV_LOCAL, content);
+}
+
+/**
+ * Run a Foundry deploy script and return the deployed address parsed from its
+ * output. Uses execFileSync with an argv array so the private key is never
+ * interpolated into a shell-parsed command string.
+ */
+export function runForgeDeploy(opts: {
+  scriptTarget: string;
+  rpcUrl: string;
+  privateKey: string;
+  addressLabel: string;
+  env?: Record<string, string>;
+}): { address: string; output: string } {
+  const output = execFileSync(
+    "forge",
+    [
+      "script",
+      opts.scriptTarget,
+      "--rpc-url",
+      opts.rpcUrl,
+      "--private-key",
+      opts.privateKey,
+      "--broadcast",
+      "-vv",
+    ],
+    {
+      cwd: CONTRACTS_DIR,
+      env: { ...process.env, ...opts.env },
+      encoding: "utf8",
+    }
+  );
+  console.log(output);
+
+  const match = output.match(
+    new RegExp(`${opts.addressLabel} deployed at:\\s*(0x[a-fA-F0-9]{40})`)
+  );
+  if (!match) {
+    throw new Error("Could not parse deployed address from forge output");
+  }
+  return { address: match[1] as string, output };
+}
+
+export function appendDeploymentRecord<T extends Record<string, unknown>>(
+  filename: string,
+  record: T
+) {
+  if (!existsSync(DEPLOYMENTS_DIR)) {
+    mkdirSync(DEPLOYMENTS_DIR, { recursive: true });
+  }
+  const filePath = join(DEPLOYMENTS_DIR, filename);
+  const existing = existsSync(filePath)
+    ? (JSON.parse(readFileSync(filePath, "utf8")) as T[])
+    : [];
+  const version = existing.length + 1;
+  existing.push({ version, ...record });
+  writeFileSync(filePath, `${JSON.stringify(existing, null, 2)}\n`);
+  return version;
+}


### PR DESCRIPTION
Closes #188

## Summary

Adds the capacity-tier **staking layer** on Base: a `SeatVault` contract that custodies MARGINCALL principal staked per trader, plus a deployable `MarginCallToken`, deploy tooling, and full test coverage. Deployed to Base Sepolia.

### Contracts
- **`SeatVault`** — custodies MARGINCALL principal staked against a `traderId`. Staking authority is bound to the current `MarginCallEscrow` depositor for that trader. Features:
  - Balance-diff accounting (`received = balanceAfter - balanceBefore`) so fee-on-transfer tokens credit the true amount.
  - Two-step ownership transfer; owner-gated `setPolicy` / `setToken` (token swap only allowed when `totalPrincipal == 0`).
  - Cooldown-gated unstake (`initiateUnstake` → wait → `completeUnstake`); tier drops immediately on initiate.
  - `Gallery` / `Seat` / `CornerOffice` tiers derived from active stake, and downgraded to `Gallery` if the escrow depositor no longer matches the staker.
- **`MarginCallToken`** — minimal 18-decimal ERC20 for test/Sepolia staking.

### Deploy tooling
- `pnpm deploy:margincall-token` and `pnpm deploy:seat-vault` (+ matching Foundry scripts).
- New `scripts/deploy-utils.ts` with a shared `runForgeDeploy` helper (argv-array `execFileSync`, no shell string); `deploy-escrow.ts` migrated onto the shared `loadEnvLocal`/`patchEnvLocal`/`runForgeDeploy` helpers, removing its duplicated copies.
- SeatVault deployment record captures the thresholds **actually applied on-chain** (parsed from forge output) rather than re-hardcoding defaults.
- `contracts/broadcast/` added to `.gitignore` (Foundry run artifacts).

### Tests
- `contracts/test/SeatVault.t.sol` — 29 tests covering stake auth, tier boundaries, unstake flow, policy/token updates, fee-on-transfer crediting, reentrancy safety, and principal conservation. All passing (`forge test`).

## Deployed — Base Sepolia
| Contract | Address |
|---|---|
| MARGINCALL token | [`0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7`](https://sepolia.basescan.org/address/0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7) |
| SeatVault | [`0xa8595b279Aeadc8a0d2ce779Dc8Ba4d978eA2f44`](https://sepolia.basescan.org/address/0xa8595b279Aeadc8a0d2ce779Dc8Ba4d978eA2f44) |

Wired to the existing escrow `0xa244550f0e35032E9c0b09DA4EB4933848d28d16`; thresholds 10,000 / 50,000 MARGINCALL, 1-day cooldown.

## Follow-ups (not in this PR)
- Set `MARGINCALL_TOKEN` / `SEAT_VAULT_ADDRESS` in Convex env (dev + prod) if the backend reads them.
- Source-verify both contracts on BaseScan (`forge verify-contract`).
- lasso.sh RPC was returning HTTP 500 during deploy; deployed via public `sepolia.base.org` instead — worth confirming the provider is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)