### PR TITLE
fix: persist deal outcomes that match on-chain settleEntry payout (#216)

### DIFF
--- a/convex/agent/cycle.ts
+++ b/convex/agent/cycle.ts
@@ -90,7 +90,80 @@ import {
   reconciledTxHash,
   type OnChainResolveResult,
 } from "./onChainSettlement";
-import { clampSettleEntryArgs } from "../lib/settlementEncoding";
+import {
+  clampSettleEntryArgs,
+  type ClampedSettleEntry,
+} from "../lib/settlementEncoding";
+
+async function createEscrowViemClients() {
+  const operatorKey = process.env.OPERATOR_PRIVATE_KEY;
+  if (!operatorKey) {
+    throw new Error("OPERATOR_PRIVATE_KEY env var is not set");
+  }
+
+  const { createWalletClient, http } = await import("viem");
+  const { privateKeyToAccount } = await import("viem/accounts");
+  const { CONTRACTS_CHAIN } = await import("../lib/baseSepoliaNetwork");
+  const { requireBaseSepoliaRpcUrl } =
+    await import("../lib/requireBaseSepoliaRpcUrl");
+  const { getBaseSepoliaPublicClient } = await import("../mcp/deskByo");
+
+  const account = privateKeyToAccount(operatorKey as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: CONTRACTS_CHAIN,
+    transport: http(requireBaseSepoliaRpcUrl()),
+  });
+  const publicClient = await getBaseSepoliaPublicClient();
+  return { account, walletClient, publicClient, CONTRACTS_CHAIN };
+}
+
+/**
+ * Read live getDeal caps and clamp outcome economics to what settleEntry will
+ * pay. Returns null when this trader has no pending entry (caller will hit
+ * already_resolved on settle).
+ */
+export async function clampOutcomeToOnChainCaps({
+  onChainDealId,
+  tokenId,
+  entryCostUsdc,
+  traderPnlUsdc,
+  rakeUsdc,
+}: {
+  onChainDealId: number;
+  tokenId: number;
+  entryCostUsdc: number;
+  traderPnlUsdc: number;
+  rakeUsdc: number;
+}): Promise<ClampedSettleEntry | null> {
+  // Read-only path: never signs, so use the shared public-client factory rather
+  // than building an operator wallet client we would only discard.
+  const { getBaseSepoliaPublicClient } = await import("../mcp/deskByo");
+  const publicClient = await getBaseSepoliaPublicClient();
+  const hasPending = await publicClient.readContract({
+    address: ESCROW_ADDRESS,
+    abi: escrowAbi,
+    functionName: "hasPendingEntry",
+    args: [BigInt(onChainDealId), BigInt(tokenId)],
+  });
+  if (!hasPending) return null;
+
+  const deal = await publicClient.readContract({
+    address: ESCROW_ADDRESS,
+    abi: escrowAbi,
+    functionName: "getDeal",
+    args: [BigInt(onChainDealId)],
+  });
+  return clampSettleEntryArgs({
+    entryCostRaw: deal.entryCost,
+    potAmountRaw: deal.potAmount,
+    reservedAmountRaw: deal.reservedAmount,
+    maxExtractionAmountRaw: deal.maxExtractionAmount,
+    entryCostUsdc,
+    traderPnlUsdc,
+    rakeUsdc,
+  });
+}
 
 async function finalizeOnChainOutcome(
   ctx: ActionCtx,
@@ -187,35 +260,21 @@ export async function resolveOnChainEntry({
   entryCostUsdc,
   traderPnlUsdc,
   rakeUsdc,
+  /**
+   * Precomputed settle args from `clampOutcomeToOnChainCaps` / `clampSettleEntryArgs`.
+   * When provided, skip a second getDeal clamp so recorded PnL matches the tx.
+   */
+  settleArgs,
 }: {
   onChainDealId: number;
   tokenId: number;
   entryCostUsdc: number;
   traderPnlUsdc: number;
   rakeUsdc: number;
+  settleArgs?: { grossPayoutRaw: bigint; rakeRaw: bigint };
 }): Promise<OnChainResolveResult> {
-  const operatorKey = process.env.OPERATOR_PRIVATE_KEY;
-  if (!operatorKey) {
-    throw new Error("OPERATOR_PRIVATE_KEY env var is not set");
-  }
-
-  const { createPublicClient, createWalletClient, http } = await import("viem");
-  const { privateKeyToAccount } = await import("viem/accounts");
-  const { CONTRACTS_CHAIN } = await import("../lib/baseSepoliaNetwork");
-  const { requireBaseSepoliaRpcUrl } =
-    await import("../lib/requireBaseSepoliaRpcUrl");
-
-  const transport = http(requireBaseSepoliaRpcUrl());
-  const account = privateKeyToAccount(operatorKey as `0x${string}`);
-  const walletClient = createWalletClient({
-    account,
-    chain: CONTRACTS_CHAIN,
-    transport,
-  });
-  const publicClient = createPublicClient({
-    chain: CONTRACTS_CHAIN,
-    transport,
-  });
+  const { account, walletClient, publicClient, CONTRACTS_CHAIN } =
+    await createEscrowViemClients();
 
   // Gate on THIS trader's pending status, read first. The global
   // `pendingEntries` count is unsafe as a short-circuit: a lagging RPC replica
@@ -247,28 +306,29 @@ export async function resolveOnChainEntry({
     };
   }
 
-  // Clamp the payout to the contract's on-chain caps so settleEntry can never
-  // revert for economic reasons (#206). The contract is the source of truth:
-  // the extraction cap is frozen at deal creation (25% of net pot), and the pot
-  // must stay solvent for every other pending entry's reserve. The off-chain
-  // outcome engine sizes wins against a live, growing pot, which can drift above
-  // these frozen on-chain limits; clamping here keeps the two in agreement
-  // instead of letting settleEntry revert and strand the entry.
-  const deal = await publicClient.readContract({
-    address: ESCROW_ADDRESS,
-    abi: escrowAbi,
-    functionName: "getDeal",
-    args: [BigInt(onChainDealId)],
-  });
-  const { grossPayoutRaw, rakeRaw } = clampSettleEntryArgs({
-    entryCostRaw: deal.entryCost,
-    potAmountRaw: deal.potAmount,
-    reservedAmountRaw: deal.reservedAmount,
-    maxExtractionAmountRaw: deal.maxExtractionAmount,
-    entryCostUsdc,
-    traderPnlUsdc,
-    rakeUsdc,
-  });
+  let settle: { grossPayoutRaw: bigint; rakeRaw: bigint } | undefined =
+    settleArgs;
+  if (!settle) {
+    // Retry path: clamp again from live getDeal so settleEntry cannot revert
+    // for economic reasons (#206). Prefer precomputed settleArgs on the happy
+    // path so persisted dealOutcomes match the on-chain payout (#216).
+    const deal = await publicClient.readContract({
+      address: ESCROW_ADDRESS,
+      abi: escrowAbi,
+      functionName: "getDeal",
+      args: [BigInt(onChainDealId)],
+    });
+    settle = clampSettleEntryArgs({
+      entryCostRaw: deal.entryCost,
+      potAmountRaw: deal.potAmount,
+      reservedAmountRaw: deal.reservedAmount,
+      maxExtractionAmountRaw: deal.maxExtractionAmount,
+      entryCostUsdc,
+      traderPnlUsdc,
+      rakeUsdc,
+    });
+  }
+  const { grossPayoutRaw, rakeRaw } = settle;
   try {
     const hash = await walletClient.writeContract({
       address: ESCROW_ADDRESS,
@@ -1145,6 +1205,37 @@ export const cycle = internalAction({
         pendingOutcome = resolved;
       }
 
+      // Pre-clamp on-chain economics before persist so dealOutcomes match what
+      // settleEntry will pay (#216). Off-chain-only deals skip this.
+      let settleArgs: { grossPayoutRaw: bigint; rakeRaw: bigint } | undefined;
+      if (
+        pendingOutcome &&
+        bestDeal.on_chain_deal_id != null &&
+        traderTokenId !== undefined
+      ) {
+        const clamped = await clampOutcomeToOnChainCaps({
+          onChainDealId: bestDeal.on_chain_deal_id,
+          tokenId: traderTokenId,
+          entryCostUsdc: bestDeal.entry_cost_usdc,
+          traderPnlUsdc: pendingOutcome.traderPnlUsdc,
+          rakeUsdc: pendingOutcome.rakeUsdc,
+        });
+        if (clamped) {
+          pendingOutcome = {
+            ...pendingOutcome,
+            traderPnlUsdc: clamped.traderPnlUsdc,
+            rakeUsdc: clamped.rakeUsdc,
+            potChangeUsdc: clamped.potChangeUsdc,
+          };
+          traderPnlUsdc = clamped.traderPnlUsdc;
+          rakeUsdc = clamped.rakeUsdc;
+          settleArgs = {
+            grossPayoutRaw: clamped.grossPayoutRaw,
+            rakeRaw: clamped.rakeRaw,
+          };
+        }
+      }
+
       // ── 9. Persist outcome BEFORE on-chain settle ────────────────────────────
       // Apply order matters: we record the off-chain outcome first so that if
       // the contract reverts settleEntry, the next cycle's
@@ -1167,17 +1258,14 @@ export const cycle = internalAction({
 
       // ── 10. Settle on-chain pending entry ──────────────────────────────────
       let resolveResult: OnChainResolveResult | null = null;
-      if (
-        bestDeal.on_chain_deal_id !== undefined &&
-        bestDeal.on_chain_deal_id !== null &&
-        traderTokenId !== undefined
-      ) {
+      if (bestDeal.on_chain_deal_id != null && traderTokenId !== undefined) {
         resolveResult = await resolveOnChainEntry({
           onChainDealId: bestDeal.on_chain_deal_id,
           tokenId: traderTokenId,
           entryCostUsdc: bestDeal.entry_cost_usdc,
           traderPnlUsdc,
           rakeUsdc,
+          settleArgs,
         });
       }
 

--- a/convex/agent/outcomeResolver.ts
+++ b/convex/agent/outcomeResolver.ts
@@ -115,7 +115,7 @@ export async function resolveOutcome(
           .map((a) => `${a.name} ($${a.valueUsdc ?? 0} USDC)`)
           .join(", ");
 
-  // Max win value: frozen extraction cap at creation (fallback: live pot * 25%).
+  // Max win profit: creation-frozen extraction cap (required; never live pot).
   const maxValuePerWin = maxWinValueUsdc(deal);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/convex/deals.ts
+++ b/convex/deals.ts
@@ -371,11 +371,18 @@ export const recordDealEntry = internalMutation({
     }
 
     const now = Date.now();
-    const { idempotencyKey: _key, traderId: _traderId, ...dealData } = args;
+    const {
+      idempotencyKey: _key,
+      traderId: _traderId,
+      maxExtractionPercentage: _pct,
+      ...dealData
+    } = args;
     void _key;
     void _traderId;
+    void _pct;
     return ctx.db.insert("deals", {
       ...dealData,
+      ...dealCreationCapFields(args.potUsdc),
       status: "open",
       entryCount: 1,
       wipeoutCount: 0,

--- a/convex/lib/extractionCap.ts
+++ b/convex/lib/extractionCap.ts
@@ -9,12 +9,17 @@ export type ExtractionCapDealFields = {
   max_extraction_amount_usdc?: number | null;
 };
 
-/** Max gross win value (USDC) before rake — frozen cap when set, else live pot fallback. */
+/**
+ * Max profit from pot (USDC) before rake — requires the creation-frozen cap.
+ * Matches on-chain `maxExtractionAmount`; never derive from the live pot.
+ */
 export function maxWinValueUsdc(deal: ExtractionCapDealFields): number {
-  if (deal.max_extraction_amount_usdc != null) {
-    return deal.max_extraction_amount_usdc;
+  if (deal.max_extraction_amount_usdc == null) {
+    throw new Error(
+      "Deal missing frozen maxExtractionAmountUsdc — stamp at creation via dealCreationCapFields"
+    );
   }
-  return frozenMaxExtractionAmountUsdc(deal.pot_usdc);
+  return deal.max_extraction_amount_usdc;
 }
 
 /** Derive the frozen cap from creation-time net pot (matches on-chain maxExtractionAmount). */

--- a/convex/lib/settlementEncoding.ts
+++ b/convex/lib/settlementEncoding.ts
@@ -10,6 +10,10 @@ export function usdcToRaw(amountUsdc: number): bigint {
   return BigInt(Math.max(0, Math.round(amountUsdc * USDC_DECIMALS)));
 }
 
+export function rawToUsdc(raw: bigint): number {
+  return Number(raw) / USDC_DECIMALS;
+}
+
 export type SettleEntryCaps = {
   entryCostRaw: bigint;
   potAmountRaw: bigint;
@@ -27,6 +31,12 @@ export type ClampedSettleEntry = {
   grossPayoutRaw: bigint;
   rakeRaw: bigint;
   profitRaw: bigint;
+  /** Net trader PnL after rake (USDC), matching on-chain paid profit − rake. */
+  traderPnlUsdc: number;
+  /** Rake paid on-chain (USDC). */
+  rakeUsdc: number;
+  /** Pot delta: −profit on wins, +|loss| on losses. */
+  potChangeUsdc: number;
 };
 
 /**
@@ -35,6 +45,9 @@ export type ClampedSettleEntry = {
  * - gross ≤ pot - reserved + entryCost (leave peer reserves intact)
  * - gross ≤ pot
  * - rake ≤ profit (gross - entryCost, floored at 0)
+ *
+ * Also returns USDC economics derived from the clamped raw values so recorded
+ * outcomes match what settleEntry actually pays (#216).
  */
 export function clampSettleEntryArgs(
   input: ClampSettleEntryInput
@@ -64,5 +77,18 @@ export function clampSettleEntryArgs(
   let rakeRaw = usdcToRaw(rakeUsdc);
   if (rakeRaw > profitRaw) rakeRaw = profitRaw;
 
-  return { grossPayoutRaw, rakeRaw, profitRaw };
+  const entryFromRaw = rawToUsdc(entryCostRaw);
+  const grossUsdc = rawToUsdc(grossPayoutRaw);
+  const rakeUsdcClamped = rawToUsdc(rakeRaw);
+  const traderPnlUsdcClamped = grossUsdc - entryFromRaw - rakeUsdcClamped;
+  const potChangeUsdc = entryFromRaw - grossUsdc;
+
+  return {
+    grossPayoutRaw,
+    rakeRaw,
+    profitRaw,
+    traderPnlUsdc: traderPnlUsdcClamped,
+    rakeUsdc: rakeUsdcClamped,
+    potChangeUsdc,
+  };
 }

--- a/src/lib/extraction-cap.test.ts
+++ b/src/lib/extraction-cap.test.ts
@@ -18,7 +18,12 @@ describe("extraction-cap", () => {
     expect(cap).toBe(237.5);
   });
 
-  it("falls back to live pot when frozen cap is unset", () => {
-    expect(maxWinValueUsdc({ pot_usdc: 1500 })).toBe(375);
+  it("throws when frozen cap is unset", () => {
+    expect(() => maxWinValueUsdc({ pot_usdc: 1500 })).toThrow(
+      /missing frozen maxExtractionAmountUsdc/
+    );
+    expect(() =>
+      maxWinValueUsdc({ pot_usdc: 1500, max_extraction_amount_usdc: null })
+    ).toThrow(/missing frozen maxExtractionAmountUsdc/);
   });
 });

--- a/src/lib/extraction-cap.ts
+++ b/src/lib/extraction-cap.ts
@@ -9,12 +9,17 @@ export type ExtractionCapDealFields = {
   max_extraction_amount_usdc?: number | null;
 };
 
-/** Max gross win value (USDC) before rake — frozen cap when set, else live pot fallback. */
+/**
+ * Max profit from pot (USDC) before rake — requires the creation-frozen cap.
+ * Matches on-chain `maxExtractionAmount`; never derive from the live pot.
+ */
 export function maxWinValueUsdc(deal: ExtractionCapDealFields): number {
-  if (deal.max_extraction_amount_usdc != null) {
-    return deal.max_extraction_amount_usdc;
+  if (deal.max_extraction_amount_usdc == null) {
+    throw new Error(
+      "Deal missing frozen maxExtractionAmountUsdc — stamp at creation via dealCreationCapFields"
+    );
   }
-  return frozenMaxExtractionAmountUsdc(deal.pot_usdc);
+  return deal.max_extraction_amount_usdc;
 }
 
 /** Derive the frozen cap from creation-time net pot (matches on-chain maxExtractionAmount). */

--- a/tests/convex/settlement-encoding.test.ts
+++ b/tests/convex/settlement-encoding.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   clampSettleEntryArgs,
+  rawToUsdc,
   usdcToRaw,
 } from "../../convex/lib/settlementEncoding";
 
@@ -25,9 +26,12 @@ describe("clampSettleEntryArgs (#206/#207 settlement encoding)", () => {
     expect(out.grossPayoutRaw).toBe(e6(100));
     expect(out.rakeRaw).toBe(0n);
     expect(out.profitRaw).toBe(0n);
+    expect(out.traderPnlUsdc).toBe(0);
+    expect(out.rakeUsdc).toBe(0);
+    expect(out.potChangeUsdc).toBe(0);
   });
 
-  it("clamps win to extraction cap", () => {
+  it("clamps win to extraction cap and returns matching USDC economics", () => {
     // Desired: entry + 500 profit + 10 rake → far above 237.5 cap.
     const out = clampSettleEntryArgs({
       ...baseCaps,
@@ -40,6 +44,10 @@ describe("clampSettleEntryArgs (#206/#207 settlement encoding)", () => {
     expect(out.grossPayoutRaw).toBe(e6(100) + e6(237.5));
     expect(out.profitRaw).toBe(e6(237.5));
     expect(out.rakeRaw).toBe(e6(10)); // still ≤ profit
+    // Recorded PnL = clamped profit − rake (what the trader is actually paid).
+    expect(out.traderPnlUsdc).toBe(237.5 - 10);
+    expect(out.rakeUsdc).toBe(10);
+    expect(out.potChangeUsdc).toBe(-237.5);
   });
 
   it("clamps rake to clamped profit", () => {
@@ -55,6 +63,9 @@ describe("clampSettleEntryArgs (#206/#207 settlement encoding)", () => {
     expect(out.grossPayoutRaw).toBe(e6(230));
     expect(out.profitRaw).toBe(e6(130));
     expect(out.rakeRaw).toBe(e6(80));
+    expect(out.traderPnlUsdc).toBe(50);
+    expect(out.rakeUsdc).toBe(80);
+    expect(out.potChangeUsdc).toBe(-130);
   });
 
   it("forces rake to 0 on full loss", () => {
@@ -71,6 +82,9 @@ describe("clampSettleEntryArgs (#206/#207 settlement encoding)", () => {
     expect(out.grossPayoutRaw).toBe(e6(25));
     expect(out.profitRaw).toBe(0n);
     expect(out.rakeRaw).toBe(0n);
+    expect(out.traderPnlUsdc).toBe(-75);
+    expect(out.rakeUsdc).toBe(0);
+    expect(out.potChangeUsdc).toBe(75);
   });
 
   it("clamps to available pot leaving peer reserves", () => {
@@ -86,10 +100,29 @@ describe("clampSettleEntryArgs (#206/#207 settlement encoding)", () => {
     });
     expect(out.grossPayoutRaw).toBe(e6(100));
     expect(out.profitRaw).toBe(0n);
+    expect(out.traderPnlUsdc).toBe(0);
+    expect(out.rakeUsdc).toBe(0);
+    expect(out.potChangeUsdc).toBe(0);
+  });
+
+  it("passes through a normal loss unchanged", () => {
+    const out = clampSettleEntryArgs({
+      ...baseCaps,
+      reservedAmountRaw: e6(100),
+      potAmountRaw: e6(1050),
+      entryCostUsdc: 100,
+      traderPnlUsdc: -70,
+      rakeUsdc: 0,
+    });
+    expect(out.grossPayoutRaw).toBe(e6(30));
+    expect(out.traderPnlUsdc).toBe(-70);
+    expect(out.rakeUsdc).toBe(0);
+    expect(out.potChangeUsdc).toBe(70);
   });
 
   it("usdcToRaw rounds and floors negatives", () => {
     expect(usdcToRaw(1.2345678)).toBe(1234568n);
     expect(usdcToRaw(-5)).toBe(0n);
+    expect(rawToUsdc(e6(237.5))).toBe(237.5);
   });
 });

--- a/tests/convex/setup.ts
+++ b/tests/convex/setup.ts
@@ -11,6 +11,7 @@
  */
 import { convexTest } from "convex-test";
 import schema from "../../convex/schema";
+import { dealCreationCapFields } from "../../convex/lib/extractionCap";
 
 // Module glob — must cover the Convex backend tree under convex/ (not tests/).
 // Evaluated at runtime by Vite/Vitest from tests/convex.
@@ -142,16 +143,24 @@ export async function seedDeal(
     creatorAddress?: string;
     onChainDealId?: number;
     onChainTxHash?: string;
+    maxExtractionAmountUsdc?: number;
+    maxExtractionPercentage?: number;
   } = {}
 ) {
   return t.run(async (ctx) => {
     const now = Date.now();
+    const potUsdc = opts.potUsdc ?? 500;
+    const caps = dealCreationCapFields(potUsdc);
     return ctx.db.insert("deals", {
       prompt: opts.prompt ?? "Buy low, sell high on IBM",
-      potUsdc: opts.potUsdc ?? 500,
+      potUsdc,
       entryCostUsdc: opts.entryCostUsdc ?? 50,
       status: opts.status ?? "open",
       creatorType: "desk_manager",
+      maxExtractionPercentage:
+        opts.maxExtractionPercentage ?? caps.maxExtractionPercentage,
+      maxExtractionAmountUsdc:
+        opts.maxExtractionAmountUsdc ?? caps.maxExtractionAmountUsdc,
       ...(opts.creatorDeskManagerId !== undefined
         ? { creatorDeskManagerId: opts.creatorDeskManagerId as never }
         : {}),


### PR DESCRIPTION
## Summary

Recorded `dealOutcomes` could drift from what the on-chain `settleEntry` actually pays: the off-chain outcome engine sizes wins against a live, growing pot, while the contract clamps to caps frozen at deal creation. This pre-clamps outcome economics against the contract's live caps **before** persisting, so the recorded PnL / rake / pot-change match the on-chain payout (#216), building on the settlement clamping added for #206.

## Changes

- **`clampSettleEntryArgs`** now also returns the USDC economics derived from the clamped raw values (`traderPnlUsdc`, `rakeUsdc`, `potChangeUsdc`) — one shared home for the derivation.
- **`cycle`** pre-clamps via `clampOutcomeToOnChainCaps` before persist and threads the resulting raw settle args into `resolveOnChainEntry`, so the happy path skips a redundant `getDeal` re-clamp and the persisted outcome matches the tx.
- **`maxWinValueUsdc`** now requires the creation-frozen extraction cap and throws when it is missing, instead of silently falling back to a live-pot estimate. All three deal-creation paths stamp `dealCreationCapFields`.

## Cleanup applied during review

- `clampOutcomeToOnChainCaps` uses the read-only `getBaseSepoliaPublicClient` factory rather than building an operator wallet client it would discard.
- `createEscrowViemClients` reuses `getBaseSepoliaPublicClient` for its public client instead of re-implementing the construction.
- Simplified the settle-arg selection branch and the `!= null` deal guards in `cycle.ts`.

## Testing

- `npx tsc --noEmit` — clean
- `vitest run` on `settlement-encoding.test.ts` + `extraction-cap.test.ts` — 10 passed (new cases cover the returned USDC economics and the missing-cap throw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)