### PR TITLE
feat(seat-vault): owner  staking panel (#191)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -70,6 +70,7 @@ import type * as ops_wipeSmokeTraders from "../ops/wipeSmokeTraders.js";
 import type * as portfolio from "../portfolio.js";
 import type * as portraits from "../portraits.js";
 import type * as seasons from "../seasons.js";
+import type * as seatVault_actions from "../seatVault/actions.js";
 import type * as seatVault_config from "../seatVault/config.js";
 import type * as seatVault_indexer from "../seatVault/indexer.js";
 import type * as seatVault_policy from "../seatVault/policy.js";
@@ -179,6 +180,7 @@ declare const fullApi: ApiFromModules<{
   portfolio: typeof portfolio;
   portraits: typeof portraits;
   seasons: typeof seasons;
+  "seatVault/actions": typeof seatVault_actions;
   "seatVault/config": typeof seatVault_config;
   "seatVault/indexer": typeof seatVault_indexer;
   "seatVault/policy": typeof seatVault_policy;

--- a/convex/seatVault/actions.ts
+++ b/convex/seatVault/actions.ts
@@ -1,0 +1,52 @@
+import { action } from "../_generated/server";
+import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import type { SeatTierName } from "./policy";
+
+/**
+ * Owner-facing reconcile after a confirmed stake / unstake tx.
+ * Mirrors escrow post-chain sync: auth → ownership → internal indexer reconcile.
+ */
+export const reconcileOwnedTrader = action({
+  args: {
+    traderId: v.id("traders"),
+    vaultAddress: v.optional(v.string()),
+  },
+  returns: v.object({
+    ok: v.boolean(),
+    effectiveTier: v.union(
+      v.literal("Gallery"),
+      v.literal("Seat"),
+      v.literal("CornerOffice")
+    ),
+    error: v.optional(v.string()),
+  }),
+  handler: async (
+    ctx,
+    args
+  ): Promise<{
+    ok: boolean;
+    effectiveTier: SeatTierName;
+    error?: string;
+  }> => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthenticated");
+    }
+
+    const trader = await ctx.runQuery(internal.traders.loadInternal, {
+      traderId: args.traderId,
+    });
+    if (!trader || trader.ownerSubject !== identity.subject) {
+      throw new Error("Not the desk for this trader");
+    }
+    if (trader.tokenId == null) {
+      throw new Error("Trader badge not minted yet");
+    }
+
+    return await ctx.runAction(internal.seatVault.indexer.reconcileTrader, {
+      onChainTraderId: trader.tokenId,
+      vaultAddress: args.vaultAddress,
+    });
+  },
+});

