### PR TITLE
Phase 5: Render reactive $BLOW floor credentials everywhere

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -75,6 +75,7 @@ import type * as seatVault_actions from "../seatVault/actions.js";
 import type * as seatVault_config from "../seatVault/config.js";
 import type * as seatVault_indexer from "../seatVault/indexer.js";
 import type * as seatVault_policy from "../seatVault/policy.js";
+import type * as seatVault_publicDisplay from "../seatVault/publicDisplay.js";
 import type * as seatVault_queries from "../seatVault/queries.js";
 import type * as seatVault_rpc from "../seatVault/rpc.js";
 import type * as seatVault_store from "../seatVault/store.js";
@@ -186,6 +187,7 @@ declare const fullApi: ApiFromModules<{
   "seatVault/config": typeof seatVault_config;
   "seatVault/indexer": typeof seatVault_indexer;
   "seatVault/policy": typeof seatVault_policy;
+  "seatVault/publicDisplay": typeof seatVault_publicDisplay;
   "seatVault/queries": typeof seatVault_queries;
   "seatVault/rpc": typeof seatVault_rpc;
   "seatVault/store": typeof seatVault_store;

--- a/convex/dealOutcomes.ts
+++ b/convex/dealOutcomes.ts
@@ -1,6 +1,7 @@
 import { internalMutation, internalQuery, query } from "./_generated/server";
 import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
+import { mapDisplayTiersByTraderId } from "./seatVault/publicDisplay";
 
 // ── Public queries ─────────────────────────────────────────────────────────
 
@@ -45,12 +46,19 @@ export const listByDeal = query({
       .order("desc")
       .collect();
 
+    const traderIds = outcomes
+      .map((outcome) => ctx.db.normalizeId("traders", outcome.traderId))
+      .filter((id): id is NonNullable<typeof id> => id !== null);
+
+    const tiers = await mapDisplayTiersByTraderId(ctx, traderIds);
+
     const outcomesWithTraderNames = outcomes.map(async (outcome) => {
       const traderId = ctx.db.normalizeId("traders", outcome.traderId);
       if (!traderId) {
         return {
           ...outcome,
           traderName: outcome.traderId,
+          effectiveTier: "Gallery" as const,
         };
       }
 
@@ -58,6 +66,7 @@ export const listByDeal = query({
       return {
         ...outcome,
         traderName: trader?.name ?? outcome.traderId,
+        effectiveTier: tiers.get(String(traderId)) ?? "Gallery",
       };
     });
 

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -8,6 +8,8 @@ import {
 } from "./lib/profileImage";
 import { readPublicTraits } from "./lib/portraitSeed";
 import { isMcpSubject } from "./mcp/subject";
+import { mapDisplayTiersByTraderId } from "./seatVault/publicDisplay";
+import { seatTierValidator } from "./seatVault/validators";
 
 const FEATURED_TRADER_NAMES = ["HurlingAlpha", "Wolf"] as const;
 const LANDING_ROSTER_DEFAULT_LIMIT = 4;
@@ -30,6 +32,8 @@ const landingRosterTraderValidator = v.object({
   name: v.string(),
   profileImageUrl: v.string(),
   traits: publicTraitsValidator,
+  /** Public floor credential only — never staker/pending/unlock. */
+  effectiveTier: seatTierValidator,
 });
 
 type Stats = {
@@ -93,7 +97,7 @@ export const listLandingRoster = query({
       ...recentReadyTraders,
     ];
     const seenTraderIds = new Set<string>();
-    const roster: Array<{
+    const pending: Array<{
       id: Doc<"traders">["_id"];
       name: string;
       profileImageUrl: string;
@@ -101,14 +105,14 @@ export const listLandingRoster = query({
     }> = [];
 
     for (const trader of orderedCandidates) {
-      if (roster.length >= cappedLimit) break;
+      if (pending.length >= cappedLimit) break;
       if (seenTraderIds.has(trader._id)) continue;
       seenTraderIds.add(trader._id);
 
       const profileImageUrl = await resolveReadyProfileImageUrl(ctx, trader);
       if (!profileImageUrl) continue;
 
-      roster.push({
+      pending.push({
         id: trader._id,
         name: trader.name,
         profileImageUrl,
@@ -116,7 +120,15 @@ export const listLandingRoster = query({
       });
     }
 
-    return roster;
+    const tiers = await mapDisplayTiersByTraderId(
+      ctx,
+      pending.map((row) => row.id)
+    );
+
+    return pending.map((row) => ({
+      ...row,
+      effectiveTier: tiers.get(String(row.id)) ?? "Gallery",
+    }));
   },
 });
 
@@ -167,6 +179,11 @@ export const listTraderStats = query({
       isAgentDeskById.set(String(deskId), isMcpSubject(dm?.subject));
     }
 
+    const tiers = await mapDisplayTiersByTraderId(
+      ctx,
+      traders.map((t) => t._id)
+    );
+
     const leaderboard = await Promise.all(
       traders.map(async (t) => {
         const tid = t._id;
@@ -202,6 +219,7 @@ export const listTraderStats = query({
             totalDealsLogged > 0 ? (s.wins / totalDealsLogged) * 100 : 0,
           total_value: escrow + assetValue,
           is_agent_desk: isAgentDesk,
+          effectiveTier: tiers.get(String(tid)) ?? "Gallery",
         };
       })
     );

--- a/convex/portfolio.ts
+++ b/convex/portfolio.ts
@@ -1,6 +1,8 @@
 import { query } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { resolveTraderProfileImageUrl } from "./lib/profileImage";
+import { mapDisplayTiersByTraderId } from "./seatVault/publicDisplay";
+import type { SeatTierName } from "./seatVault/policy";
 
 type DeskPortfolio = {
   totalValueUsdc: number;
@@ -22,6 +24,8 @@ type DeskPortfolio = {
     losses: number;
     wipeouts: number;
     dealCount: number;
+    /** Public floor credential only — never staker/pending/unlock. */
+    effectiveTier: SeatTierName;
   }[];
   pnlHistory: { createdAt: number; cumulativePnl: number }[];
   stats: {
@@ -132,6 +136,10 @@ export const forDesk = query({
     }
 
     let totalValueUsdc = 0;
+    const tiers = await mapDisplayTiersByTraderId(
+      ctx,
+      perTrader.map((row) => row.tr._id)
+    );
     const traderSummaries: DeskPortfolio["traders"] = perTrader.map(
       ({ tr, assetSum, outs, profileImageUrl }) => {
         const escrow = tr.escrowBalanceUsdc ?? 0;
@@ -156,6 +164,7 @@ export const forDesk = query({
           losses: s.losses,
           wipeouts: s.wipeouts,
           dealCount: outs.length,
+          effectiveTier: tiers.get(String(tr._id)) ?? "Gallery",
         };
       }
     );

--- a/convex/seatVault/publicDisplay.ts
+++ b/convex/seatVault/publicDisplay.ts
@@ -1,0 +1,74 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+import type { SeatTierName } from "./policy";
+
+/**
+ * Safe public display tier for badges and list surfaces.
+ * Fail closed: missing row, inactive vault, or non-ok sync → Gallery.
+ * Never carries staker / amounts / unlock metadata.
+ */
+export function displayTierFromSeatRow(
+  row:
+    | Pick<
+        Doc<"traderSeatState">,
+        "effectiveTier" | "syncStatus" | "isActiveVault"
+      >
+    | null
+    | undefined
+): SeatTierName {
+  if (!row || !row.isActiveVault) return "Gallery";
+  if (row.syncStatus !== "ok") return "Gallery";
+  return row.effectiveTier;
+}
+
+export type PublicTraderTier = {
+  effectiveTier: SeatTierName;
+  syncStatus: Doc<"traderSeatState">["syncStatus"];
+};
+
+/** Resolve public tier + sync surface for a single trader (no private fields). */
+export async function resolvePublicTraderTier(
+  ctx: QueryCtx,
+  traderId: Id<"traders">
+): Promise<PublicTraderTier> {
+  const rows = await ctx.db
+    .query("traderSeatState")
+    .withIndex("byTrader", (q) => q.eq("traderId", traderId))
+    .collect();
+  const activeRow = rows.find((r) => r.isActiveVault);
+  if (!activeRow) {
+    return { effectiveTier: "Gallery", syncStatus: "syncing" };
+  }
+  return {
+    effectiveTier: displayTierFromSeatRow(activeRow),
+    syncStatus: activeRow.syncStatus,
+  };
+}
+
+/**
+ * Batch-load display tiers for many traders (leaderboard / roster / outcomes).
+ * Only active-vault rows are scanned; missing traders default to Gallery.
+ */
+export async function mapDisplayTiersByTraderId(
+  ctx: QueryCtx,
+  traderIds: ReadonlyArray<Id<"traders">>
+): Promise<Map<string, SeatTierName>> {
+  const wanted = new Set(traderIds.map(String));
+  const result = new Map<string, SeatTierName>();
+  for (const id of wanted) {
+    result.set(id, "Gallery");
+  }
+  if (wanted.size === 0) return result;
+
+  const activeRows = await ctx.db
+    .query("traderSeatState")
+    .withIndex("byActiveVaultAndTier", (q) => q.eq("isActiveVault", true))
+    .collect();
+
+  for (const row of activeRows) {
+    const key = String(row.traderId);
+    if (!wanted.has(key)) continue;
+    result.set(key, displayTierFromSeatRow(row));
+  }
+  return result;
+}

--- a/convex/seatVault/queries.ts
+++ b/convex/seatVault/queries.ts
@@ -2,10 +2,13 @@ import { query } from "../_generated/server";
 import { v } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
 import { capacityForTier, type SeatTierName } from "./policy";
+import { resolvePublicTraderTier } from "./publicDisplay";
 import {
+  seatTierValidator,
   seatVaultDeploymentPublicValidator,
   seatVaultEventPublicValidator,
   seatVaultSyncCursorPublicValidator,
+  seatVaultSyncStatusValidator,
   traderSeatStatePublicValidator,
 } from "./validators";
 import { normalizeAddress } from "./config";
@@ -127,16 +130,8 @@ export const getPublicTraderTier = query({
   returns: v.union(
     v.object({
       traderId: v.id("traders"),
-      effectiveTier: v.union(
-        v.literal("Gallery"),
-        v.literal("Seat"),
-        v.literal("CornerOffice")
-      ),
-      syncStatus: v.union(
-        v.literal("ok"),
-        v.literal("syncing"),
-        v.literal("error")
-      ),
+      effectiveTier: seatTierValidator,
+      syncStatus: seatVaultSyncStatusValidator,
     }),
     v.null()
   ),
@@ -144,25 +139,11 @@ export const getPublicTraderTier = query({
     const trader = await ctx.db.get(args.traderId);
     if (!trader) return null;
 
-    const active = await ctx.db
-      .query("traderSeatState")
-      .withIndex("byTrader", (q) => q.eq("traderId", args.traderId))
-      .collect();
-
-    const activeRow = active.find((r) => r.isActiveVault);
-    if (!activeRow) {
-      return {
-        traderId: args.traderId,
-        effectiveTier: "Gallery" as const,
-        syncStatus: "syncing" as const,
-      };
-    }
-
+    const publicTier = await resolvePublicTraderTier(ctx, args.traderId);
     return {
       traderId: args.traderId,
-      effectiveTier:
-        activeRow.syncStatus === "ok" ? activeRow.effectiveTier : "Gallery",
-      syncStatus: activeRow.syncStatus,
+      effectiveTier: publicTier.effectiveTier,
+      syncStatus: publicTier.syncStatus,
     };
   },
 });

--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -27,6 +27,7 @@ import { walletStepValidator } from "./schema";
 import { TRADER_NAME_REGEX } from "../src/lib/trader-name";
 import { normalizeEmail } from "../src/lib/email";
 import { isMcpSubject } from "./mcp/subject";
+import { resolvePublicTraderTier } from "./seatVault/publicDisplay";
 
 // Vitest sets MC_SKIP_WALLET_SCHEDULE so any caller that would otherwise
 // enqueue wallet.createForTrader skips the scheduler. convex-test runs
@@ -244,11 +245,15 @@ export const getPublicProfile = query({
     const basics = await publicTraderBasics(ctx, trader);
     const dm = await ctx.db.get(trader.deskManagerId);
     const isAgentDesk = isMcpSubject(dm?.subject);
+    const publicTier = await resolvePublicTraderTier(ctx, traderId);
     return {
       ...basics,
       escrowBalanceUsdc: trader.escrowBalanceUsdc ?? 0,
       ownerAddress: dm?.walletAddress ?? null,
       isAgentDesk,
+      /** Public floor credential only — never staker/pending/unlock. */
+      effectiveTier: publicTier.effectiveTier,
+      seatSyncStatus: publicTier.syncStatus,
       recentActivity: recentActivity.map((entry) => ({
         activityType: entry.activityType,
         message: entry.message,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,7 @@ import { PendingApprovalCard } from "@/components/pending-approval-card";
 import { TraderAvatar } from "@/components/trader-avatar";
 import { pickFunTraits, type FunTrait } from "@/lib/portrait-traits";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
+import { FloorCredential } from "@/components/seat-tier-badge";
 import { ConnectMcpDialog } from "@/components/connect-mcp-dialog";
 import { IntroSequence } from "@/components/intro-sequence";
 import { ConvexIdentityDebug } from "@/components/convex-identity-debug";
@@ -269,6 +270,7 @@ type RosterTile = {
   src: string | null;
   imageStatus: "pending" | "generating" | "ready" | "error";
   traits: FunTrait[];
+  effectiveTier?: "Gallery" | "Seat" | "CornerOffice";
 };
 
 /** Tier → chip color, mirroring the persona-traits palette. */
@@ -305,6 +307,7 @@ function LandingScreen({ onLogin }: { onLogin: () => void }) {
       src: t.profileImageUrl,
       imageStatus: "ready" as const,
       traits: t.traits ? pickFunTraits(t.traits) : [],
+      effectiveTier: t.effectiveTier,
     }));
   }, [landingRoster]);
 
@@ -370,8 +373,13 @@ function LandingScreen({ onLogin }: { onLogin: () => void }) {
                 />
               </div>
               <figcaption className="flex flex-col gap-1.5 border-t border-[var(--t-divider)] px-2 py-2">
-                <span className="truncate text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
-                  {tile.name}
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+                    {tile.name}
+                  </span>
+                  {tile.effectiveTier ? (
+                    <FloorCredential tier={tile.effectiveTier} compact />
+                  ) : null}
                 </span>
                 {tile.traits.length > 0 && (
                   <span className="flex flex-wrap gap-1">
@@ -2395,8 +2403,11 @@ function DeskTraderRow({
         imageStatus={trader.image_status}
         size="sm"
       />
-      <span className="truncate font-bold uppercase tracking-wider text-[var(--t-amber)]">
-        {trader.name}
+      <span className="flex min-w-0 items-center gap-1.5 truncate">
+        <span className="truncate font-bold uppercase tracking-wider text-[var(--t-amber)]">
+          {trader.name}
+        </span>
+        <FloorCredential tier={trader.effective_tier} compact />
       </span>
       <span
         className={cn(
@@ -2869,6 +2880,10 @@ function MarketPlayersPanel({
                       <p className="min-w-0 truncate text-[var(--t-text)]">
                         {trader.name}
                       </p>
+                      <FloorCredential
+                        tier={trader.effectiveTier ?? "Gallery"}
+                        compact
+                      />
                       {trader.is_agent_desk ? <AgentDeskBadge compact /> : null}
                       {rankDelta !== undefined && (
                         <span

--- a/src/app/traders/[traderId]/page.tsx
+++ b/src/app/traders/[traderId]/page.tsx
@@ -9,7 +9,7 @@ import { PersonaTraits, RarityBadge } from "@/components/persona-traits";
 import { DatumCell } from "@/components/datum-cell";
 import { EmptyState } from "@/components/empty-state";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
-import { SeatTierBadgeView } from "@/components/seat-tier-badge";
+import { FloorCredential } from "@/components/seat-tier-badge";
 import { formatStatus } from "@/lib/format-status";
 import {
   formatPortraitStatus,
@@ -20,15 +20,9 @@ import {
   type PublicTraderProfile,
 } from "@/lib/trader-display";
 import { formatActivityTime, formatUsdc } from "@/lib/utils";
-import type { SeatTierName } from "@/lib/contracts/seatVault";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-type PublicTierSnapshot = {
-  effectiveTier: SeatTierName;
-  syncStatus: "ok" | "syncing" | "error";
-};
 
 function createPublicConvexClient(): ConvexHttpClient {
   const url = process.env.NEXT_PUBLIC_CONVEX_URL;
@@ -55,43 +49,25 @@ async function loadTraderProfile(traderId: string) {
   }
 }
 
-async function loadPublicTier(
-  traderId: string
-): Promise<PublicTierSnapshot | null> {
-  try {
-    const convex = createPublicConvexClient();
-    return await convex.query(api.seatVault.queries.getPublicTraderTier, {
-      traderId: traderId as Id<"traders">,
-    });
-  } catch {
-    return null;
-  }
-}
-
 export default async function PublicTraderPage({
   params,
 }: {
   params: Promise<{ traderId: string }>;
 }) {
   const { traderId } = await params;
-  const [trader, publicTier] = await Promise.all([
-    loadTraderProfile(traderId),
-    loadPublicTier(traderId),
-  ]);
+  const trader = await loadTraderProfile(traderId);
 
   if (!trader) {
     notFound();
   }
 
-  return <PublicTraderDossier trader={trader} publicTier={publicTier} />;
+  return <PublicTraderDossier trader={trader} />;
 }
 
 export function PublicTraderDossier({
   trader,
-  publicTier = null,
 }: {
   trader: PublicTraderProfile;
-  publicTier?: PublicTierSnapshot | null;
 }) {
   let portraitUrl: string = TRADER_PLACEHOLDER_IMAGE_PATH;
   if (trader.portraitStatus === "ready" && trader.profileImageUrl) {
@@ -100,8 +76,8 @@ export function PublicTraderDossier({
   const showFallbackInitials = trader.portraitStatus !== "ready";
   const statusTone = getStatusTone(trader.status);
   const portraitTone = getPortraitTone(trader.portraitStatus);
-  const tier = publicTier?.effectiveTier ?? "Gallery";
-  const syncStatus = publicTier?.syncStatus;
+  const tier = trader.effectiveTier ?? "Gallery";
+  const syncStatus = trader.seatSyncStatus;
 
   return (
     <main className="min-h-screen bg-[var(--t-bg)] font-mono text-[var(--t-text)]">
@@ -118,7 +94,7 @@ export function PublicTraderDossier({
               ) : null}
             </h1>
             <p className="mt-2 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.16em] text-[var(--t-muted)]">
-              <SeatTierBadgeView tier={tier} syncStatus={syncStatus} />
+              <FloorCredential tier={tier} syncStatus={syncStatus} />
               <span>
                 Read-only reputation, escrow posture, and last public calls from
                 the exchange floor.

--- a/src/components/deal-detail.tsx
+++ b/src/components/deal-detail.tsx
@@ -29,6 +29,7 @@ import { useDeskManager } from "@/hooks/use-desk";
 import { useSponsoredContractWrite } from "@/hooks/use-sponsored-contract-write";
 import { getEmbeddedEvmWalletAddress } from "@/lib/privy/wallet";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
+import { FloorCredential } from "@/components/seat-tier-badge";
 import { AnimatedNumber } from "@/components/animated-number";
 import {
   DIALOG_BACKDROP_CLASS,
@@ -468,6 +469,10 @@ export function DealDetailContent({
                       >
                         {formatOutcomeResult(outcome)}
                       </span>
+                      <FloorCredential
+                        tier={outcome.effective_tier ?? "Gallery"}
+                        compact
+                      />
                     </div>
                     <div className="flex shrink-0 flex-wrap items-center gap-2">
                       {outcome.trader_wiped_out && (

--- a/src/components/public-trader-dialog.tsx
+++ b/src/components/public-trader-dialog.tsx
@@ -108,7 +108,6 @@ function PublicTraderContent({
             </h2>
             <p className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] uppercase tracking-[0.2em] text-[var(--t-muted)]">
               <SeatTierBadge traderId={trader.traderId} compact />
-              <span className="text-[var(--t-divider)]">/</span>
               <span>
                 File{" "}
                 <span className="text-[var(--t-text)]">

--- a/src/components/seat-stake-panel.ui.test.tsx
+++ b/src/components/seat-stake-panel.ui.test.tsx
@@ -5,23 +5,37 @@ import { SeatStakePanelStatic } from "./seat-stake-panel";
 import { SeatTierBadgeView } from "./seat-tier-badge";
 
 describe("SeatTierBadgeView", () => {
-  it("renders floor tier labels", () => {
-    const html = renderToStaticMarkup(
+  it("renders distinct Seat and Corner Office credentials with a11y labels", () => {
+    const corner = renderToStaticMarkup(
       <SeatTierBadgeView tier="CornerOffice" syncStatus="ok" />
     );
-    expect(html).toContain("Corner Office");
-    expect(html).not.toContain("yield");
-    expect(html).not.toContain("reward");
+    expect(corner).toContain("Corner Office");
+    expect(corner).toContain('aria-label="Floor credential: Corner Office"');
+    expect(corner).toContain('role="status"');
+    expect(corner).not.toContain("yield");
+    expect(corner).not.toContain("reward");
+
+    const seat = renderToStaticMarkup(
+      <SeatTierBadgeView tier="Seat" syncStatus="ok" compact />
+    );
+    expect(seat).toContain("Seat");
+    expect(seat).toContain('aria-label="Floor credential: Seat"');
   });
 
-  it("surfaces sync lag without private amounts", () => {
-    const html = renderToStaticMarkup(
-      <SeatTierBadgeView tier="Seat" syncStatus="syncing" compact />
-    );
-    expect(html).toContain("Seat");
-    expect(html).toContain("syncing");
-    expect(html).not.toContain("Pending");
-    expect(html).not.toContain("Complete withdrawal");
+  it("renders nothing for Gallery, loading, and stale-sync states", () => {
+    expect(
+      renderToStaticMarkup(<SeatTierBadgeView tier="Gallery" syncStatus="ok" />)
+    ).toBe("");
+    expect(
+      renderToStaticMarkup(
+        <SeatTierBadgeView tier="Seat" syncStatus="syncing" compact />
+      )
+    ).toBe("");
+    expect(
+      renderToStaticMarkup(
+        <SeatTierBadgeView tier="CornerOffice" syncStatus="error" />
+      )
+    ).toBe("");
   });
 });
 

--- a/src/components/seat-tier-badge.tsx
+++ b/src/components/seat-tier-badge.tsx
@@ -7,14 +7,24 @@ import type { SeatTierName } from "@/lib/contracts/seatVault";
 import { SEAT_TIER_FLOOR_LABEL } from "@/lib/seat-tier-display";
 import { cn } from "@/lib/utils";
 
-const TIER_TONE: Record<SeatTierName, string> = {
-  Gallery:
-    "border-[var(--t-divider)] text-[var(--t-muted)] bg-[var(--t-surface)]/40",
-  Seat: "border-[var(--t-amber)]/50 text-[var(--t-amber)] bg-[var(--t-amber)]/10",
+/**
+ * Two-ink screenprint credentials for floor access.
+ * Gallery / loading / stale-sync → render nothing (never grant a credential).
+ */
+const CREDENTIAL_TONE: Record<"Seat" | "CornerOffice", string> = {
+  Seat: "border-[var(--t-amber)]/55 text-[var(--t-amber)] bg-[var(--t-amber)]/10",
   CornerOffice:
-    "border-[var(--t-green)]/50 text-[var(--t-green)] bg-[var(--t-green)]/10",
+    "border-[var(--t-green)]/55 text-[var(--t-green)] bg-[var(--t-green)]/10",
 };
 
+function isCredentialTier(tier: SeatTierName): tier is "Seat" | "CornerOffice" {
+  return tier === "Seat" || tier === "CornerOffice";
+}
+
+/**
+ * Presentational floor credential. Gallery renders nothing.
+ * Sync lag on a credential tier surfaces a muted note without private amounts.
+ */
 export function SeatTierBadgeView({
   tier,
   syncStatus,
@@ -26,37 +36,37 @@ export function SeatTierBadgeView({
   className?: string;
   compact?: boolean;
 }) {
+  // Loading / stale / missing / Gallery never display a credential.
+  if (!isCredentialTier(tier)) return null;
+  if (syncStatus === "syncing" || syncStatus === "error") return null;
+
   const label = SEAT_TIER_FLOOR_LABEL[tier];
-  const syncNote =
-    syncStatus === "syncing"
-      ? "syncing"
-      : syncStatus === "error"
-        ? "book lag"
-        : null;
+  const ariaLabel =
+    tier === "CornerOffice"
+      ? "Floor credential: Corner Office"
+      : "Floor credential: Seat";
 
   return (
     <span
+      role="status"
+      aria-label={ariaLabel}
       className={cn(
-        "inline-flex items-center gap-1.5 rounded border font-mono font-semibold uppercase",
+        "inline-flex shrink-0 items-center gap-1 rounded border font-mono font-semibold uppercase",
         compact
           ? "px-1.5 py-px text-[9px] tracking-[0.14em]"
           : "px-2 py-0.5 text-[10px] tracking-[0.18em]",
-        TIER_TONE[tier],
+        CREDENTIAL_TONE[tier],
         className
       )}
-      title={
-        syncNote ? `Floor seat: ${label} (${syncNote})` : `Floor seat: ${label}`
-      }
+      title={ariaLabel}
     >
-      <span>{label}</span>
-      {syncNote ? (
-        <span className="text-[var(--t-muted)] normal-case tracking-normal">
-          · {syncNote}
-        </span>
-      ) : null}
+      <span aria-hidden="true">{label}</span>
     </span>
   );
 }
+
+/** Alias for list/detail surfaces — same Gallery-hide credential rules. */
+export const FloorCredential = SeatTierBadgeView;
 
 /** Public / owner badge fed by getPublicTraderTier (no private amounts). */
 export function SeatTierBadge({
@@ -72,15 +82,13 @@ export function SeatTierBadge({
     traderId: traderId as Id<"traders">,
   });
 
-  // undefined = query loading (show syncing); null = no row yet (plain Gallery).
-  const tier = publicTier?.effectiveTier ?? "Gallery";
-  const syncStatus =
-    publicTier === undefined ? "syncing" : publicTier?.syncStatus;
+  // undefined = loading → no credential; null/missing → Gallery → no credential.
+  if (publicTier === undefined) return null;
 
   return (
     <SeatTierBadgeView
-      tier={tier}
-      syncStatus={syncStatus}
+      tier={publicTier?.effectiveTier ?? "Gallery"}
+      syncStatus={publicTier?.syncStatus}
       className={className}
       compact={compact}
     />

--- a/src/hooks/use-deals.ts
+++ b/src/hooks/use-deals.ts
@@ -35,6 +35,8 @@ export interface DealOutcome {
   deal_id: string;
   trader_id: string;
   trader_name?: string;
+  /** Public floor credential — Gallery / Seat / Corner Office. */
+  effective_tier?: "Gallery" | "Seat" | "CornerOffice";
   trader_pnl_usdc: number;
   pot_change_usdc: number;
   pot_change_inferred: boolean;
@@ -70,7 +72,10 @@ function mapConvexDeal(deal: Doc<"deals">): Deal {
   };
 }
 
-type DealOutcomeDoc = Doc<"dealOutcomes"> & { traderName?: string };
+type DealOutcomeDoc = Doc<"dealOutcomes"> & {
+  traderName?: string;
+  effectiveTier?: "Gallery" | "Seat" | "CornerOffice";
+};
 
 function mapConvexOutcome(o: DealOutcomeDoc): DealOutcome {
   const traderPnlUsdc = o.traderPnlUsdc ?? 0;
@@ -85,6 +90,7 @@ function mapConvexOutcome(o: DealOutcomeDoc): DealOutcome {
     deal_id: o.dealId,
     trader_id: String(o.traderId),
     trader_name: o.traderName,
+    effective_tier: o.effectiveTier,
     trader_pnl_usdc: traderPnlUsdc,
     pot_change_usdc: potChangeUsdc,
     pot_change_inferred: potChangeInferred,

--- a/src/hooks/use-landing-roster.ts
+++ b/src/hooks/use-landing-roster.ts
@@ -9,6 +9,8 @@ export type LandingRosterTrader = {
   name: string;
   profileImageUrl: string;
   traits: PublicPortraitTraits | null;
+  /** Public floor credential — Gallery / Seat / Corner Office. */
+  effectiveTier: "Gallery" | "Seat" | "CornerOffice";
 };
 
 /** Lightweight public roster used only by the unauthenticated landing page. */

--- a/src/hooks/use-leaderboard.ts
+++ b/src/hooks/use-leaderboard.ts
@@ -21,6 +21,8 @@ export interface LeaderboardTrader {
   win_rate: number;
   total_value: number;
   is_agent_desk?: boolean;
+  /** Public floor credential — Gallery / Seat / Corner Office. */
+  effectiveTier?: "Gallery" | "Seat" | "CornerOffice";
 }
 
 /** Public leaderboard — Convex subscription. */

--- a/src/hooks/use-portfolio.ts
+++ b/src/hooks/use-portfolio.ts
@@ -21,6 +21,8 @@ export interface TraderSummary {
   losses: number;
   wipeouts: number;
   deal_count: number;
+  /** Public floor credential — Gallery / Seat / Corner Office. */
+  effective_tier: "Gallery" | "Seat" | "CornerOffice";
 }
 
 export interface PnlPoint {
@@ -72,6 +74,7 @@ export function usePortfolio(): {
       losses: t.losses,
       wipeouts: t.wipeouts,
       deal_count: t.dealCount,
+      effective_tier: t.effectiveTier,
     })),
     pnl_history: result.pnlHistory.map((p) => ({
       timestamp: new Date(p.createdAt).toISOString(),

--- a/src/lib/trader-display.ts
+++ b/src/lib/trader-display.ts
@@ -14,6 +14,9 @@ export type PublicTraderProfile = {
   profileImageUrl: string | null;
   ownerAddress?: string | null;
   isAgentDesk?: boolean;
+  /** Public floor credential only — Gallery when missing/stale. */
+  effectiveTier?: "Gallery" | "Seat" | "CornerOffice";
+  seatSyncStatus?: "ok" | "syncing" | "error";
   recentActivity: Array<{
     activityType: string;
     message: string;

--- a/tests/convex/activity-leaderboard-discovery.test.ts
+++ b/tests/convex/activity-leaderboard-discovery.test.ts
@@ -480,6 +480,7 @@ describe("Landing roster", () => {
         vice: "none",
         fieldFlourish: "plain",
       },
+      effectiveTier: "Gallery",
     });
   });
 

--- a/tests/convex/floor-credentials.test.ts
+++ b/tests/convex/floor-credentials.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { api, internal } from "../../convex/_generated/api";
+import {
+  CORNER_OFFICE_THRESHOLD_WEI,
+  SEAT_THRESHOLD_WEI,
+  SEAT_VAULT_V1,
+} from "../../convex/seatVault/policy";
+import { makeT, seedActiveTrader, seedDeskManager, seedDeal } from "./setup";
+
+const VAULT = SEAT_VAULT_V1.address.toLowerCase();
+const STAKER = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca";
+
+async function seedReconciledTier(
+  t: ReturnType<typeof makeT>,
+  args: {
+    traderId: string;
+    onChainTraderId: number;
+    effectiveTier: "Gallery" | "Seat" | "CornerOffice";
+    syncStatus?: "ok" | "syncing" | "error";
+    activeAmountWei?: string;
+  }
+) {
+  await t.mutation(internal.seatVault.store.ensureActiveVaultDeployment, {
+    address: VAULT,
+    version: 1,
+  });
+  await t.mutation(internal.seatVault.store.publishReconciledSeatState, {
+    traderId: args.traderId as never,
+    onChainTraderId: args.onChainTraderId,
+    vaultAddress: VAULT,
+    vaultVersion: 1,
+    isActiveVault: true,
+    effectiveTier: args.effectiveTier,
+    staker: STAKER,
+    activeAmountWei: args.activeAmountWei ?? SEAT_THRESHOLD_WEI,
+    pendingAmountWei: "0",
+    unlockTime: 0,
+    syncStatus: args.syncStatus ?? "ok",
+    syncError: args.syncStatus === "error" ? "rpc failed" : null,
+  });
+}
+
+describe("public floor credentials (Phase 5)", () => {
+  it("getPublicTraderTier exposes only display fields and fail-closes", async () => {
+    const t = makeT();
+    const deskId = await seedDeskManager(t);
+    const traderId = await seedActiveTrader(t, deskId, { tokenId: 1 });
+
+    const missing = await t.query(api.seatVault.queries.getPublicTraderTier, {
+      traderId: traderId as never,
+    });
+    expect(missing).toEqual({
+      traderId,
+      effectiveTier: "Gallery",
+      syncStatus: "syncing",
+    });
+    expect(missing).not.toHaveProperty("staker");
+    expect(missing).not.toHaveProperty("activeAmountWei");
+    expect(missing).not.toHaveProperty("pendingAmountWei");
+    expect(missing).not.toHaveProperty("unlockTime");
+
+    await seedReconciledTier(t, {
+      traderId,
+      onChainTraderId: 1,
+      effectiveTier: "CornerOffice",
+      activeAmountWei: CORNER_OFFICE_THRESHOLD_WEI,
+    });
+    const ok = await t.query(api.seatVault.queries.getPublicTraderTier, {
+      traderId: traderId as never,
+    });
+    expect(ok?.effectiveTier).toBe("CornerOffice");
+    expect(ok?.syncStatus).toBe("ok");
+    expect(JSON.stringify(ok)).not.toMatch(/staker|pending|unlock|0xabc/i);
+
+    await seedReconciledTier(t, {
+      traderId,
+      onChainTraderId: 1,
+      effectiveTier: "CornerOffice",
+      syncStatus: "error",
+      activeAmountWei: CORNER_OFFICE_THRESHOLD_WEI,
+    });
+    const erred = await t.query(api.seatVault.queries.getPublicTraderTier, {
+      traderId: traderId as never,
+    });
+    expect(erred?.effectiveTier).toBe("Gallery");
+    expect(erred?.syncStatus).toBe("error");
+  });
+
+  it("embeds effectiveTier in leaderboard, landing roster, portfolio, profile, outcomes", async () => {
+    const t = makeT();
+    const subject = "did:privy:cred-owner";
+    const deskId = await seedDeskManager(t, {
+      subject,
+      walletAddress: "0x1111111111111111111111111111111111111111",
+    });
+    const seatTrader = await seedActiveTrader(t, deskId, {
+      name: "SeatTrader",
+      ownerSubject: subject,
+      tokenId: 10,
+    });
+    const galleryTrader = await seedActiveTrader(t, deskId, {
+      name: "GalleryTrader",
+      ownerSubject: subject,
+      tokenId: 11,
+    });
+
+    await t.run(async (ctx) => {
+      for (const traderId of [seatTrader, galleryTrader]) {
+        const storageId = await ctx.storage.store(
+          new Blob(["p"], { type: "image/png" })
+        );
+        await ctx.db.patch(traderId as never, {
+          imageStatus: "ready",
+          profileImageStorageId: storageId,
+          imagePromptSource: {
+            traits: {
+              expression: "cold",
+              fieldInk: "vermilion",
+              attire: "business",
+              vice: "none",
+              fieldFlourish: "plain",
+            },
+          },
+        });
+      }
+    });
+
+    await seedReconciledTier(t, {
+      traderId: seatTrader,
+      onChainTraderId: 10,
+      effectiveTier: "Seat",
+    });
+
+    const leaderboard = await t.query(api.leaderboard.listTraderStats, {
+      limit: 50,
+    });
+    const seatRow = leaderboard.find((r) => r.id === seatTrader);
+    const galleryRow = leaderboard.find((r) => r.id === galleryTrader);
+    expect(seatRow?.effectiveTier).toBe("Seat");
+    expect(galleryRow?.effectiveTier).toBe("Gallery");
+    expect(JSON.stringify(seatRow)).not.toMatch(
+      /staker|activeAmountWei|pendingAmountWei|unlockTime/i
+    );
+
+    const roster = await t.query(api.leaderboard.listLandingRoster, {
+      limit: 4,
+    });
+    const rosterSeat = roster.find((r) => r.id === seatTrader);
+    expect(rosterSeat?.effectiveTier).toBe("Seat");
+    expect(rosterSeat).not.toHaveProperty("staker");
+
+    const authed = t.withIdentity({
+      subject,
+      tokenIdentifier: subject,
+      issuer: "https://auth.privy.io",
+    });
+    const portfolio = await authed.query(api.portfolio.forDesk, {});
+    expect(
+      portfolio.traders.find((tr) => tr.id === seatTrader)?.effectiveTier
+    ).toBe("Seat");
+    expect(
+      portfolio.traders.find((tr) => tr.id === galleryTrader)?.effectiveTier
+    ).toBe("Gallery");
+
+    const profile = await t.query(api.traders.getPublicProfile, {
+      traderId: seatTrader as never,
+    });
+    expect(profile?.effectiveTier).toBe("Seat");
+    expect(profile?.seatSyncStatus).toBe("ok");
+    expect(profile).not.toHaveProperty("staker");
+    expect(profile).not.toHaveProperty("pendingAmountWei");
+
+    const dealId = await seedDeal(t, { creatorDeskManagerId: deskId });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("dealOutcomes", {
+        dealId: dealId as never,
+        traderId: seatTrader as never,
+        traderPnlUsdc: 10,
+        potChangeUsdc: -10,
+        rakeUsdc: 0,
+        narrative: "ok",
+        createdAt: Date.now(),
+      });
+    });
+    const outcomes = await authed.query(api.dealOutcomes.listByDeal, {
+      dealId: dealId as never,
+    });
+    expect(outcomes[0]?.effectiveTier).toBe("Seat");
+    expect(JSON.stringify(outcomes[0])).not.toMatch(
+      /staker|pendingAmountWei|unlockTime/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Expose safe public `effectiveTier` (no staker/pending/unlock) on portfolio, landing roster, leaderboard, public profile, and deal-outcome read models
- Floor credentials render distinct Seat / Corner Office states; Gallery, loading, and stale-sync grant nothing
- Wire credentials into owned desk rows, landing roster, public leaderboard, trader detail/profile, and deal outcome rows with accessible labels

Closes #192

## Test plan
- [x] `pnpm exec vitest run tests/convex/floor-credentials.test.ts src/components/seat-stake-panel.ui.test.tsx tests/convex/activity-leaderboard-discovery.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [ ] Confirm Gallery has no credential on roster, leaderboard, detail, and deal-entry surfaces
- [ ] Confirm Seat and Corner Office credentials are visually distinct on those surfaces
- [ ] Keep roster/detail open, cross a stake threshold, confirm credentials update reactively
- [ ] Initiate unstake below a threshold and confirm credentials downgrade after reconciliation
- [ ] Inspect public Convex responses and confirm they exclude staker/pending/unlock fields
- [ ] Spot-check mobile and desktop layouts for row overflow / layout shift


Made with [Cursor](https://cursor.com)