### PR TITLE
ci: auto-deploy Convex functions on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,36 @@ jobs:
 
       - name: Typecheck
         run: pnpm typecheck
+
+  # Push Convex functions on merge to main so the backend never lags the
+  # Vercel frontend deploy. Skipping this is what broke the trader dialog:
+  # the frontend shipped calling seatVault/queries:getPublicTraderTier while
+  # the deployment never had it. Runs only after checks pass.
+  deploy-convex:
+    name: Deploy Convex functions
+    needs: checks
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # CONVEX_DEPLOY_KEY targets the deployment associated with the key
+      # (formal-pigeon-323). Add it as a repo secret: Settings → Secrets and
+      # variables → Actions. Generate with `npx convex dashboard` → Settings,
+      # or reuse the key in .env.local.
+      - name: Deploy to Convex
+        run: npx convex deploy
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}


### PR DESCRIPTION
## Problem

The frontend deploys via Vercel on push to `main`, but Convex functions only shipped through a manual `npx convex dev --once`. When that step was skipped after the seatVault/staking module merged, the deployed backend (`formal-pigeon-323`) was missing `seatVault/queries:getPublicTraderTier`. Opening a trader in the leaderboard renders `SeatTierBadge`, whose `useQuery` hit the absent function and threw — surfacing as the **DESK FAULT // CIRCUIT BREAKER** error boundary.

## Fix

Add a `deploy-convex` job to `ci.yml` that runs `npx convex deploy` on push to `main`, gated behind the existing `checks` job (lint / typecheck / codegen). Now the backend ships on the same trigger as the Vercel frontend deploy, so the two can't drift.

- Runs **only** on `push` to `main` (not on PRs).
- `convex deploy` targets the deployment associated with the `CONVEX_DEPLOY_KEY` secret (= `formal-pigeon-323`), which is already configured as a repo secret.

## Notes

- The already-missing functions were deployed manually to unblock the live site; this PR prevents a recurrence.
- The deploy job pushes whatever is on `main` at merge time — for rapid successive merges the later run wins, which is fine for functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)