### PR TITLE
Harden SeatVault cooldown and depositor transitions

### DIFF
--- a/contracts/src/SeatVault.sol
+++ b/contracts/src/SeatVault.sol
@@ -30,6 +30,9 @@ contract SeatVault {
 
     address public owner;
     address public pendingOwner;
+    address public pauser;
+
+    bool public paused;
 
     IERC20 public token;
     uint256 public seatThreshold;
@@ -47,9 +50,17 @@ contract SeatVault {
     event TokenUpdated(address indexed token);
     event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event Paused(address indexed account);
+    event Unpaused(address indexed account);
+    event PauserUpdated(address indexed pauser);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier whenNotPaused() {
+        require(!paused, "Paused");
         _;
     }
 
@@ -72,7 +83,7 @@ contract SeatVault {
         owner = msg.sender;
     }
 
-    function stake(uint256 traderId, uint256 amount) external {
+    function stake(uint256 traderId, uint256 amount) external whenNotPaused {
         require(amount > 0, "Zero amount");
 
         address depositor = escrow.depositors(traderId);
@@ -97,19 +108,19 @@ contract SeatVault {
         emit Staked(traderId, msg.sender, received);
     }
 
-    function initiateUnstake(uint256 traderId, uint256 amount) external {
+    function initiateUnstake(uint256 traderId, uint256 amount) external whenNotPaused {
         require(amount > 0, "Zero amount");
 
         StakeInfo storage info = _stakes[traderId];
         require(info.staker != address(0), "No stake");
         require(info.active >= amount, "Over unstake");
-
-        address depositor = escrow.depositors(traderId);
-        require(msg.sender == depositor || msg.sender == info.staker, "Not authorized");
+        require(msg.sender == info.staker, "Not staker");
 
         info.active -= amount;
         info.pending += amount;
-        info.unlockTime = block.timestamp + unstakeCooldown;
+        if (info.pending == amount) {
+            info.unlockTime = block.timestamp + unstakeCooldown;
+        }
 
         emit UnstakeInitiated(traderId, info.staker, amount, info.unlockTime);
     }
@@ -172,6 +183,28 @@ contract SeatVault {
 
     function stakeOf(uint256 traderId) external view returns (StakeInfo memory) {
         return _stakes[traderId];
+    }
+
+    function hasLockedPrincipal(uint256 traderId) external view returns (bool) {
+        StakeInfo storage info = _stakes[traderId];
+        return info.active + info.pending > 0;
+    }
+
+    function pause() external {
+        require(msg.sender == owner || msg.sender == pauser, "Not pauser");
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external {
+        require(msg.sender == owner || msg.sender == pauser, "Not pauser");
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function setPauser(address pauser_) external onlyOwner {
+        pauser = pauser_;
+        emit PauserUpdated(pauser_);
     }
 
     function tierOf(uint256 traderId) external view returns (Tier) {

--- a/contracts/src/SeatVault.sol
+++ b/contracts/src/SeatVault.sol
@@ -64,6 +64,11 @@ contract SeatVault {
         _;
     }
 
+    modifier onlyPauser() {
+        require(msg.sender == owner || msg.sender == pauser, "Not pauser");
+        _;
+    }
+
     constructor(
         address escrow_,
         address token_,
@@ -117,10 +122,12 @@ contract SeatVault {
         require(msg.sender == info.staker, "Not staker");
 
         info.active -= amount;
-        info.pending += amount;
-        if (info.pending == amount) {
+        // Only a fresh pending batch (nothing pending before) starts the
+        // cooldown clock; a repeated initiate must not extend an open one.
+        if (info.pending == 0) {
             info.unlockTime = block.timestamp + unstakeCooldown;
         }
+        info.pending += amount;
 
         emit UnstakeInitiated(traderId, info.staker, amount, info.unlockTime);
     }
@@ -190,14 +197,12 @@ contract SeatVault {
         return info.active + info.pending > 0;
     }
 
-    function pause() external {
-        require(msg.sender == owner || msg.sender == pauser, "Not pauser");
+    function pause() external onlyPauser {
         paused = true;
         emit Paused(msg.sender);
     }
 
-    function unpause() external {
-        require(msg.sender == owner || msg.sender == pauser, "Not pauser");
+    function unpause() external onlyPauser {
         paused = false;
         emit Unpaused(msg.sender);
     }

--- a/contracts/test/SeatVault.t.sol
+++ b/contracts/test/SeatVault.t.sol
@@ -214,7 +214,32 @@ contract SeatVaultTest is Test {
         _assertTier(SeatVault.Tier.Seat);
     }
 
-    function test_setPolicy_newCooldownAffectsNewInitiatesOnly() public {
+    function test_replacementDepositorCannotInitiateUnstake() public {
+        _stake(5_000e18);
+        escrow.setDepositor(TRADER, otherDesk);
+
+        vm.prank(otherDesk);
+        vm.expectRevert("Not staker");
+        vault.initiateUnstake(TRADER, 1_000e18);
+    }
+
+    function test_repeatedInitiateDoesNotExtendCooldown() public {
+        _stake(1_000e18);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 100e18);
+        uint256 unlockAfterFirst = vault.stakeOf(TRADER).unlockTime;
+
+        vm.warp(block.timestamp + 1 hours);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 50e18);
+        uint256 unlockAfterSecond = vault.stakeOf(TRADER).unlockTime;
+
+        assertEq(unlockAfterSecond, unlockAfterFirst);
+    }
+
+    function test_setPolicy_newCooldownDoesNotAffectExistingPending() public {
         _stake(1_000e18);
 
         vm.prank(desk);
@@ -223,16 +248,100 @@ contract SeatVaultTest is Test {
 
         vault.setPolicy(SEAT, CORNER, 2 days);
 
-        // Existing pending unlock is unchanged until another initiate refreshes it.
         assertEq(vault.stakeOf(TRADER).unlockTime, unlockAfterFirst);
 
         vm.warp(block.timestamp + 1 hours);
         vm.prank(desk);
         vault.initiateUnstake(TRADER, 50e18);
+
+        assertEq(vault.stakeOf(TRADER).unlockTime, unlockAfterFirst);
+    }
+
+    // ========== Pause ==========
+
+    function test_pause_blocksStake() public {
+        vault.pause();
+
+        vm.prank(desk);
+        vm.expectRevert("Paused");
+        vault.stake(TRADER, 1_000e18);
+    }
+
+    function test_pause_blocksInitiate() public {
+        _stake(1_000e18);
+        vault.pause();
+
+        vm.prank(desk);
+        vm.expectRevert("Paused");
+        vault.initiateUnstake(TRADER, 500e18);
+    }
+
+    function test_pause_allowsMaturedClaim() public {
+        _stake(1_000e18);
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 400e18);
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.pause();
+
+        uint256 before = token.balanceOf(desk);
+        vault.completeUnstake(TRADER);
+        assertEq(token.balanceOf(desk) - before, 400e18);
+    }
+
+    function test_pause_onlyPauserOrOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not pauser");
+        vault.pause();
+
+        address pauserAddr = makeAddr("pauser");
+        vault.setPauser(pauserAddr);
+        vm.prank(pauserAddr);
+        vault.pause();
+        assertTrue(vault.paused());
+    }
+
+    // ========== hasLockedPrincipal ==========
+
+    function test_hasLockedPrincipal() public {
+        assertFalse(vault.hasLockedPrincipal(TRADER));
+
+        _stake(1_000e18);
+        assertTrue(vault.hasLockedPrincipal(TRADER));
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 400e18);
+        assertTrue(vault.hasLockedPrincipal(TRADER));
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+        assertTrue(vault.hasLockedPrincipal(TRADER));
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 600e18);
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+        assertFalse(vault.hasLockedPrincipal(TRADER));
+    }
+
+    function test_setPolicy_newCooldownAffectsNewInitiatesOnly() public {
+        _stake(1_000e18);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 100e18);
+        uint256 unlockAfterFirst = vault.stakeOf(TRADER).unlockTime;
+
+        vm.warp(block.timestamp + COOLDOWN);
+        vault.completeUnstake(TRADER);
+
+        vault.setPolicy(SEAT, CORNER, 2 days);
+
+        vm.prank(desk);
+        vault.initiateUnstake(TRADER, 50e18);
         uint256 unlockAfterSecond = vault.stakeOf(TRADER).unlockTime;
 
-        assertGt(unlockAfterSecond, unlockAfterFirst);
         assertGe(unlockAfterSecond, block.timestamp + 2 days);
+        assertGt(unlockAfterSecond, unlockAfterFirst);
     }
 
     // ========== setToken ==========

--- a/convex/seatVault/policy.ts
+++ b/convex/seatVault/policy.ts
@@ -265,6 +265,63 @@ export const seatVaultAbi = [
     stateMutability: "view",
   },
   {
+    type: "function",
+    name: "hasLockedPrincipal",
+    inputs: [{ name: "traderId", type: "uint256" }],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "paused",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "pause",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "unpause",
+    inputs: [],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "pauser",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "setPauser",
+    inputs: [{ name: "pauser_", type: "address" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "event",
+    name: "Paused",
+    inputs: [{ name: "account", type: "address", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "Unpaused",
+    inputs: [{ name: "account", type: "address", indexed: true }],
+  },
+  {
+    type: "event",
+    name: "PauserUpdated",
+    inputs: [{ name: "pauser", type: "address", indexed: true }],
+  },
+  {
     type: "event",
     name: "Staked",
     inputs: [

--- a/convex/seatVault/rpc.ts
+++ b/convex/seatVault/rpc.ts
@@ -108,7 +108,11 @@ export async function fetchSeatVaultLogs(
 
 type DecodedContractLog = Log & {
   eventName?: string;
-  args?: {
+  // `getContractEvents({ strict: true })` yields a union of per-event arg
+  // shapes (some SeatVault events carry only `{ account }`). Keep the shape
+  // open so any event assigns here; we read the stake fields below and return
+  // null for everything else.
+  args?: Record<string, unknown> & {
     traderId?: bigint;
     staker?: `0x${string}`;
     amount?: bigint;

--- a/src/components/seat-stake-panel.tsx
+++ b/src/components/seat-stake-panel.tsx
@@ -134,7 +134,6 @@ export function SeatStakePanel({
   const canPull = active
     ? canInitiateUnstake({
         walletAddress,
-        depositorAddress: depositor,
         stakerAddress: active.staker,
         activeWei: active.activeAmountWei,
       })

--- a/src/components/seat-stake-panel.tsx
+++ b/src/components/seat-stake-panel.tsx
@@ -195,7 +195,6 @@ export function SeatStakePanel({
         amountHuman: unstakeAmount,
         vaultAddress: active.vaultAddress as `0x${string}`,
         activeWei: active.activeAmountWei,
-        depositor,
         staker: active.staker,
       });
       setUnstakeAmount("");

--- a/src/hooks/use-seat-vault.ts
+++ b/src/hooks/use-seat-vault.ts
@@ -254,11 +254,10 @@ export function useSeatVaultFlows() {
         }
 
         const walletLc = wallet.toLowerCase();
-        const depositorLc = args.depositor?.toLowerCase();
         const stakerLc = args.staker?.toLowerCase();
-        if (walletLc !== depositorLc && walletLc !== stakerLc) {
+        if (walletLc !== stakerLc) {
           throw new Error(
-            "Not authorized — only the depositor or recorded staker can pull principal."
+            "Not authorized — only the recorded staker can pull principal."
           );
         }
 

--- a/src/hooks/use-seat-vault.ts
+++ b/src/hooks/use-seat-vault.ts
@@ -231,7 +231,6 @@ export function useSeatVaultFlows() {
       amountHuman: string;
       vaultAddress?: `0x${string}`;
       activeWei: string;
-      depositor: string | null;
       staker: string | null;
     }) => {
       setState({ step: "checking" });

--- a/src/lib/seat-tier-display.test.ts
+++ b/src/lib/seat-tier-display.test.ts
@@ -97,19 +97,17 @@ describe("lapsed seat + authorization", () => {
     ).toBe(false);
   });
 
-  it("allows depositor or staker to initiate; complete only after cooldown", () => {
+  it("allows only recorded staker to initiate; complete only after cooldown", () => {
     expect(
       canInitiateUnstake({
         walletAddress: "0x1",
-        depositorAddress: "0x1",
         stakerAddress: "0x2",
         activeWei: parseBlowAmount("10"),
       })
-    ).toBe(true);
+    ).toBe(false);
     expect(
       canInitiateUnstake({
         walletAddress: "0x2",
-        depositorAddress: "0x1",
         stakerAddress: "0x2",
         activeWei: parseBlowAmount("10"),
       })
@@ -117,7 +115,6 @@ describe("lapsed seat + authorization", () => {
     expect(
       canInitiateUnstake({
         walletAddress: "0x3",
-        depositorAddress: "0x1",
         stakerAddress: "0x2",
         activeWei: parseBlowAmount("10"),
       })
@@ -125,7 +122,6 @@ describe("lapsed seat + authorization", () => {
     expect(
       canInitiateUnstake({
         walletAddress: "0x1",
-        depositorAddress: "0x1",
         stakerAddress: "0x1",
         activeWei: "0",
       })

--- a/src/lib/seat-tier-display.ts
+++ b/src/lib/seat-tier-display.ts
@@ -122,20 +122,18 @@ export function canPostPrincipal(args: {
 
 /**
  * Can this wallet pull principal off the floor (initiate unstake)?
- * Contract: current depositor OR recorded staker.
+ * Contract: only the recorded staker may initiate.
  */
 export function canInitiateUnstake(args: {
   walletAddress: string | null | undefined;
-  depositorAddress: string | null | undefined;
   stakerAddress: string | null | undefined;
   activeWei: string;
 }): boolean {
   if (!args.walletAddress) return false;
   if (compareWei(args.activeWei, "0") <= 0) return false;
   const wallet = args.walletAddress.toLowerCase();
-  const depositor = args.depositorAddress?.toLowerCase();
   const staker = args.stakerAddress?.toLowerCase();
-  return wallet === depositor || wallet === staker;
+  return wallet === staker;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Restrict `initiateUnstake` to the recorded staker so replacement depositors cannot grief cooldowns
- Preserve the existing unlock deadline when additional unstake amounts are queued
- Add emergency pause that blocks new stake/unstake but still allows matured `completeUnstake`
- Expose `hasLockedPrincipal` for escrow depositor-binding coordination

## Test plan
- [x] `forge test --match-contract SeatVault` (38 tests)
- [x] `pnpm test src/lib/seat-tier-display.test.ts src/lib/contracts/__tests__/seatVault.test.ts`
- [ ] Base Sepolia redeploy/activation tracked separately in #211

Closes #204

Made with [Cursor](https://cursor.com)