### PR TITLE
chore: untrack orphan .claude/skills gitlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,11 @@ jobs:
           python-version: "3.10"
 
       # Run Slither directly instead of via crytic/slither-action. The action
-      # ran two things that both broke here:
-      #   1. ignore-compile made crytic-compile parse Foundry build-info, whose
-      #      newer layout (no top-level "output" key) crashes it with
-      #      KeyError: 'output'.
-      #   2. its dependency-install wrapper runs `git submodule` at the repo
-      #      root, which fails on the stray `.claude/skills` gitlink.
-      # Letting crytic-compile drive `forge build` with the pinned toolchain
-      # (deps already installed by setup-foundry) avoids both.
+      # forced ignore-compile, which made crytic-compile parse Foundry
+      # build-info whose newer layout (no top-level "output" key) crashes it
+      # with KeyError: 'output'. Letting crytic-compile drive `forge build`
+      # with the pinned toolchain (deps already installed by setup-foundry)
+      # avoids that.
       - name: Install Slither
         run: pip install "slither-analyzer==0.11.4"
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ next-env.d.ts
 
 # agent skills (managed locally)
 .agents/skills/
+.claude/skills/

--- a/scripts/install-forge-deps.sh
+++ b/scripts/install-forge-deps.sh
@@ -30,8 +30,8 @@ while IFS=$'\t' read -r name dep; do
   [[ -z "$name" || -z "$dep" ]] && continue
   # Replace any prior checkout so local + CI always match the manifest tag.
   rm -rf "$LIB_DIR/$name"
-  # --no-git installs as plain dirs (not submodules), avoiding forge's
-  # whole-repo submodule scan on orphan gitlinks (e.g. .claude/skills).
+  # --no-git installs as plain dirs (not submodules), keeping deps out of the
+  # repo's submodule machinery so install is reproducible from the manifest.
   forge install "$dep" --no-git
   count=$((count + 1))
 done < <(


### PR DESCRIPTION
## Problem

`.claude/skills` is committed as a **gitlink** (mode `160000`) with **no matching `.gitmodules` entry**:

```
$ git ls-files -s | grep 160000
160000 47043da...  0  .claude/skills
$ cat .gitmodules
cat: .gitmodules: No such file or directory
```

Because it's an orphan gitlink, any `git submodule update --init --recursive` in this repo fails:

```
fatal: no submodule mapping found in .gitmodules for path '.claude/skills'
```

This already forced a defensive `--no-git` workaround in `scripts/install-forge-deps.sh`, and it broke the `crytic/slither-action` dependency-install step (see #231).

## Fix

Skills are managed locally — mirroring the existing `.agents/skills/` ignore — so:

- `git rm --cached .claude/skills` — drop the orphan gitlink from the index (local files untouched).
- Add `.claude/skills/` to `.gitignore`.

After this there are no gitlinks in the index, and submodule commands no longer fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)