### PR TITLE
Freeze extraction cap at creation; block own-desk deals by wallet

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -36,6 +36,7 @@ import type * as leaderboard from "../leaderboard.js";
 import type * as lib_activeDeployment from "../lib/activeDeployment.js";
 import type * as lib_baseSepoliaNetwork from "../lib/baseSepoliaNetwork.js";
 import type * as lib_dealEntryEligibility from "../lib/dealEntryEligibility.js";
+import type * as lib_extractionCap from "../lib/extractionCap.js";
 import type * as lib_limits from "../lib/limits.js";
 import type * as lib_portraitChecks from "../lib/portraitChecks.js";
 import type * as lib_portraitSeed from "../lib/portraitSeed.js";
@@ -152,6 +153,7 @@ declare const fullApi: ApiFromModules<{
   "lib/activeDeployment": typeof lib_activeDeployment;
   "lib/baseSepoliaNetwork": typeof lib_baseSepoliaNetwork;
   "lib/dealEntryEligibility": typeof lib_dealEntryEligibility;
+  "lib/extractionCap": typeof lib_extractionCap;
   "lib/limits": typeof lib_limits;
   "lib/portraitChecks": typeof lib_portraitChecks;
   "lib/portraitSeed": typeof lib_portraitSeed;

--- a/convex/agent/_types.ts
+++ b/convex/agent/_types.ts
@@ -23,6 +23,7 @@ export interface Deal {
   on_chain_deal_id?: number | null;
   creator_id?: string | null;
   creator_address?: string | null;
+  max_extraction_amount_usdc?: number | null;
   entry_count?: number;
   wipeout_count?: number;
   [key: string]: unknown;

--- a/convex/agent/cycle.ts
+++ b/convex/agent/cycle.ts
@@ -865,6 +865,8 @@ export const cycle = internalAction({
           on_chain_deal_id: recoveryDeal.onChainDealId ?? null,
           creator_id: recoveryDeal.creatorDeskManagerId ?? null,
           creator_address: recoveryDeal.creatorAddress ?? null,
+          max_extraction_amount_usdc:
+            recoveryDeal.maxExtractionAmountUsdc ?? null,
           entry_count: recoveryDeal.entryCount ?? 0,
           wipeout_count: recoveryDeal.wipeoutCount ?? 0,
         };

--- a/convex/agent/dealSelection.ts
+++ b/convex/agent/dealSelection.ts
@@ -147,6 +147,7 @@ export async function selectDeal(
       on_chain_deal_id: d.onChainDealId ?? null,
       creator_id: d.creatorDeskManagerId ?? null,
       creator_address: d.creatorAddress ?? null,
+      max_extraction_amount_usdc: d.maxExtractionAmountUsdc ?? null,
       entry_count: d.entryCount ?? 0,
       wipeout_count: d.wipeoutCount ?? 0,
     }));
@@ -160,11 +161,20 @@ export async function selectDeal(
   }
 
   // ── 2b. Exclude own desk's deals (adversarial / no self-dealing) ───────────
+  const deskManager = await ctx.runQuery(
+    internal.deskManagers.getByIdInternal,
+    { id: deskManagerId as Id<"deskManagers"> }
+  );
+  const deskWalletAddress = deskManager?.walletAddress ?? null;
+
   const notOwnDeskDeals = deals.filter(
     (d) =>
       !isOwnDeskCreatedDeal(
-        { creatorDeskManagerId: d.creator_id },
-        deskManagerId
+        {
+          creatorDeskManagerId: d.creator_id,
+          creatorAddress: d.creator_address,
+        },
+        { deskManagerId, deskWalletAddress }
       )
   );
   const skippedOwnDeskCount = deals.length - notOwnDeskDeals.length;

--- a/convex/agent/outcomeResolver.ts
+++ b/convex/agent/outcomeResolver.ts
@@ -19,7 +19,6 @@ import type { RunActionCtx } from "./_ctx";
 import { internal } from "../_generated/api";
 import {
   RAKE_PERCENTAGE,
-  MAX_EXTRACTION_PERCENTAGE,
   BASE_WIN_PROBABILITY,
   WIN_PROB_MARKET_SWING,
   MIN_WIN_PROBABILITY,
@@ -29,6 +28,7 @@ import {
   LOSS_MAGNITUDE_MIN_FRACTION,
   LOSS_MAGNITUDE_MAX_FRACTION,
 } from "./_constants";
+import { maxWinValueUsdc } from "../lib/extractionCap";
 import { DealOutcomeSchema, type DealOutcomePayload } from "./_schemas";
 import type { Deal } from "./_types";
 
@@ -115,8 +115,8 @@ export async function resolveOutcome(
           .map((a) => `${a.name} ($${a.valueUsdc ?? 0} USDC)`)
           .join(", ");
 
-  // Max win value: MAX_EXTRACTION_PERCENTAGE % of pot
-  const maxValuePerWin = deal.pot_usdc * (MAX_EXTRACTION_PERCENTAGE / 100);
+  // Max win value: frozen extraction cap at creation (fallback: live pot * 25%).
+  const maxValuePerWin = maxWinValueUsdc(deal);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const narrative = marketNarrative as Record<string, any> | null;

--- a/convex/deals.ts
+++ b/convex/deals.ts
@@ -4,12 +4,14 @@ import {
   internalQuery,
   mutation,
   query,
+  type MutationCtx,
   type QueryCtx,
 } from "./_generated/server";
 import type { Doc, Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import { isOwnDeskCreatedDeal } from "./lib/dealEntryEligibility";
+import { dealCreationCapFields } from "./lib/extractionCap";
 import { clampLimit } from "./lib/limits";
 import { assertTradingHoursWithCloseGrace } from "./lib/tradingHours";
 import { isMcpSubject } from "./mcp/subject";
@@ -45,6 +47,28 @@ async function enrichWithCreatorAgentStatus(
     }
     return { ...d, creatorIsAgentDesk };
   });
+}
+
+async function assertTraderCanEnterDeal(
+  ctx: MutationCtx,
+  dealDoc: Doc<"deals">,
+  traderDoc: Doc<"traders">
+): Promise<void> {
+  const dm = await ctx.db.get(traderDoc.deskManagerId);
+  if (
+    isOwnDeskCreatedDeal(
+      {
+        creatorDeskManagerId: dealDoc.creatorDeskManagerId,
+        creatorAddress: dealDoc.creatorAddress,
+      },
+      {
+        deskManagerId: String(traderDoc.deskManagerId),
+        deskWalletAddress: dm?.walletAddress,
+      }
+    )
+  ) {
+    throw new Error("Trader cannot enter deals created by its own desk.");
+  }
 }
 
 // ── Public queries (auth-checked) ──────────────────────────────────────────
@@ -162,6 +186,7 @@ export const recordOnChainCreationVerified = internalMutation({
       prompt: args.prompt,
       potUsdc: args.potUsdc,
       entryCostUsdc: args.entryCostUsdc,
+      ...dealCreationCapFields(args.potUsdc),
       status: "open",
       onChainDealId: args.onChainDealId,
       onChainTxHash: args.onChainTxHash,
@@ -460,14 +485,7 @@ export const beginEntryRecording = internalMutation({
     if (traderDoc.status !== "active") {
       throw new Error("Trader is not active");
     }
-    if (
-      isOwnDeskCreatedDeal(
-        { creatorDeskManagerId: dealDoc.creatorDeskManagerId },
-        String(traderDoc.deskManagerId)
-      )
-    ) {
-      throw new Error("Trader cannot enter deals created by its own desk.");
-    }
+    await assertTraderCanEnterDeal(ctx, dealDoc, traderDoc);
 
     const paymentId = `pending:${args.traderId}:${args.dealId}`;
     const entryId = await ctx.db.insert("dealEntries", {
@@ -546,14 +564,7 @@ export const recordVerifiedEntry = internalMutation({
         if (args.entryCostUsdc !== dealDoc.entryCostUsdc) {
           throw new Error("Entry cost mismatch");
         }
-        if (
-          isOwnDeskCreatedDeal(
-            { creatorDeskManagerId: dealDoc.creatorDeskManagerId },
-            String(traderDoc.deskManagerId)
-          )
-        ) {
-          throw new Error("Trader cannot enter deals created by its own desk.");
-        }
+        await assertTraderCanEnterDeal(ctx, dealDoc, traderDoc);
 
         await ctx.db.patch(existingByPair._id, {
           paymentId: args.paymentId,
@@ -595,14 +606,7 @@ export const recordVerifiedEntry = internalMutation({
     if (args.entryCostUsdc !== dealDoc.entryCostUsdc) {
       throw new Error("Entry cost mismatch");
     }
-    if (
-      isOwnDeskCreatedDeal(
-        { creatorDeskManagerId: dealDoc.creatorDeskManagerId },
-        String(traderDoc.deskManagerId)
-      )
-    ) {
-      throw new Error("Trader cannot enter deals created by its own desk.");
-    }
+    await assertTraderCanEnterDeal(ctx, dealDoc, traderDoc);
 
     const id = await ctx.db.insert("dealEntries", {
       ...args,

--- a/convex/lib/dealEntryEligibility.ts
+++ b/convex/lib/dealEntryEligibility.ts
@@ -4,24 +4,37 @@
 
 export type DealDeskCreatorFields = {
   creatorDeskManagerId?: string | null;
+  creatorAddress?: string | null;
 };
 
 export type TraderDeskFields = {
   deskManagerId: string;
+  deskWalletAddress?: string | null;
 };
+
+function walletAddressesMatch(
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean {
+  if (!a || !b) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}
 
 export function isOwnDeskCreatedDeal(
   deal: DealDeskCreatorFields,
-  traderDeskManagerId: string
+  trader: TraderDeskFields
 ): boolean {
   const creator = deal.creatorDeskManagerId;
-  if (creator == null || creator === "") return false;
-  return String(creator) === String(traderDeskManagerId);
+  const idMatch = !!creator && String(creator) === String(trader.deskManagerId);
+  return (
+    idMatch ||
+    walletAddressesMatch(deal.creatorAddress, trader.deskWalletAddress)
+  );
 }
 
 export function isTraderEligibleToEnterDealByDesk(
   deal: DealDeskCreatorFields,
   trader: TraderDeskFields
 ): boolean {
-  return !isOwnDeskCreatedDeal(deal, trader.deskManagerId);
+  return !isOwnDeskCreatedDeal(deal, trader);
 }

--- a/convex/lib/extractionCap.ts
+++ b/convex/lib/extractionCap.ts
@@ -1,0 +1,38 @@
+/**
+ * Frozen extraction cap helpers. Convex copy of `src/lib/extraction-cap.ts`.
+ */
+
+import { MAX_EXTRACTION_PERCENTAGE } from "../agent/_constants";
+
+export type ExtractionCapDealFields = {
+  pot_usdc: number;
+  max_extraction_amount_usdc?: number | null;
+};
+
+/** Max gross win value (USDC) before rake — frozen cap when set, else live pot fallback. */
+export function maxWinValueUsdc(deal: ExtractionCapDealFields): number {
+  if (deal.max_extraction_amount_usdc != null) {
+    return deal.max_extraction_amount_usdc;
+  }
+  return frozenMaxExtractionAmountUsdc(deal.pot_usdc);
+}
+
+/** Derive the frozen cap from creation-time net pot (matches on-chain maxExtractionAmount). */
+export function frozenMaxExtractionAmountUsdc(netPotUsdc: number): number {
+  return netPotUsdc * (MAX_EXTRACTION_PERCENTAGE / 100);
+}
+
+/**
+ * Cap fields every deal-creation insert must stamp, kept as one unit so the
+ * percentage and frozen amount can never drift or be half-set on a new path.
+ * Convex-only (deal creation never happens client-side).
+ */
+export function dealCreationCapFields(netPotUsdc: number): {
+  maxExtractionPercentage: number;
+  maxExtractionAmountUsdc: number;
+} {
+  return {
+    maxExtractionPercentage: MAX_EXTRACTION_PERCENTAGE,
+    maxExtractionAmountUsdc: frozenMaxExtractionAmountUsdc(netPotUsdc),
+  };
+}

--- a/convex/mcp/deals.ts
+++ b/convex/mcp/deals.ts
@@ -1,6 +1,8 @@
 import { internalMutation, internalQuery } from "../_generated/server";
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
+import { isOwnDeskCreatedDeal } from "../lib/dealEntryEligibility";
+import { dealCreationCapFields } from "../lib/extractionCap";
 
 export type McpDealWriteResult = {
   dealId: string;
@@ -36,9 +38,19 @@ export const list = internalQuery({
     }
 
     const deals = await q.take(bounded);
+    const desk = await ctx.db.get(deskManagerId);
 
     const items = deals.map((d) => {
-      const isOwnDesk = d.creatorDeskManagerId === deskManagerId;
+      const isOwnDesk = isOwnDeskCreatedDeal(
+        {
+          creatorDeskManagerId: d.creatorDeskManagerId,
+          creatorAddress: d.creatorAddress,
+        },
+        {
+          deskManagerId: String(deskManagerId),
+          deskWalletAddress: desk?.walletAddress,
+        }
+      );
       return {
         dealId: d._id,
         prompt: d.prompt,
@@ -108,6 +120,7 @@ export const recordOnChainCreationForMcp = internalMutation({
       prompt: args.prompt,
       potUsdc: args.potUsdc,
       entryCostUsdc: args.entryCostUsdc,
+      ...dealCreationCapFields(args.potUsdc),
       sourceHeadline: args.sourceHeadline,
       status: "open",
       onChainDealId: args.onChainDealId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -174,6 +174,8 @@ export default defineSchema({
     potUsdc: v.number(),
     entryCostUsdc: v.number(),
     maxExtractionPercentage: v.optional(v.number()),
+    /** Frozen at deal creation: netPot * maxExtractionPercentage (matches on-chain maxExtractionAmount). */
+    maxExtractionAmountUsdc: v.optional(v.number()),
     feeUsdc: v.optional(v.number()),
     status: v.union(
       v.literal("open"),

--- a/src/app/api/deal/enter/route.ts
+++ b/src/app/api/deal/enter/route.ts
@@ -122,6 +122,7 @@ async function handleAgentCycleDealEnter(
     entryCostUsdc: number;
     onChainDealId?: number | null;
     creatorDeskManagerId?: Id<"deskManagers">;
+    creatorAddress?: string | null;
   } | null;
 
   if (!deal) {
@@ -157,10 +158,22 @@ async function handleAgentCycleDealEnter(
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const loadDeskFn = internal.deskManagers.getByIdInternal as any;
+  const deskManager = (await convex.query(loadDeskFn, {
+    id: trader.deskManagerId,
+  })) as { walletAddress?: string } | null;
+
   if (
     !isTraderEligibleToEnterDealByDesk(
-      { creatorDeskManagerId: deal.creatorDeskManagerId ?? null },
-      { deskManagerId: String(trader.deskManagerId) }
+      {
+        creatorDeskManagerId: deal.creatorDeskManagerId,
+        creatorAddress: deal.creatorAddress,
+      },
+      {
+        deskManagerId: String(trader.deskManagerId),
+        deskWalletAddress: deskManager?.walletAddress,
+      }
     )
   ) {
     return NextResponse.json(

--- a/src/lib/deal-entry-eligibility.test.ts
+++ b/src/lib/deal-entry-eligibility.test.ts
@@ -7,15 +7,23 @@ import {
 describe("deal-entry-eligibility (same-desk rule)", () => {
   const deskA = "jd7abc123" as const;
   const deskB = "jd7xyz999" as const;
+  const walletA = "0xAbC123";
+  const walletB = "0xDeF456";
 
-  it("house / no creator desk id is never own-desk", () => {
-    expect(isOwnDeskCreatedDeal({}, deskA)).toBe(false);
-    expect(isOwnDeskCreatedDeal({ creatorDeskManagerId: null }, deskA)).toBe(
-      false
-    );
-    expect(isOwnDeskCreatedDeal({ creatorDeskManagerId: "" }, deskA)).toBe(
-      false
-    );
+  it("house / no creator desk id and no wallet match is never own-desk", () => {
+    expect(isOwnDeskCreatedDeal({}, { deskManagerId: deskA })).toBe(false);
+    expect(
+      isOwnDeskCreatedDeal(
+        { creatorDeskManagerId: null },
+        { deskManagerId: deskA }
+      )
+    ).toBe(false);
+    expect(
+      isOwnDeskCreatedDeal(
+        { creatorDeskManagerId: "" },
+        { deskManagerId: deskA }
+      )
+    ).toBe(false);
     expect(
       isTraderEligibleToEnterDealByDesk(
         { creatorDeskManagerId: undefined },
@@ -24,10 +32,13 @@ describe("deal-entry-eligibility (same-desk rule)", () => {
     ).toBe(true);
   });
 
-  it("same desk is own-desk and not eligible", () => {
-    expect(isOwnDeskCreatedDeal({ creatorDeskManagerId: deskA }, deskA)).toBe(
-      true
-    );
+  it("same desk id is own-desk and not eligible", () => {
+    expect(
+      isOwnDeskCreatedDeal(
+        { creatorDeskManagerId: deskA },
+        { deskManagerId: deskA }
+      )
+    ).toBe(true);
     expect(
       isTraderEligibleToEnterDealByDesk(
         { creatorDeskManagerId: deskA },
@@ -36,7 +47,7 @@ describe("deal-entry-eligibility (same-desk rule)", () => {
     ).toBe(false);
   });
 
-  it("another desk is eligible", () => {
+  it("another desk id is eligible", () => {
     expect(
       isTraderEligibleToEnterDealByDesk(
         { creatorDeskManagerId: deskB },
@@ -47,7 +58,43 @@ describe("deal-entry-eligibility (same-desk rule)", () => {
 
   it("compares ids as strings", () => {
     expect(
-      isOwnDeskCreatedDeal({ creatorDeskManagerId: deskA }, `${deskA}`)
+      isOwnDeskCreatedDeal(
+        { creatorDeskManagerId: deskA },
+        { deskManagerId: `${deskA}` }
+      )
+    ).toBe(true);
+  });
+
+  it("same creator wallet with null desk id is own-desk", () => {
+    expect(
+      isOwnDeskCreatedDeal(
+        { creatorDeskManagerId: null, creatorAddress: walletA },
+        { deskManagerId: deskA, deskWalletAddress: walletA }
+      )
+    ).toBe(true);
+    expect(
+      isTraderEligibleToEnterDealByDesk(
+        { creatorAddress: walletA },
+        { deskManagerId: deskA, deskWalletAddress: walletA }
+      )
+    ).toBe(false);
+  });
+
+  it("different wallets with null desk id is eligible", () => {
+    expect(
+      isTraderEligibleToEnterDealByDesk(
+        { creatorAddress: walletB },
+        { deskManagerId: deskA, deskWalletAddress: walletA }
+      )
+    ).toBe(true);
+  });
+
+  it("compares wallet addresses case-insensitively", () => {
+    expect(
+      isOwnDeskCreatedDeal(
+        { creatorAddress: "0xabc123" },
+        { deskManagerId: deskA, deskWalletAddress: "0xAbC123" }
+      )
     ).toBe(true);
   });
 });

--- a/src/lib/deal-entry-eligibility.ts
+++ b/src/lib/deal-entry-eligibility.ts
@@ -1,28 +1,42 @@
 /**
  * Desk-based entry eligibility for Next.js. Convex duplicate: `convex/lib/dealEntryEligibility.ts`.
- * No `creatorDeskManagerId` ⇒ house-style ⇒ allowed. Same id as trader's desk ⇒ blocked.
+ * Block when desk ids match, or when creator wallet equals the trader's desk treasury wallet.
+ * No creator id and no wallet match ⇒ house-style ⇒ allowed.
  */
 
 export type DealDeskCreatorFields = {
   creatorDeskManagerId?: string | null;
+  creatorAddress?: string | null;
 };
 
 export type TraderDeskFields = {
   deskManagerId: string;
+  deskWalletAddress?: string | null;
 };
+
+function walletAddressesMatch(
+  a: string | null | undefined,
+  b: string | null | undefined
+): boolean {
+  if (!a || !b) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}
 
 export function isOwnDeskCreatedDeal(
   deal: DealDeskCreatorFields,
-  traderDeskManagerId: string
+  trader: TraderDeskFields
 ): boolean {
   const creator = deal.creatorDeskManagerId;
-  if (creator == null || creator === "") return false;
-  return String(creator) === String(traderDeskManagerId);
+  const idMatch = !!creator && String(creator) === String(trader.deskManagerId);
+  return (
+    idMatch ||
+    walletAddressesMatch(deal.creatorAddress, trader.deskWalletAddress)
+  );
 }
 
 export function isTraderEligibleToEnterDealByDesk(
   deal: DealDeskCreatorFields,
   trader: TraderDeskFields
 ): boolean {
-  return !isOwnDeskCreatedDeal(deal, trader.deskManagerId);
+  return !isOwnDeskCreatedDeal(deal, trader);
 }

--- a/src/lib/extraction-cap.test.ts
+++ b/src/lib/extraction-cap.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import {
+  frozenMaxExtractionAmountUsdc,
+  maxWinValueUsdc,
+} from "./extraction-cap";
+
+describe("extraction-cap", () => {
+  it("derives frozen cap from creation net pot", () => {
+    expect(frozenMaxExtractionAmountUsdc(950)).toBe(237.5);
+    expect(frozenMaxExtractionAmountUsdc(1000)).toBe(250);
+  });
+
+  it("uses frozen cap when set even if live pot grew", () => {
+    const cap = maxWinValueUsdc({
+      pot_usdc: 1500,
+      max_extraction_amount_usdc: 237.5,
+    });
+    expect(cap).toBe(237.5);
+  });
+
+  it("falls back to live pot when frozen cap is unset", () => {
+    expect(maxWinValueUsdc({ pot_usdc: 1500 })).toBe(375);
+  });
+});

--- a/src/lib/extraction-cap.ts
+++ b/src/lib/extraction-cap.ts
@@ -1,0 +1,23 @@
+/**
+ * Frozen extraction cap helpers. Convex duplicate: `convex/lib/extractionCap.ts`.
+ */
+
+import { MAX_EXTRACTION_PERCENTAGE } from "@/lib/constants";
+
+export type ExtractionCapDealFields = {
+  pot_usdc: number;
+  max_extraction_amount_usdc?: number | null;
+};
+
+/** Max gross win value (USDC) before rake — frozen cap when set, else live pot fallback. */
+export function maxWinValueUsdc(deal: ExtractionCapDealFields): number {
+  if (deal.max_extraction_amount_usdc != null) {
+    return deal.max_extraction_amount_usdc;
+  }
+  return frozenMaxExtractionAmountUsdc(deal.pot_usdc);
+}
+
+/** Derive the frozen cap from creation-time net pot (matches on-chain maxExtractionAmount). */
+export function frozenMaxExtractionAmountUsdc(netPotUsdc: number): number {
+  return netPotUsdc * (MAX_EXTRACTION_PERCENTAGE / 100);
+}

--- a/tests/convex/setup.ts
+++ b/tests/convex/setup.ts
@@ -139,6 +139,7 @@ export async function seedDeal(
     status?: "open" | "closed" | "depleted";
     /** When set, deal is treated as created by that desk (not house). */
     creatorDeskManagerId?: string;
+    creatorAddress?: string;
     onChainDealId?: number;
     onChainTxHash?: string;
   } = {}
@@ -153,6 +154,9 @@ export async function seedDeal(
       creatorType: "desk_manager",
       ...(opts.creatorDeskManagerId !== undefined
         ? { creatorDeskManagerId: opts.creatorDeskManagerId as never }
+        : {}),
+      ...(opts.creatorAddress !== undefined
+        ? { creatorAddress: opts.creatorAddress }
         : {}),
       ...(opts.onChainDealId !== undefined
         ? { onChainDealId: opts.onChainDealId }

--- a/tests/convex/x402-auth.test.ts
+++ b/tests/convex/x402-auth.test.ts
@@ -212,6 +212,22 @@ describe("recordVerifiedEntry same-desk rule (no self-dealing)", () => {
     });
     expect(entryId).toBeTruthy();
   });
+
+  it("rejects entry when creator wallet matches desk wallet without creatorDeskManagerId", async () => {
+    const t = makeT();
+    const dmId = await seedDeskManager(t, { walletAddress: "0xabc123" });
+    const traderId = await seedActiveTrader(t, dmId);
+    const dealId = await seedDeal(t, { creatorAddress: "0xabc123" });
+
+    await expect(
+      t.mutation(internal.deals.recordVerifiedEntry, {
+        paymentId: "pay-own-wallet",
+        dealId: dealId as never,
+        traderId,
+        entryCostUsdc: 50,
+      })
+    ).rejects.toThrow("Trader cannot enter deals created by its own desk.");
+  });
 });
 
 // ── x402 boundary: no public mutation surface for verified flags ───────────────
@@ -450,6 +466,10 @@ describe("Auth-protected mutations: authenticated callers succeed", () => {
     );
 
     expect(replayedDealId).toBe(dealId);
+
+    const deal = await t.run(async (ctx) => ctx.db.get(dealId as never));
+    expect(deal?.maxExtractionAmountUsdc).toBe(125);
+    expect(deal?.maxExtractionPercentage).toBe(25);
   });
 
   it("traders.setStatus rejects activation before wallet is ready", async () => {


### PR DESCRIPTION
## Summary

Two related hardening changes to deal entry and outcome resolution, plus cleanup from a `/simplify` pass.

### Freeze the max-extraction cap at deal creation
- New `dealCreationCapFields(netPotUsdc)` helper (`convex/lib/extractionCap.ts`) stamps `maxExtractionPercentage` + `maxExtractionAmountUsdc` (net pot × 25%, matching the on-chain `maxExtractionAmount`) as **one unit** on both creation paths (`recordOnChainCreationVerified`, `recordOnChainCreationForMcp`), so the pair can't drift or be half-set on a future path.
- `outcomeResolver` reads the frozen value via `maxWinValueUsdc`, falling back to the live pot only for pre-existing deals that predate the field.
- New schema field `maxExtractionAmountUsdc` (optional).

### Detect own-desk deals by creator wallet, not just deskManagerId
- `isOwnDeskCreatedDeal` now takes a trader object and also blocks entry when the creator **wallet address** matches the trader's desk treasury wallet (case-insensitive).
- Fixes the raw id-only comparison previously used in the MCP `list` path.
- Applied consistently across the agent cycle, MCP, deal-selection, and the `/api/deal/enter` route (both convex and `src` mirror copies).

### Cleanup (`/simplify`)
- Flattened `isOwnDeskCreatedDeal` to a single boolean expression; collapsed falsy guards.
- `maxWinValueUsdc` fallback delegates to `frozenMaxExtractionAmountUsdc` instead of re-deriving the formula.
- Moved the desk lookup in `dealSelection` past the early-return guards so idle trader cycles don't waste a query.

## Test plan
- `convex/lib/extraction-cap` + `src/lib/deal-entry-eligibility` unit tests (frozen cap, live fallback, wallet-match case-insensitivity, house deals).
- `tests/convex/x402-auth` covers rejecting entry when creator wallet matches desk wallet without a `creatorDeskManagerId`, and asserts the frozen cap is persisted on creation.
- Convex typecheck + affected suites green (48 tests); pre-push CI gates (codegen/lint/typecheck) pass.

## Notes / follow-ups
- Dead internal mutation `recordDealEntry` (no callers) inserts deals **without** the frozen cap — a latent footgun given the new invariant. Left untouched as pre-existing/out-of-scope; worth deleting in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)