### PR TITLE
feat(agent): Phase 3 — apply $BLOW capacity to agent scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    name: Lint, Typecheck & Codegen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Fails if convex/_generated is stale — i.e. a Convex module was added
+      # without committing `npx convex codegen`. This is the exact drift that
+      # broke the Vercel deploy in PR #197; catch it before merge here.
+      - name: Convex codegen guard
+        run: pnpm check:codegen
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,6 +13,7 @@ import type * as agent__ctx from "../agent/_ctx.js";
 import type * as agent__evaluator from "../agent/_evaluator.js";
 import type * as agent__schemas from "../agent/_schemas.js";
 import type * as agent__types from "../agent/_types.js";
+import type * as agent_capacity from "../agent/capacity.js";
 import type * as agent_cycle from "../agent/cycle.js";
 import type * as agent_dealSelection from "../agent/dealSelection.js";
 import type * as agent_internal from "../agent/internal.js";
@@ -122,6 +123,7 @@ declare const fullApi: ApiFromModules<{
   "agent/_evaluator": typeof agent__evaluator;
   "agent/_schemas": typeof agent__schemas;
   "agent/_types": typeof agent__types;
+  "agent/capacity": typeof agent_capacity;
   "agent/cycle": typeof agent_cycle;
   "agent/dealSelection": typeof agent_dealSelection;
   "agent/internal": typeof agent_internal;

--- a/convex/agent/capacity.ts
+++ b/convex/agent/capacity.ts
@@ -1,0 +1,165 @@
+/**
+ * SeatVault tier capacity for agent scheduling (PRD #187 / issue #190).
+ *
+ * Authoritative capacity comes from on-chain `tierOf` (via injectable reader).
+ * RPC/config/malformed failures fail closed to Gallery. Tier is never fed into
+ * deal selection, outcome narration, probability, payout, or rake.
+ *
+ * Queries cannot RPC — `listStaleTradersForCycle` uses the shortest cadence as
+ * a pre-filter; scheduler + cycle re-check with this module before granting.
+ */
+
+import { v } from "convex/values";
+import { internalQuery } from "../_generated/server";
+import {
+  capacityForTier,
+  SEAT_TIER_NAMES,
+  TIER_CAPACITY,
+  type SeatTierName,
+} from "../seatVault/policy";
+
+/** Gallery cadence — default / fail-closed interval. */
+export const GALLERY_CYCLE_INTERVAL_MS = TIER_CAPACITY.Gallery.cycleIntervalMs;
+
+/** Shortest tier cadence (Seat / Corner Office). Pre-filter floor for listStale. */
+export const MIN_CYCLE_INTERVAL_MS = TIER_CAPACITY.Seat.cycleIntervalMs;
+
+export type AuthoritativeCapacity = {
+  tier: SeatTierName;
+  cycleIntervalMs: number;
+  maxUnresolvedEntries: number;
+  source: "rpc" | "fail_closed";
+  diagnostic: string | null;
+};
+
+export type TierOfReader = (
+  vaultAddress: `0x${string}`,
+  onChainTraderId: number
+) => Promise<SeatTierName>;
+
+/** Test-only injectable seam — production passes an explicit reader. */
+let tierOfReaderOverride: TierOfReader | undefined;
+
+export function setTierOfReaderForTests(
+  reader: TierOfReader | undefined
+): void {
+  tierOfReaderOverride = reader;
+}
+
+export function getTierOfReaderOverride(): TierOfReader | undefined {
+  return tierOfReaderOverride;
+}
+
+export function isValidSeatTier(value: unknown): value is SeatTierName {
+  return (
+    typeof value === "string" &&
+    (SEAT_TIER_NAMES as readonly string[]).includes(value)
+  );
+}
+
+export function capacityFromTier(tier: SeatTierName): AuthoritativeCapacity {
+  const capacity = capacityForTier(tier);
+  return {
+    tier,
+    cycleIntervalMs: capacity.cycleIntervalMs,
+    maxUnresolvedEntries: capacity.maxUnresolvedEntries,
+    source: "rpc",
+    diagnostic: null,
+  };
+}
+
+export function failClosedGallery(diagnostic: string): AuthoritativeCapacity {
+  const capacity = capacityForTier("Gallery");
+  return {
+    tier: "Gallery",
+    cycleIntervalMs: capacity.cycleIntervalMs,
+    maxUnresolvedEntries: capacity.maxUnresolvedEntries,
+    source: "fail_closed",
+    diagnostic,
+  };
+}
+
+/** True when the trader may start a new cycle for the given interval. */
+export function isCycleIntervalElapsed(
+  lastCycleAt: number | undefined,
+  now: number,
+  intervalMs: number
+): boolean {
+  if (lastCycleAt === undefined) return true;
+  return lastCycleAt <= now - intervalMs;
+}
+
+/**
+ * Resolve capacity from on-chain tierOf (or injected test reader).
+ * Never trusts traderSeatState alone for accelerated cadence.
+ */
+export async function resolveAuthoritativeCapacity(args: {
+  onChainTraderId: number | null | undefined;
+  vaultAddress: string | null | undefined;
+  readTierOf?: TierOfReader;
+}): Promise<AuthoritativeCapacity> {
+  const { onChainTraderId, vaultAddress } = args;
+
+  if (onChainTraderId === null || onChainTraderId === undefined) {
+    return failClosedGallery("missing_token_id");
+  }
+  if (!vaultAddress || !/^0x[a-fA-F0-9]{40}$/i.test(vaultAddress)) {
+    return failClosedGallery("missing_or_invalid_vault");
+  }
+
+  const reader = args.readTierOf ?? tierOfReaderOverride;
+  if (!reader) {
+    return failClosedGallery("tier_reader_unavailable");
+  }
+
+  try {
+    const tier = await reader(
+      vaultAddress.toLowerCase() as `0x${string}`,
+      onChainTraderId
+    );
+    if (!isValidSeatTier(tier)) {
+      return failClosedGallery(`malformed_tier:${String(tier)}`);
+    }
+    return capacityFromTier(tier);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "tierOf_rpc_failed";
+    return failClosedGallery(`rpc_error:${message}`);
+  }
+}
+
+/**
+ * Count verified deal entries that are still unresolved (no outcome, or
+ * outcome without on-chain settlement). Aligns with recovery concepts in
+ * findPendingRecoveryEntry / findUnresolvedOnChain. 24h window.
+ */
+export const countUnresolvedEntries = internalQuery({
+  args: {
+    traderId: v.id("traders"),
+    now: v.number(),
+  },
+  returns: v.number(),
+  handler: async (ctx, { traderId, now }) => {
+    const since = now - 24 * 60 * 60_000;
+    const recent = await ctx.db
+      .query("dealEntries")
+      .withIndex("byTraderAndCreatedAt", (q) =>
+        q.eq("traderId", traderId).gt("createdAt", since)
+      )
+      .collect();
+
+    let count = 0;
+    for (const entry of recent) {
+      const outcome = await ctx.db
+        .query("dealOutcomes")
+        .withIndex("byTraderAndDeal", (q) =>
+          q.eq("traderId", traderId).eq("dealId", entry.dealId)
+        )
+        .unique();
+      if (!outcome || !outcome.onChainTxHash) {
+        count += 1;
+      }
+    }
+    return count;
+  },
+});

--- a/convex/agent/cycle.ts
+++ b/convex/agent/cycle.ts
@@ -4,7 +4,14 @@ import { internalAction, type ActionCtx } from "../_generated/server";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
-import { CYCLE_LEASE_TTL_MS, DEFAULT_CYCLE_INTERVAL_MS } from "./internal";
+import { CYCLE_LEASE_TTL_MS } from "./internal";
+import {
+  getTierOfReaderOverride,
+  isCycleIntervalElapsed,
+  resolveAuthoritativeCapacity,
+  type AuthoritativeCapacity,
+  type TierOfReader,
+} from "./capacity";
 import { APPROVAL_EXPIRY_MS } from "./_constants";
 import { selectDeal } from "./dealSelection";
 import { resolveOutcome, type ResolvedOutcome } from "./outcomeResolver";
@@ -16,7 +23,64 @@ import {
   isTradingHours,
 } from "../lib/tradingHours";
 import { ESCROW_ADDRESS } from "../mcp/escrowConstants";
+import { createSeatVaultPublicClient, readTierOf } from "../seatVault/rpc";
 const USDC_DECIMALS = 1_000_000;
+
+async function defaultReadTierOf(
+  vaultAddress: `0x${string}`,
+  onChainTraderId: number
+) {
+  const client = createSeatVaultPublicClient();
+  return readTierOf(client, vaultAddress, onChainTraderId);
+}
+
+function resolveTierReader(): TierOfReader {
+  return getTierOfReaderOverride() ?? defaultReadTierOf;
+}
+
+async function loadAuthoritativeCapacity(
+  ctx: ActionCtx,
+  trader: { tokenId?: number | null }
+): Promise<AuthoritativeCapacity> {
+  const deployment = await ctx.runQuery(
+    internal.seatVault.store.getActiveDeploymentInternal,
+    {}
+  );
+  return resolveAuthoritativeCapacity({
+    onChainTraderId: trader.tokenId,
+    vaultAddress: deployment?.address ?? null,
+    readTierOf: resolveTierReader(),
+  });
+}
+
+async function logCapacityDiagnostic(
+  ctx: ActionCtx,
+  {
+    traderId,
+    capacity,
+    correlationId,
+  }: {
+    traderId: Id<"traders">;
+    capacity: AuthoritativeCapacity;
+    correlationId?: string;
+  }
+) {
+  if (capacity.source !== "fail_closed" || !capacity.diagnostic) return;
+  console.warn(
+    `[cycle] capacity fail-closed Gallery for ${traderId}: ${capacity.diagnostic}`
+  );
+  await ctx.runMutation(internal.agentActivityLog.append, {
+    traderId,
+    activityType: "capacity_diagnostic",
+    message: `SeatVault tier read failed closed to Gallery: ${capacity.diagnostic}`,
+    metadata: {
+      diagnostic: capacity.diagnostic,
+      tier: capacity.tier,
+      source: capacity.source,
+    },
+    correlationId,
+  });
+}
 
 function usdcToRaw(amountUsdc: number): bigint {
   return BigInt(Math.max(0, Math.round(amountUsdc * USDC_DECIMALS)));
@@ -474,12 +538,20 @@ export const cycle = internalAction({
       );
       if (!recoveryEntry) {
         // Stamp `lastCycleAt = nextOpenAt - intervalMs` so the trader becomes
-        // stale exactly at the next open. Falls back to `now` if the trading
-        // calendar can't resolve a next open (defensive — shouldn't happen).
+        // stale exactly at the next open. Use authoritative tier cadence.
+        // Falls back to `now` if the trading calendar can't resolve a next open.
+        // Fail-closed diagnostics stay on console here so the silent skip
+        // (no activity rows) contract from trading-hours tests is preserved.
+        const capacity = await loadAuthoritativeCapacity(ctx, trader);
+        if (capacity.source === "fail_closed" && capacity.diagnostic) {
+          console.warn(
+            `[cycle] capacity fail-closed Gallery for ${traderId}: ${capacity.diagnostic}`
+          );
+        }
         const state = getTradingHoursState(now);
         const lastCycleAt =
           state.nextOpenAt !== undefined
-            ? state.nextOpenAt - DEFAULT_CYCLE_INTERVAL_MS
+            ? state.nextOpenAt - capacity.cycleIntervalMs
             : now;
         await ctx.runMutation(internal.agent.internal.stampLastCycleAt, {
           traderId,
@@ -636,6 +708,7 @@ export const cycle = internalAction({
       const mandate = (trader.mandate ?? {}) as Mandate;
 
       // Read live on-chain balance so stale Convex cache never blocks trading.
+      // Hoisted so after-hours recovery / outcome resolution can reuse it.
       let escrowBalanceUsdc = trader.escrowBalanceUsdc ?? 0;
       if (trader.tokenId !== undefined && trader.tokenId !== null) {
         try {
@@ -680,6 +753,67 @@ export const cycle = internalAction({
       let bestDeal: Deal | null = null;
 
       if (marketOpen) {
+        // Capacity gate for NEW entries (approval bypass + cron share this path).
+        // §3c recovery above is intentionally ungated. Cadence + unresolved-entry
+        // caps always apply before selectDeal / enterDeal.
+        const capacity = await loadAuthoritativeCapacity(ctx, trader);
+        await logCapacityDiagnostic(ctx, {
+          traderId,
+          capacity,
+          correlationId,
+        });
+
+        if (
+          !isCycleIntervalElapsed(
+            trader.lastCycleAt,
+            now,
+            capacity.cycleIntervalMs
+          )
+        ) {
+          await ctx.runMutation(internal.agentActivityLog.append, {
+            traderId,
+            activityType: "cycle_end",
+            message: `Cycle complete — cadence not elapsed for ${capacity.tier} (${capacity.cycleIntervalMs}ms)`,
+            metadata: {
+              tier: capacity.tier,
+              cycle_interval_ms: capacity.cycleIntervalMs,
+              source: capacity.source,
+            },
+            correlationId,
+          });
+          await ctx.runMutation(internal.agent.internal.markCycleComplete, {
+            traderId,
+            generation,
+            lastCycleAt: trader.lastCycleAt ?? now,
+          });
+          return;
+        }
+
+        const unresolvedCount = await ctx.runQuery(
+          internal.agent.capacity.countUnresolvedEntries,
+          { traderId, now }
+        );
+        if (unresolvedCount >= capacity.maxUnresolvedEntries) {
+          await ctx.runMutation(internal.agentActivityLog.append, {
+            traderId,
+            activityType: "cycle_end",
+            message: `Cycle complete — unresolved entry cap reached (${unresolvedCount}/${capacity.maxUnresolvedEntries} for ${capacity.tier})`,
+            metadata: {
+              tier: capacity.tier,
+              unresolved_count: unresolvedCount,
+              max_unresolved_entries: capacity.maxUnresolvedEntries,
+              source: capacity.source,
+            },
+            correlationId,
+          });
+          await ctx.runMutation(internal.agent.internal.markCycleComplete, {
+            traderId,
+            generation,
+            lastCycleAt: Date.now(),
+          });
+          return;
+        }
+
         const selection = await selectDeal(ctx, {
           traderId,
           traderName: trader.name,

--- a/convex/agent/internal.ts
+++ b/convex/agent/internal.ts
@@ -2,33 +2,31 @@ import { Doc } from "../_generated/dataModel";
 import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
 import { clampLimit } from "../lib/limits";
+import { GALLERY_CYCLE_INTERVAL_MS, MIN_CYCLE_INTERVAL_MS } from "./capacity";
 
 /** Cycle lease TTL: 90 seconds. Longer than the cycle itself to avoid false-recovery. */
 export const CYCLE_LEASE_TTL_MS = 90_000;
 
 /**
- * Minimum time between successful cycle completions for traders without acceleration.
- * The Convex cron runs every minute as a heartbeat; eligibility is gated by this
- * per-trader interval (not by the cron period).
+ * Gallery / fail-closed cadence. Authoritative SeatVault tiers may shorten this
+ * (see `convex/agent/capacity.ts`); queries cannot RPC so they pre-filter with
+ * {@link MIN_CYCLE_INTERVAL_MS} and scheduler/cycle re-check on-chain.
  */
-export const DEFAULT_CYCLE_INTERVAL_MS = 10 * 60_000;
+export const DEFAULT_CYCLE_INTERVAL_MS = GALLERY_CYCLE_INTERVAL_MS;
+
+/** @deprecated Prefer MIN_CYCLE_INTERVAL_MS from capacity — kept for call-site clarity. */
+export const SPEED_TOKEN_CYCLE_INTERVAL_MS = MIN_CYCLE_INTERVAL_MS;
 
 /**
- * Future: interval when speed-token acceleration applies (stored flags only; no chain reads).
- * Matches default today — reserved so the resolver can branch without API churn later.
- */
-export const SPEED_TOKEN_CYCLE_INTERVAL_MS = 10 * 60_000;
-
-/**
- * Per-trader minimum spacing between cycles. Extend with stored fields such as
- * `speedTokenEligible` / `hasSpeedToken` later; never read on-chain balances here.
+ * Pre-filter interval for listStaleTradersForCycle. Uses the shortest tier
+ * cadence so Seat/Corner Office are not missed; scheduler + cycle apply
+ * authoritative `tierOf` before granting capacity. Never trusts chain here.
  */
 export function resolveCycleIntervalMsForTrader(
   _trader: Doc<"traders">
 ): number {
   void _trader;
-  // Future: if (_trader.speedTokenEligible ?? false) return SPEED_TOKEN_CYCLE_INTERVAL_MS;
-  return DEFAULT_CYCLE_INTERVAL_MS;
+  return MIN_CYCLE_INTERVAL_MS;
 }
 
 // ── Queries ───────────────────────────────────────────────────────────────────
@@ -49,10 +47,12 @@ export const loadTraderForCycle = internalQuery({
  *   - status === "active"
  *   - walletStatus === "ready"
  *   - escrowBalanceUsdc > 0
- *   - lastCycleAt is either unset or older than resolveCycleIntervalMsForTrader(trader)
+ *   - lastCycleAt is either unset or older than MIN_CYCLE_INTERVAL_MS (5m pre-filter)
  *   - cycleLeaseUntil is either unset or in the past (no active lease)
  *
- * The 1-minute cron is only a heartbeat; each trader uses their own eligibility interval.
+ * The 1-minute cron is only a heartbeat. This query uses the shortest SeatVault
+ * cadence as a pre-filter; the scheduler action re-checks authoritative on-chain
+ * `tierOf` before enqueueing (Gallery remains 10m).
  * Called by the scheduler action — no auth context required.
  */
 export const listStaleTradersForCycle = internalQuery({

--- a/convex/agent/scheduler.ts
+++ b/convex/agent/scheduler.ts
@@ -4,6 +4,13 @@ import { internalAction } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { getTradingHoursState } from "../lib/tradingHours";
 import type { Doc } from "../_generated/dataModel";
+import {
+  getTierOfReaderOverride,
+  isCycleIntervalElapsed,
+  resolveAuthoritativeCapacity,
+  type TierOfReader,
+} from "./capacity";
+import { createSeatVaultPublicClient, readTierOf } from "../seatVault/rpc";
 
 export const MAX_CYCLES_PER_SCHEDULER_TICK = 5;
 
@@ -12,16 +19,29 @@ type SchedulerResult =
   | { enqueued: number; skipped: "no_eligible_traders" }
   | { enqueued: number; skipped: null };
 
+async function defaultReadTierOf(
+  vaultAddress: `0x${string}`,
+  onChainTraderId: number
+) {
+  const client = createSeatVaultPublicClient();
+  return readTierOf(client, vaultAddress, onChainTraderId);
+}
+
+function resolveTierReader(): TierOfReader {
+  return getTierOfReaderOverride() ?? defaultReadTierOf;
+}
+
 /**
  * Convex internal scheduler action — replaces the legacy Vercel Cron HTTP path.
  *
  * Triggered every 1 minute via convex/crons.ts as a heartbeat (Convex minimum).
- * Trader eligibility uses per-trader cycle intervals (see listStaleTradersForCycle),
- * not the cron period — traders may skip many heartbeats until they are stale enough.
+ * Trader eligibility uses per-trader cycle intervals from SeatVault tier capacity
+ * (authoritative on-chain `tierOf`), not the cron period — traders may skip many
+ * heartbeats until they are stale enough for their tier.
  *
  * For each eligible trader (active, wallet ready, no live lease,
- * lastCycleAt outside their minimum spacing) it enqueues an immediate cycle action
- * via ctx.scheduler.runAfter.
+ * lastCycleAt outside their authoritative spacing) it enqueues an immediate cycle
+ * action via ctx.scheduler.runAfter.
  * No HMAC, no HTTP self-call, no user auth context (internal-only action).
  */
 export const scheduler = internalAction({
@@ -36,17 +56,58 @@ export const scheduler = internalAction({
       };
     }
 
-    const staleTraders: Array<Doc<"traders">> = await ctx.runQuery(
+    const now = Date.now();
+    // Pre-filter at the shortest cadence; authoritative tier may still skip.
+    const candidates: Array<Doc<"traders">> = await ctx.runQuery(
       internal.agent.internal.listStaleTradersForCycle,
-      { limit: MAX_CYCLES_PER_SCHEDULER_TICK, now: Date.now() }
+      { limit: MAX_CYCLES_PER_SCHEDULER_TICK * 4, now }
     );
 
-    if (staleTraders.length === 0) {
+    if (candidates.length === 0) {
+      return { enqueued: 0, skipped: "no_eligible_traders" as const };
+    }
+
+    const deployment = await ctx.runQuery(
+      internal.seatVault.store.getActiveDeploymentInternal,
+      {}
+    );
+    const readTierOfFn = resolveTierReader();
+    const eligible: Array<Doc<"traders">> = [];
+
+    for (const trader of candidates) {
+      if (eligible.length >= MAX_CYCLES_PER_SCHEDULER_TICK) break;
+
+      const capacity = await resolveAuthoritativeCapacity({
+        onChainTraderId: trader.tokenId,
+        vaultAddress: deployment?.address ?? null,
+        readTierOf: readTierOfFn,
+      });
+
+      if (capacity.source === "fail_closed" && capacity.diagnostic) {
+        console.warn(
+          `[scheduler] capacity fail-closed Gallery for ${trader._id}: ${capacity.diagnostic}`
+        );
+      }
+
+      if (
+        !isCycleIntervalElapsed(
+          trader.lastCycleAt,
+          now,
+          capacity.cycleIntervalMs
+        )
+      ) {
+        continue;
+      }
+
+      eligible.push(trader);
+    }
+
+    if (eligible.length === 0) {
       return { enqueued: 0, skipped: "no_eligible_traders" as const };
     }
 
     await Promise.all(
-      staleTraders.map((trader) =>
+      eligible.map((trader) =>
         ctx.scheduler.runAfter(0, internal.agent.cycle.cycle, {
           traderId: trader._id,
         })
@@ -54,10 +115,10 @@ export const scheduler = internalAction({
     );
 
     console.log(
-      `[scheduler] enqueued ${staleTraders.length} cycle(s):`,
-      staleTraders.map((t: { _id: string }) => t._id)
+      `[scheduler] enqueued ${eligible.length} cycle(s):`,
+      eligible.map((t: { _id: string }) => t._id)
     );
 
-    return { enqueued: staleTraders.length, skipped: null };
+    return { enqueued: eligible.length, skipped: null };
   },
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "node scripts/check-convex-codegen.mjs && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
+    "check:codegen": "node scripts/check-convex-codegen.mjs",
     "test": "vitest run",
     "test:convex": "vitest run tests/convex",
     "seed:wire": "convex run seasons:importSeason",

--- a/tests/convex/agent-capacity.test.ts
+++ b/tests/convex/agent-capacity.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Phase 3 ($BLOW capacity) — scheduler/cycle capacity gates (issue #190).
+ *
+ * Covers: tier transitions, exact cadence boundaries, unresolved-entry caps,
+ * stale read-model vs RPC, RPC failure fail-closed, lease races, and
+ * idempotent settlement remaining ungated by capacity.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../../convex/schema";
+import { internal } from "../../convex/_generated/api";
+import { DEFAULT_CYCLE_INTERVAL_MS } from "../../convex/agent/internal";
+import {
+  GALLERY_CYCLE_INTERVAL_MS,
+  MIN_CYCLE_INTERVAL_MS,
+  capacityFromTier,
+  failClosedGallery,
+  isCycleIntervalElapsed,
+  resolveAuthoritativeCapacity,
+  setTierOfReaderForTests,
+} from "../../convex/agent/capacity";
+import { TIER_CAPACITY } from "../../convex/seatVault/policy";
+import { SEAT_VAULT_V1 } from "../../convex/seatVault/policy";
+import { MAX_CYCLES_PER_SCHEDULER_TICK } from "../../convex/agent/scheduler";
+import {
+  seedActiveTrader,
+  seedDeal,
+  seedDeskManager,
+  useRealMarketHours,
+} from "./setup";
+import type { SeatTierName } from "../../convex/seatVault/policy";
+
+const modules = import.meta.glob("../../convex/**/*.ts");
+
+// Mon 2026-05-04 10:00 ET → 14:00 UTC.
+const MON_10_ET = Date.UTC(2026, 4, 4, 14, 0, 0);
+
+const VAULT = SEAT_VAULT_V1.address.toLowerCase();
+
+describe("capacity pure helpers", () => {
+  it("maps tiers to cadence and unresolved caps", () => {
+    expect(capacityFromTier("Gallery")).toMatchObject({
+      cycleIntervalMs: 10 * 60_000,
+      maxUnresolvedEntries: 1,
+      source: "rpc",
+    });
+    expect(capacityFromTier("Seat")).toMatchObject({
+      cycleIntervalMs: 5 * 60_000,
+      maxUnresolvedEntries: 1,
+    });
+    expect(capacityFromTier("CornerOffice")).toMatchObject({
+      cycleIntervalMs: 5 * 60_000,
+      maxUnresolvedEntries: 2,
+    });
+    expect(GALLERY_CYCLE_INTERVAL_MS).toBe(DEFAULT_CYCLE_INTERVAL_MS);
+    expect(MIN_CYCLE_INTERVAL_MS).toBe(TIER_CAPACITY.Seat.cycleIntervalMs);
+  });
+
+  it("treats exact cadence boundary as elapsed", () => {
+    const now = 1_000_000;
+    const interval = 5 * 60_000;
+    expect(isCycleIntervalElapsed(now - interval, now, interval)).toBe(true);
+    expect(isCycleIntervalElapsed(now - interval + 1, now, interval)).toBe(
+      false
+    );
+    expect(isCycleIntervalElapsed(undefined, now, interval)).toBe(true);
+  });
+
+  it("fail-closes to Gallery on missing config / RPC / malformed tier", async () => {
+    expect(failClosedGallery("x")).toMatchObject({
+      tier: "Gallery",
+      source: "fail_closed",
+      diagnostic: "x",
+    });
+
+    expect(
+      await resolveAuthoritativeCapacity({
+        onChainTraderId: undefined,
+        vaultAddress: VAULT,
+      })
+    ).toMatchObject({ tier: "Gallery", diagnostic: "missing_token_id" });
+
+    expect(
+      await resolveAuthoritativeCapacity({
+        onChainTraderId: 1,
+        vaultAddress: null,
+      })
+    ).toMatchObject({
+      tier: "Gallery",
+      diagnostic: "missing_or_invalid_vault",
+    });
+
+    expect(
+      await resolveAuthoritativeCapacity({
+        onChainTraderId: 1,
+        vaultAddress: VAULT,
+        readTierOf: async () => {
+          throw new Error("rpc down");
+        },
+      })
+    ).toMatchObject({
+      tier: "Gallery",
+      source: "fail_closed",
+    });
+
+    expect(
+      await resolveAuthoritativeCapacity({
+        onChainTraderId: 1,
+        vaultAddress: VAULT,
+        readTierOf: async () => "NotATier" as SeatTierName,
+      })
+    ).toMatchObject({
+      tier: "Gallery",
+      diagnostic: expect.stringContaining("malformed_tier"),
+    });
+  });
+});
+
+describe("countUnresolvedEntries", () => {
+  it("counts entries missing outcomes or on-chain settlement", async () => {
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, { tokenId: 11 });
+    const dealA = await seedDeal(t, { onChainDealId: 1 });
+    const dealB = await seedDeal(t, { onChainDealId: 2 });
+    const dealC = await seedDeal(t, { onChainDealId: 3 });
+    const now = Date.now();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("dealEntries", {
+        paymentId: "pay-a",
+        dealId: dealA as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 1_000,
+      });
+      await ctx.db.insert("dealEntries", {
+        paymentId: "pay-b",
+        dealId: dealB as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 2_000,
+      });
+      await ctx.db.insert("dealOutcomes", {
+        dealId: dealB as never,
+        traderId: traderId as never,
+        traderPnlUsdc: 1,
+        createdAt: now - 1_500,
+        // no onChainTxHash → still unresolved
+      });
+      await ctx.db.insert("dealEntries", {
+        paymentId: "pay-c",
+        dealId: dealC as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 3_000,
+      });
+      await ctx.db.insert("dealOutcomes", {
+        dealId: dealC as never,
+        traderId: traderId as never,
+        traderPnlUsdc: 1,
+        onChainTxHash: "0xsettled",
+        createdAt: now - 2_500,
+      });
+    });
+
+    const count = await t.query(
+      internal.agent.capacity.countUnresolvedEntries,
+      { traderId: traderId as never, now }
+    );
+    expect(count).toBe(2);
+  });
+});
+
+describe("scheduler authoritative capacity", () => {
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    restoreEnv = useRealMarketHours();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(MON_10_ET));
+  });
+
+  afterEach(() => {
+    setTierOfReaderForTests(undefined);
+    vi.useRealTimers();
+    restoreEnv();
+  });
+
+  async function seedVault(t: ReturnType<typeof convexTest>) {
+    await t.mutation(internal.seatVault.store.ensureActiveVaultDeployment, {
+      address: VAULT,
+      version: 1,
+    });
+  }
+
+  it("keeps Gallery on 10-minute cadence at the exact boundary", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    await seedActiveTrader(t, dmId, {
+      tokenId: 1,
+      lastCycleAt: MON_10_ET - GALLERY_CYCLE_INTERVAL_MS,
+    });
+    setTierOfReaderForTests(async () => "Gallery");
+
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({ enqueued: 1, skipped: null });
+  });
+
+  it("does not enqueue Gallery one ms inside the 10-minute window", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    await seedActiveTrader(t, dmId, {
+      tokenId: 2,
+      // Past 5m pre-filter, still inside Gallery 10m.
+      lastCycleAt: MON_10_ET - (GALLERY_CYCLE_INTERVAL_MS - 1),
+    });
+    setTierOfReaderForTests(async () => "Gallery");
+
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({ enqueued: 0, skipped: "no_eligible_traders" });
+  });
+
+  it("enqueues Seat at the exact 5-minute boundary", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    await seedActiveTrader(t, dmId, {
+      tokenId: 3,
+      lastCycleAt: MON_10_ET - MIN_CYCLE_INTERVAL_MS,
+    });
+    setTierOfReaderForTests(async () => "Seat");
+
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({ enqueued: 1, skipped: null });
+  });
+
+  it("enqueues Corner Office at the exact 5-minute boundary", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    await seedActiveTrader(t, dmId, {
+      tokenId: 4,
+      lastCycleAt: MON_10_ET - MIN_CYCLE_INTERVAL_MS,
+    });
+    setTierOfReaderForTests(async () => "CornerOffice");
+
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({ enqueued: 1, skipped: null });
+  });
+
+  it("applies a tier upgrade at the next scheduler tick without restart", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    await seedActiveTrader(t, dmId, {
+      tokenId: 5,
+      lastCycleAt: MON_10_ET - MIN_CYCLE_INTERVAL_MS - 1_000,
+    });
+
+    let tier: SeatTierName = "Gallery";
+    setTierOfReaderForTests(async () => tier);
+
+    const blocked = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(blocked).toEqual({ enqueued: 0, skipped: "no_eligible_traders" });
+
+    tier = "Seat";
+    const allowed = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(allowed).toEqual({ enqueued: 1, skipped: null });
+  });
+
+  it("ignores stale Corner Office read-model when RPC says Gallery", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, {
+      tokenId: 6,
+      lastCycleAt: MON_10_ET - MIN_CYCLE_INTERVAL_MS - 1_000,
+    });
+
+    await t.mutation(internal.seatVault.store.publishReconciledSeatState, {
+      traderId: traderId as never,
+      onChainTraderId: 6,
+      vaultAddress: VAULT,
+      vaultVersion: 1,
+      isActiveVault: true,
+      effectiveTier: "CornerOffice",
+      staker: "0xabcabcabcabcabcabcabcabcabcabcabcabcabca",
+      activeAmountWei: "50000000000000000000000",
+      pendingAmountWei: "0",
+      unlockTime: 0,
+      syncStatus: "ok",
+      syncError: null,
+    });
+
+    setTierOfReaderForTests(async () => "Gallery");
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({ enqueued: 0, skipped: "no_eligible_traders" });
+  });
+
+  it("fail-closes to Gallery cadence on RPC failure (no accelerated enqueue)", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    await seedActiveTrader(t, dmId, {
+      tokenId: 7,
+      lastCycleAt: MON_10_ET - MIN_CYCLE_INTERVAL_MS - 1_000,
+    });
+    setTierOfReaderForTests(async () => {
+      throw new Error("boom");
+    });
+
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({ enqueued: 0, skipped: "no_eligible_traders" });
+  });
+
+  it("still respects per-tick fanout after capacity filtering", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    setTierOfReaderForTests(async () => "Seat");
+
+    for (let i = 0; i < MAX_CYCLES_PER_SCHEDULER_TICK + 3; i += 1) {
+      await seedActiveTrader(t, dmId, {
+        name: `Seat ${i}`,
+        tokenId: 100 + i,
+        lastCycleAt: MON_10_ET - MIN_CYCLE_INTERVAL_MS - 1_000,
+      });
+    }
+
+    const result = await t.action(internal.agent.scheduler.scheduler, {});
+    expect(result).toEqual({
+      enqueued: MAX_CYCLES_PER_SCHEDULER_TICK,
+      skipped: null,
+    });
+  });
+});
+
+describe("cycle capacity gates", () => {
+  let priorForceOpen: string | undefined;
+
+  beforeEach(() => {
+    priorForceOpen = process.env.MC_FORCE_MARKET_OPEN;
+    process.env.MC_FORCE_MARKET_OPEN = "1";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(MON_10_ET));
+  });
+
+  afterEach(() => {
+    setTierOfReaderForTests(undefined);
+    vi.useRealTimers();
+    if (priorForceOpen === undefined) {
+      delete process.env.MC_FORCE_MARKET_OPEN;
+    } else {
+      process.env.MC_FORCE_MARKET_OPEN = priorForceOpen;
+    }
+  });
+
+  async function seedVault(t: ReturnType<typeof convexTest>) {
+    await t.mutation(internal.seatVault.store.ensureActiveVaultDeployment, {
+      address: VAULT,
+      version: 1,
+    });
+  }
+
+  it("blocks new entries at Gallery/Seat unresolved cap of 1", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, {
+      tokenId: 20,
+      lastCycleAt: undefined,
+      cycleGeneration: 0,
+    });
+    const dealId = await seedDeal(t, { onChainDealId: 20 });
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("dealEntries", {
+        paymentId: "cap-1",
+        dealId: dealId as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 1_000,
+      });
+    });
+
+    setTierOfReaderForTests(async () => "Seat");
+    await t.action(internal.agent.cycle.cycle, {
+      traderId: traderId as never,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("agentActivityLog")
+        .withIndex("byTrader", (q) => q.eq("traderId", traderId as never))
+        .collect()
+    );
+    const capEnd = rows.find(
+      (r) =>
+        r.activityType === "cycle_end" &&
+        r.message.includes("unresolved entry cap")
+    );
+    expect(capEnd).toBeDefined();
+    expect(rows.some((r) => r.activityType === "enter")).toBe(false);
+  });
+
+  it("allows Corner Office a second unresolved entry (cap 2)", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, { tokenId: 21 });
+    const dealId = await seedDeal(t, { onChainDealId: 21 });
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("dealEntries", {
+        paymentId: "cap-co-1",
+        dealId: dealId as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 1_000,
+      });
+    });
+
+    const count = await t.query(
+      internal.agent.capacity.countUnresolvedEntries,
+      {
+        traderId: traderId as never,
+        now,
+      }
+    );
+    expect(count).toBe(1);
+    expect(capacityFromTier("CornerOffice").maxUnresolvedEntries).toBe(2);
+    expect(count < capacityFromTier("CornerOffice").maxUnresolvedEntries).toBe(
+      true
+    );
+  });
+
+  it("blocks Corner Office at unresolved cap of 2", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, {
+      tokenId: 22,
+      lastCycleAt: undefined,
+      cycleGeneration: 0,
+    });
+    const dealA = await seedDeal(t, { onChainDealId: 22 });
+    const dealB = await seedDeal(t, { onChainDealId: 23 });
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("dealEntries", {
+        paymentId: "cap-co-a",
+        dealId: dealA as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 2_000,
+      });
+      await ctx.db.insert("dealEntries", {
+        paymentId: "cap-co-b",
+        dealId: dealB as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 1_000,
+      });
+    });
+
+    setTierOfReaderForTests(async () => "CornerOffice");
+    await t.action(internal.agent.cycle.cycle, {
+      traderId: traderId as never,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("agentActivityLog").collect()
+    );
+    expect(
+      rows.some(
+        (r) =>
+          r.activityType === "cycle_end" &&
+          r.message.includes("unresolved entry cap")
+      )
+    ).toBe(true);
+  });
+
+  it("logs a diagnostic when tier RPC fails closed", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, {
+      tokenId: 23,
+      // Inside Gallery cadence so cycle exits after diagnostic (no selectDeal).
+      lastCycleAt: Date.now() - 60_000,
+      cycleGeneration: 0,
+    });
+    setTierOfReaderForTests(async () => {
+      throw new Error("rpc unavailable");
+    });
+
+    await t.action(internal.agent.cycle.cycle, {
+      traderId: traderId as never,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("agentActivityLog").collect()
+    );
+    expect(
+      rows.some(
+        (r) =>
+          r.activityType === "capacity_diagnostic" &&
+          r.message.includes("failed closed to Gallery")
+      )
+    ).toBe(true);
+    expect(rows.some((r) => r.activityType === "enter")).toBe(false);
+  });
+
+  it("lease CAS still prevents overlapping cycles under capacity", async () => {
+    const t = convexTest(schema, modules);
+    await seedVault(t);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, {
+      tokenId: 24,
+      cycleGeneration: 0,
+      lastCycleAt: undefined,
+    });
+    setTierOfReaderForTests(async () => "Seat");
+
+    const first = await t.mutation(internal.agent.internal.acquireCycleLease, {
+      traderId: traderId as never,
+      expectedGeneration: 0,
+      leaseUntil: Date.now() + 60_000,
+    });
+    expect(first.acquired).toBe(true);
+
+    const second = await t.mutation(internal.agent.internal.acquireCycleLease, {
+      traderId: traderId as never,
+      expectedGeneration: 0,
+      leaseUntil: Date.now() + 60_000,
+    });
+    expect(second.acquired).toBe(false);
+
+    // Concurrent cycle invocations lose the lease race.
+    await t.action(internal.agent.cycle.cycle, {
+      traderId: traderId as never,
+    });
+    const trader = await t.run((ctx) => ctx.db.get(traderId as never));
+    expect(trader?.cycleGeneration).toBe(1);
+  });
+
+  it("does not gate §3c-style settlement by entry caps (idempotent settle path)", async () => {
+    // Capacity caps only block NEW entries. An existing outcome waiting for
+    // on-chain settlement must remain recoverable — countUnresolved includes it,
+    // but findUnresolvedOnChain / markOnChainResolved stay independent.
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, dmId, { tokenId: 25 });
+    const dealId = await seedDeal(t, { onChainDealId: 25 });
+    const now = Date.now();
+
+    const outcomeId = await t.run(async (ctx) => {
+      await ctx.db.insert("dealEntries", {
+        paymentId: "settle-1",
+        dealId: dealId as never,
+        traderId: traderId as never,
+        entryCostUsdc: 10,
+        createdAt: now - 1_000,
+      });
+      return ctx.db.insert("dealOutcomes", {
+        dealId: dealId as never,
+        traderId: traderId as never,
+        traderPnlUsdc: 5,
+        rakeUsdc: 0.5,
+        createdAt: now - 500,
+      });
+    });
+
+    const unresolved = await t.query(
+      internal.agent.capacity.countUnresolvedEntries,
+      { traderId: traderId as never, now }
+    );
+    expect(unresolved).toBe(1);
+
+    await t.mutation(internal.dealOutcomes.markOnChainResolved, {
+      outcomeId: outcomeId as never,
+      onChainTxHash: "0xabc",
+    });
+    await t.mutation(internal.dealOutcomes.markOnChainResolved, {
+      outcomeId: outcomeId as never,
+      onChainTxHash: "0xshould-not-overwrite",
+    });
+
+    const outcome = await t.run((ctx) => ctx.db.get(outcomeId as never));
+    expect(outcome?.onChainTxHash).toBe("0xabc");
+
+    const after = await t.query(
+      internal.agent.capacity.countUnresolvedEntries,
+      { traderId: traderId as never, now }
+    );
+    expect(after).toBe(0);
+  });
+});

