### PR TITLE
fix(ui): trader cycle countdown honors SeatVault tier cadence

### DIFF
--- a/convex/traders.ts
+++ b/convex/traders.ts
@@ -116,6 +116,9 @@ async function toTraderReadModel(ctx: QueryCtx, trader: Doc<"traders">) {
     profileImageUrl: await resolveTraderProfileImageUrl(ctx, trader),
     traits: readPublicTraits(trader.imagePromptSource),
     rarity: humanizeRarity(trader.imageVariant),
+    /** SeatVault floor credential (DB-only read model) — drives cycle cadence. */
+    effectiveTier: (await resolvePublicTraderTier(ctx, trader._id))
+      .effectiveTier,
     createdAt: trader.createdAt,
     updatedAt: trader.updatedAt,
   };

--- a/src/hooks/use-traders.ts
+++ b/src/hooks/use-traders.ts
@@ -5,6 +5,7 @@ import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import type { PublicPortraitTraits } from "@/lib/portrait-traits";
+import type { SeatTierName } from "@/lib/contracts/seatVault";
 
 type TraderReadModel = Pick<
   Doc<"traders">,
@@ -32,6 +33,7 @@ type TraderReadModel = Pick<
   profileImageUrl: string;
   traits: PublicPortraitTraits | null;
   rarity: string;
+  effectiveTier: SeatTierName;
 };
 
 export type TraderStatus = "active" | "paused" | "wiped_out";
@@ -61,6 +63,8 @@ export interface Trader {
   last_cycle_at_ms: number | null;
   cycle_lease_until_ms: number | null;
   last_cycle_at: string | null;
+  /** SeatVault tier — drives cycle cadence (Seat/CornerOffice run faster). */
+  effective_tier: SeatTierName;
   created_at: string;
   updated_at: string;
 }
@@ -92,6 +96,7 @@ function mapTrader(doc: TraderReadModel, ownerAddress: string): Trader {
     last_cycle_at: doc.lastCycleAt
       ? new Date(doc.lastCycleAt).toISOString()
       : null,
+    effective_tier: doc.effectiveTier,
     created_at: new Date(doc.createdAt).toISOString(),
     updated_at: new Date(doc.updatedAt).toISOString(),
   };

--- a/src/lib/trader-cycle.ts
+++ b/src/lib/trader-cycle.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_CYCLE_INTERVAL_MS,
   SPEED_TOKEN_CYCLE_INTERVAL_MS,
 } from "@/lib/constants";
+import { capacityForTier, type SeatTierName } from "@/lib/contracts/seatVault";
 
 /** Fields needed for cycle eligibility display (Convex trader doc subset). */
 export type TraderCycleDoc = Pick<
@@ -11,11 +12,18 @@ export type TraderCycleDoc = Pick<
 > & {
   /** Future: persisted flag when speed token applies (no contract reads). */
   speedTokenEligible?: boolean;
+  /** SeatVault tier — drives cadence (Seat/CornerOffice = faster than Gallery). */
+  effectiveTier?: SeatTierName;
 };
 
 export function resolveTraderCycleIntervalMs(trader: TraderCycleDoc): number {
   if (trader.speedTokenEligible === true) {
     return SPEED_TOKEN_CYCLE_INTERVAL_MS;
+  }
+  // Match the backend scheduler, which gates cycles on the on-chain seat tier's
+  // cadence (convex/agent/capacity.ts). Gallery falls back to the 10m default.
+  if (trader.effectiveTier) {
+    return capacityForTier(trader.effectiveTier).cycleIntervalMs;
   }
   return DEFAULT_CYCLE_INTERVAL_MS;
 }
@@ -206,6 +214,7 @@ export function traderCycleDocFromDeskSummary(summary: {
   last_cycle_at?: number;
   cycle_lease_until?: number;
   wallet_error?: string;
+  effective_tier?: SeatTierName;
 }): TraderCycleDoc {
   return {
     status: summary.status as TraderCycleDoc["status"],
@@ -213,6 +222,7 @@ export function traderCycleDocFromDeskSummary(summary: {
     lastCycleAt: summary.last_cycle_at,
     cycleLeaseUntil: summary.cycle_lease_until,
     walletError: summary.wallet_error,
+    effectiveTier: summary.effective_tier,
   };
 }
 

--- a/src/lib/trader-cycle.ts
+++ b/src/lib/trader-cycle.ts
@@ -233,6 +233,7 @@ export function traderCycleDocFromDetailTrader(trader: {
   last_cycle_at_ms: number | null;
   cycle_lease_until_ms: number | null;
   wallet_error: string | null;
+  effective_tier?: SeatTierName;
 }): TraderCycleDoc {
   return {
     status: trader.status,
@@ -240,5 +241,6 @@ export function traderCycleDocFromDetailTrader(trader: {
     lastCycleAt: trader.last_cycle_at_ms ?? undefined,
     cycleLeaseUntil: trader.cycle_lease_until_ms ?? undefined,
     walletError: trader.wallet_error ?? undefined,
+    effectiveTier: trader.effective_tier,
   };
 }


### PR DESCRIPTION
## Problem
A trader upgraded to **Corner Office** (5-minute cadence) still showed a **10-minute** countdown in the desk roster.

## Root cause
`resolveTraderCycleIntervalMs` (`src/lib/trader-cycle.ts`) only checked the never-set `speedTokenEligible` flag and otherwise returned `DEFAULT_CYCLE_INTERVAL_MS` (10 min). It ignored the seat tier entirely, so **every** trader's countdown showed 10 min regardless of tier.

This was **display-only** — the backend scheduler (`convex/agent/scheduler.ts` → `convex/agent/capacity.ts`) already gates cycles on the authoritative on-chain `tierOf`, so a Corner Office trader genuinely runs every 5 min. The UI label just didn't reflect it.

## Fix
Thread `effectiveTier` into `TraderCycleDoc` and resolve the interval via `capacityForTier(tier).cycleIntervalMs` — the same source of truth the scheduler uses (Gallery 10m, Seat/CornerOffice 5m). Desk-roster data already carries `effective_tier`, so this is a pure display correction.

## Scope / follow-up
- Fixes the **desk roster** countdown (the reported surface).
- The **trader detail** view still shows the Gallery default because `useTrader` doesn't expose the tier yet — noted as a separate follow-up (needs a small query-field addition).

## Testing
- `pnpm typecheck` clean (excluding the unrelated untracked `video/` dir), `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)