### PR TITLE
ci: fix Slither job crashing with KeyError: 'output'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,27 @@ jobs:
 
       - uses: ./.github/actions/setup-foundry
 
-      # Let crytic-compile drive `forge build` itself. Pre-building and passing
-      # ignore-compile: true made Slither parse Foundry's build-info artifacts,
-      # whose newer layout (no top-level "output" key) crashes crytic-compile
-      # with KeyError: 'output'. Compiling in-process avoids that stale path.
-      - name: Run Slither
-        uses: crytic/slither-action@v0.4.0
+      - uses: actions/setup-python@v5
         with:
-          target: contracts
-          fail-on: high
-          slither-config: contracts/slither.config.json
+          python-version: "3.10"
+
+      # Run Slither directly instead of via crytic/slither-action. The action
+      # ran two things that both broke here:
+      #   1. ignore-compile made crytic-compile parse Foundry build-info, whose
+      #      newer layout (no top-level "output" key) crashes it with
+      #      KeyError: 'output'.
+      #   2. its dependency-install wrapper runs `git submodule` at the repo
+      #      root, which fails on the stray `.claude/skills` gitlink.
+      # Letting crytic-compile drive `forge build` with the pinned toolchain
+      # (deps already installed by setup-foundry) avoids both.
+      - name: Install Slither
+        run: pip install "slither-analyzer==0.11.4"
+
+      - name: Run Slither
+        working-directory: contracts
+        # --fail-high mirrors the action's `fail-on: high`: exit non-zero only
+        # on High-severity findings.
+        run: slither . --config-file slither.config.json --fail-high
 
   contracts-fork:
     name: Foundry (Base Sepolia fork)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,15 @@ jobs:
 
       - uses: ./.github/actions/setup-foundry
 
-      - name: Forge build (artifacts for Slither)
-        working-directory: contracts
-        run: forge build
-
+      # Let crytic-compile drive `forge build` itself. Pre-building and passing
+      # ignore-compile: true made Slither parse Foundry's build-info artifacts,
+      # whose newer layout (no top-level "output" key) crashes crytic-compile
+      # with KeyError: 'output'. Compiling in-process avoids that stale path.
       - name: Run Slither
         uses: crytic/slither-action@v0.4.0
         with:
           target: contracts
           fail-on: high
-          ignore-compile: true
           slither-config: contracts/slither.config.json
 
   contracts-fork:


### PR DESCRIPTION
## Problem

The **Slither static analysis** CI job had been failing on every run — `main` included, not just #220 — crashing before a single detector executed:

```
crytic_compile/platform/hardhat.py, line 72, in hardhat_like_parsing
    targets_json = loaded_json["output"]
KeyError: 'output'
```

So static analysis had effectively been providing **zero coverage**.

## Root causes (two, uncovered in sequence)

1. **`KeyError: 'output'`** — the job pre-ran `forge build` and invoked Slither with `ignore-compile: true`, making crytic-compile parse Foundry's build-info artifacts. Recent Foundry emits build-info without the top-level `"output"` key that crytic-compile 0.3.11 expects. (Independent of the `slither-action` version — reproduces on 0.4.0 and 0.4.2.)

2. **`git submodule ... no submodule mapping found for '.claude/skills'`** — dropping `ignore-compile` exposed a second issue: the `crytic/slither-action` wrapper runs `git submodule` at the repo root during its dependency-install step, which fails on the stray `.claude/skills` gitlink (a nested repo committed with no `.gitmodules` entry). The old `ignore-compile` path never ran submodule commands, so this stayed hidden.

## Fix

Run Slither **directly via pip** instead of through the Docker action:

- Uses the pinned `setup-foundry` toolchain (forge v1.4.3, deps already installed) — no re-install, no root-level `git submodule` step.
- crytic-compile drives `forge build` itself, avoiding the stale build-info parse path.
- `--fail-high` mirrors the action's `fail-on: high` (exit non-zero only on High-severity findings).

## Verification

- **Local** (`slither-analyzer==0.11.4`, forge 1.4.3): old path reproduces `KeyError: 'output'`; new path analyzes **16 contracts, 100 detectors, 6 Low + 1 Informational, 0 High**; `--fail-high` exits **0**.
- **CI on this PR**: Slither job now passes (35s) and logs `. analyzed (16 contracts with 100 detectors)` — real coverage restored.

## Note (out of scope)

`.claude/skills` is committed as a gitlink with no `.gitmodules` entry, so any `git submodule update --init --recursive` in this repo fails. This PR routes around it; the gitlink itself should probably be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)