--- a/tests/convex/blow-capacity-invariants.test.ts
+++ b/tests/convex/blow-capacity-invariants.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Dependency invariant: SeatVault / tier / staking modules must not be imported
+ * by deal selection, outcome resolution prompts, probability, payout, or rake
+ * code paths (issue #190 / PRD #187).
+ *
+ * Capacity scheduling may use seatVault; ranking and economic outcomes must not.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "../..");
+
+const FORBIDDEN_MODULES = [
+  "convex/agent/dealSelection.ts",
+  "convex/agent/outcomeResolver.ts",
+  "convex/agent/_evaluator.ts",
+  "convex/agent/_constants.ts",
+  "convex/agent/_schemas.ts",
+] as const;
+
+/** Import paths / identifiers that would leak staking into economic logic. */
+const FORBIDDEN_PATTERNS = [
+  /from\s+["'].*seatVault/i,
+  /from\s+["'].*\/capacity["']/i,
+  /seatVault\//i,
+  /readTierOf/,
+  /TIER_CAPACITY/,
+  /capacityForTier/,
+  /traderSeatState/,
+  /effectiveTier/,
+  /SeatTierName/,
+  /CornerOffice/,
+  /\$BLOW/,
+] as const;
+
+describe("blow capacity invariants", () => {
+  it("forbids seatVault/tier imports in selection, resolution, probability, payout, rake modules", () => {
+    const violations: string[] = [];
+
+    for (const rel of FORBIDDEN_MODULES) {
+      const source = readFileSync(join(ROOT, rel), "utf8");
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        if (pattern.test(source)) {
+          violations.push(`${rel} matches ${pattern}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps RAKE_PERCENTAGE and win probability constants free of tier coupling", () => {
+    const constants = readFileSync(
+      join(ROOT, "convex/agent/_constants.ts"),
+      "utf8"
+    );
+    expect(constants).toMatch(/RAKE_PERCENTAGE\s*=\s*10/);
+    expect(constants).toMatch(/BASE_WIN_PROBABILITY/);
+    expect(constants).not.toMatch(/tier/i);
+    expect(constants).not.toMatch(/seat/i);
+    expect(constants).not.toMatch(/blow/i);
+  });
+});

--- a/tests/convex/cycle-idempotency.test.ts
+++ b/tests/convex/cycle-idempotency.test.ts
@@ -17,6 +17,7 @@ import { convexTest } from "convex-test";
 import schema from "../../convex/schema";
 import { internal } from "../../convex/_generated/api";
 import { DEFAULT_CYCLE_INTERVAL_MS } from "../../convex/agent/internal";
+import { MIN_CYCLE_INTERVAL_MS } from "../../convex/agent/capacity";
 import { seedDeskManager, seedActiveTrader, seedDeal } from "./setup";
 
 const modules = import.meta.glob("../../convex/**/*.ts");
@@ -49,10 +50,10 @@ describe("Cycle lease: stale trader eligibility", () => {
     expect(stale.length).toBe(1);
   });
 
-  it("returns stale trader (lastCycleAt past default interval) as eligible", async () => {
+  it("returns stale trader (lastCycleAt past min pre-filter interval) as eligible", async () => {
     const t = convexTest(schema, modules);
     const dmId = await seedDeskManager(t);
-    const oldCycleAt = Date.now() - DEFAULT_CYCLE_INTERVAL_MS;
+    const oldCycleAt = Date.now() - MIN_CYCLE_INTERVAL_MS;
     await seedActiveTrader(t, dmId, { lastCycleAt: oldCycleAt });
 
     const stale = await t.query(
@@ -62,10 +63,10 @@ describe("Cycle lease: stale trader eligibility", () => {
     expect(stale.length).toBe(1);
   });
 
-  it("does NOT return trader with lastCycleAt within default cycle interval", async () => {
+  it("does NOT return trader with lastCycleAt within min pre-filter interval", async () => {
     const t = convexTest(schema, modules);
     const dmId = await seedDeskManager(t);
-    const freshCycleAt = Date.now() - 10_000; // well inside the default interval
+    const freshCycleAt = Date.now() - 10_000; // well inside the min interval
     await seedActiveTrader(t, dmId, { lastCycleAt: freshCycleAt });
 
     const stale = await t.query(
@@ -75,11 +76,10 @@ describe("Cycle lease: stale trader eligibility", () => {
     expect(stale.length).toBe(0);
   });
 
-  it("does NOT return trader whose lastCycleAt is just inside the cycle interval (boundary: still fresh)", async () => {
+  it("does NOT return trader whose lastCycleAt is just inside the min interval (boundary: still fresh)", async () => {
     const t = convexTest(schema, modules);
     const dmId = await seedDeskManager(t);
-    const justInsideInterval =
-      Date.now() - (DEFAULT_CYCLE_INTERVAL_MS - 60_000);
+    const justInsideInterval = Date.now() - (MIN_CYCLE_INTERVAL_MS - 60_000);
     await seedActiveTrader(t, dmId, { lastCycleAt: justInsideInterval });
 
     const stale = await t.query(
@@ -89,11 +89,30 @@ describe("Cycle lease: stale trader eligibility", () => {
     expect(stale.length).toBe(0);
   });
 
-  it("returns trader whose lastCycleAt is older than default interval by a margin", async () => {
+  it("returns trader whose lastCycleAt is older than min interval by a margin", async () => {
     const t = convexTest(schema, modules);
     const dmId = await seedDeskManager(t);
-    const wellPastInterval = Date.now() - DEFAULT_CYCLE_INTERVAL_MS - 1_000;
+    const wellPastInterval = Date.now() - MIN_CYCLE_INTERVAL_MS - 1_000;
     await seedActiveTrader(t, dmId, { lastCycleAt: wellPastInterval });
+
+    const stale = await t.query(
+      internal.agent.internal.listStaleTradersForCycle,
+      { now: Date.now() }
+    );
+    expect(stale.length).toBe(1);
+  });
+
+  it("pre-filter may surface Gallery traders before authoritative 10m cadence (scheduler re-checks)", async () => {
+    // listStale uses MIN (5m) so Seat/Corner are not missed; Gallery is filtered
+    // again by authoritative tierOf in the scheduler/cycle.
+    const t = convexTest(schema, modules);
+    const dmId = await seedDeskManager(t);
+    const betweenMinAndGallery = Date.now() - (MIN_CYCLE_INTERVAL_MS + 1_000);
+    // Still inside Gallery's DEFAULT (10m) window.
+    expect(betweenMinAndGallery).toBeGreaterThan(
+      Date.now() - DEFAULT_CYCLE_INTERVAL_MS
+    );
+    await seedActiveTrader(t, dmId, { lastCycleAt: betweenMinAndGallery });
 
     const stale = await t.query(
       internal.agent.internal.listStaleTradersForCycle,


### PR DESCRIPTION
## Summary
- Apply authoritative SeatVault `tierOf` capacity at scheduler/cycle boundaries (Gallery 10m / 1 unresolved; Seat & Corner Office 5m; Corner Office max 2 unresolved).
- Fail closed to Gallery on RPC/config/malformed-tier with console + activity diagnostics; keep tier out of deal selection, outcome prompts, probability, payout, and rake.
- Add capacity module with injectable `tierOf` seam, unresolved-entry counting, and invariant + scheduling tests.

Closes #190

## Test plan
- [x] `pnpm exec vitest run tests/convex/agent-capacity.test.ts tests/convex/blow-capacity-invariants.test.ts tests/convex/agent-scheduler-cost-controls.test.ts tests/convex/cycle-idempotency.test.ts`
- [x] `pnpm exec vitest run tests/convex/agent-cycle-trading-hours.test.ts`
- [ ] Manual: three funded traders (Gallery / Seat / Corner Office) — cadence + cap checks per issue #190


Made with [Cursor](https://cursor.com)