### PR TITLE
ci: skip Convex deploy when CONVEX_DEPLOY_KEY is unset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,21 +43,34 @@ jobs:
   deploy-convex:
     name: Deploy Convex functions
     needs: checks
+    # Only on merge to main, and only when a deploy key is actually configured.
+    # Without the secret `npx convex deploy` errors ("No CONVEX_DEPLOYMENT set"),
+    # so the job is gated on it rather than painting every main commit red.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    env:
+      CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
     steps:
+      - name: Check for deploy key
+        id: guard
+        run: echo "enabled=${{ env.CONVEX_DEPLOY_KEY != '' }}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
+        if: steps.guard.outputs.enabled == 'true'
 
       - uses: pnpm/action-setup@v4
+        if: steps.guard.outputs.enabled == 'true'
         with:
           version: 10
 
       - uses: actions/setup-node@v4
+        if: steps.guard.outputs.enabled == 'true'
         with:
           node-version: 22
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.guard.outputs.enabled == 'true'
         run: pnpm install --frozen-lockfile
 
       # CONVEX_DEPLOY_KEY targets the deployment associated with the key
@@ -65,6 +78,5 @@ jobs:
       # variables → Actions. Generate with `npx convex dashboard` → Settings,
       # or reuse the key in .env.local.
       - name: Deploy to Convex
+        if: steps.guard.outputs.enabled == 'true'
         run: npx convex deploy
-        env:
-          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}


### PR DESCRIPTION
## Problem

Every commit on `main` shows a **2 / 3 ✗** status. The failing check is the `Deploy Convex functions` job:

```
✖ No CONVEX_DEPLOYMENT set, run `npx convex dev` to configure a Convex project
##[error]Process completed with exit code 1.
```

It runs `npx convex deploy` on every push to `main`, but the `CONVEX_DEPLOY_KEY` repo secret was never configured — so the deploy step errors out and drags the whole commit status red (Lint/Typecheck/Codegen ✓ and Vercel ✓ are the 2 that pass).

## Fix

Gate the job's real steps on the deploy key being present. A cheap `guard` step reads `env.CONVEX_DEPLOY_KEY != ''` into an output; checkout / install / deploy only run when it's `true`. With no secret the job **skips green** instead of failing; once the secret is added it deploys as before.

This preserves the incident-driven intent documented in the job comment (backend must not lag the Vercel frontend) rather than deleting the job outright.

## Follow-up

To actually enable Convex deploys from CI, add `CONVEX_DEPLOY_KEY` under **Settings → Secrets and variables → Actions** (generate in the Convex dashboard → Settings, or reuse the key in `.env.local`). Until then the manual `convex dev --once` path remains the deploy mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)