### PR TITLE
docs: Base Sepolia security scope, trust model, and runbooks

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+Margin Call currently operates on **Base Sepolia only** (chain ID `84532`). This policy covers vulnerability reporting and disclosure for the repository and the active testnet deployment. It does **not** authorize Base mainnet deployment, configuration, or transactions.
+
+## Supported surfaces
+
+In scope for reports:
+
+- Smart contracts under `contracts/src/` as pinned by the active Base Sepolia deployment pointer
+- Convex backend functions that move or authenticate money (escrow, MCP prepare/confirm, agent enter/resolve)
+- Next.js API routes that sign operator transactions or mint identity wallets
+- Privileged configuration and secrets handling documented in [`docs/security/`](docs/security/)
+
+Out of scope:
+
+- Social engineering of individual desks or users
+- Issues that require a compromised third-party provider with no Margin Call mitigation path (report for awareness; triage may defer)
+- Findings against third-party registries (ERC-8004 / ERC-6551) that Margin Call does not control
+- Speculative mainnet attack scenarios presented as active production risk while only Sepolia is authorized
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+1. Email the maintainers with a private report (prefer a GitHub Security Advisory draft if you have repository access).
+2. Include:
+   - Affected commit SHA or branch
+   - Affected contract address / function / API route (if known)
+   - Impact (funds at risk, privilege escalation, auth bypass, DoS)
+   - Reproduction steps or proof-of-concept against **Base Sepolia test funds only**
+   - Suggested fix if you have one
+3. We aim to acknowledge within **3 business days** and provide a triage status within **10 business days**.
+
+While triage is open, please keep details private unless we agree otherwise.
+
+## Disclosure
+
+- We prefer coordinated disclosure after a fix or documented mitigation is available on the supported network.
+- Public write-ups may reference fixed commits and Base Sepolia deployment evidence once released.
+- Do not present Base mainnet addresses or transactions as in-scope active targets; mainnet work is planning-only (see [`docs/security/base-mainnet-launch-plan.md`](docs/security/base-mainnet-launch-plan.md) when present).
+
+## Safe harbor
+
+We will not pursue legal action against good-faith researchers who:
+
+- Follow this policy
+- Avoid privacy violations, destruction of data, and disruption of non-test users beyond what is needed to demonstrate the issue
+- Use only testnet / faucet funds on Base Sepolia
+- Give us reasonable time to remediate before public disclosure
+
+## Related documentation
+
+| Document | Purpose |
+| -------- | ------- |
+| [`docs/security/AUDIT_SCOPE.md`](docs/security/AUDIT_SCOPE.md) | What is (and is not) under review |
+| [`docs/security/threat-model.md`](docs/security/threat-model.md) | Trust assumptions and attack themes |
+| [`docs/security/role-matrix.md`](docs/security/role-matrix.md) | Privileged roles and compromise impact |
+| [`docs/security/incident-response.md`](docs/security/incident-response.md) | Pause, rotate, refund, rollback |
+| [`docs/security/evidence-requirements.md`](docs/security/evidence-requirements.md) | Deploy / verify / operate evidence |
+
+## Distinctions (do not conflate)
+
+| Term | Meaning |
+| ---- | ------- |
+| **Source review** | Human reading of repository code (may be stale relative to HEAD). |
+| **Vulnerability audit** | Time-bounded engagement that produces a security verdict against a fixed commit and deployment. |
+| **Source verification** | Explorer/build proof that on-chain bytecode matches reviewed source. |
+| **Deployment evidence** | Record of addresses, txs, roles, compiler pins, and activation approvals. |
+
+An informal emailed repository review is **documentation support**, not a vulnerability audit or security verdict. See [`docs/review-findings.md`](docs/review-findings.md) and the stale-review caveat in [`docs/security/AUDIT_SCOPE.md`](docs/security/AUDIT_SCOPE.md).

