### PR TITLE
feat(dashboard): show $BLOW holdings in top status bar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,6 +94,8 @@ import { useWireTickOnNew } from "@/hooks/use-wire-tick-on-new";
 import { usePnlStreaks, useRankDeltas } from "@/hooks/use-rank-deltas";
 import { useSecondTick } from "@/hooks/use-second-tick";
 import { useUsdcBalance } from "@/hooks/use-usdc-balance";
+import { useBlowBalance } from "@/hooks/use-seat-vault";
+import { formatBlowAmount } from "@/lib/contracts/seatVault";
 import {
   DIALOG_BACKDROP_CLASS,
   dialogPopupClass,
@@ -127,6 +129,10 @@ const TONE_CLASS = {
 } as const;
 
 const EMPTY_PENDING: PendingApproval[] = [];
+
+function formatBlow(value: number): string {
+  return value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
 
 // Fallback copy only appears when Convex has no generated wire epochs yet.
 const FALLBACK_WIRE_ITEMS = [
@@ -764,6 +770,18 @@ function TopStatusBar({
     ...NY_TIME,
   });
   const { isOpen, countdownLabel: hms } = useMarketHours();
+  const { balanceWei: blowWei } = useBlowBalance();
+  const blowHoldings =
+    blowWei === undefined
+      ? undefined
+      : (() => {
+          try {
+            const n = Number(formatBlowAmount(blowWei.toString()));
+            return Number.isFinite(n) ? n : undefined;
+          } catch {
+            return undefined;
+          }
+        })();
   const shortDeskWallet = deskWalletAddress
     ? formatShortAddress(deskWalletAddress)
     : "Embedding...";
@@ -892,7 +910,17 @@ function TopStatusBar({
         </div>
 
         <div className="terminal-panel grid grid-cols-4 divide-x divide-[var(--t-divider)] text-[11px] uppercase">
-          <StatusCell label="Firm" value="Trading Desk" />
+          <StatusCell
+            label="$BLOW"
+            value={
+              blowHoldings === undefined ? (
+                "..."
+              ) : (
+                <AnimatedNumber value={blowHoldings} format={formatBlow} live />
+              )
+            }
+            tone="amber"
+          />
           <StatusCell
             label="Cash"
             value={


### PR DESCRIPTION
## What

Replaces the static **FIRM / TRADING DESK** cell in the desktop top status bar with a live **$BLOW holdings** readout.

Before → after (first column):

| Before | After |
|---|---|
| FIRM · TRADING DESK | $BLOW · `<live balance>` |

## How

- Adds `useBlowBalance()` (from `@/hooks/use-seat-vault`) to `TopStatusBar` — an on-chain `balanceOf` read against the MARGINCALL token for the desk's embedded wallet, refetching every 15s.
- Formats the wei balance via the existing `formatBlowAmount` helper, then renders it through `AnimatedNumber` (with a small `formatBlow` number formatter) to match the Cash/Equity cells.
- Toned **amber** to distinguish the token from the green USD figures. Shows `...` while the balance loads.

Only the desktop 4-column grid is affected; the compact mobile header never had a FIRM/Trading Desk cell, so it's unchanged.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `eslint src/app/page.tsx` — clean
- [ ] Visual check: `$BLOW` cell renders the live balance and updates on-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)