### PR TITLE
fix: exclude packages/ from root TS type-check (fixes flaky Vercel build)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "tests", "scripts"]
+  "exclude": ["node_modules", "tests", "scripts", "packages"]
 }


### PR DESCRIPTION
## Problem

PR preview builds on Vercel intermittently fail with:

```
./packages/mcp-server/src/index.ts:27
Type error: Cannot find module '@modelcontextprotocol/sdk/server/mcp.js' or its corresponding type declarations.
Next.js build worker exited with code: 1
Error: Command "pnpm run build" exited with 1
```

(seen on #225, #231, #232 previews; `vercel ls` shows previews flapping Ready ↔ Error while production stays Ready.)

## Root cause

The root `tsconfig.json` includes `**/*.ts` and excludes only `node_modules/tests/scripts`, so `next build` type-checks `packages/mcp-server/src/index.ts` — a **standalone workspace package** with its own NodeNext `tsconfig.json` and its own `build`/`typecheck` scripts.

That file imports the SDK via a subpath export (`@modelcontextprotocol/sdk/server/mcp.js`). Resolving it depends on the pnpm symlink `packages/mcp-server/node_modules/@modelcontextprotocol/sdk` being present. Locally and in the CI `Typecheck` job the symlink exists, so it passes — but it isn't reliably present during Vercel builds, so `next build` fails. Production `main` passed only by build-cache luck; that's why the symptom looked flaky.

## Fix

Add `packages` to the root tsconfig `exclude`. The Next app never imports `mcp-server` (only references it as file-path / CLI strings in `src/app/api/mcp/plugin/route.ts` and `connect-mcp-dialog.tsx`), and the package keeps its own `build`/`typecheck`, so type coverage is unchanged.

## Verification

- Before: `tsc --listFilesOnly` includes `packages/mcp-server/src/index.ts`.
- After: **0** `packages/mcp-server` files in the root program; `pnpm typecheck` still passes; `pnpm --filter @margin-call/mcp-server typecheck` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)