--- a/convex/seatVault/policy.ts
+++ b/convex/seatVault/policy.ts
@@ -177,6 +177,33 @@ export const SEAT_VAULT_MAX_BLOCKS_PER_TICK = 2_000;
 export const seatVaultAbi = [
   {
     type: "function",
+    name: "stake",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "initiateUnstake",
+    inputs: [
+      { name: "traderId", type: "uint256" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "completeUnstake",
+    inputs: [{ name: "traderId", type: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
     name: "stakeOf",
     inputs: [{ name: "traderId", type: "uint256" }],
     outputs: [

--- a/src/app/traders/[traderId]/page.tsx
+++ b/src/app/traders/[traderId]/page.tsx
@@ -9,6 +9,7 @@ import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
 import { DatumCell } from "@/components/datum-cell";
 import { EmptyState } from "@/components/empty-state";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
+import { SeatTierBadgeView } from "@/components/seat-tier-badge";
 import { formatStatus } from "@/lib/format-status";
 import {
   formatPortraitStatus,
@@ -19,9 +20,15 @@ import {
   type PublicTraderProfile,
 } from "@/lib/trader-display";
 import { formatActivityTime, formatUsdc } from "@/lib/utils";
+import type { SeatTierName } from "@/lib/contracts/seatVault";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+type PublicTierSnapshot = {
+  effectiveTier: SeatTierName;
+  syncStatus: "ok" | "syncing" | "error";
+};
 
 function createPublicConvexClient(): ConvexHttpClient {
   const url = process.env.NEXT_PUBLIC_CONVEX_URL;
@@ -48,25 +55,43 @@ async function loadTraderProfile(traderId: string) {
   }
 }
 
+async function loadPublicTier(
+  traderId: string
+): Promise<PublicTierSnapshot | null> {
+  try {
+    const convex = createPublicConvexClient();
+    return await convex.query(api.seatVault.queries.getPublicTraderTier, {
+      traderId: traderId as Id<"traders">,
+    });
+  } catch {
+    return null;
+  }
+}
+
 export default async function PublicTraderPage({
   params,
 }: {
   params: Promise<{ traderId: string }>;
 }) {
   const { traderId } = await params;
-  const trader = await loadTraderProfile(traderId);
+  const [trader, publicTier] = await Promise.all([
+    loadTraderProfile(traderId),
+    loadPublicTier(traderId),
+  ]);
 
   if (!trader) {
     notFound();
   }
 
-  return <PublicTraderDossier trader={trader} />;
+  return <PublicTraderDossier trader={trader} publicTier={publicTier} />;
 }
 
 export function PublicTraderDossier({
   trader,
+  publicTier = null,
 }: {
   trader: PublicTraderProfile;
+  publicTier?: PublicTierSnapshot | null;
 }) {
   let portraitUrl: string = TRADER_PLACEHOLDER_IMAGE_PATH;
   if (trader.portraitStatus === "ready" && trader.profileImageUrl) {
@@ -75,6 +100,8 @@ export function PublicTraderDossier({
   const showFallbackInitials = trader.portraitStatus !== "ready";
   const statusTone = getStatusTone(trader.status);
   const portraitTone = getPortraitTone(trader.portraitStatus);
+  const tier = publicTier?.effectiveTier ?? "Gallery";
+  const syncStatus = publicTier?.syncStatus;
 
   return (
     <main className="min-h-screen bg-[var(--t-bg)] font-mono text-[var(--t-text)]">
@@ -90,9 +117,12 @@ export function PublicTraderDossier({
                 <AgentDeskBadge className="ml-2 scale-125 align-baseline" />
               ) : null}
             </h1>
-            <p className="mt-2 max-w-2xl text-xs uppercase tracking-[0.16em] text-[var(--t-muted)]">
-              Read-only reputation, escrow posture, and last public calls from
-              the exchange floor.
+            <p className="mt-2 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.16em] text-[var(--t-muted)]">
+              <SeatTierBadgeView tier={tier} syncStatus={syncStatus} />
+              <span>
+                Read-only reputation, escrow posture, and last public calls from
+                the exchange floor.
+              </span>
             </p>
           </div>
           <Link

--- a/src/components/public-trader-dialog.tsx
+++ b/src/components/public-trader-dialog.tsx
@@ -8,6 +8,7 @@ import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { TraderAvatar } from "@/components/trader-avatar";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
+import { SeatTierBadge } from "@/components/seat-tier-badge";
 import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
 import { formatStatus } from "@/lib/format-status";
 import {
@@ -106,6 +107,8 @@ function PublicTraderContent({
               ) : null}
             </h2>
             <p className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] uppercase tracking-[0.2em] text-[var(--t-muted)]">
+              <SeatTierBadge traderId={trader.traderId} compact />
+              <span className="text-[var(--t-divider)]">/</span>
               <span>
                 File{" "}
                 <span className="text-[var(--t-text)]">

--- a/src/components/seat-stake-panel.tsx
+++ b/src/components/seat-stake-panel.tsx
@@ -1,0 +1,538 @@
+"use client";
+
+import { useMemo, useState, type FormEvent } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { DatumCell } from "@/components/datum-cell";
+import { SeatTierBadgeView } from "@/components/seat-tier-badge";
+import { useSecondTick } from "@/hooks/use-second-tick";
+import {
+  useBlowBalance,
+  useSeatVaultFlows,
+  useTraderDepositor,
+  seatVaultStepLabel,
+} from "@/hooks/use-seat-vault";
+import { useBaseNetwork } from "@/hooks/use-base-network";
+import {
+  formatBlowAmount,
+  SEAT_VAULT_ADDRESS,
+  type SeatTierName,
+} from "@/lib/contracts/seatVault";
+import {
+  amountNeededForNextTier,
+  canCompleteWithdrawal,
+  canInitiateUnstake,
+  canPostPrincipal,
+  formatUnlockCountdown,
+  isCooldownActive,
+  isLapsedSeat,
+  SEAT_TIER_FLOOR_LABEL,
+} from "@/lib/seat-tier-display";
+import { cn } from "@/lib/utils";
+
+type SeatStateRow = {
+  traderId: Id<"traders">;
+  onChainTraderId: number;
+  vaultAddress: string;
+  vaultVersion: number;
+  isActiveVault: boolean;
+  effectiveTier: SeatTierName;
+  staker: string | null;
+  activeAmountWei: string;
+  pendingAmountWei: string;
+  unlockTime: number;
+  syncStatus: "ok" | "syncing" | "error";
+  syncError: string | null;
+  cycleIntervalMs: number;
+  maxUnresolvedEntries: number;
+};
+
+function formatWeiOrDash(wei: string): string {
+  try {
+    return formatBlowAmount(wei);
+  } catch {
+    return "—";
+  }
+}
+
+function sectionTitle(title: string) {
+  return (
+    <h2 className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
+      {title}
+    </h2>
+  );
+}
+
+export function SeatStakePanel({
+  traderId,
+  onChainTraderId,
+}: {
+  traderId: string;
+  onChainTraderId: number;
+}) {
+  const convexId = traderId as Id<"traders">;
+  const nowMs = useSecondTick();
+  const nowSeconds = Math.floor(nowMs / 1000);
+
+  const seatState = useQuery(api.seatVault.queries.getTraderSeatState, {
+    traderId: convexId,
+  }) as SeatStateRow | null | undefined;
+
+  const vaultRows = useQuery(api.seatVault.queries.listTraderVaultWithdrawals, {
+    traderId: convexId,
+  }) as SeatStateRow[] | undefined;
+
+  const {
+    balanceWei,
+    walletAddress,
+    refetch: refetchBalance,
+  } = useBlowBalance();
+  const { depositor } = useTraderDepositor(onChainTraderId);
+  const { isWrongNetwork, switchToBase, isSwitching } = useBaseNetwork();
+  const {
+    stake,
+    initiateUnstake,
+    completeUnstake,
+    reset,
+    step,
+    error,
+    isLoading,
+  } = useSeatVaultFlows();
+
+  const [stakeAmount, setStakeAmount] = useState("");
+  const [unstakeAmount, setUnstakeAmount] = useState("");
+  const [localError, setLocalError] = useState<string | undefined>();
+
+  const active = seatState ?? null;
+  const nextTier = useMemo(
+    () =>
+      active
+        ? amountNeededForNextTier(active.activeAmountWei)
+        : amountNeededForNextTier("0"),
+    [active]
+  );
+
+  const canStake = canPostPrincipal({
+    walletAddress,
+    depositorAddress: depositor,
+    isActiveVault: active?.isActiveVault ?? true,
+  });
+
+  const canPull = active
+    ? canInitiateUnstake({
+        walletAddress,
+        depositorAddress: depositor,
+        stakerAddress: active.staker,
+        activeWei: active.activeAmountWei,
+      })
+    : false;
+
+  const pendingVaults = (vaultRows ?? []).filter(
+    (row) => BigInt(row.pendingAmountWei) > BigInt(0)
+  );
+
+  const lapsed =
+    active != null &&
+    isLapsedSeat(active.activeAmountWei, active.pendingAmountWei);
+
+  const balanceHuman =
+    balanceWei !== undefined ? formatBlowAmount(balanceWei.toString()) : "…";
+
+  const displayError = localError ?? error;
+
+  async function handleStake(e: FormEvent) {
+    e.preventDefault();
+    setLocalError(undefined);
+    if (!walletAddress) {
+      setLocalError("Connect the desk treasury wallet first.");
+      return;
+    }
+    if (isWrongNetwork) {
+      setLocalError("Wrong chain — switch to Base Sepolia.");
+      return;
+    }
+    try {
+      await stake({
+        convexTraderId: convexId,
+        onChainTraderId,
+        amountHuman: stakeAmount,
+        vaultAddress: (active?.vaultAddress ||
+          SEAT_VAULT_ADDRESS) as `0x${string}`,
+        depositor,
+      });
+      setStakeAmount("");
+      void refetchBalance();
+      reset();
+    } catch {
+      // surfaced via hook
+    }
+  }
+
+  async function handleInitiate(e: FormEvent) {
+    e.preventDefault();
+    setLocalError(undefined);
+    if (!active) return;
+    try {
+      await initiateUnstake({
+        convexTraderId: convexId,
+        onChainTraderId,
+        amountHuman: unstakeAmount,
+        vaultAddress: active.vaultAddress as `0x${string}`,
+        activeWei: active.activeAmountWei,
+        depositor,
+        staker: active.staker,
+      });
+      setUnstakeAmount("");
+      reset();
+    } catch {
+      // surfaced via hook
+    }
+  }
+
+  async function handleComplete(row: SeatStateRow) {
+    setLocalError(undefined);
+    try {
+      await completeUnstake({
+        convexTraderId: convexId,
+        onChainTraderId: row.onChainTraderId,
+        vaultAddress: row.vaultAddress as `0x${string}`,
+        pendingWei: row.pendingAmountWei,
+        unlockTime: row.unlockTime,
+      });
+      void refetchBalance();
+      reset();
+    } catch {
+      // surfaced via hook
+    }
+  }
+
+  if (seatState === undefined) {
+    return (
+      <section className="border border-[var(--t-divider)] bg-[#070b09] p-4">
+        {sectionTitle("Floor seat")}
+        <p className="mt-3 text-xs uppercase tracking-[0.16em] text-[var(--t-muted)]">
+          Checking the book…
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="overflow-hidden border border-[var(--t-divider)] bg-[#070b09]">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--t-divider)] p-3">
+        {sectionTitle("Floor seat · $BLOW principal")}
+        <SeatTierBadgeView
+          tier={active?.effectiveTier ?? "Gallery"}
+          syncStatus={active?.syncStatus}
+        />
+      </div>
+
+      <div className="grid sm:grid-cols-3">
+        <DatumCell
+          label="Active principal"
+          value={`${formatWeiOrDash(active?.activeAmountWei ?? "0")} $BLOW`}
+          className="border-0 border-b border-[var(--t-divider)] sm:border-b-0 sm:border-r"
+        />
+        <DatumCell
+          label="Pending in cage"
+          value={`${formatWeiOrDash(active?.pendingAmountWei ?? "0")} $BLOW`}
+          className="border-0 border-b border-[var(--t-divider)] sm:border-b-0 sm:border-r"
+          valueClassName={
+            active && BigInt(active.pendingAmountWei) > BigInt(0)
+              ? "text-[var(--t-amber)]"
+              : undefined
+          }
+        />
+        <DatumCell
+          label="Cadence / open tickets"
+          value={`${Math.round((active?.cycleIntervalMs ?? 600_000) / 60_000)}m · ${active?.maxUnresolvedEntries ?? 1}`}
+          className="border-0"
+        />
+      </div>
+
+      <div className="space-y-3 border-t border-[var(--t-divider)] p-4">
+        {lapsed ? (
+          <p className="text-xs uppercase tracking-[0.14em] text-[var(--t-amber)]">
+            Lapsed seat — active principal sits below the Seat line while chips
+            wait in the cage. Capacity reads Gallery until you post again.
+          </p>
+        ) : null}
+
+        {nextTier ? (
+          <p className="text-xs uppercase tracking-[0.14em] text-[var(--t-muted)]">
+            Need{" "}
+            <span className="text-[var(--t-text)]">
+              {nextTier.deltaHuman} $BLOW
+            </span>{" "}
+            more active principal for{" "}
+            <span className="text-[var(--t-amber)]">
+              {SEAT_TIER_FLOOR_LABEL[nextTier.nextTier]}
+            </span>
+            .
+          </p>
+        ) : (
+          <p className="text-xs uppercase tracking-[0.14em] text-[var(--t-green)]">
+            Corner Office cleared — no higher floor desk.
+          </p>
+        )}
+
+        <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
+          Desk $BLOW:{" "}
+          <span className="text-[var(--t-text)]">{balanceHuman}</span>
+          {isWrongNetwork ? (
+            <>
+              {" · "}
+              <button
+                type="button"
+                onClick={() => void switchToBase()}
+                disabled={isSwitching}
+                className="text-[var(--t-amber)] underline-offset-2 hover:underline"
+              >
+                {isSwitching ? "Switching…" : "Switch to Base Sepolia"}
+              </button>
+            </>
+          ) : null}
+        </p>
+
+        {canStake ? (
+          <form
+            onSubmit={handleStake}
+            className="flex flex-wrap items-end gap-2"
+          >
+            <label className="min-w-[10rem] flex-1">
+              <span className="mb-1 block text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
+                Post principal
+              </span>
+              <input
+                type="text"
+                inputMode="decimal"
+                value={stakeAmount}
+                onChange={(e) => setStakeAmount(e.target.value)}
+                placeholder="0"
+                disabled={isLoading}
+                className="w-full border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 py-2 font-mono text-sm text-[var(--t-text)] outline-none focus:border-[var(--t-amber)]"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={isLoading || !stakeAmount.trim()}
+              className="min-h-10 border border-[var(--t-amber)]/60 bg-[var(--t-amber)]/10 px-4 text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--t-amber)] transition-colors hover:bg-[var(--t-amber)]/20 disabled:opacity-40"
+            >
+              Post $BLOW
+            </button>
+          </form>
+        ) : (
+          <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
+            {!walletAddress
+              ? "Connect desk treasury to post principal."
+              : !depositor
+                ? "Fund escrow first — depositor must be on file before a seat posts."
+                : depositor.toLowerCase() !== walletAddress.toLowerCase()
+                  ? "This wallet is not the depositor. Withdrawals from old stakes may still clear below."
+                  : "Active vault only accepts new principal from the assigned depositor."}
+          </p>
+        )}
+
+        {canPull && active ? (
+          <form
+            onSubmit={handleInitiate}
+            className="flex flex-wrap items-end gap-2 border-t border-[var(--t-divider)] pt-3"
+          >
+            <label className="min-w-[10rem] flex-1">
+              <span className="mb-1 block text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
+                Pull principal (24h cage)
+              </span>
+              <input
+                type="text"
+                inputMode="decimal"
+                value={unstakeAmount}
+                onChange={(e) => setUnstakeAmount(e.target.value)}
+                placeholder="0"
+                disabled={isLoading}
+                className="w-full border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 py-2 font-mono text-sm text-[var(--t-text)] outline-none focus:border-[var(--t-amber)]"
+              />
+            </label>
+            <button
+              type="button"
+              disabled={isLoading}
+              onClick={() =>
+                setUnstakeAmount(formatWeiOrDash(active.activeAmountWei))
+              }
+              className="min-h-10 border border-[var(--t-divider)] px-3 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)] hover:text-[var(--t-text)]"
+            >
+              Max
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading || !unstakeAmount.trim()}
+              className="min-h-10 border border-[var(--t-divider)] px-4 text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--t-text)] transition-colors hover:border-[var(--t-amber)] hover:text-[var(--t-amber)] disabled:opacity-40"
+            >
+              File pull
+            </button>
+          </form>
+        ) : null}
+
+        {pendingVaults.length > 0 ? (
+          <div className="space-y-2 border-t border-[var(--t-divider)] pt-3">
+            <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--t-muted)]">
+              Cage withdrawals
+            </p>
+            {pendingVaults.map((row) => {
+              const cooling = isCooldownActive(
+                row.unlockTime,
+                row.pendingAmountWei,
+                nowSeconds
+              );
+              const ready = canCompleteWithdrawal({
+                pendingWei: row.pendingAmountWei,
+                unlockTimeSeconds: row.unlockTime,
+                nowSeconds,
+              });
+              return (
+                <div
+                  key={`${row.vaultAddress}:${row.vaultVersion}`}
+                  className="flex flex-wrap items-center justify-between gap-3 border border-[var(--t-divider)] bg-[var(--t-bg)]/40 px-3 py-2"
+                >
+                  <div className="min-w-0 text-[10px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
+                    <p>
+                      Vault v{row.vaultVersion}
+                      {!row.isActiveVault ? (
+                        <span className="ml-2 text-[var(--t-amber)]">
+                          prior book · no capacity
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="mt-1 text-[var(--t-text)]">
+                      {formatWeiOrDash(row.pendingAmountWei)} $BLOW ·{" "}
+                      {cooling
+                        ? `Unlock ${formatUnlockCountdown(row.unlockTime, nowSeconds)}`
+                        : ready
+                          ? "Ready for release"
+                          : "—"}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={isLoading || !ready}
+                    onClick={() => void handleComplete(row)}
+                    className={cn(
+                      "min-h-9 border px-3 text-[10px] font-bold uppercase tracking-[0.16em] transition-colors disabled:opacity-40",
+                      ready
+                        ? "border-[var(--t-green)]/50 text-[var(--t-green)] hover:bg-[var(--t-green)]/10"
+                        : "border-[var(--t-divider)] text-[var(--t-muted)]"
+                    )}
+                  >
+                    {ready ? "Complete withdrawal" : "Cage locked"}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+
+        {isLoading || step === "done" ? (
+          <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--t-green)]">
+            {seatVaultStepLabel(step)}
+          </p>
+        ) : null}
+
+        {displayError ? (
+          <p className="text-xs text-[var(--t-red)]" role="alert">
+            {displayError}
+          </p>
+        ) : null}
+
+        {active?.syncStatus === "error" && active.syncError ? (
+          <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--t-amber)]">
+            Book lag: {active.syncError}
+          </p>
+        ) : null}
+
+        <p className="text-[10px] leading-relaxed tracking-[0.04em] text-[var(--t-muted)]">
+          Principal sets desk cadence and open-ticket capacity only. No yield,
+          no dividends, no payout promises — just a seat on the floor.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+/** Narrow export for static markup tests without Convex/wagmi. */
+export function SeatStakePanelStatic({
+  tier,
+  activeHuman,
+  pendingHuman,
+  nextTierDeltaHuman,
+  nextTierLabel,
+  showControls,
+  showPendingDetails,
+  cooldownLabel,
+  canComplete,
+  vaultVersionLabel,
+  error,
+}: {
+  tier: SeatTierName;
+  activeHuman: string;
+  pendingHuman: string;
+  nextTierDeltaHuman?: string;
+  nextTierLabel?: string;
+  showControls: boolean;
+  showPendingDetails: boolean;
+  cooldownLabel?: string;
+  canComplete?: boolean;
+  vaultVersionLabel?: string;
+  error?: string;
+}) {
+  return (
+    <section className="border border-[var(--t-divider)] bg-[#070b09] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
+          Floor seat · $BLOW principal
+        </h2>
+        <SeatTierBadgeView tier={tier} />
+      </div>
+      <p className="mt-3 text-xs uppercase tracking-[0.14em] text-[var(--t-text)]">
+        Active {activeHuman} $BLOW
+      </p>
+      {showPendingDetails ? (
+        <p className="mt-1 text-xs uppercase tracking-[0.14em] text-[var(--t-amber)]">
+          Pending {pendingHuman} $BLOW
+          {cooldownLabel ? ` · ${cooldownLabel}` : null}
+        </p>
+      ) : null}
+      {nextTierDeltaHuman && nextTierLabel ? (
+        <p className="mt-2 text-xs uppercase tracking-[0.14em] text-[var(--t-muted)]">
+          Need {nextTierDeltaHuman} $BLOW for {nextTierLabel}
+        </p>
+      ) : null}
+      {showControls ? (
+        <div className="mt-3 flex gap-2">
+          <button type="button">Post $BLOW</button>
+          <button type="button">File pull</button>
+          {canComplete ? (
+            <button type="button">Complete withdrawal</button>
+          ) : (
+            <button type="button" disabled>
+              Cage locked
+            </button>
+          )}
+        </div>
+      ) : (
+        <p className="mt-3 text-[10px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
+          Public view — management locked
+        </p>
+      )}
+      {vaultVersionLabel ? (
+        <p className="mt-2 text-[10px] uppercase tracking-[0.14em] text-[var(--t-amber)]">
+          {vaultVersionLabel}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-2 text-xs text-[var(--t-red)]" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/seat-stake-panel.tsx
+++ b/src/components/seat-stake-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
@@ -15,6 +15,7 @@ import {
 } from "@/hooks/use-seat-vault";
 import { useBaseNetwork } from "@/hooks/use-base-network";
 import {
+  capacityForTier,
   formatBlowAmount,
   SEAT_VAULT_ADDRESS,
   type SeatTierName,
@@ -105,13 +106,7 @@ export function SeatStakePanel({
   const [localError, setLocalError] = useState<string | undefined>();
 
   const active = seatState ?? null;
-  const nextTier = useMemo(
-    () =>
-      active
-        ? amountNeededForNextTier(active.activeAmountWei)
-        : amountNeededForNextTier("0"),
-    [active]
-  );
+  const nextTier = amountNeededForNextTier(active?.activeAmountWei ?? "0");
 
   const canStake = canPostPrincipal({
     walletAddress,
@@ -246,7 +241,7 @@ export function SeatStakePanel({
         />
         <DatumCell
           label="Cadence / open tickets"
-          value={`${Math.round((active?.cycleIntervalMs ?? 600_000) / 60_000)}m · ${active?.maxUnresolvedEntries ?? 1}`}
+          value={`${Math.round((active?.cycleIntervalMs ?? capacityForTier("Gallery").cycleIntervalMs) / 60_000)}m · ${active?.maxUnresolvedEntries ?? capacityForTier("Gallery").maxUnresolvedEntries}`}
           className="border-0"
         />
       </div>

--- a/src/components/seat-stake-panel.ui.test.tsx
+++ b/src/components/seat-stake-panel.ui.test.tsx
@@ -1,0 +1,120 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SeatStakePanelStatic } from "./seat-stake-panel";
+import { SeatTierBadgeView } from "./seat-tier-badge";
+
+describe("SeatTierBadgeView", () => {
+  it("renders floor tier labels", () => {
+    const html = renderToStaticMarkup(
+      <SeatTierBadgeView tier="CornerOffice" syncStatus="ok" />
+    );
+    expect(html).toContain("Corner Office");
+    expect(html).not.toContain("yield");
+    expect(html).not.toContain("reward");
+  });
+
+  it("surfaces sync lag without private amounts", () => {
+    const html = renderToStaticMarkup(
+      <SeatTierBadgeView tier="Seat" syncStatus="syncing" compact />
+    );
+    expect(html).toContain("Seat");
+    expect(html).toContain("syncing");
+    expect(html).not.toContain("Pending");
+    expect(html).not.toContain("Complete withdrawal");
+  });
+});
+
+describe("SeatStakePanelStatic", () => {
+  it("shows owner controls and next-tier principal need", () => {
+    const html = renderToStaticMarkup(
+      <SeatStakePanelStatic
+        tier="Gallery"
+        activeHuman="2500"
+        pendingHuman="0"
+        nextTierDeltaHuman="7500"
+        nextTierLabel="Seat"
+        showControls
+        showPendingDetails={false}
+      />
+    );
+
+    expect(html).toContain("Floor seat");
+    expect(html).toContain("Post $BLOW");
+    expect(html).toContain("File pull");
+    expect(html).toContain("Need 7500 $BLOW for Seat");
+    expect(html).not.toContain("yield");
+    expect(html).not.toContain("dividend");
+    expect(html).not.toContain("payout");
+  });
+
+  it("hides management from non-owners while keeping public tier", () => {
+    const html = renderToStaticMarkup(
+      <SeatStakePanelStatic
+        tier="Seat"
+        activeHuman="10000"
+        pendingHuman="5000"
+        showControls={false}
+        showPendingDetails={false}
+      />
+    );
+
+    expect(html).toContain("Seat");
+    expect(html).toContain("Public view — management locked");
+    expect(html).not.toContain("Post $BLOW");
+    expect(html).not.toContain("Pending 5000");
+    expect(html).not.toContain("Complete withdrawal");
+  });
+
+  it("surfaces pending withdrawal + cooldown for owners across vault versions", () => {
+    const locked = renderToStaticMarkup(
+      <SeatStakePanelStatic
+        tier="Gallery"
+        activeHuman="0"
+        pendingHuman="4000"
+        showControls
+        showPendingDetails
+        cooldownLabel="Unlock 2h 00m 00s"
+        canComplete={false}
+        vaultVersionLabel="Vault v1 · prior book · no capacity"
+      />
+    );
+
+    expect(locked).toContain("Pending 4000 $BLOW");
+    expect(locked).toContain("Unlock 2h 00m 00s");
+    expect(locked).toContain("Cage locked");
+    expect(locked).toContain("prior book · no capacity");
+    expect(locked).not.toContain("Complete withdrawal");
+
+    const ready = renderToStaticMarkup(
+      <SeatStakePanelStatic
+        tier="Gallery"
+        activeHuman="0"
+        pendingHuman="4000"
+        showControls
+        showPendingDetails
+        cooldownLabel="Ready"
+        canComplete
+        vaultVersionLabel="Vault v2"
+      />
+    );
+    // Ready path enables the complete button (no disabled attr on that control).
+    expect(ready).toContain("Complete withdrawal");
+    expect(ready).not.toContain("Cage locked");
+  });
+
+  it("renders actionable tx failure copy", () => {
+    const html = renderToStaticMarkup(
+      <SeatStakePanelStatic
+        tier="Gallery"
+        activeHuman="0"
+        pendingHuman="0"
+        showControls
+        showPendingDetails={false}
+        error="Insufficient $BLOW on the desk — wire more chips before posting."
+      />
+    );
+    expect(html).toContain("Insufficient $BLOW");
+    expect(html).toContain('role="alert"');
+  });
+});

--- a/src/components/seat-tier-badge.tsx
+++ b/src/components/seat-tier-badge.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import type { SeatTierName } from "@/lib/contracts/seatVault";
+import { SEAT_TIER_FLOOR_LABEL } from "@/lib/seat-tier-display";
+import { cn } from "@/lib/utils";
+
+const TIER_TONE: Record<SeatTierName, string> = {
+  Gallery:
+    "border-[var(--t-divider)] text-[var(--t-muted)] bg-[var(--t-surface)]/40",
+  Seat: "border-[var(--t-amber)]/50 text-[var(--t-amber)] bg-[var(--t-amber)]/10",
+  CornerOffice:
+    "border-[var(--t-green)]/50 text-[var(--t-green)] bg-[var(--t-green)]/10",
+};
+
+export function SeatTierBadgeView({
+  tier,
+  syncStatus,
+  className,
+  compact = false,
+}: {
+  tier: SeatTierName;
+  syncStatus?: "ok" | "syncing" | "error";
+  className?: string;
+  compact?: boolean;
+}) {
+  const label = SEAT_TIER_FLOOR_LABEL[tier];
+  const syncNote =
+    syncStatus === "syncing"
+      ? "syncing"
+      : syncStatus === "error"
+        ? "book lag"
+        : null;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded border font-mono font-semibold uppercase",
+        compact
+          ? "px-1.5 py-px text-[9px] tracking-[0.14em]"
+          : "px-2 py-0.5 text-[10px] tracking-[0.18em]",
+        TIER_TONE[tier],
+        className
+      )}
+      title={
+        syncNote ? `Floor seat: ${label} (${syncNote})` : `Floor seat: ${label}`
+      }
+    >
+      <span>{label}</span>
+      {syncNote ? (
+        <span className="text-[var(--t-muted)] normal-case tracking-normal">
+          · {syncNote}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** Public / owner badge fed by getPublicTraderTier (no private amounts). */
+export function SeatTierBadge({
+  traderId,
+  className,
+  compact = false,
+}: {
+  traderId: string;
+  className?: string;
+  compact?: boolean;
+}) {
+  const publicTier = useQuery(api.seatVault.queries.getPublicTraderTier, {
+    traderId: traderId as Id<"traders">,
+  });
+
+  if (publicTier === undefined) {
+    return (
+      <SeatTierBadgeView
+        tier="Gallery"
+        syncStatus="syncing"
+        className={className}
+        compact={compact}
+      />
+    );
+  }
+
+  if (publicTier === null) {
+    return (
+      <SeatTierBadgeView
+        tier="Gallery"
+        className={className}
+        compact={compact}
+      />
+    );
+  }
+
+  return (
+    <SeatTierBadgeView
+      tier={publicTier.effectiveTier}
+      syncStatus={publicTier.syncStatus}
+      className={className}
+      compact={compact}
+    />
+  );
+}

--- a/src/components/seat-tier-badge.tsx
+++ b/src/components/seat-tier-badge.tsx
@@ -72,31 +72,15 @@ export function SeatTierBadge({
     traderId: traderId as Id<"traders">,
   });
 
-  if (publicTier === undefined) {
-    return (
-      <SeatTierBadgeView
-        tier="Gallery"
-        syncStatus="syncing"
-        className={className}
-        compact={compact}
-      />
-    );
-  }
-
-  if (publicTier === null) {
-    return (
-      <SeatTierBadgeView
-        tier="Gallery"
-        className={className}
-        compact={compact}
-      />
-    );
-  }
+  // undefined = query loading (show syncing); null = no row yet (plain Gallery).
+  const tier = publicTier?.effectiveTier ?? "Gallery";
+  const syncStatus =
+    publicTier === undefined ? "syncing" : publicTier?.syncStatus;
 
   return (
     <SeatTierBadgeView
-      tier={publicTier.effectiveTier}
-      syncStatus={publicTier.syncStatus}
+      tier={tier}
+      syncStatus={syncStatus}
       className={className}
       compact={compact}
     />

--- a/src/components/trader-detail.tsx
+++ b/src/components/trader-detail.tsx
@@ -29,6 +29,8 @@ import {
 import { TraderActivityPanel } from "@/components/trader-activity-panel";
 import { PendingApprovalCard } from "@/components/pending-approval-card";
 import { WalletDialog } from "@/components/wire/wallet-dialog";
+import { SeatStakePanel } from "@/components/seat-stake-panel";
+import { SeatTierBadge } from "@/components/seat-tier-badge";
 import { MarketClosedButton } from "@/components/market-closed-button";
 import { shortAssetLabel } from "@/lib/format-asset-label";
 import { useMarketHours } from "@/hooks/use-market-hours";
@@ -248,6 +250,7 @@ export function TraderDetailContent({
               {trader.name}
             </h2>
             <StatusBadge status={trader.status} />
+            <SeatTierBadge traderId={id} compact />
             <span className="min-w-0">
               <TraderCycleLine trader={trader} />
             </span>
@@ -345,6 +348,7 @@ export function TraderDetailContent({
             walletReady={trader.wallet_status === "ready"}
             onOpenWallet={() => setWalletOpen(true)}
           />
+          <SeatStakePanel traderId={id} onChainTraderId={trader.token_id} />
           <TraderPendingApprovals traderId={id} />
           <ReputationSection traderId={id} />
           <MandateConfig

--- a/src/hooks/use-seat-vault.ts
+++ b/src/hooks/use-seat-vault.ts
@@ -1,0 +1,399 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useAction } from "convex/react";
+import { usePrivy } from "@privy-io/react-auth";
+import { useReadContract } from "wagmi";
+import { erc20Abi, maxUint256 } from "viem";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { useSponsoredContractWrite } from "@/hooks/use-sponsored-contract-write";
+import { useBaseNetwork } from "@/hooks/use-base-network";
+import { getEmbeddedEvmWalletAddress } from "@/lib/privy/wallet";
+import { makePublicClient } from "@/lib/contracts/client";
+import {
+  CONTRACTS_CHAIN_ID,
+  ESCROW_ADDRESS,
+  escrowAbi,
+} from "@/lib/contracts/escrow";
+import {
+  MARGINCALL_TOKEN_ADDRESS,
+  SEAT_VAULT_ADDRESS,
+  parseBlowAmount,
+  seatVaultAbi,
+} from "@/lib/contracts/seatVault";
+
+export type SeatVaultStep =
+  | "idle"
+  | "checking"
+  | "approving"
+  | "confirmingApproval"
+  | "staking"
+  | "confirmingStake"
+  | "initiating"
+  | "confirmingInitiate"
+  | "completing"
+  | "confirmingComplete"
+  | "reconciling"
+  | "done";
+
+type SeatVaultState = {
+  step: SeatVaultStep;
+  error?: string;
+  txHash?: `0x${string}`;
+};
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function floorError(message: string): Error {
+  return new Error(message);
+}
+
+export function useBlowBalance() {
+  const { user } = usePrivy();
+  const walletAddress = getEmbeddedEvmWalletAddress(user) ?? undefined;
+
+  const { data, isLoading, error, refetch } = useReadContract({
+    address: MARGINCALL_TOKEN_ADDRESS,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: walletAddress ? [walletAddress] : undefined,
+    chainId: CONTRACTS_CHAIN_ID,
+    query: {
+      enabled: !!walletAddress,
+      refetchInterval: 15_000,
+    },
+  });
+
+  return {
+    balanceWei: data,
+    isLoading,
+    error,
+    refetch,
+    walletAddress: walletAddress ?? null,
+  };
+}
+
+export function useTraderDepositor(onChainTraderId: number | undefined) {
+  const { data, isLoading, refetch } = useReadContract({
+    address: ESCROW_ADDRESS,
+    abi: escrowAbi,
+    functionName: "depositors",
+    args: onChainTraderId !== undefined ? [BigInt(onChainTraderId)] : undefined,
+    chainId: CONTRACTS_CHAIN_ID,
+    query: {
+      enabled: onChainTraderId !== undefined && onChainTraderId > 0,
+      refetchInterval: 30_000,
+    },
+  });
+
+  const depositor =
+    data && data.toLowerCase() !== ZERO_ADDRESS.toLowerCase()
+      ? (data as `0x${string}`)
+      : null;
+
+  return { depositor, isLoading, refetch };
+}
+
+async function waitConfirmed(hash: `0x${string}`) {
+  const publicClient = makePublicClient();
+  return publicClient.waitForTransactionReceipt({
+    hash,
+    confirmations: 2,
+  });
+}
+
+export function useSeatVaultFlows() {
+  const [state, setState] = useState<SeatVaultState>({ step: "idle" });
+  const writeSponsoredContract = useSponsoredContractWrite();
+  const { user } = usePrivy();
+  const walletAddress = getEmbeddedEvmWalletAddress(user);
+  const { isWrongNetwork } = useBaseNetwork();
+  const reconcileOwnedTrader = useAction(
+    api.seatVault.actions.reconcileOwnedTrader
+  );
+
+  const assertWalletReady = useCallback(() => {
+    if (!walletAddress) {
+      throw floorError("Connect the desk treasury wallet first.");
+    }
+    if (isWrongNetwork) {
+      throw floorError("Wrong chain — switch to Base Sepolia before posting.");
+    }
+    if (state.step !== "idle" && state.step !== "done") {
+      throw floorError("A floor ticket is already pending. Wait for the wire.");
+    }
+    return walletAddress;
+  }, [walletAddress, isWrongNetwork, state.step]);
+
+  const stake = useCallback(
+    async (args: {
+      convexTraderId: Id<"traders">;
+      onChainTraderId: number;
+      amountHuman: string;
+      vaultAddress?: `0x${string}`;
+      depositor: string | null;
+    }) => {
+      setState({ step: "checking" });
+
+      try {
+        const wallet = assertWalletReady();
+        const vault = args.vaultAddress ?? SEAT_VAULT_ADDRESS;
+
+        let amountWei: bigint;
+        try {
+          amountWei = BigInt(parseBlowAmount(args.amountHuman));
+        } catch {
+          throw floorError("Enter a valid $BLOW amount.");
+        }
+        if (amountWei <= BigInt(0)) {
+          throw floorError("Zero won't clear compliance. Post a real figure.");
+        }
+
+        if (!args.depositor) {
+          throw floorError(
+            "No depositor on file — fund escrow first so the desk owns this badge."
+          );
+        }
+        if (args.depositor.toLowerCase() !== wallet.toLowerCase()) {
+          throw floorError(
+            "Depositor mismatch — only the assigned desk treasury can post principal."
+          );
+        }
+
+        const publicClient = makePublicClient();
+
+        const [balance, allowance] = await Promise.all([
+          publicClient.readContract({
+            address: MARGINCALL_TOKEN_ADDRESS,
+            abi: erc20Abi,
+            functionName: "balanceOf",
+            args: [wallet],
+          }),
+          publicClient.readContract({
+            address: MARGINCALL_TOKEN_ADDRESS,
+            abi: erc20Abi,
+            functionName: "allowance",
+            args: [wallet, vault],
+          }),
+        ]);
+
+        if (balance < amountWei) {
+          throw floorError(
+            "Insufficient $BLOW on the desk — wire more chips before posting."
+          );
+        }
+
+        let approveHash: `0x${string}` | undefined;
+        if (allowance < amountWei) {
+          setState({ step: "approving" });
+          approveHash = await writeSponsoredContract({
+            address: MARGINCALL_TOKEN_ADDRESS,
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [vault, maxUint256],
+            chainId: CONTRACTS_CHAIN_ID,
+          });
+          setState({
+            step: "confirmingApproval",
+            txHash: approveHash,
+          });
+          await waitConfirmed(approveHash);
+        }
+
+        setState({ step: "staking", txHash: approveHash });
+        const stakeHash = await writeSponsoredContract({
+          address: vault,
+          abi: seatVaultAbi,
+          functionName: "stake",
+          args: [BigInt(args.onChainTraderId), amountWei],
+          chainId: CONTRACTS_CHAIN_ID,
+        });
+        setState({ step: "confirmingStake", txHash: stakeHash });
+        await waitConfirmed(stakeHash);
+
+        setState({ step: "reconciling", txHash: stakeHash });
+        await reconcileOwnedTrader({
+          traderId: args.convexTraderId,
+          vaultAddress: vault,
+        });
+
+        setState({ step: "done", txHash: stakeHash });
+        return { hash: stakeHash };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Stake ticket failed";
+        setState({ step: "idle", error: message });
+        throw err;
+      }
+    },
+    [assertWalletReady, writeSponsoredContract, reconcileOwnedTrader]
+  );
+
+  const initiateUnstake = useCallback(
+    async (args: {
+      convexTraderId: Id<"traders">;
+      onChainTraderId: number;
+      amountHuman: string;
+      vaultAddress?: `0x${string}`;
+      activeWei: string;
+      depositor: string | null;
+      staker: string | null;
+    }) => {
+      setState({ step: "checking" });
+
+      try {
+        const wallet = assertWalletReady();
+        const vault = args.vaultAddress ?? SEAT_VAULT_ADDRESS;
+
+        let amountWei: bigint;
+        try {
+          amountWei = BigInt(parseBlowAmount(args.amountHuman));
+        } catch {
+          throw floorError("Enter a valid $BLOW amount.");
+        }
+        if (amountWei <= BigInt(0)) {
+          throw floorError("Zero won't clear compliance. Name a real pull.");
+        }
+        if (amountWei > BigInt(args.activeWei)) {
+          throw floorError("That pull exceeds active principal on this seat.");
+        }
+
+        const walletLc = wallet.toLowerCase();
+        const depositorLc = args.depositor?.toLowerCase();
+        const stakerLc = args.staker?.toLowerCase();
+        if (walletLc !== depositorLc && walletLc !== stakerLc) {
+          throw floorError(
+            "Not authorized — only the depositor or recorded staker can pull principal."
+          );
+        }
+
+        setState({ step: "initiating" });
+        const hash = await writeSponsoredContract({
+          address: vault,
+          abi: seatVaultAbi,
+          functionName: "initiateUnstake",
+          args: [BigInt(args.onChainTraderId), amountWei],
+          chainId: CONTRACTS_CHAIN_ID,
+        });
+        setState({ step: "confirmingInitiate", txHash: hash });
+        await waitConfirmed(hash);
+
+        setState({ step: "reconciling", txHash: hash });
+        await reconcileOwnedTrader({
+          traderId: args.convexTraderId,
+          vaultAddress: vault,
+        });
+
+        setState({ step: "done", txHash: hash });
+        return { hash };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Unstake initiate failed";
+        setState({ step: "idle", error: message });
+        throw err;
+      }
+    },
+    [assertWalletReady, writeSponsoredContract, reconcileOwnedTrader]
+  );
+
+  const completeUnstake = useCallback(
+    async (args: {
+      convexTraderId: Id<"traders">;
+      onChainTraderId: number;
+      vaultAddress: `0x${string}`;
+      pendingWei: string;
+      unlockTime: number;
+    }) => {
+      setState({ step: "checking" });
+
+      try {
+        assertWalletReady();
+        if (BigInt(args.pendingWei) <= BigInt(0)) {
+          throw floorError("Nothing pending on this vault.");
+        }
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        if (nowSeconds < args.unlockTime) {
+          throw floorError(
+            "Cooldown still running — the cage won't release principal yet."
+          );
+        }
+
+        setState({ step: "completing" });
+        const hash = await writeSponsoredContract({
+          address: args.vaultAddress,
+          abi: seatVaultAbi,
+          functionName: "completeUnstake",
+          args: [BigInt(args.onChainTraderId)],
+          chainId: CONTRACTS_CHAIN_ID,
+        });
+        setState({ step: "confirmingComplete", txHash: hash });
+        await waitConfirmed(hash);
+
+        setState({ step: "reconciling", txHash: hash });
+        await reconcileOwnedTrader({
+          traderId: args.convexTraderId,
+          vaultAddress: args.vaultAddress,
+        });
+
+        setState({ step: "done", txHash: hash });
+        return { hash };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Complete unstake failed";
+        setState({ step: "idle", error: message });
+        throw err;
+      }
+    },
+    [assertWalletReady, writeSponsoredContract, reconcileOwnedTrader]
+  );
+
+  const reset = useCallback(() => {
+    setState({ step: "idle" });
+  }, []);
+
+  return {
+    stake,
+    initiateUnstake,
+    completeUnstake,
+    reset,
+    step: state.step,
+    error: state.error,
+    txHash: state.txHash,
+    isLoading: state.step !== "idle" && state.step !== "done",
+    walletAddress,
+  };
+}
+
+export function seatVaultStepLabel(step: SeatVaultStep): string {
+  switch (step) {
+    case "idle":
+      return "Standing by";
+    case "checking":
+      return "Running compliance…";
+    case "approving":
+      return "Clearing $BLOW allowance…";
+    case "confirmingApproval":
+      return "Waiting on approval receipt…";
+    case "staking":
+      return "Posting principal…";
+    case "confirmingStake":
+      return "Waiting on stake receipt…";
+    case "initiating":
+      return "Filing pull request…";
+    case "confirmingInitiate":
+      return "Waiting on pull receipt…";
+    case "completing":
+      return "Releasing from the cage…";
+    case "confirmingComplete":
+      return "Waiting on release receipt…";
+    case "reconciling":
+      return "Updating the floor book…";
+    case "done":
+      return "Ticket cleared";
+    default: {
+      const _exhaustive: never = step;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/hooks/use-seat-vault.ts
+++ b/src/hooks/use-seat-vault.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import { useAction } from "convex/react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useReadContract } from "wagmi";
-import { erc20Abi, maxUint256 } from "viem";
+import { erc20Abi, isAddressEqual, maxUint256, zeroAddress } from "viem";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useSponsoredContractWrite } from "@/hooks/use-sponsored-contract-write";
@@ -42,12 +42,6 @@ type SeatVaultState = {
   error?: string;
   txHash?: `0x${string}`;
 };
-
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-function floorError(message: string): Error {
-  return new Error(message);
-}
 
 export function useBlowBalance() {
   const { user } = usePrivy();
@@ -88,7 +82,7 @@ export function useTraderDepositor(onChainTraderId: number | undefined) {
   });
 
   const depositor =
-    data && data.toLowerCase() !== ZERO_ADDRESS.toLowerCase()
+    data && !isAddressEqual(data as `0x${string}`, zeroAddress)
       ? (data as `0x${string}`)
       : null;
 
@@ -115,13 +109,13 @@ export function useSeatVaultFlows() {
 
   const assertWalletReady = useCallback(() => {
     if (!walletAddress) {
-      throw floorError("Connect the desk treasury wallet first.");
+      throw new Error("Connect the desk treasury wallet first.");
     }
     if (isWrongNetwork) {
-      throw floorError("Wrong chain — switch to Base Sepolia before posting.");
+      throw new Error("Wrong chain — switch to Base Sepolia before posting.");
     }
     if (state.step !== "idle" && state.step !== "done") {
-      throw floorError("A floor ticket is already pending. Wait for the wire.");
+      throw new Error("A floor ticket is already pending. Wait for the wire.");
     }
     return walletAddress;
   }, [walletAddress, isWrongNetwork, state.step]);
@@ -144,19 +138,19 @@ export function useSeatVaultFlows() {
         try {
           amountWei = BigInt(parseBlowAmount(args.amountHuman));
         } catch {
-          throw floorError("Enter a valid $BLOW amount.");
+          throw new Error("Enter a valid $BLOW amount.");
         }
         if (amountWei <= BigInt(0)) {
-          throw floorError("Zero won't clear compliance. Post a real figure.");
+          throw new Error("Zero won't clear compliance. Post a real figure.");
         }
 
         if (!args.depositor) {
-          throw floorError(
+          throw new Error(
             "No depositor on file — fund escrow first so the desk owns this badge."
           );
         }
         if (args.depositor.toLowerCase() !== wallet.toLowerCase()) {
-          throw floorError(
+          throw new Error(
             "Depositor mismatch — only the assigned desk treasury can post principal."
           );
         }
@@ -179,7 +173,7 @@ export function useSeatVaultFlows() {
         ]);
 
         if (balance < amountWei) {
-          throw floorError(
+          throw new Error(
             "Insufficient $BLOW on the desk — wire more chips before posting."
           );
         }
@@ -250,20 +244,20 @@ export function useSeatVaultFlows() {
         try {
           amountWei = BigInt(parseBlowAmount(args.amountHuman));
         } catch {
-          throw floorError("Enter a valid $BLOW amount.");
+          throw new Error("Enter a valid $BLOW amount.");
         }
         if (amountWei <= BigInt(0)) {
-          throw floorError("Zero won't clear compliance. Name a real pull.");
+          throw new Error("Zero won't clear compliance. Name a real pull.");
         }
         if (amountWei > BigInt(args.activeWei)) {
-          throw floorError("That pull exceeds active principal on this seat.");
+          throw new Error("That pull exceeds active principal on this seat.");
         }
 
         const walletLc = wallet.toLowerCase();
         const depositorLc = args.depositor?.toLowerCase();
         const stakerLc = args.staker?.toLowerCase();
         if (walletLc !== depositorLc && walletLc !== stakerLc) {
-          throw floorError(
+          throw new Error(
             "Not authorized — only the depositor or recorded staker can pull principal."
           );
         }
@@ -310,11 +304,11 @@ export function useSeatVaultFlows() {
       try {
         assertWalletReady();
         if (BigInt(args.pendingWei) <= BigInt(0)) {
-          throw floorError("Nothing pending on this vault.");
+          throw new Error("Nothing pending on this vault.");
         }
         const nowSeconds = Math.floor(Date.now() / 1000);
         if (nowSeconds < args.unlockTime) {
-          throw floorError(
+          throw new Error(
             "Cooldown still running — the cage won't release principal yet."
           );
         }

--- a/src/lib/contracts/__tests__/seatVault.test.ts
+++ b/src/lib/contracts/__tests__/seatVault.test.ts
@@ -3,6 +3,7 @@ import {
   BLOW_DECIMALS,
   CORNER_OFFICE_THRESHOLD_HUMAN,
   CORNER_OFFICE_THRESHOLD_WEI,
+  MARGINCALL_TOKEN_ADDRESS,
   SEAT_THRESHOLD_HUMAN,
   SEAT_THRESHOLD_WEI,
   SEAT_VAULT_V1,
@@ -16,6 +17,7 @@ import {
   parseBlowAmount,
   seatTierNameFromOnChain,
   seatTierToOnChain,
+  seatVaultAbi,
   seatVaultEventDedupeKey,
   tierFromActiveAmount,
 } from "@/lib/contracts/seatVault";
@@ -104,5 +106,23 @@ describe("seatVaultEventDedupeKey", () => {
         3
       )
     ).toBe("0xa8595b279aeadc8a0d2ce779dc8ba4d978ea2f44:12:3");
+  });
+});
+
+describe("client token + write ABI", () => {
+  it("exports MARGINCALL_TOKEN_ADDRESS from v1 defaults", () => {
+    expect(MARGINCALL_TOKEN_ADDRESS.toLowerCase()).toBe(
+      SEAT_VAULT_V1.margincallToken.toLowerCase()
+    );
+  });
+
+  it("includes stake / initiateUnstake / completeUnstake writes", () => {
+    const names = seatVaultAbi
+      .filter((item) => item.type === "function")
+      .map((item) => item.name);
+    expect(names).toContain("stake");
+    expect(names).toContain("initiateUnstake");
+    expect(names).toContain("completeUnstake");
+    expect(names).toContain("stakeOf");
   });
 });

--- a/src/lib/contracts/seatVault.ts
+++ b/src/lib/contracts/seatVault.ts
@@ -39,3 +39,12 @@ const RESOLVED_SEAT_VAULT_ADDRESS =
   SEAT_VAULT_V1.address;
 
 export const SEAT_VAULT_ADDRESS = RESOLVED_SEAT_VAULT_ADDRESS as `0x${string}`;
+
+const RESOLVED_MARGINCALL_TOKEN_ADDRESS =
+  process.env.NEXT_PUBLIC_MARGINCALL_TOKEN_ADDRESS ??
+  process.env.MARGINCALL_TOKEN_ADDRESS ??
+  SEAT_VAULT_V1.margincallToken;
+
+/** $BLOW staking token (on-chain symbol may be MARGINCALL). */
+export const MARGINCALL_TOKEN_ADDRESS =
+  RESOLVED_MARGINCALL_TOKEN_ADDRESS as `0x${string}`;

--- a/src/lib/seat-tier-display.test.ts
+++ b/src/lib/seat-tier-display.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  amountNeededForNextTier,
+  canCompleteWithdrawal,
+  canInitiateUnstake,
+  canPostPrincipal,
+  formatUnlockCountdown,
+  isCooldownActive,
+  isCooldownComplete,
+  isLapsedSeat,
+  SEAT_TIER_FLOOR_LABEL,
+} from "./seat-tier-display";
+import {
+  CORNER_OFFICE_THRESHOLD_WEI,
+  SEAT_THRESHOLD_WEI,
+  parseBlowAmount,
+} from "@/lib/contracts/seatVault";
+
+describe("amountNeededForNextTier", () => {
+  it("targets Seat from Gallery", () => {
+    const next = amountNeededForNextTier(parseBlowAmount("2500"));
+    expect(next?.nextTier).toBe("Seat");
+    expect(next?.deltaHuman).toBe("7500");
+    expect(next?.thresholdWei).toBe(SEAT_THRESHOLD_WEI);
+  });
+
+  it("targets Corner Office from Seat", () => {
+    const next = amountNeededForNextTier(SEAT_THRESHOLD_WEI);
+    expect(next?.nextTier).toBe("CornerOffice");
+    expect(next?.deltaHuman).toBe("40000");
+    expect(next?.thresholdWei).toBe(CORNER_OFFICE_THRESHOLD_WEI);
+  });
+
+  it("returns null at Corner Office", () => {
+    expect(amountNeededForNextTier(CORNER_OFFICE_THRESHOLD_WEI)).toBeNull();
+  });
+});
+
+describe("cooldown boundaries", () => {
+  it("treats unlockTime 0 as incomplete", () => {
+    expect(isCooldownComplete(0, 1_000)).toBe(false);
+    expect(isCooldownActive(0, parseBlowAmount("100"), 1_000)).toBe(false);
+  });
+
+  it("blocks before unlock and clears at/after unlock", () => {
+    const unlock = 1_700_000_100;
+    expect(isCooldownComplete(unlock, unlock - 1)).toBe(false);
+    expect(isCooldownComplete(unlock, unlock)).toBe(true);
+    expect(isCooldownComplete(unlock, unlock + 5)).toBe(true);
+    expect(isCooldownActive(unlock, parseBlowAmount("10"), unlock - 1)).toBe(
+      true
+    );
+    expect(isCooldownActive(unlock, parseBlowAmount("10"), unlock)).toBe(false);
+    expect(isCooldownActive(unlock, "0", unlock - 1)).toBe(false);
+  });
+
+  it("formats countdown and Ready", () => {
+    expect(formatUnlockCountdown(0, 100)).toBe("—");
+    expect(formatUnlockCountdown(200, 200)).toBe("Ready");
+    expect(formatUnlockCountdown(200, 199)).toBe("1s");
+    expect(formatUnlockCountdown(3_661 + 100, 100)).toBe("1h 01m 01s");
+  });
+});
+
+describe("lapsed seat + authorization", () => {
+  it("flags lapsed when pending exists below Seat", () => {
+    expect(isLapsedSeat(parseBlowAmount("9999"), parseBlowAmount("100"))).toBe(
+      true
+    );
+    expect(isLapsedSeat(SEAT_THRESHOLD_WEI, parseBlowAmount("100"))).toBe(
+      false
+    );
+    expect(isLapsedSeat(parseBlowAmount("100"), "0")).toBe(false);
+  });
+
+  it("gates posting to matching depositor on active vault", () => {
+    expect(
+      canPostPrincipal({
+        walletAddress: "0xAbc",
+        depositorAddress: "0xabc",
+        isActiveVault: true,
+      })
+    ).toBe(true);
+    expect(
+      canPostPrincipal({
+        walletAddress: "0xAbc",
+        depositorAddress: "0xdef",
+        isActiveVault: true,
+      })
+    ).toBe(false);
+    expect(
+      canPostPrincipal({
+        walletAddress: "0xAbc",
+        depositorAddress: "0xabc",
+        isActiveVault: false,
+      })
+    ).toBe(false);
+  });
+
+  it("allows depositor or staker to initiate; complete only after cooldown", () => {
+    expect(
+      canInitiateUnstake({
+        walletAddress: "0x1",
+        depositorAddress: "0x1",
+        stakerAddress: "0x2",
+        activeWei: parseBlowAmount("10"),
+      })
+    ).toBe(true);
+    expect(
+      canInitiateUnstake({
+        walletAddress: "0x2",
+        depositorAddress: "0x1",
+        stakerAddress: "0x2",
+        activeWei: parseBlowAmount("10"),
+      })
+    ).toBe(true);
+    expect(
+      canInitiateUnstake({
+        walletAddress: "0x3",
+        depositorAddress: "0x1",
+        stakerAddress: "0x2",
+        activeWei: parseBlowAmount("10"),
+      })
+    ).toBe(false);
+    expect(
+      canInitiateUnstake({
+        walletAddress: "0x1",
+        depositorAddress: "0x1",
+        stakerAddress: "0x1",
+        activeWei: "0",
+      })
+    ).toBe(false);
+
+    expect(
+      canCompleteWithdrawal({
+        pendingWei: parseBlowAmount("5"),
+        unlockTimeSeconds: 100,
+        nowSeconds: 99,
+      })
+    ).toBe(false);
+    expect(
+      canCompleteWithdrawal({
+        pendingWei: parseBlowAmount("5"),
+        unlockTimeSeconds: 100,
+        nowSeconds: 100,
+      })
+    ).toBe(true);
+    expect(
+      canCompleteWithdrawal({
+        pendingWei: "0",
+        unlockTimeSeconds: 100,
+        nowSeconds: 200,
+      })
+    ).toBe(false);
+  });
+
+  it("uses floor labels without yield language", () => {
+    expect(SEAT_TIER_FLOOR_LABEL.CornerOffice).toBe("Corner Office");
+    expect(SEAT_TIER_FLOOR_LABEL.Seat).toBe("Seat");
+    expect(SEAT_TIER_FLOOR_LABEL.Gallery).toBe("Gallery");
+  });
+});

--- a/src/lib/seat-tier-display.ts
+++ b/src/lib/seat-tier-display.ts
@@ -1,0 +1,152 @@
+import {
+  CORNER_OFFICE_THRESHOLD_WEI,
+  SEAT_THRESHOLD_WEI,
+  compareWei,
+  formatBlowAmount,
+  type SeatTierName,
+} from "@/lib/contracts/seatVault";
+
+/** Floor-facing labels — never imply yield or odds. */
+export const SEAT_TIER_FLOOR_LABEL: Record<SeatTierName, string> = {
+  Gallery: "Gallery",
+  Seat: "Seat",
+  CornerOffice: "Corner Office",
+};
+
+export type NextTierTarget = {
+  nextTier: SeatTierName;
+  thresholdWei: string;
+  deltaWei: string;
+  deltaHuman: string;
+};
+
+/**
+ * Principal still needed to clear the next floor tier threshold.
+ * Returns null at Corner Office (no higher desk).
+ */
+export function amountNeededForNextTier(
+  activeWei: string,
+  seatThresholdWei: string = SEAT_THRESHOLD_WEI,
+  cornerThresholdWei: string = CORNER_OFFICE_THRESHOLD_WEI
+): NextTierTarget | null {
+  if (compareWei(activeWei, cornerThresholdWei) >= 0) {
+    return null;
+  }
+  if (compareWei(activeWei, seatThresholdWei) >= 0) {
+    const delta = (BigInt(cornerThresholdWei) - BigInt(activeWei)).toString();
+    return {
+      nextTier: "CornerOffice",
+      thresholdWei: cornerThresholdWei,
+      deltaWei: delta,
+      deltaHuman: formatBlowAmount(delta),
+    };
+  }
+  const delta = (BigInt(seatThresholdWei) - BigInt(activeWei)).toString();
+  return {
+    nextTier: "Seat",
+    thresholdWei: seatThresholdWei,
+    deltaWei: delta,
+    deltaHuman: formatBlowAmount(delta),
+  };
+}
+
+/** True when pending principal is waiting past unlock. */
+export function isCooldownComplete(
+  unlockTimeSeconds: number,
+  nowSeconds: number
+): boolean {
+  if (unlockTimeSeconds <= 0) return false;
+  return nowSeconds >= unlockTimeSeconds;
+}
+
+/** True when pending principal exists but unlock has not arrived. */
+export function isCooldownActive(
+  unlockTimeSeconds: number,
+  pendingWei: string,
+  nowSeconds: number
+): boolean {
+  if (compareWei(pendingWei, "0") <= 0) return false;
+  if (unlockTimeSeconds <= 0) return false;
+  return nowSeconds < unlockTimeSeconds;
+}
+
+/**
+ * Lapsed seat: active principal is below Seat while a withdrawal is still
+ * pending (principal left the floor, badge capacity already Gallery).
+ */
+export function isLapsedSeat(
+  activeWei: string,
+  pendingWei: string,
+  seatThresholdWei: string = SEAT_THRESHOLD_WEI
+): boolean {
+  return (
+    compareWei(pendingWei, "0") > 0 &&
+    compareWei(activeWei, seatThresholdWei) < 0
+  );
+}
+
+/** Format remaining cooldown as Hh Mm Ss (or "Ready"). */
+export function formatUnlockCountdown(
+  unlockTimeSeconds: number,
+  nowSeconds: number
+): string {
+  if (unlockTimeSeconds <= 0) return "—";
+  const remaining = unlockTimeSeconds - nowSeconds;
+  if (remaining <= 0) return "Ready";
+
+  const hours = Math.floor(remaining / 3600);
+  const minutes = Math.floor((remaining % 3600) / 60);
+  const seconds = remaining % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${String(minutes).padStart(2, "0")}m ${String(seconds).padStart(2, "0")}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+  }
+  return `${seconds}s`;
+}
+
+/** Can this wallet post new principal on the active vault? */
+export function canPostPrincipal(args: {
+  walletAddress: string | null | undefined;
+  depositorAddress: string | null | undefined;
+  isActiveVault: boolean;
+}): boolean {
+  if (!args.isActiveVault) return false;
+  if (!args.walletAddress || !args.depositorAddress) return false;
+  return (
+    args.walletAddress.toLowerCase() === args.depositorAddress.toLowerCase()
+  );
+}
+
+/**
+ * Can this wallet pull principal off the floor (initiate unstake)?
+ * Contract: current depositor OR recorded staker.
+ */
+export function canInitiateUnstake(args: {
+  walletAddress: string | null | undefined;
+  depositorAddress: string | null | undefined;
+  stakerAddress: string | null | undefined;
+  activeWei: string;
+}): boolean {
+  if (!args.walletAddress) return false;
+  if (compareWei(args.activeWei, "0") <= 0) return false;
+  const wallet = args.walletAddress.toLowerCase();
+  const depositor = args.depositorAddress?.toLowerCase();
+  const staker = args.stakerAddress?.toLowerCase();
+  return wallet === depositor || wallet === staker;
+}
+
+/**
+ * Former depositor / current staker may finish a withdrawal after cooldown
+ * without receiving capacity on an inactive vault.
+ */
+export function canCompleteWithdrawal(args: {
+  pendingWei: string;
+  unlockTimeSeconds: number;
+  nowSeconds: number;
+}): boolean {
+  if (compareWei(args.pendingWei, "0") <= 0) return false;
+  return isCooldownComplete(args.unlockTimeSeconds, args.nowSeconds);
+}


### PR DESCRIPTION
## Summary
- Adds an owner-only `$BLOW` staking panel on trader detail using Privy sponsored contract writes (approve → stake / initiate unstake / complete unstake), with 2-confirmation receipt waits and authoritative `reconcileOwnedTrader` after each confirmed tx.
- Surfaces public tier badges (Gallery / Seat / Corner Office) on owner detail, public dossier dialog, and public trader page without exposing management controls or private pending-withdrawal details.
- Extends `seatVaultAbi` with write fns, exports `MARGINCALL_TOKEN_ADDRESS`, and keeps floor-language copy (principal / seat / cage) with no yield/rewards/odds claims.

Closes #191

## Test plan
- [x] `pnpm exec vitest run src/lib/seat-tier-display.test.ts src/components/seat-stake-panel.ui.test.tsx src/lib/contracts/__tests__/seatVault.test.ts`
- [x] Public dossier static UI tests still pass with server-passed tier badge
- [ ] Connect desk treasury on Base Sepolia; stake below/at Seat and Corner Office thresholds; confirm tier after reconcile
- [ ] Initiate partial unstake; confirm pending + countdown; complete after cooldown
- [ ] Non-owner / wrong wallet sees badge only (no post/pull controls)
- [ ] Prior vault version with pending principal remains completable without capacity


Made with [Cursor](https://cursor.com)