--- a/docs/base-sepolia-configuration.md
+++ b/docs/base-sepolia-configuration.md
@@ -48,6 +48,10 @@ Changing the active deployment requires human approval ([#211](https://github.co
 - MCP plugin markdown matches canonical chain slug, escrow, and USDC
 - Mainnet chain `8453` and mainnet USDC are not reachable from active exports
 
+## Security documentation
+
+Operational security posture for this testnet configuration lives under [`docs/security/`](./security/AUDIT_SCOPE.md) (audit scope, threat model, role matrix, runbooks, evidence). Reporting policy: [`SECURITY.md`](../SECURITY.md).
+
 ## Explicitly prohibited
 
 - Base mainnet chain `8453` in wallet `supportedChains`

--- a/docs/security/AUDIT_SCOPE.md
+++ b/docs/security/AUDIT_SCOPE.md
@@ -1,0 +1,91 @@
+# Audit scope (Base Sepolia)
+
+> **Network:** Base Sepolia only — chain ID `84532`.  
+> **Authorization:** Documentation and testnet operations described here do **not** authorize Base mainnet (`8453`) deployment, configuration, or transactions.  
+> No mainnet address or transaction in this repository is presented as active.
+
+This file defines what a reviewer or auditor should treat as in scope for the current testnet security posture. Update the commit and deployment fields whenever the active pointer or reviewed tip changes.
+
+## Review posture kinds (keep distinct)
+
+| Kind | What it proves | What it does not prove |
+| ---- | -------------- | ---------------------- |
+| Source review | Someone read code at a point in time | That HEAD is safe, or that on-chain code matches |
+| Vulnerability audit | A scoped engagement's findings against a fixed commit + deployment | Ongoing production safety after later commits |
+| Source verification | Bytecode at an address matches a build of reviewed source | Economic safety or off-chain key hygiene |
+| Deployment evidence | Who deployed what, when, with which roles and pins | That ops or IR were exercised |
+
+## Immutable anchors (fill / refresh at each review)
+
+Update before citing this file as evidence for a review.
+
+| Field | Value |
+| ----- | ----- |
+| Reviewed git commit | `b36f504a443b5d68f0371474c98e3cce986a6482` (tip of `main` when this doc landed; **refresh for each engagement**) |
+| Active deployment pointer | [`contracts/deployments/base-sepolia.active.json`](../../contracts/deployments/base-sepolia.active.json) |
+| Chain ID | `84532` |
+| Active escrow | `0xa244550f0e35032E9c0b09DA4EB4933848d28d16` |
+| Active `MarginCallToken` (`$BLOW` test) | `0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7` |
+| Active SeatVault | `0xa8595b279Aeadc8a0d2ce779Dc8Ba4d978eA2f44` |
+| Active pointer `deployedAt` | `2026-07-11T14:54:08.995Z` |
+| Sepolia USDC (canonical) | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+| Identity registry (canonical) | `0x8004A818BFB912233c491871b3d84c89A494BD9e` |
+
+History append-only lists (do not treat historical rows as active unless they match `base-sepolia.active.json`):
+
+- [`contracts/deployments/base-sepolia.escrows.json`](../../contracts/deployments/base-sepolia.escrows.json)
+- [`contracts/deployments/base-sepolia.margincall-tokens.json`](../../contracts/deployments/base-sepolia.margincall-tokens.json)
+- [`contracts/deployments/base-sepolia.seat-vaults.json`](../../contracts/deployments/base-sepolia.seat-vaults.json)
+
+Compiler and dependency pins for reproducible builds: [`contracts/REPRODUCIBILITY.md`](../../contracts/REPRODUCIBILITY.md).
+
+Canonical app/network config: [`docs/base-sepolia-configuration.md`](../base-sepolia-configuration.md).
+
+## In scope
+
+### On-chain
+
+- `contracts/src/MarginCallEscrow.sol` as deployed at the active escrow address
+- `contracts/src/SeatVault.sol` as deployed at the active SeatVault address
+- `contracts/src/MarginCallToken.sol` as deployed at the active token address (Sepolia `$BLOW` capacity token)
+- Constructor arguments, role holders, pause state, and SeatVault policy parameters as recorded in deployment evidence ([evidence requirements](./evidence-requirements.md))
+
+### Off-chain (money / auth adjacency)
+
+- Operator-signed deal entry (`OPERATOR_PRIVATE_KEY` path)
+- MCP prepare → Base Account `send_calls` → `confirm_intent` treasury flows
+- Convex agent cycle enter / settle / refund paths that call the escrow
+- Address and chain resolvers that must fail closed on non-Sepolia values
+- Secret handling for operator, MCP HMAC / service token, CDP, Privy, Convex, and Vercel
+
+### Documentation under review for ops correctness
+
+- This directory (`docs/security/`)
+- [`docs/base-sepolia-configuration.md`](../base-sepolia-configuration.md)
+
+## Explicit exclusions
+
+- Base mainnet (`8453`) contracts, USDC (`0x833589…`), wallets, or env profiles
+- Bankr mainnet `$BLOW` launch and token economics
+- Third-party ERC-8004 / ERC-6551 registry implementations (trust assumptions only; see [threat model](./threat-model.md))
+- Frontend cosmetic / marketing pages with no financial path
+- Historical deployment rows that are not the active pointer
+- Wire narrative content generation (LLM storytelling) except where it gates a financial action
+- Any future mainnet launch plan content ([placeholder plan](./base-mainnet-launch-plan.md) when present) — planning only
+
+## Stale-review caveat
+
+An emailed repository review that covered an older commit is useful as **documentation support** and as a checklist of themes ([`docs/review-findings.md`](../review-findings.md)). It is **not**:
+
+- a vulnerability audit,
+- a security verdict for HEAD,
+- proof of source verification for the active deployment, or
+- authorization to deploy or change environments.
+
+Re-open or refresh any engagement that does not name the commit SHA and active deployment pointer in the table above.
+
+## Forbidden presentations
+
+- Listing Base mainnet addresses as “current” or “production”
+- Implying informal review = audit complete
+- Treating env overrides that disagree with `base-sepolia.active.json` as valid (they must fail closed — see base Sepolia configuration doc)

--- a/docs/security/base-sepolia-operations.md
+++ b/docs/security/base-sepolia-operations.md
@@ -1,0 +1,73 @@
+# Base Sepolia operations runbook
+
+> **Network:** Base Sepolia only — chain ID `84532`.  
+> These steps are for another operator to run day-2 testnet operations with faucet/test funds.  
+> This document does **not** authorize deployment, env mutation, or enabling autonomous cycles — those require human approval under [#211](https://github.com/hurley87/margin-call/issues/211).
+
+Canonical config: [`docs/base-sepolia-configuration.md`](../base-sepolia-configuration.md).  
+Active contracts: [`contracts/deployments/base-sepolia.active.json`](../../contracts/deployments/base-sepolia.active.json).
+
+## Preconditions checklist
+
+- [ ] `git rev-parse HEAD` recorded (see [AUDIT_SCOPE.md](./AUDIT_SCOPE.md))
+- [ ] Active pointer chain ID is `84532`
+- [ ] `NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL` / `BASE_SEPOLIA_RPC_URL` set; no silent public fallback
+- [ ] Optional address env vars unset **or** exact match to active JSON
+- [ ] Operator EOA is an on-chain `settlementOperators` entry and funded with Sepolia ETH for gas
+- [ ] Escrow / SeatVault `paused == false` unless intentionally halted
+- [ ] Autonomous agent cycles enabled only after explicit [#211](https://github.com/hurley87/margin-call/issues/211) Gate 3 approval
+
+## Read health
+
+1. Resolve escrow / vault / token from active JSON (or matching env).
+2. `eth_chainId` via configured RPC must return `0x14a34` (`84532`).
+3. Read `paused`, `owner`, `entryTimeoutSeconds`, and a known trader’s `getBalance`.
+4. Confirm Convex desk and trader rows for a smoke desk match recent on-chain deposits (money SoT is escrow).
+
+## Routine financial smoke (manual / MCP)
+
+Use faucet Sepolia USDC only.
+
+1. **sync_wallet** — desk Base Account balance refresh against chain.
+2. **create_trader** — server mint (CDP / ERC-8004); ensure depositor bound.
+3. **fund_trader** — MCP prepare → Base MCP `send_calls` → `confirm_intent` with matching `txHash`.
+4. **create_deal** — same prepare/confirm path; verify `DealCreated` on escrow.
+5. **enterDeal** — operator-signed path only when cycles approved; verify `DealEntered`.
+6. **settle / refund** — settlement operator settles, or after timeout call `refundExpiredEntry`.
+7. **withdraw** — depositor withdraws to desk; confirm event + Convex resync.
+
+SeatVault path (capacity): stake → optional initiate unstake → wait cooldown → unstake. Do not allow depositor rebinds mid-cooldown except per hardened contract rules.
+
+## Monitoring (minimum)
+
+| Signal | Action if bad |
+| ------ | ------------- |
+| Escrow or SeatVault `paused` unexpectedly | Investigate; do not unpause until root cause known ([IR](./incident-response.md)) |
+| Pending entries older than `entryTimeoutSeconds` | Refund expired entries; page operator |
+| RPC errors / chain ID mismatch | Fail closed; fix env; do not “try mainnet RPC” |
+| Operator wallet ETH low | Top up Sepolia ETH only |
+| Drift test / CI fail on addresses | Block activation; restore active JSON + TS mirror |
+
+## Pause / unpause (operational)
+
+1. Prefer dedicated **pauser** key (owner may also pause).
+2. Call `pause()` on escrow (halts `enterDeal` / settle paths gated by `whenNotPaused`).
+3. Call SeatVault `pause()` if staking must stop.
+4. Record evidence per [evidence-requirements.md](./evidence-requirements.md).
+5. Unpause only after written go-ahead from owner / incident lead.
+
+## Config change (activation)
+
+Changing `base-sepolia.active.json`, `convex/lib/activeDeployment.ts`, or hosted env requires **human approval Gate 2** in [#211](https://github.com/hurley87/margin-call/issues/211). Follow the activation procedure in [base-sepolia-configuration.md](../base-sepolia-configuration.md). Never point active config at Base mainnet.
+
+## Rollback posture (ops)
+
+- **Pointer rollback:** Point active JSON + TS mirror back to a prior verified Sepolia deployment in history files; redeploy hosted env to match. Does not reverse on-chain history.
+- **Code rollback:** Redeploy previous app/Convex revision; does not move USDC.
+- **Contract rollback:** Impossible in-place; requires new deploy + pointer change under approval.
+
+See [incident-response.md](./incident-response.md) for what cannot be reversed.
+
+## Contacts / ownership
+
+Maintain a private pager list for: escrow owner, pauser, settlement operator custodian, Convex/Vercel admins. Do not commit private keys or personal phone numbers in this repository.

--- a/docs/security/dependency-exceptions.md
+++ b/docs/security/dependency-exceptions.md
@@ -7,6 +7,18 @@ blocking release of app dependencies we do not ship.
 
 Owner: Margin Call maintainers. Review on Dependabot PRs and at least quarterly.
 
+## Security documentation
+
+| Doc | Purpose |
+| --- | ------- |
+| [`../SECURITY.md`](../../SECURITY.md) | Vulnerability reporting and disclosure |
+| [`AUDIT_SCOPE.md`](./AUDIT_SCOPE.md) | Commit, contracts, exclusions, stale-review caveat |
+| [`threat-model.md`](./threat-model.md) | Trust assumptions and threat themes |
+| [`role-matrix.md`](./role-matrix.md) | Privileged roles, impact, rotation |
+| [`base-sepolia-operations.md`](./base-sepolia-operations.md) | Day-2 Base Sepolia runbook |
+| [`incident-response.md`](./incident-response.md) | Pause, rotate, refund, rollback, recovery |
+| [`evidence-requirements.md`](./evidence-requirements.md) | Deploy / verify / operate evidence checklist |
+
 | Advisory                                                                                                                                                                                                                     | Package                            | Severity | Reachability                                                                                                                                                      | Mitigation                                                                                                                              | Expiry     |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | [GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r), [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583), [GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff) | `vite` `7.3.1` via `vitest@4.1.10` | high     | **Dev-only.** Vitest / Vite transform path used in unit tests and optional Vitest UI. Not in Next.js production bundle; UI server is not run in CI or production. | Stay on Vitest `4.1.x`; bump when Vitest ships a release that depends on Vite `>=7.3.5`. Do not expose Vitest UI on untrusted networks. | 2026-10-13 |

--- a/docs/security/evidence-requirements.md
+++ b/docs/security/evidence-requirements.md
@@ -1,0 +1,95 @@
+# Evidence requirements (Base Sepolia)
+
+> **Network:** Base Sepolia only — chain ID `84532`.  
+> Collect and retain the artifacts below so another reviewer can verify what was deployed, configured, and operated.  
+> Filling this checklist is **not** itself an approval to deploy — see [#211](https://github.com/hurley87/margin-call/issues/211).
+
+Distinguish evidence kinds ([AUDIT_SCOPE.md](./AUDIT_SCOPE.md)):
+
+| Kind | Typical artifacts |
+| ---- | ----------------- |
+| Source review | Diff comments, commit SHA, reviewer identity, date |
+| Vulnerability audit | Engagement letter, fixed commit, findings PDF, remediation PR links |
+| Source verification | Explorer verification URL, matching solc/optimizer settings, bytecode hash |
+| Deployment evidence | Tx hashes, addresses, constructor args, role holders, block numbers |
+
+## Deploy
+
+Record for each contract create:
+
+- [ ] Git commit SHA built
+- [ ] Foundry / solc / optimizer / EVM pins ([`contracts/REPRODUCIBILITY.md`](../../contracts/REPRODUCIBILITY.md))
+- [ ] `forge build` bytecode hash (`deployedBytecode.object` hash)
+- [ ] Deployer address and Sepolia ETH funding tx
+- [ ] Create transaction hash, block number, timestamp
+- [ ] Constructor arguments (USDC, identity registry, settlement operator, depositor binder, entry timeout; SeatVault: escrow, token, thresholds, cooldown)
+- [ ] Resulting contract address
+- [ ] `eth_chainId` proof = `84532` at send time
+- [ ] Append row to the appropriate `contracts/deployments/base-sepolia.*.json` history file
+
+## Verify (source verification)
+
+- [ ] Explorer verification success URL (Base Sepolia)
+- [ ] Compiler version `0.8.28`, optimizer `200` runs, EVM `cancun` (or exact pins used)
+- [ ] Runtime bytecode matches local reproducible build
+- [ ] Constructor ABI-encoded args match deploy record
+
+## Configure / activate
+
+Activation requires human Gate 2 approval ([#211](https://github.com/hurley87/margin-call/issues/211)).
+
+- [ ] Diff of `base-sepolia.active.json` and `convex/lib/activeDeployment.ts` (must match)
+- [ ] Hosted env var values (or confirmation unset → canonical defaults)
+- [ ] Drift tests: `pnpm test` network config suite green
+- [ ] MCP plugin markdown addresses aligned
+- [ ] On-chain role holders after configure (owner, pauser, operators, binders)
+- [ ] Written approval artifact (who / when / ticket)
+
+## Monitor
+
+Retain for the operational window:
+
+- [ ] RPC endpoint identity (provider + URL host; no secrets in-repo)
+- [ ] Pause-state polls / alerts configuration
+- [ ] Pending-entry age alerts vs `entryTimeoutSeconds`
+- [ ] Operator gas balance checks
+- [ ] Links to Convex / Vercel log queries used during the window
+
+## Pause
+
+- [ ] Tx hash for `pause` / `unpause` (escrow and SeatVault separately)
+- [ ] Caller address (pauser vs owner)
+- [ ] Block number and reason code/ticket
+- [ ] Autonomous-cycle disable confirmation
+
+## Rotate
+
+- [ ] Before: role mapping read (old address authorized)
+- [ ] Tx: `remove*` then `add*` (or ownership two-step txs)
+- [ ] After: mapping read (only new address)
+- [ ] Env secret rotation timestamps (Convex + Vercel)
+- [ ] Smoke tx hashes post-rotation
+
+## Refund
+
+- [ ] `dealId`, `traderId`, entry timestamp, timeout threshold
+- [ ] `refundExpiredEntry` tx hash and `EntryRefunded` log
+- [ ] Convex balance reconciliation evidence
+
+## Rollback
+
+- [ ] Prior active pointer snapshot (JSON + TS)
+- [ ] New (rollback) pointer commit SHA
+- [ ] Hosted env redeploy ID
+- [ ] Explicit note of on-chain actions that **cannot** be rolled back (settles, withdrawals)
+
+## Recovery
+
+- [ ] Root-cause write-up link
+- [ ] Completed smoke sequence checklist ([operations](./base-sepolia-operations.md))
+- [ ] Separate approvals: unpause vs re-enable autonomy
+- [ ] Updated [AUDIT_SCOPE.md](./AUDIT_SCOPE.md) anchors if deployment changed
+
+## Storage
+
+Keep evidence in a private ops store (drive/ticket). Commit to git only non-sensitive, source-controlled pieces (deployment JSON history, this documentation). Never commit private keys, raw MCP keys, or access tokens.

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -1,0 +1,89 @@
+# Incident response (Base Sepolia)
+
+> **Network:** Base Sepolia only — chain ID `84532`.  
+> Practice these steps with test funds. This runbook does **not** authorize mainnet actions or silent environment changes.
+
+Severity is relative to **testnet funds and reputation**, but treat procedures as rehearsal for any future mainnet plan.
+
+## Severity guide
+
+| Level | Examples | Initial action |
+| ----- | -------- | -------------- |
+| Sev-1 | Active unauthorized settles; binder reassigning depositors; mass drain | Pause escrow (+ SeatVault if needed); remove bad roles |
+| Sev-2 | Stale RPC causing false confirms; pending-entry backlog; operator key exposure without observed abuse | Pause if uncertain; rotate; verify chain state |
+| Sev-3 | Dependency advisory; docs drift; monitoring gap | Ticket; no unnecessary pause |
+
+## Immediate containment (Sev-1 / uncertain Sev-2)
+
+1. **Pause** escrow via pauser or owner: `pause()`.
+2. **Pause** SeatVault if stakes are at risk: `pause()`.
+3. **Disable** autonomous cycles (Convex cron / feature flag / withhold Gate 3 approval) so operators stop calling `enterDeal`.
+4. **Snapshot** evidence: block number, `eth_chainId`, role mappings, recent txs, Convex logs (see [evidence requirements](./evidence-requirements.md)).
+5. **Communicate** to maintainers on a private channel; no public issue with exploit detail.
+
+## Role / key rotation
+
+Order matters — revoke on-chain **before** destroying usable old key access if you still need it for revoke txs; prefer using **owner** to revoke a compromised operator.
+
+### Compromised settlement operator
+
+1. Owner: `removeSettlementOperator(compromised)`.
+2. Confirm mapping is false on-chain.
+3. Generate new operator key offline; fund with Sepolia ETH.
+4. Owner: `addSettlementOperator(new)`.
+5. Update `OPERATOR_PRIVATE_KEY` in Convex/Vercel.
+6. Smoke a single enter/settle on a tiny Faust deal after unpause approval.
+
+### Compromised depositor binder
+
+1. Owner: `removeDepositorBinder(compromised)`.
+2. Add new binder; audit recent `DepositorSet` events; rebind affected traders under policy.
+3. Rotate any off-chain key that had binder rights.
+
+### Compromised owner
+
+1. If two-step pending to attacker: do not accept; race to a safe acceptor if still owner.
+2. If attacker is already owner: pause if still possible via pauser; otherwise treat as lost admin — plan emergency desk notifications and pointer freeze (stop advertising the deployment).
+
+### Compromised MCP / CDP / Privy secrets
+
+1. Rotate secrets in both Convex and Vercel (MCP service token must match).
+2. Force desk MCP key re-issue (SIWE).
+3. Review recent `confirm_intent` and mint events.
+
+Full matrix: [role-matrix.md](./role-matrix.md).
+
+## Refunds
+
+- After `entryTimeoutSeconds`, anyone may call `refundExpiredEntry(dealId, traderId)` for an expired pending entry (per contract).
+- Prefer scripted, logged refunds; verify `EntryRefunded` and Convex balance apply idempotently.
+- Do **not** invent off-chain refunds that skip the contract.
+
+## Rollback
+
+| Action | Reversible? | Notes |
+| ------ | ----------- | ----- |
+| App / Convex code deploy | Yes | Redeploy prior revision |
+| Env var change | Yes (config) | Can break address fail-closed checks if mismatched |
+| Active pointer JSON | Yes (pointer) | On-chain state of old/new contracts remains |
+| Pause / unpause | Yes | Log who unpaused |
+| Settlement / binder membership | Yes | Additive history remains on-chain |
+| Ownership transfer (completed) | Difficult | Only via new transfer by current owner |
+| Individual `settleEntry` payout | **No** | Funds already moved; compensate only via new txs if policy allows |
+| Desk USDC spent with confirmation | **No** on-chain | Desk controls Base Account |
+
+Freeze the **active pointer** and hosted config under incident lead approval rather than hastily “rolling forward” to an unaudited bytecode.
+
+## Recovery / reopen
+
+1. Root cause written and linked from the incident ticket.
+2. Compromised roles removed; new roles verified on explorer.
+3. Source verification still matches claimed bytecode for active addresses.
+4. Smoke sequence from [base-sepolia-operations.md](./base-sepolia-operations.md) passes on faucet funds.
+5. Explicit human approvals to **unpause** and (separately) to **re-enable autonomous cycles**.
+
+## Post-incident
+
+- Update [AUDIT_SCOPE.md](./AUDIT_SCOPE.md) commit/deployment anchors if contracts changed.
+- Append deployment evidence if a replacement was activated under [#211](https://github.com/hurley87/margin-call/issues/211).
+- Feed themes into [threat-model.md](./threat-model.md) and private lessons learned (no secret material in-repo).

--- a/docs/security/role-matrix.md
+++ b/docs/security/role-matrix.md
@@ -1,0 +1,61 @@
+# Role matrix (Base Sepolia)
+
+> **Network:** Base Sepolia only — chain ID `84532`.  
+> Distinct humans or hardware should hold distinct privileged roles on any hardened redeploy.  
+> This matrix documents compromise impact and rotation; it does **not** authorize role changes.
+
+On-chain roles are defined in [`MarginCallEscrow.sol`](../../contracts/src/MarginCallEscrow.sol) and [`SeatVault.sol`](../../contracts/src/SeatVault.sol). Off-chain actors hold secrets or approve intents.
+
+## Escrow (`MarginCallEscrow`)
+
+| Role | How granted | Capabilities | Compromise impact | Rotation procedure |
+| ---- | ----------- | ------------ | ----------------- | ------------------ |
+| **Owner (admin)** | Deployer becomes `owner`; two-step transfer via `transferOwnership` / `acceptOwnership` | Add/remove settlement operators and depositor binders; set pauser; set SeatVault; set entry timeout; `withdrawFees`; pause/unpause | Full admin: fee drain, role packing, SeatVault repoint, timeout grief | Start two-step transfer to new EOA/multisig → acceptor calls `acceptOwnership` → verify `owner` on explorer → retire old key |
+| **Pending owner** | `transferOwnership` | Only `acceptOwnership` | Low alone; social-engineer accept | Cancel by transferring ownership to a burn/current owner pattern if supported in ops policy, or complete intentionally |
+| **Pauser** | `setPauser` by owner (owner can always pause) | `pause` / `unpause` | Freeze trading / unfreeze under attack | Owner `setPauser(new)`; test pause on Sepolia; update runbook contacts |
+| **Settlement operator** | Constructor seed + `addSettlementOperator` | `enterDeal`, `settleEntry` | Malicious entry/settlement of any deal | `removeSettlementOperator(old)` **before** rotating `OPERATOR_PRIVATE_KEY` / env; `addSettlementOperator(new)`; verify mapping |
+| **Depositor binder** | Constructor seed + `addDepositorBinder` | `setDepositor(traderId, depositor)` | Redirect withdraw rights for traders | `removeDepositorBinder(old)` then add new; re-bind depositors only under empty-balance / policy constraints in hardened builds |
+| **Depositor (per trader)** | Set by binder | `depositFor`, `withdraw`, SeatVault stake authority for that traderId | Drain that trader’s escrow (+ stake control) | Binder sets new depositor per policy; desk rotates Base Account if treasury was the depositor |
+
+## SeatVault
+
+| Role | How granted | Capabilities | Compromise impact | Rotation procedure |
+| ---- | ----------- | ------------ | ----------------- | ------------------ |
+| **Owner** | Constructor; two-step transfer | Policy updates (`setToken`, thresholds, cooldown); set pauser; ownership transfer | Change capacity economics; freeze via pause collusion | Same two-step pattern as escrow |
+| **Pauser** | `setPauser` | Pause / unpause staking | Halt stake/unstake | Owner sets new pauser |
+| **Staker** | Current escrow depositor for `traderId` | Stake / initiate unstake / complete unstake | Steal or lock own principal; cannot steal others’ without depositor bind | Desk controls via depositor address |
+
+## Deployer
+
+| Role | Capabilities | Compromise impact | Rotation / notes |
+| ---- | ------------ | ----------------- | ---------------- |
+| **Deployer EOA** | Broadcasts create txs; usually first `owner` | Can be retired after ownership transfer | Fund with Sepolia ETH only; transfer admin off deployer after smoke; never reuse as settlement hot wallet |
+
+## Off-chain / platform
+
+| Actor | Privileges | Compromise impact | Rotation procedure |
+| ----- | ---------- | ----------------- | ------------------ |
+| **Operator hot wallet** (`OPERATOR_PRIVATE_KEY`) | Must match an on-chain settlement operator (and historically binder duties if same key — prefer split) | See settlement / binder rows | On-chain remove → new key → add → update Convex/Vercel env → smoke enter/settle |
+| **MCP service** (`MCP_SERVICE_TOKEN`) | Next.js ↔ Convex MCP HTTP | Forge MCP calls if exposed | Rotate token in both places identically; invalidate old deploys |
+| **MCP API key HMAC** (`MCP_API_KEY_SECRET`) | Hash `mc_live_*` keys | Forge key hashes | Rotate secret; force desks to re-issue SIWE keys |
+| **Per-desk MCP key** (`mc_live_*`) | Desk-scoped MCP API | Desk treasury prepare abuse until unbound | Desk re-SIWE; new key supersedes |
+| **Desk treasury (Base Account)** | Approves MCP `send_calls` | Loss of desk Sepolia USDC | User recovers via Base Account controls; rebind desk wallet only with proof-of-control |
+| **CDP credentials** | Mint/manage trader identity smart accounts | Identity wallet abuse | Rotate CDP secrets; audit recent mints |
+| **Privy app secrets** | Auth / embedded wallets | Session/user spoof risk | Rotate in Privy dashboard + Vercel |
+| **Convex / Vercel admins** | Deploy code and env | Silent config mutation | Enforce dual-review on env; [#211](https://github.com/hurley87/margin-call/issues/211) activation gates |
+
+## Preferred separation (testnet hardening)
+
+For any replacement Sepolia deploy under approval gate [#211](https://github.com/hurley87/margin-call/issues/211):
+
+1. Deployer ≠ owner (transfer after smoke)
+2. Owner ≠ settlement operator
+3. Settlement operator ≠ depositor binder
+4. Pauser is a cold/watched key separate from the hot operator
+5. Desk treasuries remain end-user Base Accounts (non-custodial)
+
+## Related
+
+- [Threat model](./threat-model.md)
+- [Incident response](./incident-response.md)
+- [Base Sepolia operations](./base-sepolia-operations.md)

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,82 @@
+# Threat model (Base Sepolia)
+
+> **Network:** Base Sepolia only — chain ID `84532`.  
+> Documentation may describe testnet operations but does **not** authorize deployment or environment changes.  
+> No Base mainnet address or transaction is active.
+
+Trust boundaries for Margin Call’s testnet stack: on-chain escrow / SeatVault / token, operator and binder keys, MCP desk treasury, Convex game state, and RPC / config integrity.
+
+Companion docs: [role matrix](./role-matrix.md), [audit scope](./AUDIT_SCOPE.md), [incident response](./incident-response.md).
+
+## Assets
+
+| Asset | Why it matters |
+| ----- | -------------- |
+| Escrow USDC balances (per trader) | Desk funds at risk on testnet |
+| Platform fees in escrow | Extractable by owner |
+| Pending deal entries | Can lock entry cost until settle / refund / timeout |
+| SeatVault `$BLOW` principal | Capacity stake; cooldown grief if mis-bound |
+| Operator settlement authority | Can enter and settle deals |
+| Depositor binder authority | Can reassign who may withdraw a trader’s escrow |
+| Desk treasury wallet (Base Account) | Funds traders and creates deals via MCP |
+| Convex desk / trader balance mirrors | Gate create_trader and UX; must not invent chain truth |
+| Secrets: `OPERATOR_PRIVATE_KEY`, MCP tokens, CDP, Privy | Full or partial protocol control |
+
+## Trust assumptions
+
+1. **Chain:** Only Base Sepolia `84532` appears in active financial paths. Mainnet `8453` and mainnet USDC are forbidden in active exports ([`convex/lib/baseSepoliaNetwork.ts`](../../convex/lib/baseSepoliaNetwork.ts)).
+2. **USDC / registries:** Canonical Sepolia USDC and ERC-8004 identity registry addresses are trusted as published; Margin Call does not patch their code.
+3. **Desk non-custodial path:** Desk treasury USDC leaves the operator’s custody; desks approve MCP prepare intents via Base Account `send_calls`.
+4. **Operator is hot:** Settlement / entry uses a hot operator key for autonomy. Compromise equals malicious settlement until rotated and paused.
+5. **Convex is game SoT; escrow is money SoT:** On disagreement, on-chain balances and events win for financial truth.
+6. **LLM does not decide odds:** Mechanical odds decide outcomes; the model narrates. Prompt injection into narration is reputational, not a payout oracle — **unless** a bug wires LLM output into settle parameters (treat that as critical if found).
+
+## Threat themes
+
+### T1 — Hot-key compromise (operator / binder / CDP)
+
+- **Attack:** Steal `OPERATOR_PRIVATE_KEY` or depositor-binder key material; or CDP secrets for identity wallets.
+- **Impact:** Unauthorized `enterDeal` / `settleEntry`; binder can re-point depositors and enable wrongful withdraw; CDP compromise affects trader identity wallets (not desk treasury under BYO Base Account).
+- **Mitigations:** Distinct roles ([role matrix](./role-matrix.md)); pause escrow; remove compromised operator/binder; rotate secrets in Vercel/Convex; record evidence ([evidence requirements](./evidence-requirements.md)).
+
+### T2 — Malicious settlement
+
+- **Attack:** Colluding or compromised settlement operator settles with inflated/deflated payouts, or enters deals against desk intent.
+- **Impact:** Distorts testnet pots and trader balances; destroys fairness.
+- **Mitigations:** Owner can remove settlement operators; pause; audit settle call args against Convex outcomes; keep operator gas wallet funded separately from treasury.
+
+### T3 — Stale RPC / config
+
+- **Attack:** Point `BASE_SEPOLIA_RPC_URL` at a malicious or lagging endpoint; or set env addresses that diverge from `base-sepolia.active.json`.
+- **Impact:** False confirms, missed events, or attempted use of wrong contracts. Mismatch must **fail closed** (see [base Sepolia configuration](../base-sepolia-configuration.md)).
+- **Mitigations:** Pin RPC to a known provider; drift tests; refuse silent public-RPC fallbacks; never accept mainnet addresses in env.
+
+### T4 — Timeout / liveness
+
+- **Attack:** Entries left `pending` without settle; grief via unstake cooldown; agent cron offline during NYSE hours; pause left on indefinitely.
+- **Impact:** Locked USDC until `refundExpiredEntry` after `entryTimeoutSeconds`; capacity lockups; trading halt.
+- **Mitigations:** Documented refund path in [operations](./base-sepolia-operations.md) and [IR](./incident-response.md); monitor pending entries and pause state; SeatVault cooldown rules that prevent replacement-depositor grief (hardened contract behavior).
+
+### T5 — Treasury ownership / MCP desk wallet
+
+- **Attack:** Compromise Base Account controlling a desk; steal `mc_live_*` MCP key + coerce confirms; inflate Convex `walletBalanceUsdc` if sync is not chain-backed.
+- **Impact:** Loss of desk test USDC; fraudulent trader funding gates if balance sync is trusted blindly.
+- **Mitigations:** Non-custodial prepare/confirm; SIWE key binding; sync from chain where implemented; desk wallet rebind requires proof-of-control policies as hardened.
+
+### T6 — Role rotation gaps
+
+- **Attack:** Rotate only the operator secret in Vercel but leave old address still authorized on-chain; or transfer ownership without completing two-step accept.
+- **Impact:** Dual-control confusion; old key remains live.
+- **Mitigations:** On-chain remove before destroying old key material; complete `transferOwnership` + `acceptOwnership`; checklist in [role matrix](./role-matrix.md) and [IR](./incident-response.md).
+
+### T7 — Own-desk / economic rule bypass
+
+- **Attack:** Call paths that skip desk-dedup or own-desk checks off-chain while on-chain allows entry.
+- **Impact:** Self-dealing or duplicate exposures.
+- **Mitigations:** Enforce on-chain where possible; keep selection and `recordVerifiedEntry` checks aligned ([review findings](../review-findings.md) for residual risks).
+
+## Out of model (for this testnet doc)
+
+- Nation-state RPC eclipse of all public Sepolia endpoints simultaneously
+- Zero-day in `solc` 0.8.28 or OpenZeppelin 5.2.0 (track advisories; pin versions per [`contracts/REPRODUCIBILITY.md`](../../contracts/REPRODUCIBILITY.md))
+- Bankr / mainnet token launch economics (see future mainnet plan doc when present)


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` plus audit scope, threat model, role matrix, Base Sepolia ops/IR runbooks, and evidence requirements under `docs/security/`.
- Links the new security docs from the Sepolia configuration guide and dependency-exceptions index.
- Documents testnet-only posture with explicit stale-review caveat and no active mainnet addresses.

Closes #209

## Test plan
- [ ] Review `AUDIT_SCOPE.md` anchors against `base-sepolia.active.json` and commit SHA
- [ ] Confirm every privileged role in `role-matrix.md` matches escrow/SeatVault capabilities
- [ ] Walk `base-sepolia-operations.md` + `incident-response.md` as an external operator checklist
- [ ] Verify docs distinguish source review vs vulnerability audit vs source verification vs deployment evidence
- [ ] Grep for any mainnet address presented as active (should be none)


Made with [Cursor](https://cursor.com)