### PR TITLE
feat(seat-vault): one-click floor tier picker + table upgrade button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { Dialog } from "@base-ui/react/dialog";
 import {
   ArrowRight,
   Check,
+  ChevronsUp,
   Copy,
   Github,
   HelpCircle,
@@ -48,6 +49,7 @@ import { TraderAvatar } from "@/components/trader-avatar";
 import { pickFunTraits, type FunTrait } from "@/lib/portrait-traits";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
 import { FloorCredential } from "@/components/seat-tier-badge";
+import { SeatUpgradeDialog } from "@/components/seat-upgrade-dialog";
 import { ConnectMcpDialog } from "@/components/connect-mcp-dialog";
 import { IntroSequence } from "@/components/intro-sequence";
 import { ConvexIdentityDebug } from "@/components/convex-identity-debug";
@@ -473,6 +475,9 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
   const [selectedPublicTraderId, setSelectedPublicTraderId] = useState<
     string | null
   >(null);
+  const [selectedUpgradeTraderId, setSelectedUpgradeTraderId] = useState<
+    string | null
+  >(null);
   const [mobileTab, setMobileTab] = useState<MobileTab>("desk");
 
   const openTraderProfile = useCallback((traderId: string) => {
@@ -480,6 +485,9 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
   }, []);
   const openTraderWallet = useCallback((traderId: string) => {
     setSelectedWalletTraderId(traderId);
+  }, []);
+  const openTraderUpgrade = useCallback((traderId: string) => {
+    setSelectedUpgradeTraderId(traderId);
   }, []);
 
   const activity = useMemo(() => feedData?.activity ?? [], [feedData]);
@@ -610,6 +618,7 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
               portfolioLoading={portfolioLoading}
               onOpenProfile={openTraderProfile}
               onManageWallet={openTraderWallet}
+              onUpgrade={openTraderUpgrade}
               onHireTrader={() => {
                 if (!deskWalletFunded) return;
                 setHireDialogOpen(true);
@@ -719,6 +728,11 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
         traderId={selectedPublicTraderId}
         open={selectedPublicTraderId !== null}
         onOpenChange={(open) => !open && setSelectedPublicTraderId(null)}
+      />
+      <SeatUpgradeDialog
+        traderId={selectedUpgradeTraderId}
+        open={selectedUpgradeTraderId !== null}
+        onOpenChange={(open) => !open && setSelectedUpgradeTraderId(null)}
       />
     </div>
   );
@@ -2168,6 +2182,7 @@ function TradingDeskPanel({
   portfolioLoading,
   onOpenProfile,
   onManageWallet,
+  onUpgrade,
   onHireTrader,
   canHireTrader,
   hireDisabledReason,
@@ -2180,6 +2195,7 @@ function TradingDeskPanel({
   portfolioLoading: boolean;
   onOpenProfile: (id: string) => void;
   onManageWallet: (id: string) => void;
+  onUpgrade: (id: string) => void;
   onHireTrader: () => void;
   canHireTrader: boolean;
   hireDisabledReason: string;
@@ -2259,6 +2275,7 @@ function TradingDeskPanel({
         nowMs={nowMs}
         onOpenProfile={onOpenProfile}
         onManageWallet={onManageWallet}
+        onUpgrade={onUpgrade}
         onOpenDeal={onOpenDeal}
         onHireTrader={onHireTrader}
         canHireTrader={canHireTrader}
@@ -2277,6 +2294,7 @@ function TradingDeskMain({
   nowMs,
   onOpenProfile,
   onManageWallet,
+  onUpgrade,
   onOpenDeal,
   onHireTrader,
   canHireTrader,
@@ -2290,6 +2308,7 @@ function TradingDeskMain({
   nowMs: number;
   onOpenProfile: (id: string) => void;
   onManageWallet: (id: string) => void;
+  onUpgrade: (id: string) => void;
   onOpenDeal: (dealId: string) => void;
   onHireTrader: () => void;
   canHireTrader: boolean;
@@ -2335,23 +2354,26 @@ function TradingDeskMain({
       traders={traders}
       onOpenProfile={onOpenProfile}
       onManageWallet={onManageWallet}
+      onUpgrade={onUpgrade}
       nowMs={nowMs}
     />
   );
 }
 
 const DESK_ROW_GRID =
-  "grid-cols-[2rem_2.25rem_minmax(0,1fr)_3.5rem] sm:grid-cols-[2rem_2.25rem_minmax(0,1fr)_5rem_5.5rem_5rem_4.5rem_5rem_3.5rem]";
+  "grid-cols-[2rem_2.25rem_minmax(0,1fr)_5.5rem] sm:grid-cols-[2rem_2.25rem_minmax(0,1fr)_5rem_5.5rem_5rem_4.5rem_5rem_5.5rem]";
 
 function DeskTradersView({
   traders,
   onOpenProfile,
   onManageWallet,
+  onUpgrade,
   nowMs,
 }: {
   traders: TraderSummary[];
   onOpenProfile: (id: string) => void;
   onManageWallet: (id: string) => void;
+  onUpgrade: (id: string) => void;
   nowMs: number;
 }) {
   const ranked = useMemo(
@@ -2386,6 +2408,7 @@ function DeskTradersView({
             nowMs={nowMs}
             onOpenProfile={onOpenProfile}
             onManageWallet={onManageWallet}
+            onUpgrade={onUpgrade}
           />
         ))}
       </div>
@@ -2399,12 +2422,14 @@ function DeskTraderRow({
   nowMs,
   onOpenProfile,
   onManageWallet,
+  onUpgrade,
 }: {
   rank: number;
   trader: TraderSummary;
   nowMs: number;
   onOpenProfile: (id: string) => void;
   onManageWallet: (id: string) => void;
+  onUpgrade: (id: string) => void;
 }) {
   const statusTone = statusToneClass(trader.status);
   const pnlPct = pnlPercent(trader.total_pnl, trader.total_value_usdc);
@@ -2474,6 +2499,17 @@ function DeskTraderRow({
         {cycleUi.text}
       </span>
       <div className="flex items-center justify-end gap-1">
+        {trader.effective_tier !== "CornerOffice" ? (
+          <button
+            type="button"
+            onClick={() => onUpgrade(trader.id)}
+            title="Upgrade floor seat with $BLOW"
+            aria-label={`Upgrade ${trader.name} floor seat`}
+            className="grid h-6 w-6 place-items-center border border-[var(--t-amber)]/70 text-[var(--t-amber)] transition-colors hover:border-[var(--t-amber)] hover:bg-[var(--t-amber)]/10 focus:border-[var(--t-amber)] focus:outline-none"
+          >
+            <ChevronsUp className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={() => onManageWallet(trader.id)}

--- a/src/components/seat-stake-panel.tsx
+++ b/src/components/seat-stake-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
+import { Check } from "lucide-react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
@@ -16,12 +17,13 @@ import {
 import { useBaseNetwork } from "@/hooks/use-base-network";
 import {
   capacityForTier,
+  CORNER_OFFICE_THRESHOLD_WEI,
   formatBlowAmount,
+  SEAT_THRESHOLD_WEI,
   SEAT_VAULT_ADDRESS,
   type SeatTierName,
 } from "@/lib/contracts/seatVault";
 import {
-  amountNeededForNextTier,
   canCompleteWithdrawal,
   canInitiateUnstake,
   canPostPrincipal,
@@ -55,6 +57,18 @@ function formatWeiOrDash(wei: string): string {
   } catch {
     return "—";
   }
+}
+
+/** Floor ladder, cheapest first — drives the one-click tier picker. */
+const TIER_LADDER: { tier: SeatTierName; thresholdWei: string }[] = [
+  { tier: "Gallery", thresholdWei: "0" },
+  { tier: "Seat", thresholdWei: SEAT_THRESHOLD_WEI },
+  { tier: "CornerOffice", thresholdWei: CORNER_OFFICE_THRESHOLD_WEI },
+];
+
+function tierCapacityLabel(tier: SeatTierName): string {
+  const cap = capacityForTier(tier);
+  return `${Math.round(cap.cycleIntervalMs / 60_000)}m cadence · ${cap.maxUnresolvedEntries} open`;
 }
 
 function sectionTitle(title: string) {
@@ -106,7 +120,10 @@ export function SeatStakePanel({
   const [localError, setLocalError] = useState<string | undefined>();
 
   const active = seatState ?? null;
-  const nextTier = amountNeededForNextTier(active?.activeAmountWei ?? "0");
+  const currentTier: SeatTierName = active?.effectiveTier ?? "Gallery";
+  const activeWei = BigInt(active?.activeAmountWei ?? "0");
+  const balanceBig =
+    balanceWei !== undefined ? BigInt(balanceWei.toString()) : undefined;
 
   const canStake = canPostPrincipal({
     walletAddress,
@@ -136,8 +153,7 @@ export function SeatStakePanel({
 
   const displayError = localError ?? error;
 
-  async function handleStake(e: FormEvent) {
-    e.preventDefault();
+  async function postPrincipal(amountHuman: string) {
     setLocalError(undefined);
     if (!walletAddress) {
       setLocalError("Connect the desk treasury wallet first.");
@@ -151,7 +167,7 @@ export function SeatStakePanel({
       await stake({
         convexTraderId: convexId,
         onChainTraderId,
-        amountHuman: stakeAmount,
+        amountHuman,
         vaultAddress: (active?.vaultAddress ||
           SEAT_VAULT_ADDRESS) as `0x${string}`,
         depositor,
@@ -162,6 +178,11 @@ export function SeatStakePanel({
     } catch {
       // surfaced via hook
     }
+  }
+
+  async function handleStake(e: FormEvent) {
+    e.preventDefault();
+    await postPrincipal(stakeAmount);
   }
 
   async function handleInitiate(e: FormEvent) {
@@ -254,24 +275,6 @@ export function SeatStakePanel({
           </p>
         ) : null}
 
-        {nextTier ? (
-          <p className="text-xs uppercase tracking-[0.14em] text-[var(--t-muted)]">
-            Need{" "}
-            <span className="text-[var(--t-text)]">
-              {nextTier.deltaHuman} $BLOW
-            </span>{" "}
-            more active principal for{" "}
-            <span className="text-[var(--t-amber)]">
-              {SEAT_TIER_FLOOR_LABEL[nextTier.nextTier]}
-            </span>
-            .
-          </p>
-        ) : (
-          <p className="text-xs uppercase tracking-[0.14em] text-[var(--t-green)]">
-            Corner Office cleared — no higher floor desk.
-          </p>
-        )}
-
         <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
           Desk $BLOW:{" "}
           <span className="text-[var(--t-text)]">{balanceHuman}</span>
@@ -291,32 +294,116 @@ export function SeatStakePanel({
         </p>
 
         {canStake ? (
-          <form
-            onSubmit={handleStake}
-            className="flex flex-wrap items-end gap-2"
-          >
-            <label className="min-w-[10rem] flex-1">
-              <span className="mb-1 block text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
-                Post principal
-              </span>
-              <input
-                type="text"
-                inputMode="decimal"
-                value={stakeAmount}
-                onChange={(e) => setStakeAmount(e.target.value)}
-                placeholder="0"
-                disabled={isLoading}
-                className="w-full border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 py-2 font-mono text-sm text-[var(--t-text)] outline-none focus:border-[var(--t-amber)]"
-              />
-            </label>
-            <button
-              type="submit"
-              disabled={isLoading || !stakeAmount.trim()}
-              className="min-h-10 border border-[var(--t-amber)]/60 bg-[var(--t-amber)]/10 px-4 text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--t-amber)] transition-colors hover:bg-[var(--t-amber)]/20 disabled:opacity-40"
+          <div className="space-y-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+              Choose your floor
+            </p>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {TIER_LADDER.map((entry) => {
+                const thresholdWei = BigInt(entry.thresholdWei);
+                const cleared = activeWei >= thresholdWei;
+                const deltaWei = cleared ? BigInt(0) : thresholdWei - activeWei;
+                const deltaHuman = formatBlowAmount(deltaWei.toString());
+                const affordable =
+                  balanceBig !== undefined && balanceBig >= deltaWei;
+                const isCurrent = currentTier === entry.tier;
+                const isGallery = entry.tier === "Gallery";
+                return (
+                  <div
+                    key={entry.tier}
+                    className={cn(
+                      "flex flex-col gap-1.5 border p-3",
+                      isCurrent
+                        ? "border-[var(--t-amber)] bg-[var(--t-amber)]/5"
+                        : "border-[var(--t-divider)] bg-[var(--t-bg)]/40"
+                    )}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-text)]">
+                        {SEAT_TIER_FLOOR_LABEL[entry.tier]}
+                      </span>
+                      {isCurrent ? (
+                        <span className="text-[9px] font-bold uppercase tracking-[0.16em] text-[var(--t-amber)]">
+                          Current
+                        </span>
+                      ) : cleared ? (
+                        <Check className="h-3.5 w-3.5 text-[var(--t-green)]" />
+                      ) : null}
+                    </div>
+                    <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
+                      {isGallery
+                        ? "Free floor"
+                        : `${formatBlowAmount(entry.thresholdWei)} $BLOW`}
+                    </p>
+                    <p className="text-[10px] uppercase tracking-[0.1em] text-[var(--t-muted)]">
+                      {tierCapacityLabel(entry.tier)}
+                    </p>
+                    <div className="mt-auto pt-1.5">
+                      {isGallery || cleared ? (
+                        <p
+                          className={cn(
+                            "text-[10px] font-bold uppercase tracking-[0.14em]",
+                            isCurrent
+                              ? "text-[var(--t-amber)]"
+                              : "text-[var(--t-green)]"
+                          )}
+                        >
+                          {isCurrent
+                            ? "Seated here"
+                            : cleared
+                              ? "Cleared"
+                              : "Base floor"}
+                        </p>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={isLoading || !affordable}
+                          onClick={() => void postPrincipal(deltaHuman)}
+                          title={
+                            affordable
+                              ? `Post ${deltaHuman} $BLOW to take the ${SEAT_TIER_FLOOR_LABEL[entry.tier]}`
+                              : `Need ${deltaHuman} $BLOW — desk holds ${balanceHuman}`
+                          }
+                          className="w-full border border-[var(--t-amber)]/60 bg-[var(--t-amber)]/10 px-2 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--t-amber)] transition-colors hover:bg-[var(--t-amber)]/20 disabled:opacity-40"
+                        >
+                          {affordable
+                            ? `Post ${deltaHuman} $BLOW`
+                            : `Need ${deltaHuman} $BLOW`}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <form
+              onSubmit={handleStake}
+              className="flex flex-wrap items-end gap-2 border-t border-[var(--t-divider)] pt-3"
             >
-              Post $BLOW
-            </button>
-          </form>
+              <label className="min-w-[10rem] flex-1">
+                <span className="mb-1 block text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
+                  Custom top-up
+                </span>
+                <input
+                  type="text"
+                  inputMode="decimal"
+                  value={stakeAmount}
+                  onChange={(e) => setStakeAmount(e.target.value)}
+                  placeholder="0"
+                  disabled={isLoading}
+                  className="w-full border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 py-2 font-mono text-sm text-[var(--t-text)] outline-none focus:border-[var(--t-amber)]"
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={isLoading || !stakeAmount.trim()}
+                className="min-h-10 border border-[var(--t-divider)] px-4 text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--t-text)] transition-colors hover:border-[var(--t-amber)] hover:text-[var(--t-amber)] disabled:opacity-40"
+              >
+                Post $BLOW
+              </button>
+            </form>
+          </div>
         ) : (
           <p className="text-[10px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
             {!walletAddress

--- a/src/components/seat-upgrade-dialog.tsx
+++ b/src/components/seat-upgrade-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Dialog } from "@base-ui/react/dialog";
+import { useTrader } from "@/hooks/use-traders";
+import { SeatStakePanel } from "@/components/seat-stake-panel";
+import { DIALOG_BACKDROP_CLASS, dialogPopupClass } from "@/lib/utils";
+
+/** Loads the trader's on-chain id, then renders the floor-seat picker. */
+function SeatUpgradeContent({
+  traderId,
+  onClose,
+}: {
+  traderId: string;
+  onClose: () => void;
+}) {
+  const { data: trader, isLoading, error } = useTrader(traderId);
+
+  return (
+    <div className="space-y-3 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
+          Upgrade floor seat
+          {trader ? (
+            <span className="ml-2 text-[var(--t-amber)]">{trader.name}</span>
+          ) : null}
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)] hover:text-[var(--t-text)]"
+        >
+          Close
+        </button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-xs uppercase tracking-[0.16em] text-[var(--t-muted)]">
+          Reading the book…
+        </p>
+      ) : error || !trader ? (
+        <p className="text-xs text-[var(--t-red)]">Trader not found.</p>
+      ) : (
+        <SeatStakePanel traderId={traderId} onChainTraderId={trader.token_id} />
+      )}
+    </div>
+  );
+}
+
+export function SeatUpgradeDialog({
+  traderId,
+  open,
+  onOpenChange,
+}: {
+  traderId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={DIALOG_BACKDROP_CLASS} />
+        <Dialog.Popup className={dialogPopupClass("lg")}>
+          <Dialog.Title className="sr-only">Upgrade floor seat</Dialog.Title>
+          <div className="max-h-[calc(100dvh-1rem)] overflow-y-auto sm:max-h-[88vh]">
+            {traderId ? (
+              <SeatUpgradeContent
+                traderId={traderId}
+                onClose={() => onOpenChange(false)}
+              />
+            ) : null}
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}


### PR DESCRIPTION
## What

Improves the **Floor Seat · $BLOW principal** UX in two places.

### 1. Clickable tier picker (replaces the free-text input)
The single "Post $BLOW" box is replaced with a **three-card floor ladder**:

| Tier | Threshold | Capacity | Action |
|---|---|---|---|
| Gallery | Free floor | 10m cadence · 1 open | Base floor |
| Seat | 10,000 $BLOW | 5m cadence · 1 open | **Post {delta} $BLOW** |
| Corner Office | 50,000 $BLOW | 5m cadence · 2 open | **Post {delta} $BLOW** |

- Each button posts the **delta** needed to clear that tier from current active principal (staking is additive), so one click takes the desk straight there.
- Current tier is highlighted (amber, "Seated here"); cleared tiers show a green check.
- Unaffordable tiers disable and read **"Need X $BLOW"** (tooltip shows shortfall vs. desk balance).
- A subordinate **"Custom top-up"** input remains for odd amounts.

### 2. Upgrade button in the traders table
Each desk-trader row gains an amber **⇧ Upgrade** icon button (hidden at Corner Office). It opens a new focused **`SeatUpgradeDialog`** that loads the trader's on-chain id and renders the same picker — no need to open the full trader profile.

## How
- `seat-stake-panel.tsx`: extracted `postPrincipal(amount)` from the old form handler; added a `TIER_LADDER` + per-tier delta/affordability computation; kept the custom-amount form as a secondary control.
- `seat-upgrade-dialog.tsx` (new): Base UI dialog that resolves `token_id` via `useTrader` then mounts `SeatStakePanel`.
- `page.tsx`: threaded an `onUpgrade` handler from `Dashboard` → `TradingDeskPanel` → `TradingDeskMain` → `DeskTradersView` → `DeskTraderRow`; added the row button, the dialog mount, and widened the row's action column.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean
- [x] `vitest run` — 577 passed / 1 skipped (incl. seat-stake-panel + page UI tests)
- [ ] Live click-through of the tier buttons + row Upgrade dialog (needs authed desk + wallet)

Note: tier buttons trigger a real on-chain `stake` (approve + stake via the sponsored write flow) — same mechanism as the previous input, just triggered from the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)