### PR TITLE
chore(dev): add pre-push hook mirroring the CI checks job

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+# Mirror the CI "Lint, Typecheck & Codegen" job so a push can't fail a check
+# that runs green locally. Same three gates, same order as .github/workflows/ci.yml.
+pnpm check:ci

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "check:codegen": "node scripts/check-convex-codegen.mjs",
+    "check:ci": "pnpm check:codegen && pnpm lint && pnpm typecheck",
     "test": "vitest run",
     "test:convex": "vitest run tests/convex",
     "seed:wire": "convex run seasons:importSeason",


### PR DESCRIPTION
## Problem

PR #212 (stale `convex/_generated`) and PR #214 (a `tsc` error in `convex/seatVault/rpc.ts`) both failed the **Lint, Typecheck & Codegen** CI job — on checks that never run locally before code leaves the machine. The only git hook is `pre-commit → lint-staged`, which just runs Prettier on staged files. So codegen drift and type errors sail through to CI (and take the Vercel build down with them, since `next build` type-checks against the committed generated types).

## Fix

Add a **pre-push** hook that runs `pnpm check:ci` — the exact three gates from `.github/workflows/ci.yml`, in the same order:

```
pnpm check:codegen && pnpm lint && pnpm typecheck
```

Pre-push (not pre-commit) is the right place: these are project-wide, slower checks you want run once before publishing, not on every commit. If the hook passes, the CI checks job is guaranteed to pass.

Also exposes the combo as a `check:ci` script so it can be run by hand.

## Notes
- Warnings don't block (eslint exits 0 on warnings), matching CI behavior.
- Verified by pushing this branch — the hook ran lint + typecheck before the push completed.
- Out of scope: the CI job does not run the vitest suite; this hook mirrors CI exactly rather than adding new gates. PR #214 still needs its actual type error fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)