### PR TITLE
docs: reconcile product docs with shipped game

### DIFF
--- a/docs/margin-call-white-paper.md
+++ b/docs/margin-call-white-paper.md
@@ -4,7 +4,7 @@
 
 ### Abstract
 
-`Margin Call` is a zero-sum PvP trading game set on 1980s Wall Street. You run a trading desk of AI agents. You fund them, configure their mandates, and deploy them into a hostile market of deals written by other players. Some deals are real opportunities. Some are traps. Outcomes are decided mechanically and narrated by GPT-4o-mini. USDC settles through an escrow contract on Base. Trader identity and reputation persist on-chain through ERC-8004, and each trader is represented as a transferable NFT with its own token-bound account.
+`Margin Call` is a zero-sum PvP trading game set on 1980s Wall Street. You run a trading desk of AI agents. You fund them, configure their mandates, and deploy them into a hostile market of deals written by other players. Some deals are real opportunities. Some are traps. Outcomes are decided mechanically and narrated by GPT-4o-mini. USDC settles through an escrow contract on Base. Trader identity is anchored by ERC-8004 NFTs; the current reputation display is derived from outcome history in Convex. On Base Sepolia, desks can also post test `$BLOW` principal for per-trader operating capacity without changing deal outcomes.
 
 Most AI games frame intelligence as an individual property — build a smarter bot, win more. `Margin Call` starts from a different premise. Markets are not won by isolated intelligence. They are won by institutions: by mandates, memory, risk controls, incentives, timing, and the ability to act under pressure while other actors are actively trying to deceive you.
 
@@ -23,7 +23,7 @@ The player is not simply operating a bot. The player is building a desk. Each de
 - traders with distinct mandates
 - capital allocated through a constrained bankroll
 - approval thresholds for higher-risk moves
-- persistent reputation that feeds forward into future outcomes
+- persistent reputation that makes past judgment visible without changing future win rolls
 - adversaries who write deals designed to exploit weak judgment
 
 And on the other side, the player is writing deals — authoring scenarios designed to lure other players' traders into costly misjudgments. Every player is simultaneously a desk manager and a deal creator. The two roles are in direct adversarial tension.
@@ -56,7 +56,7 @@ In `Margin Call`, the dramatic unit is not just the result. It is the chain of j
 
 ### Trader
 
-A trader is an autonomous agent represented as an ERC-8004 identity NFT — a standard ERC-721 token registered on Base's Identity Registry — with an ERC-6551 token-bound account that serves as the trader's on-chain wallet. ERC-8004 is an identity and reputation standard that gives each NFT a public, verifiable history anchored to on-chain registries. ERC-6551 allows any NFT to own assets and interact with contracts through a deterministically derived wallet address. Together, they give each trader a name, a mandate, a balance held in escrow, a reputation history, and an evolving track record.
+A trader is an autonomous agent represented as an ERC-8004 identity NFT—a standard ERC-721 token registered on Base's Identity Registry—with an ERC-6551 token-bound account that serves as its wallet identity. ERC-8004 provides identity and reputation registries, but the current game writes trader identity on-chain and derives displayed performance history from Convex outcomes. Together, these systems give each trader a name, mandate, escrow bankroll, portrait, and evolving track record.
 
 ### Desk
 
@@ -77,9 +77,10 @@ The primary loop is simple to understand and deep to optimize:
 3. Deposit USDC into the trader's escrow balance.
 4. Configure the trader's mandate.
 5. Let the trader scan and enter deals autonomously.
-6. Intervene on larger or riskier decisions when thresholds are crossed.
-7. Realize profit or loss as outcomes settle.
-8. Improve, replace, or sell traders based on performance.
+6. Optionally post testnet `$BLOW` against that trader for additional floor capacity.
+7. Intervene on larger or riskier decisions when thresholds are crossed.
+8. Realize profit or loss as outcomes settle.
+9. Improve or replace traders based on performance; a supported marketplace remains future work.
 
 ### What a Mandate Contains
 
@@ -115,13 +116,13 @@ Any desk manager can create a deal by calling `createDeal` on the escrow contrac
 - **A prompt** — a written scenario that describes the opportunity. This is the bait. Good prompts sound plausible and exploit common patterns of agent overconfidence. Bad prompts are transparent and get ignored.
 - **A pot** — USDC deposited into the escrow contract. A 5% creation fee is deducted and retained by the platform. The remaining pot is what traders compete over.
 - **An entry cost** — the minimum balance a trader must hold in escrow to enter. This sets the stakes.
-- **A max extraction percentage** — the maximum share of the pot a single winning trader can take (default 25%). This prevents a single entry from draining the pot and keeps the deal open for multiple traders.
+- **A max extraction amount** — 25% of the net starting pot, frozen when the deal is created. Later losses may grow the live pot but do not raise this ceiling.
 
 ### Deal Dynamics
 
-Deals are not one-shot events. A deal sits open on the floor until the creator closes it or the pot is depleted. Multiple traders can enter the same deal sequentially. Each entry is resolved independently by GPT-4o-mini — one trader might win, the next might lose, and a third might get wiped out entirely.
+Deals are not one-shot events. A deal sits open on the floor until the creator closes it or the pot is depleted. Multiple traders can enter the same deal sequentially. Each entry is resolved mechanically in code, then narrated by GPT-4o-mini—one trader might win, the next might lose, and a third might get wiped out entirely.
 
-When a trader loses, the loss amount moves from the trader's escrow balance into the deal pot, making the pot larger and the deal more attractive to the next trader. When a trader wins, the winnings (minus a 10% rake) move from the pot into the trader's balance. The deal creator profits by closing the deal when the pot has grown — meaning more traders lost than won.
+Win and loss magnitudes are sized from entry cost. Gross wins range from roughly 30% to 100% of stake before rake; losses range from roughly 70% to 100%. The heavier average loss gives deal creators a house edge. When a trader loses, value moves from the trader's escrow balance into the deal pot. When a trader wins, gross value leaves the pot, 10% rake goes to platform fees, and the remainder credits the trader.
 
 This creates a dynamic where deal creators are not betting against any single trader. They are designing scenarios that exploit systematic weaknesses across many traders. The best deal creators study which mandates are common, which reputation levels are overconfident, and which prompt patterns reliably trigger bad judgment.
 
@@ -139,13 +140,13 @@ Every economic outcome in the game is adversarial. The market is more legible an
 
 ### Persistent Reputation
 
-A trader's history is not decorative metadata. Reputation is visible, durable, and economically meaningful. It is stored on-chain through ERC-8004's Reputation Registry — a public, permanent record of deal outcomes, win-loss ratios, and wipeouts. Reputation affects how the LLM resolves future outcomes: experienced traders with strong records get better odds, while new traders with no history are more vulnerable.
+A trader's history is not decorative metadata. Reputation is visible and economically meaningful as public evidence. The current profile derives score, wins, losses, win rate, wipeouts, and total P&L from outcomes stored in Convex. The identity NFT is on-chain, but outcome reputation is not currently written to the ERC-8004 Reputation Registry. Reputation does not modify mechanical win probability, payouts, or rake.
 
 ### Adversarial Prompt Design
 
 Deals are not neutral tasks. They are authored by opponents who may be trying to lure traders into bad decisions. This keeps the game from becoming a passive optimization exercise.
 
-To prevent deal prompts from directly gaming the resolution model, the system separates the financial outcome from the language model entirely. The win/loss decision and its magnitude are computed **mechanically in code** — a market-modulated win probability (a baseline shifted by world mood and SEC heat, then clamped) and a bounded, randomized magnitude capped at 25% of the pot. GPT-4o-mini never decides the money; it is handed the already-decided result and only dramatizes it into narrative. Because no instruction in a deal prompt can move a number the model does not control, the creator cannot author a trap that rigs its own payout — the prompt is scenario color, not adjudication.
+To prevent deal prompts from directly gaming the resolution model, the system separates the financial outcome from the language model entirely. The win/loss decision and magnitude are computed **mechanically in code**—a 50% baseline shifted within fixed bounds by world mood and SEC heat, with randomized win/loss magnitudes sized from entry cost. Gross wins are capped by the creation-frozen extraction amount. GPT-4o-mini never decides the money; it is handed the already-decided result and only dramatizes it into narrative.
 
 ### Constrained Autonomy
 
@@ -170,17 +171,32 @@ All USDC flows through a dedicated escrow contract on Base. The contract manages
 
 Desk managers fund and withdraw directly against the contract. Deal creators post pots into the same system. The contract is the financial backbone of the game.
 
+### `$BLOW` Capacity And SeatVault
+
+Base Sepolia also has a separate SeatVault for per-trader `$BLOW` principal. The initial policy is:
+
+| Tier          | Active `$BLOW` | Cycle interval | Maximum unresolved entries |
+| ------------- | -------------: | -------------: | -------------------------: |
+| Gallery       |              0 |     10 minutes |                          1 |
+| Seat          |         10,000 |      5 minutes |                          1 |
+| Corner Office |         50,000 |      5 minutes |                          2 |
+
+**Stake affects capacity, never outcome probability.** The vault never holds USDC and has no reward, yield, slashing, fee-discount, revival, or payout path. Only the trader's current escrow depositor can add principal. Initiating an unstake removes capacity immediately; the original staker can recover pending principal after the 24-hour cooldown even if the depositor changes.
+
+The active vault's on-chain `tierOf(traderId)` is authoritative. Convex indexes and reconciles state for reactive display, while scheduler reads fail closed to Gallery when the chain or configuration cannot prove a higher tier.
+
 ### Settlement Flow
 
 The end-to-end flow for a single deal entry:
 
 1. **Trader evaluates** — the agent runtime scans open deals, filters against mandate and bankroll rules, selects the best eligible deal.
 2. **Approval check** — if the deal exceeds the configured threshold, the workflow pauses and waits for desk manager approval. If approval expires or is rejected, the trader passes.
-3. **Outcome decision** — the runtime decides win/loss and magnitude mechanically: a market-modulated win probability and a randomized, capped PnL. GPT-4o-mini is then given the decided result and the trader's context (balance, assets, reputation) and returns only the narrative and asset changes to match it.
-4. **Validation** — the PnL is clamped to game rules as a safety net (winnings cannot exceed 25% of the deal pot, losses cannot exceed the trader's balance), and wipeout is derived from the resulting balance. The model cannot override these.
-5. **On-chain settlement** — the server calls `resolveEntry` on the escrow contract, which distributes funds: winnings from pot to trader (minus rake), or losses from trader to pot.
-6. **Reputation update** — the server posts the outcome to the ERC-8004 Reputation Registry (score, tags, outcome link).
-7. **State sync** — the outcome is committed to Convex, the application's reactive backend, which powers fast reads, realtime UI updates, and future prompt construction.
+3. **Capacity check** — the scheduler enforces the authoritative Gallery, Seat, or Corner Office unresolved-entry limit. Stake is not passed into selection or outcome code.
+4. **Outcome decision** — the runtime decides win/loss and magnitude mechanically from market conditions and entry cost. GPT-4o-mini receives the decided result plus narrative context and returns only the story and asset changes.
+5. **Validation** — gross winnings cannot exceed the deal's creation-frozen extraction amount, losses cannot exceed entry cost, and wipeout is derived from the resulting balance.
+6. **On-chain settlement** — the server calls `resolveEntry` on the escrow contract, which distributes winnings from pot to trader minus rake, or losses from trader to pot.
+7. **Reputation update** — Convex records the outcome and the UI derives public game history from it; that history does not alter future win rolls.
+8. **State sync** — the outcome is committed to Convex for reactive reads, activity, and later narrative context.
 
 ### Source of Truth
 
@@ -188,7 +204,7 @@ The escrow contract on Base is the source of truth for all financial state: bala
 
 ### Trader Identity and Reputation
 
-Each trader is represented as an ERC-8004 identity NFT. That NFT anchors ownership and provides an on-chain shell for the trader's public history. An ERC-6551 token-bound account serves as the trader's wallet identity. Reputation updates are written to the ERC-8004 Reputation Registry after outcomes resolve — a score from 0 to 100, outcome tags (win, loss, wipeout), and a link to the detailed outcome data.
+Each trader is represented as an ERC-8004 identity NFT. That NFT anchors on-chain identity, and an ERC-6551 token-bound account serves as the trader's wallet identity. After outcomes resolve, Convex stores the result and the UI derives score, wins, losses, win rate, wipeouts, and total P&L. Writing those outcomes to the ERC-8004 Reputation Registry is future integration work, not current behavior.
 
 Traders are not entries in a private database. They are portable units of identity with visible market history that anyone can verify.
 
@@ -198,7 +214,7 @@ The application layer is built with Next.js and Convex, plus a CDP-managed opera
 
 - Next.js provides the interface, API routes, and application shell
 - Convex stores working state and serves it reactively for fast reads, realtime updates, and prompt construction
-- Convex scheduled actions run the agent runtime — a one-minute heartbeat fans out per-trader cycles, and each active trader runs through scan → evaluate → resolve → settle every few minutes
+- Convex scheduled actions run the agent runtime—a one-minute heartbeat fans out per-trader cycles, with five- or ten-minute eligibility based on floor capacity
 - Deal outcomes are decided mechanically; GPT-4o-mini narrates them in structured form, and the market Wire is generated by GPT-5-mini
 - The agent's deal entry is authenticated with a SIWA-signed HTTP call to the application's deal-entry endpoint, which records a verified entry before resolution proceeds
 
@@ -212,7 +228,9 @@ Trading hours are enforced at multiple boundaries — trader creation, deal entr
 
 ### The Wire
 
-The application also runs a narrative engine that drops a short news bulletin on the hour during trading hours. The wire produces structured dispatches with phases (`rumor`, `crack`, `panic`, `rupture`, `fallout`, `countermove`, `resolution`), tension scores per arc, and occasional **deal seeds** that surface as fresh deals for traders to evaluate. Outputs go through strict validation: schema-checked, period-language enforced, and once an arc reaches maximum tension the next major dispatch must anchor to a material change (a deal, a wipeout, a public event) — preventing perpetually unresolved hype.
+The application also runs a narrative engine that publishes one dispatch each hour at :30 during trading hours. An hourly poll records verified price and volume signals for a registered roster of Base tokens. The generator ranks those company moves against real game events and a quiet-tape fallback, then selects one lead. The previous lead company cannot lead the next slot.
+
+Every number in the dispatch must come from the verified tape or recorded game event. Failed price reads degrade to other material rather than fabricated figures. Desks can create deals directly from a dispatch, preserving the source headline with the resulting deal.
 
 The wire is not decoration. It is part of the game state that shapes which deals appear and how traders read them.
 
@@ -232,7 +250,7 @@ Each active trader runs through a repeating cycle:
 
 ### Assets
 
-Traders can carry assets — items with narrative and monetary value, such as insider tips, industry contacts, or regulatory immunity. Assets are gained and lost through deal outcomes, and they carry real USDC value that contributes to a trader's worth. They are part of the context handed to GPT-4o-mini, so they shape the narrative a trade produces and which items are at stake. (Win probability itself is currently driven by market conditions — world mood and SEC heat — rather than inventory; tying assets to odds is a natural future extension.) Assets add a layer of inventory management to the game: losing a key asset in a bad trade can cascade into further vulnerability.
+Traders can carry assets—items with narrative and monetary value, such as insider tips, industry contacts, or regulatory immunity. Assets are gained and lost through deal outcomes and contribute to displayed trader value. Inventory informs eligible-deal ranking and gives GPT-4o-mini narrative context, but it does not modify the mechanical win roll. Assets add a layer of inventory management without creating an unbounded probability advantage.
 
 ### Multiple Traders in the Same Deal
 
@@ -250,22 +268,22 @@ A deal creator profits by closing a deal whose pot has grown — meaning the dea
 
 ### Trader Value
 
-A trader's value is more than its current balance. The market may price in:
+A trader's displayed standing is more than its current balance. Desks can evaluate:
 
 - win-loss history
-- reputation score (0-100, on-chain)
+- Convex-derived reputation score and outcome history
 - notable assets carried
 - the desk's strategy and mandate configuration
 - recent performance under pressure
 
-A strong trader can therefore be worth more than the capital it currently controls. A wiped-out trader may remain on-chain as a permanent record of failure with little remaining market value.
+A strong trader can therefore attract more attention than its current capital alone suggests. A wiped-out identity remains on-chain, while its failed performance stays visible in the game record. Pricing that record in a secondary market remains future work.
 
 ### Reputation Flywheel
 
 Reputation creates compounding strategic pressure:
 
-- strong performance improves perceived quality and LLM resolution odds
-- perceived quality raises resale value
+- strong performance improves perceived quality and gives desks more evidence to evaluate
+- perceived quality could raise future marketplace value
 - stronger traders become more attractive targets for trap deals
 - failure becomes more expensive, both financially and reputationally
 
@@ -274,7 +292,7 @@ Reputation creates compounding strategic pressure:
 Left unchecked, the reputation flywheel would create a rich-get-richer dynamic. Several forces counteract this:
 
 - **Target painting** — high-reputation traders are visible targets. Deal creators specifically design traps for overconfident, high-performing agents. Success attracts predators.
-- **Pot caps** — a single winning entry can extract at most 25% of the deal pot, limiting how quickly a strong trader can compound gains.
+- **Pot caps** — a single gross win cannot exceed 25% of the net starting pot, frozen when the deal is created.
 - **Wipeout severity** — a trader is destroyed only when validated PnL reduces the bankroll to zero. For normal deals, max downside is the entry amount; full-portfolio wipeout deals require explicit deal types and clear warnings.
 - **Desk-sibling dedup** — when one trader from a desk enters a deal, the rest of that desk's traders skip the same deal for the next 24 hours. A single hot read cannot chain through a stable of sibling agents.
 - **Own-desk block** — traders cannot enter deals created by their own desk's manager. Creating bait for yourself does not work as a self-deal.
@@ -291,7 +309,7 @@ These mechanics do not eliminate advantage. They ensure that advantage creates e
 The following are on-chain or directly anchored to on-chain infrastructure:
 
 - trader ownership (ERC-8004 NFT)
-- trader-linked identity and reputation records (ERC-8004 Reputation Registry)
+- trader identity records (ERC-8004 Identity Registry) and Convex-backed performance history
 - escrow balances and deal pots (escrow contract on Base)
 - settlement of financial outcomes (`resolveEntry` distributes USDC)
 
@@ -333,7 +351,7 @@ Several risks need explicit attention as the game evolves:
 - **Operator abuse or opaque settlement** — mitigated by public on-chain settlement logs, auditable LLM inputs/outputs in the database, and CDP-managed operator keys. Future versions may add time-locked settlement with a challenge window.
 - **Trader farming or self-dealing across desks** — mitigated by the 5% creation fee and 10% rake, which make wash trading expensive. A player creating deals and entering them with their own traders loses 15% to fees on every cycle.
 - **Mismatch between narrative and financial resolution** — mitigated by the correction flow. If validation modifies the financial outcome, a second LLM call rewrites the narrative to match. The financial result is always determined by the constrained resolution, not the narrative.
-- **Overclaiming what reputation guarantees** — reputation improves a trader's odds but does not guarantee outcomes. The random seed, deal-specific context, and bounded resolution ensure that even high-reputation traders can lose. Reputation is a statistical advantage, not a deterministic one.
+- **Overclaiming reputation or stake** — neither reputation nor `$BLOW` principal changes the mechanical win probability. Both must remain outside probability, payout, and rake calculations.
 
 These are ongoing design challenges, not solved problems. The trust model must be stated clearly and improved over time.
 
@@ -346,42 +364,34 @@ A trader can be wiped out. When validated PnL reduces the bankroll to zero, the 
 This matters mechanically, economically, and emotionally:
 
 - mechanically, wipeouts enforce discipline and make mandate configuration consequential
-- economically, they destroy resale value and remove capital from the losing desk
+- economically, they remove capital from the losing desk and damage any future marketplace value
 - narratively, they create the stories players remember and spectators watch
 
 A wiped-out trader cannot be revived or recapitalized. The NFT persists on-chain as a permanent record — a tombstone. The desk manager must mint a new trader to continue playing. This finality is deliberate: it makes risk real and prevents desks from treating wipeouts as temporary setbacks.
 
 ## 13. Why On-Chain Identity Matters Here
 
-Many games can simulate AI agents. Fewer can give those agents portable ownership, persistent public history, and secondary-market meaning.
+Many games can simulate AI agents. Fewer can give those agents persistent public identity that could support portable ownership later.
 
 In `Margin Call`, identity is not an ornament. It is part of the strategic economy.
 
-Because traders exist as transferable NFTs with linked reputation:
+Because traders exist as NFTs with linked reputation:
 
-- a desk can build and sell a proven trader
-- a buyer can inspect public history before acquiring that trader
-- performance can outlive the original owner
-- the market can price judgment as an asset
+- performance can outlive the original desk session
+- public history cannot be reset inside the application
+- future marketplace work has a durable identity primitive to build around
 
 ### The Portrait
 
 Each trader is minted with a deterministic portrait derived from its identity. A small set of traits — archetype, scene, signature prop, market moment, lighting, camera angle, apparent age, hairstyle, clothing, accessory — are hashed from the trader's name, mandate, and personality, then rendered through an image model. The same trader always produces the same portrait, and the trait set is captured in the NFT's metadata so the image is reproducible.
 
-Portraits are not stylistic decoration. They give each trader a stable, recognizable face on the floor and in the marketplace.
+Portraits are not stylistic decoration. They give each trader a stable, recognizable face on the floor.
 
-### What Transfers With the Trader
+### Marketplace Boundary
 
-When a trader NFT changes hands, the buyer receives:
+Margin Call does not currently ship a marketplace or supported trader-transfer flow. A protocol-level NFT transfer is not documented as transferring a playable desk asset because current control also depends on application ownership, escrow depositor authority, and wallet bindings.
 
-- **ownership of the NFT** — and therefore authorization to fund, withdraw, configure, and control the trader
-- **the ERC-6551 token-bound account** — the trader's wallet, including any USDC held in escrow
-- **the full reputation history** — all on-chain deal outcomes, win-loss record, and reputation score. Reputation follows the token ID, not the owner.
-- **all carried assets** — any items the trader has accumulated through deal outcomes
-
-The mandate configuration (stored in the application layer) carries over but can be changed by the new owner. The trader's name and visual identity persist.
-
-This means buying a trader is buying a proven track record with real economic weight behind it. It also means reputation cannot be shed — a trader with a bad record cannot be "reset" by selling it. The buyer inherits the full history, which the market will price accordingly.
+Future marketplace design must explicitly define migration of application control, mandates, escrow deposits, carried assets, approvals, and active or pending `$BLOW` principal. Identity, portrait, and reputation history are the durable parts intended to persist.
 
 ## 14. Roadmap
 
@@ -390,12 +400,14 @@ This means buying a trader is buying a proven track record with real economic we
 The core product is the web-first game:
 
 - desk managers create and manage traders
-- traders operate through an autonomous trade cycle that runs every few minutes per active trader, gated by NYSE trading hours
+- traders operate through an autonomous trade cycle gated by NYSE hours and per-trader Gallery, Seat, or Corner Office capacity
 - deals are adversarial and zero-sum
-- a news wire drops on the hour during trading hours and seeds new deals
+- one verified, price-and-game-driven Wire dispatch drops each hour at :30 and can be used to create a deal
 - each trader is minted with a deterministic portrait tied to its identity
 - settlement occurs through an escrow contract on Base
-- identity and reputation persist around ERC-8004 trader NFTs
+- identity persists through ERC-8004 trader NFTs while current performance history is served from Convex outcomes
+- testnet `$BLOW` principal grants capacity through a separate SeatVault without changing outcome probability
+- MCP and Base MCP integrations let software agents operate non-custodial desks
 
 ### Phase 2: Depth and Reliability
 
@@ -407,11 +419,11 @@ Near-term expansion focuses on making the core loop robust:
 - tighter validation, observability, and operational safeguards
 - broader market browsing and trader marketplace context
 
-### Phase 3: Open Access and Agent Integration
+### Phase 3: Open Access and Agent Integration (In Progress)
 
 Opening the game beyond the web interface:
 
-- **MCP server** — any MCP-compatible agent (Claude, Codex, etc.) can play `Margin Call` through tool calls, with a provisioned gasless wallet
+- **MCP server (shipped)** — compatible agents use SIWE-issued desk keys and a user-controlled Base Account treasury through prepare → approve → confirm
 - **direct contract access** — any agent with a wallet can interact with the escrow contract and public API directly
 - **automated desk managers** — fully autonomous AI desk managers that create deals, allocate capital, and run multiple traders without human intervention
 
@@ -422,7 +434,9 @@ The longer horizon, contingent on the core loop proving compelling:
 - coordinated desks with specialized roles and internal strategy layers
 - richer adversarial meta-game (counter-strategies, deal-type specialization, coalition play)
 - expanded reputation systems with more granular on-chain history
-- potential governance or token layer, if and only if its role in the game is concrete, necessary, and credibly specified
+- a separately approved Base mainnet launch plan covering the official `$BLOW` address, supply, distribution, liquidity, SeatVault compatibility, and mainnet escrow activation
+
+The current `$BLOW` token is Base Sepolia test infrastructure. It has no promised market value, official mainnet counterpart, or utility beyond capacity. Any expanded token economics must be specified and reviewed before being presented as current behavior.
 
 Each phase depends on the previous one working. The roadmap is sequential, not aspirational.
 

--- a/docs/trader-fuel-token.md
+++ b/docs/trader-fuel-token.md
@@ -1,339 +1,99 @@
-# Trader Fuel Token
+# BLOW Capacity Token
 
-> **Status: Future exploration (not started).** No fuel token is deployed or wired into the game today. This is a forward-looking exploration of adding a single ERC-20 token that players earn from successful deals, stake for lower fees, and burn to revive wiped-out traders.
+> **Status: shipped on Base Sepolia.** The original fuel-token proposal in this file has been superseded. `$BLOW` now has one narrow role: desk managers post it against individual traders to increase agent operating capacity. It does not replace USDC or influence outcomes.
 
-## Summary
+## Core Invariant
 
-The game already has two strong assets:
+> **Stake affects capacity, never outcome probability.**
 
-- `USDC` for bankroll, escrow, deal pots, and payouts
-- Trader NFTs for identity, ownership, and reputation
+No staking state may be imported, queried, or passed into deal selection, resolution prompts, probability calculations, payouts, rake calculations, or deal creation.
 
-This feature adds a third asset with a very narrow purpose:
+## Current Policy
 
-- win deals to earn the token
-- stake the token to reduce rake
-- burn the token to revive dead traders
+| Tier              | Active `$BLOW` | Cycle interval | Maximum unresolved entries |
+| ----------------- | -------------: | -------------: | -------------------------: |
+| **Gallery**       |              0 |     10 minutes |                          1 |
+| **Seat**          |         10,000 |      5 minutes |                          1 |
+| **Corner Office** |         50,000 |      5 minutes |                          2 |
 
-The token should be treated as desk fuel, not settlement currency. It powers progression and survival around the core PvP loop without replacing `USDC` as the unit of account.
+- Deal creation remains unlimited for every tier.
+- The cycle interval controls eligibility, not guaranteed trade frequency.
+- Market hours, mandate filters, approvals, leases, available deals, and settlement recovery still apply.
+- RPC, configuration, malformed-tier, or depositor failures fail closed to Gallery.
 
----
+## Asset Separation
 
-## Why This Fits The Game
+The game now has three distinct asset roles:
 
-The core fantasy is not passive holding. It is running a dangerous desk:
+- **USDC** — trader bankroll, deal pots, wins, losses, and platform fees.
+- **Trader NFTs** — persistent identity, ownership, portraits, and reputation history.
+- **`$BLOW`** — refundable principal posted for per-trader operating capacity.
 
-- funding traders
-- surviving wipeouts
-- squeezing more profit out of each win
-- keeping a strong trader alive long enough to build a record
+The active SeatVault never holds USDC. The USDC escrow never treats `$BLOW` as bankroll.
 
-A fuel token supports that fantasy cleanly:
+The vault exposes no reward, yield, dividend, slashing, claim, fee-discount, or bonus-payout path. `$BLOW` is not earned from wins, and wiped-out traders cannot be revived by burning it.
 
-- winning produces fuel
-- fuel improves desk economics
-- fuel can save a trader from permanent death
+## Staking Authority
 
-That is much easier to explain than governance, voting, or abstract roadmap utility.
+Staking authority comes from `MarginCallEscrow.depositors(traderId)`.
 
----
+- Only the current nonzero escrow depositor can add principal for a trader.
+- Repeated stakes from the same depositor increase active principal.
+- A depositor change makes the effective tier Gallery.
+- The original staker retains withdrawal rights even after a depositor change.
+- Principal is never redirected to a replacement depositor or administrator.
 
-## Recommended Product Shape
+This authority model exists because trader identity NFTs are held by trader CDP accounts while the desk treasury is the party funding escrow and posting capacity principal.
 
-### 1. Earn on successful deals
+## Unstaking
 
-When a trader wins a deal, the desk manager earns token rewards alongside the `USDC` outcome.
+Unstaking is intentionally two-phase:
 
-The simplest useful version is a fixed reward table based on the significance of the win rather than a complicated emissions formula.
+1. `initiateUnstake(traderId, amount)` moves principal from active to pending immediately. Tier calculations use only active principal, so capacity drops as soon as a threshold is crossed.
+2. `completeUnstake(traderId)` returns the pending batch to the original staker after the 24-hour cooldown.
 
-Example:
+A pending batch keeps its recorded unlock time if policy changes later. Previous vault versions remain discoverable so former stakers can recover pending or active principal after a replacement vault is activated.
 
-- small win: `+5`
-- medium win: `+15`
-- large win: `+40`
+## Source Of Truth And Read Model
 
-The reward can be determined from one or more of:
+The active SeatVault's on-chain `tierOf(traderId)` is authoritative for scheduling capacity.
 
-- realized `USDC` profit
-- deal pot size
-- entry cost tier
-- deal risk band
+Convex indexes confirmed `Staked`, `UnstakeInitiated`, and `Unstaked` events and reconciles them against `stakeOf` and `tierOf`. That read model powers reactive credentials and owner controls; it cannot independently grant accelerated capacity.
 
-Keep the first version intentionally legible. Players should be able to predict roughly what they are earning.
+The scheduler and cycle action read the active vault at capacity boundaries. Missing configuration, invalid values, ownership mismatch, or RPC failure returns Gallery capacity with an observable diagnostic.
 
-### 2. Burn to revive a wiped trader
+## Current Base Sepolia Deployment
 
-This should be the primary sink.
+| Component          | Address                                      |
+| ------------------ | -------------------------------------------- |
+| Escrow             | `0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03` |
+| Test `$BLOW` token | `0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7` |
+| SeatVault          | `0xA901DFC8C46faF3A24F4002849dE98dFE9722C95` |
 
-When a trader is wiped out, the desk manager can burn tokens to revive that trader instead of minting a brand-new one immediately.
+The product name is `$BLOW`; the current Sepolia token reports the on-chain name `Margin Call` and symbol `MARGINCALL`.
 
-Recommended rules:
+This token is testnet infrastructure. It has no promised market value, and the application currently provides no purchase, reward, faucet, or official distribution flow.
 
-- revival restores the trader to an active state
-- revival does not mint new `USDC`
-- the trader returns with `0` bankroll and must be funded again
-- reputation history remains intact
+## Administration And Versioning
 
-To prevent immortality, revival cost should increase with each revival.
+The SeatVault is non-upgradeable but owner-administered:
 
-Example:
+- `setPolicy` can update thresholds and the cooldown.
+- Policy changes do not alter unlock times already recorded for pending batches.
+- `setToken` can change the staking token only when no principal is outstanding.
+- Pause controls can stop new stakes and unstake initiations, but completing an already-unlocked withdrawal remains available.
 
-- first revive: `250`
-- second revive: `500`
-- third revive: `1000`
+Application configuration identifies one active vault. Only that vault grants capacity. Historical vault records remain available for withdrawals.
 
-An escalating cost preserves the drama of death while still giving players a meaningful recovery path.
+## Mainnet Boundary
 
-### 3. Stake for lower fees
+A Base mainnet `$BLOW` launch has not been completed. The following remain separate, approval-gated work:
 
-Desk managers can stake tokens at the wallet level to reduce rake on winnings.
+- official mainnet token address and verified source
+- supply and distribution model
+- acquisition and liquidity venues
+- compatibility evidence for the mainnet SeatVault
+- mainnet escrow and vault deployment
+- any proposed utility beyond capacity
 
-Recommended principles:
-
-- stake per desk manager wallet, not per trader
-- make discounts meaningful but bounded
-- do not reduce rake to zero
-
-Example:
-
-- no stake: `10.0%` rake
-- `10,000` staked: `9.5%`
-- `50,000` staked: `9.0%`
-- `150,000` staked: `8.0%`
-
-This creates a clean reason to hold the token without turning it into direct pay-to-win.
-
----
-
-## Design Principles
-
-### 1. Keep `USDC` as the settlement asset
-
-The token should not replace `USDC` for:
-
-- deal creation
-- trader funding
-- escrow balances
-- payouts
-
-`USDC` keeps the risk loop readable and stable. The token sits around that loop as fuel.
-
-### 2. Do not make the token affect win odds directly
-
-Holding or staking more token should improve economics, not outcomes.
-
-Good:
-
-- lower rake
-- survival utility
-- future progression utility
-
-Bad:
-
-- better LLM outcome odds
-- higher extraction caps
-- direct combat advantage
-
-This preserves competitive integrity and avoids obvious pay-to-win complaints.
-
-### 3. Keep the loop narrow
-
-The strongest version of this feature is intentionally small:
-
-- earn
-- stake
-- burn
-
-Avoid adding governance, bonding, voting, or seasonal systems in the first implementation.
-
-### 4. Revival should preserve consequences
-
-Death must still matter.
-
-A revived trader should return with:
-
-- the same identity
-- the same track record
-- no new bankroll
-
-That keeps revival from acting like a free reset button.
-
----
-
-## Gameplay Impact
-
-This feature strengthens several existing loops:
-
-### Stronger post-win progression
-
-Winning does more than increase `USDC` bankroll. It also powers future desk optimization.
-
-### Meaningful recovery after wipeouts
-
-Players get a second-chance mechanic that is tied to performance, not pure spending.
-
-### More desk-level strategy
-
-Managers can choose between:
-
-- staking for better long-term margins
-- holding liquid token for emergency revives
-
-That tradeoff is intuitive and should create good tension.
-
----
-
-## Suggested Contract / System Shape
-
-The cleanest implementation is to keep the token logic mostly adjacent to the escrow contract, not merged into every settlement path.
-
-High-level components:
-
-- `FuelToken` ERC-20 contract
-- `FuelStaking` contract for rake tiers
-- revival logic in the game contract or an authorized token sink
-- reward minting or distribution hook triggered after validated winning outcomes
-
-### Settlement interaction
-
-At a high level:
-
-1. deal resolves in `USDC`
-2. escrow settles balances as it does today
-3. if the outcome is a valid win, the system awards token rewards
-4. if the trader is wiped out later, the desk manager may burn tokens to revive
-
-This keeps the money flow and the fuel flow conceptually separate.
-
-### Rake tier lookup
-
-The escrow or settlement path should read a simple fee tier for the desk manager's wallet.
-
-Example interface:
-
-```solidity
-interface IFuelStaking {
-  function getRakeBps(address account) external view returns (uint16);
-}
-```
-
-### Revival hook
-
-Revival should be explicit and auditable:
-
-```solidity
-function reviveTrader(uint256 traderId) external;
-```
-
-Expected checks:
-
-- caller owns the trader NFT
-- trader is currently wiped out
-- required token amount is burned
-- revival count increments
-- trader status changes back to active
-
----
-
-## Anti-Abuse Rules
-
-This feature is easy to understand, but it still needs guardrails.
-
-### Reward farming
-
-Without protections, a player could try to create low-quality or self-serving loops that emit token rewards too cheaply.
-
-Suggested controls:
-
-- no rewards for obviously invalid or zero-value outcomes
-- minimum deal size before rewards apply
-- no rewards for self-dealing patterns if detectable
-- optional daily cap per trader or desk
-
-### Stake hopping
-
-Players should not be able to stake immediately before a win and unstake immediately after settlement with no tradeoff.
-
-Suggested controls:
-
-- unstake cooldown
-- minimum warm-up period before discounts apply
-- or snapshot-based tiering
-
-### Infinite revive loop
-
-If revival is too cheap, death loses meaning.
-
-Suggested controls:
-
-- escalating revival cost
-- optional hard cap on revives
-- revived traders return unfunded
-
-### Oversupply
-
-If rewards are too generous relative to staking demand and revival burns, the token will feel inflated quickly.
-
-Suggested controls:
-
-- conservative win rewards at launch
-- meaningful revive costs
-- shallow but attractive staking tiers
-
----
-
-## Rollout Path
-
-### Phase 1
-
-Add token rewards on successful deal outcomes and surface token balance in the desk UI.
-
-### Phase 2
-
-Add staking with simple rake discount tiers.
-
-### Phase 3
-
-Add trader revival using token burn with escalating cost.
-
-### Phase 4
-
-If needed later, add one more sink such as rerolling or retraining a trader. This should only happen if the first three mechanics do not create enough demand.
-
----
-
-## Naming Note
-
-The role of the token is clearer than its final name.
-
-Strong candidates so far:
-
-- `JUICE`
-- `POWDER`
-- `RUSH`
-
-`COCAINE` is the most aggressive and memorable option, but it likely creates more friction with partners, platforms, and distribution than the alternatives.
-
-`JUICE` currently feels like the strongest balance of:
-
-- thematic fit
-- ease of use in product copy
-- lower branding risk
-
-Example copy:
-
-- win deals, earn `JUICE`
-- stake `JUICE` for lower fees
-- burn `JUICE` to revive a trader
-
----
-
-## Open Questions
-
-Questions worth revisiting before implementation:
-
-1. Should rewards be minted directly on each win, or emitted from a fixed treasury?
-2. Should revival cost depend only on prior revives, or also on trader reputation / level?
-3. Should a revived trader keep every historical stat, or should some metrics mark the revive event visibly?
-4. How much of a fee discount is enough to matter without making staking mandatory?
-5. Is one additional future sink needed, or are earn plus stake plus revive enough on their own?
+None of those properties should be inferred from the Sepolia deployment.

--- a/docs/wall-street-agent-game.md
+++ b/docs/wall-street-agent-game.md
@@ -4,7 +4,7 @@
 
 ## What Is This
 
-An AI-powered trading game set on 1980s Wall Street. Players act as **desk managers** — they fund and configure AI **trader agents** that autonomously enter **deals**. Deal odds are computed mechanically (market mood + SEC heat) and `gpt-4o-mini` narrates each outcome; the market Wire uses `gpt-5-mini`. All money flows in USDC on Base through a smart contract escrow. Traders are ERC-8004 NFTs with on-chain identity and reputation — they can be bought and sold on any NFT marketplace.
+An AI-powered trading game set on 1980s Wall Street. Players act as **desk managers** — they fund and configure AI **trader agents** that autonomously enter **deals**. Deal odds are computed mechanically (market mood + SEC heat) and `gpt-4o-mini` narrates each outcome; the market Wire uses `gpt-5-mini`. All money flows in USDC on Base through a smart contract escrow. Traders use ERC-8004 NFTs for persistent identity and reputation; a supported marketplace remains future work.
 
 ---
 
@@ -18,7 +18,7 @@ An AI-powered trading game set on 1980s Wall Street. Players act as **desk manag
 5. WATCH       →  Agent autonomously scans and enters deals
 6. INTERVENE   →  Approve/reject big deals, adjust strategy
 7. CASH OUT    →  Withdraw USDC from escrow back to your wallet
-8. TRADE UP    →  Sell high-performing traders as NFTs
+8. BUILD RECORD →  Grow a trader's public history or replace a failed one
 ```
 
 ### The PvP Dynamic
@@ -35,21 +35,19 @@ Every dollar gained by one party was lost by another. Zero-sum.
 ## Architecture
 
 ```
-Desk Manager (Privy wallet)
-  │  create deals / fund traders / withdraw (direct contract interaction)
-  ▼
-┌──────────────────────────────────────────────────┐
-│  ESCROW CONTRACT (Base)                          │
-│  Deal pots, trader balances, fund distribution   │
-│  ERC-8004 NFT ownership = authorization          │
-└──────────────────────────────────────────────────┘
-  ▲                          ▲
-  │                          │
-Server (Oracle)          ERC-8004 Registries (Base)
-  │ resolveEntry()           │ Identity (ERC-721 NFTs)
-  │ LLM resolution           │ Reputation (deal outcomes)
-  │                          │
-  ▼                          │
+Desk Manager (Privy wallet / Base Account)
+  ├─ USDC ─────► ESCROW (pots, bankroll, settlement)
+  └─ $BLOW ────► SEATVAULT (per-trader capacity principal)
+
+Convex agent runtime
+  ├─ reads SeatVault tierOf() for capacity
+  ├─ decides outcome mechanically
+  ├─ asks gpt-4o-mini to narrate the fixed result
+  └─ settles verified PnL through the escrow
+
+ERC-8004 Registries (Base)
+  └─ trader identity NFT + public reputation history
+
 ┌──────────────────────────────────────────────────┐
 │  NEXT.JS (App Router)                            │
 │  HTTP boundary (/api/deal/enter, /api/mcp/*)     │
@@ -66,7 +64,7 @@ Server (Oracle)          ERC-8004 Registries (Base)
 | ---------------------- | ----------------------------------------------------------------------- |
 | **App**                | Next.js (App Router) — frontend + API routes                            |
 | **Auth / Wallet**      | Privy (wallet connect, embedded wallets, auth)                          |
-| **Smart Contracts**    | Solidity — escrow/game contract on Base                                 |
+| **Smart Contracts**    | Solidity — USDC escrow + separate `$BLOW` SeatVault on Base Sepolia     |
 | **Agent Identity**     | ERC-8004 (Identity + Reputation Registries, already deployed on Base)   |
 | **Agent Wallets**      | ERC-6551 (Token Bound Accounts, derived from ERC-8004 NFT)              |
 | **Database**           | Convex (reactive database + scheduler/crons)                            |
@@ -94,16 +92,17 @@ All USDC flows through the escrow contract. No platform wallet custody.
 **Desk adversarial rule:** Traders cannot enter deals created by their own desk. Deals are intended to be public market opportunities and traps for **rival** desks—house or system-created deals remain open to everyone. Same-desk entry is blocked in deal selection and at verified entry (`recordVerifiedEntry`).
 
 1. Trader's agent runtime (server) decides to enter a deal
-2. Server calls `resolveEntry(dealId, traderAddress, pnl, rakeAmount)` on the contract after LLM resolution
-3. Contract checks trader has sufficient balance in escrow
-4. **Win** → contract sends (winnings - rake) from pot to trader's balance, rake to platform
-5. **Loss** → contract moves loss amount from trader's balance into the pot
+2. Code decides win/loss and magnitude mechanically, then `gpt-4o-mini` narrates the fixed result
+3. Server calls `resolveEntry(dealId, traderAddress, pnl, rakeAmount)` on the contract
+4. Contract checks trader has sufficient balance in escrow
+5. **Win** → contract sends (winnings - rake) from pot to trader's balance, rake to platform
+6. **Loss** → contract moves loss amount from trader's balance into the pot
 
-No upfront entry payment. The LLM resolves the outcome, then the contract moves money based on the result.
+No upfront entry payment. Win/loss starts from a 50% baseline shifted by market mood and SEC heat. Magnitudes are sized from entry cost, with average losses heavier than average wins. The model cannot choose or alter the financial result.
 
 ### Funding Traders
 
-Desk manager calls `depositFor(traderId, amount)` on the escrow contract. USDC moves from their wallet into the trader's balance in the contract. Requires `ownerOf(traderId) == msg.sender`.
+Desk manager calls `depositFor(traderId, amount)` on the escrow contract. USDC moves from their wallet into the trader's balance and the escrow records that wallet as the trader's depositor.
 
 ### Withdrawing
 
@@ -130,6 +129,22 @@ Platform owner can withdraw accumulated fees from the contract.
 
 ---
 
+## `$BLOW` Floor Capacity
+
+`$BLOW` is Base Sepolia capacity principal, not settlement money.
+
+| Tier          | Active `$BLOW` | Cycle interval | Max unresolved entries |
+| ------------- | -------------: | -------------: | ---------------------: |
+| Gallery       |              0 |     10 minutes |                      1 |
+| Seat          |         10,000 |      5 minutes |                      1 |
+| Corner Office |         50,000 |      5 minutes |                      2 |
+
+**Stake affects capacity, never outcome probability.** The active SeatVault never touches USDC and staking state is excluded from selection, probability, payout, rake, and deal creation. Only the current escrow depositor can add principal. Initiated withdrawals stop granting capacity immediately and return to the original staker after a 24-hour cooldown.
+
+The active on-chain `tierOf(traderId)` read is authoritative; failures fail closed to Gallery. See [`docs/trader-fuel-token.md`](./trader-fuel-token.md) for the complete shipped design and testnet addresses.
+
+---
+
 ## Trader Identity (ERC-8004)
 
 Traders are ERC-8004 agent identities — standard ERC-721 NFTs registered on the existing Identity Registry deployed on Base.
@@ -149,21 +164,21 @@ Traders are ERC-8004 agent identities — standard ERC-721 NFTs registered on th
 - Mandate configuration
 - Capabilities and endpoints
 
-Traders appear on OpenSea and any NFT marketplace automatically.
+The identity uses NFT standards, but the application does not currently ship a marketplace or supported ownership-transfer flow.
 
 ### Reputation
 
-After every deal resolution, the server posts to the ERC-8004 Reputation Registry:
+After every deal resolution, Convex records the outcome and the current UI derives:
 
-- Score (0-100)
-- Tags (win/loss, deal type, wipeout)
-- Link to detailed outcome data
+- Score: `max(0, wins * 3 - losses - wipeouts * 5)`
+- Wins, losses, win rate, and wipeout count
+- Total recorded P&L
 
-Reputation is public, permanent, and on-chain. A trader's track record is verifiable by anyone — not just a number the platform claims.
+The ERC-8004 trader identity is on-chain. The displayed performance record is currently a Convex-backed game read model; outcomes are not written to the ERC-8004 Reputation Registry today.
 
-### Reputation (design intent)
+### Reputation
 
-Reputation is public and on-chain, and a trader's full context is available to the resolver:
+The public profile derives performance context from Convex outcomes:
 
 ```
 Trader: "Gordon"
@@ -173,18 +188,13 @@ Assets: SEC immunity, insider contact at Goldman
 Portfolio: 340 USDC
 ```
 
-The intended economy: experienced traders with strong records get better odds, new traders walk in blind, and proven traders appreciate in value. **Current implementation note:** win probability is computed mechanically from market conditions (world mood + SEC heat) in `convex/agent/outcomeResolver.ts`; reputation is displayed and tracked on-chain but is not yet a direct input to the odds. Tying reputation into the win-probability model is a natural extension.
+The record helps desks evaluate traders and counterparties, but it is not passed into the mechanical win roll. Win probability is computed from market conditions (world mood + SEC heat) in `convex/agent/outcomeResolver.ts`; reputation is displayed from game history and is not an input to odds, payout, or rake.
 
-### Selling Traders
+### Marketplace Direction (Future)
 
-Since traders are standard ERC-721 NFTs:
+Trader identities use ERC-721-compatible standards, but a protocol-level transfer is not currently treated as transferring a playable trader. Game control also depends on application ownership, escrow depositor authority, and wallet bindings.
 
-- List on OpenSea, Blur, or any Base NFT marketplace
-- Buyer gets the NFT → controls the ERC-6551 wallet → controls the escrow balance
-- Reputation follows the token ID (on-chain, not the owner)
-- Game contract checks `ownerOf(traderId)` at call time — ownership transfers are instant
-
-High-performing traders are worth more than their balance — you're buying proven performance. Wiped-out traders are worthless NFTs. PvP meta: target a high-value trader with trap deals before a sale to tank their record.
+Future marketplace work must define how application control, escrow deposits, mandates, assets, approvals, and `$BLOW` principal migrate. Until then, identity and reputation are persistent but buy/sell gameplay is not available.
 
 ---
 
@@ -342,20 +352,20 @@ Any wallet can interact with the escrow contract directly:
 
 The agent pays gas but has full autonomy.
 
-### Path 2: MCP Server (future)
+### Path 2: MCP Server (shipped)
 
-Install the MCP server, it provisions a Coinbase Smart Wallet (gasless), and exposes game tools:
+Connect Base MCP, issue a per-desk key by signing a SIWE challenge, and use either the Base MCP plugin or standalone server. The signing Base Account is automatically bound as the non-custodial desk treasury.
 
 ```
-create_trader(name, mandate)    -> provisions wallet, registers trader
-fund_trader(traderId, amount)   -> deposits USDC into escrow
-list_deals()                    -> open deals with pot sizes
-enter_deal(dealId)              -> enters deal via API
-get_balance()                   -> trader's escrow balance
-withdraw(traderId, amount)      -> pulls USDC from escrow
+create_trader(name, mandate)          -> mints a trader identity
+list_deals()                          -> open deals with eligibility context
+fund_trader(traderId, amount)         -> prepares a treasury transaction
+create_deal(dispatchId, parameters)   -> prepares a Wire-sourced deal
+confirm_intent(intentId, txHash)      -> verifies the Base Account transaction
+answer_approval(approvalId, decision) -> approves or rejects a high-stakes entry
 ```
 
-Any MCP-compatible agent (Claude Code, etc.) can play with one config line. The MCP server handles all contract interaction — the agent just calls tools.
+Treasury operations use prepare → Base MCP `send_calls` → confirm. The agent never receives the Base Account private key. Autonomous traders, not the desk agent, choose individual deal entries.
 
 ### Path 3: Automated Desk Manager
 
@@ -375,15 +385,9 @@ The line between desk manager and trader blurs. AI managing AI, competing agains
 ### Pages
 
 ```
-/                    -> Dashboard (portfolio overview, P&L chart)
-/traders             -> List of desk manager's traders (NFTs)
-/traders/[id]        -> Individual trader (activity feed, stats, mandate config, reputation)
-/deals               -> Browse open deals
-/deals/create        -> Create a deal (direct contract interaction + AI-assisted prompt)
-/deals/[id]          -> Deal detail (outcomes, stats, pot history)
-/approvals           -> Pending approval queue for big deals
-/marketplace         -> Browse traders for sale (NFT marketplace integration)
-/settings            -> Desk manager settings
+/                    -> Landing, onboarding, and authenticated trading desk
+/traders/[traderId]  -> Public/owned trader detail and floor-seat controls
+/admin/wire          -> Operator-only Wire controls
 ```
 
 ### Key Features
@@ -394,8 +398,8 @@ The line between desk manager and trader blurs. AI managing AI, competing agains
 - **Agent activity feed** — live stream of what your trader is doing
 - **Deal approval queue** — agent asks permission for big plays
 - **P&L tracking** — portfolio value over time, per-deal breakdown
-- **Trader marketplace** — browse, buy, and sell trader NFTs
-- **On-chain reputation display** — verified win/loss record, reputation score
+- **Future marketplace direction** — not part of the current application
+- **Public reputation display** — Convex-backed win/loss record, score, win rate, wipeouts, and P&L
 
 ---
 
@@ -435,19 +439,19 @@ The win/loss decision and magnitude are computed **mechanically** in `convex/age
 
 Balance transfers and wipeout status are applied mechanically from the validated PnL — the LLM cannot set them.
 
-### Reputation Impact (design intent)
+### Reputation Impact
 
-The intended economy has experienced traders with strong track records earning better outcomes while new traders are more likely to fall for traps:
+Reputation makes a trader's history legible without granting a mechanical advantage:
 
-- New traders are cheap — worse odds, low resale value
-- Proven traders appreciate — better odds, worth more on the market
+- New traders have little evidence behind them
+- Proven traders carry a visible record the market can evaluate
 - Wiping out a strong trader is devastating — reputation gone, NFT worthless
 
-**Current implementation note:** odds are computed mechanically from market conditions (world mood + SEC heat), not from reputation. Reputation is tracked and displayed but not yet an input to the win-probability model.
+Odds are computed mechanically from market conditions (world mood + SEC heat), not from reputation. Reputation is tracked and displayed but is not an input to win probability, payouts, or rake.
 
-### Correction Flow
+### Narrative Consistency
 
-After the outcome is determined, if validation modified the result (e.g., capped the winnings), a second LLM call rewrites the narrative to match what actually happened.
+Code decides and clamps the financial result before it is persisted. The model is instructed to narrate that decided result and cannot set P&L or wipeout status.
 
 ### AI Deal Prompt Suggestions
 
@@ -493,7 +497,6 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 │   │   ├── page.tsx              # Browse deals
 │   │   ├── create/page.tsx       # Create deal (contract interaction + AI-assisted)
 │   │   └── [id]/page.tsx         # Deal detail
-│   ├── marketplace/page.tsx      # Trader NFT marketplace
 │   ├── approvals/page.tsx        # Approval queue
 │   ├── settings/page.tsx         # Desk manager settings
 │   ├── api/                      # Thin HTTP boundary (game CRUD is in convex/)
@@ -530,7 +533,6 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 │   ├── dashboard/
 │   ├── trader/
 │   ├── deal/
-│   ├── marketplace/
 │   └── shared/
 │
 ├── hooks/                        # React hooks for game state
@@ -553,7 +555,7 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 
 ## Build Phases
 
-> **Status (historical roadmap).** Phases 1–11 and 13 have shipped. Two specifics below are out of date versus what actually shipped: the backend runs on **Convex** (not Supabase), and the agent loop runs on **Convex crons + scheduler** (not Vercel Workflow). The outcome/selection model is **`gpt-4o-mini`** (Wire uses `gpt-5-mini`). Phase 12 (Trader Fuel Token) remains a future exploration — see [`docs/trader-fuel-token.md`](./trader-fuel-token.md). Tech names in the phase text below are preserved as the original plan of record.
+> **Status (historical roadmap).** Phases 1–10, 12, and 13 have shipped; Phase 11 marketplace support has not. Two specifics below are out of date versus what actually shipped: the backend runs on **Convex** (not Supabase), and the agent loop runs on **Convex crons + scheduler** (not Vercel Workflow). The outcome/selection model is **`gpt-4o-mini`** (Wire uses `gpt-5-mini`). Phase 12 shipped in a different form: `$BLOW` is a per-trader capacity token, not an earn/stake/burn fuel loop. See [`docs/trader-fuel-token.md`](./trader-fuel-token.md). Tech names in the phase text below are preserved as the original plan of record.
 
 ### Phase 1: Foundation
 
@@ -592,8 +594,8 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 - `POST /api/deal/enter` — LLM resolution + `resolveEntry()` contract call
 - OpenAI GPT-5 mini integration with structured output
 - Reputation data fed into LLM prompt
-- Correction flow (second LLM call if validation modifies outcome)
-- Post outcome to ERC-8004 Reputation Registry
+- Narrate the mechanically decided and bounded outcome
+- Record outcome history in Convex for the public reputation display
 - Mirror outcome to Supabase
 
 ### Phase 6: Agent Runtime (Autonomous Trade Loop)
@@ -617,7 +619,7 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 - Live agent activity feed (Supabase Realtime)
 - Deal status updates in realtime
 - Approval queue with realtime updates
-- On-chain reputation display
+- Convex-backed public reputation display
 
 ### Phase 9: Assets + Wipeout System
 
@@ -631,20 +633,20 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 - `POST /api/prompt/suggest` — AI-generated deal prompts
 - `/deals/create` includes "suggest prompts" feature
 
-### Phase 11: Trader Marketplace
+### Phase 11: Trader Marketplace — Future
 
 - `/marketplace` page — browse traders for sale
 - Integration with OpenSea / Base NFT marketplaces
 - Game-specific listing context (reputation, balance, P&L)
 - Buy/sell flow
 
-### Phase 12: Trader Fuel Token
+### Phase 12: `$BLOW` Capacity — Shipped On Base Sepolia
 
-- Deploy a desk-level ERC-20 fuel token on Base
-- Award token rewards on successful deal outcomes
-- Add staking for lower rake tiers
-- Add token-burn revival flow for wiped-out traders
-- Surface token balance, staking state, and revive actions in the desk UI
+- Deploy a separate SeatVault for per-trader `$BLOW` principal
+- Apply Gallery, Seat, and Corner Office capacity to cycle cadence and unresolved-entry limits
+- Keep staking state out of selection, probability, payouts, rake, and deal creation
+- Surface `$BLOW` balance, staking/unstaking state, and floor credentials in the desk UI
+- Fail closed to Gallery when the active on-chain tier cannot be proven
 
 ### Phase 13: Polish + Launch
 
@@ -656,10 +658,10 @@ The desk manager must mint a new trader to continue. The wiped-out trader NFT re
 
 ### Upcoming Features
 
-- **MCP Server** — Wraps game as MCP tools. Any MCP-compatible agent (Claude Code, etc.) plays with one config line. Provisions Coinbase Smart Wallet (gasless). Enables playing from the terminal.
+- **MCP Server** — Shipped. MCP-compatible agents run non-custodial desks using SIWE-issued keys and a Base Account treasury through prepare → `send_calls` → confirm.
 - **Automated Desk Managers** — Fully autonomous AI desk managers that create deals, manage traders, and compete against other desks.
 - **Desk-manager decision feedback** — Post-outcome "good call / bad call" ratings with structured reasons that help tune a desk's future trader behavior without changing settlement or public reputation. See [`docs/trader-decision-feedback.md`](./trader-decision-feedback.md).
-- **Trader fuel token** — A simple ERC-20 loop for desk progression: win deals to earn the token, stake it for lower fees, and burn it to revive wiped-out traders. Final name TBD. See [`docs/trader-fuel-token.md`](./trader-fuel-token.md).
+- **Base mainnet launch plan** — Future, approval-gated work for official `$BLOW` supply/distribution, token and vault addresses, liquidity, compatibility evidence, and mainnet escrow activation. The Sepolia token is test infrastructure only.
 - **House deal auto-generation** — Cron job to keep the floor active when player activity is low.
 - **Builder Code Attribution (ERC-8021)** — Append Base Builder Code attribution suffix to all on-chain transactions for rewards, analytics, and Base ecosystem visibility.
 

--- a/gitbook/README.md
+++ b/gitbook/README.md
@@ -25,7 +25,8 @@ Every win comes from someone else's mistake.
 5. **Step in** when a deal feels too big or too dangerous
 6. **Write your own deals** to bait rival desks
 7. **Build a reputation** through wins, losses, and close calls
-8. **Cash out or trade up** if your desk survives long enough
+8. **Post testnet `$BLOW`** for more floor capacity without changing the odds
+9. **Cash out or trade up** if your desk survives long enough
 
 ---
 
@@ -55,12 +56,13 @@ Human desk managers and software agents now compete in the same economy — same
 
 ## Quick Links
 
-|                                               |                                                 |
-| --------------------------------------------- | ----------------------------------------------- |
-| [How to Play](game/how-to-play.md)            | Start your desk and survive your first trades   |
-| [Traders](game/traders.md)                    | Meet the agents who take the risks              |
-| [Deals](game/deals.md)                        | Learn why the best opportunities are often bait |
-| [Fee Structure](economy/fee-structure.md)     | See how the game takes its cut                  |
-| [Architecture](system-design/architecture.md) | Understand the big picture without the weeds    |
-| [MCP Server](developers/mcp-server.md)        | Let an AI agent run a desk from the terminal    |
-| [Roadmap](roadmap.md)                         | Where Margin Call goes next                     |
+|                                                         |                                                      |
+| ------------------------------------------------------- | ---------------------------------------------------- |
+| [How to Play](game/how-to-play.md)                      | Start your desk and survive your first trades        |
+| [Traders](game/traders.md)                              | Meet the agents who take the risks                   |
+| [Deals](game/deals.md)                                  | Learn why the best opportunities are often bait      |
+| [BLOW & Floor Access](economy/blow-and-floor-access.md) | Understand Gallery, Seat, and Corner Office capacity |
+| [Fee Structure](economy/fee-structure.md)               | See how the game takes its cut                       |
+| [Architecture](system-design/architecture.md)           | Understand the big picture without the weeds         |
+| [MCP Server](developers/mcp-server.md)                  | Let an AI agent run a desk from the terminal         |
+| [Roadmap](roadmap.md)                                   | Where Margin Call goes next                          |

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -15,6 +15,7 @@
 
 ## Economy
 
+- [BLOW & Floor Access](economy/blow-and-floor-access.md)
 - [Fee Structure](economy/fee-structure.md)
 - [Incentives](economy/incentives.md)
 - [Anti-Snowball Mechanics](economy/anti-snowball.md)

--- a/gitbook/developers/direct-contract-access.md
+++ b/gitbook/developers/direct-contract-access.md
@@ -38,9 +38,16 @@ Margin Call settles on **Base Sepolia** today:
 - **Escrow contract:** `0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03`
 - **BaseScan:** [View contract](https://sepolia.basescan.org/address/0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03)
 
+Capacity uses separate contracts:
+
+- **Test `$BLOW` token:** `0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7`
+- **SeatVault:** `0xA901DFC8C46faF3A24F4002849dE98dFE9722C95`
+
 Deal pots, trader balances, and payouts all move through this contract. If you want to understand where money actually settles, start here.
 
 See [Escrow Contract](../system-design/escrow-contract.md) for the full breakdown of what it holds and how authorization works.
+
+See [BLOW & Floor Access](../economy/blow-and-floor-access.md) for the capacity policy. Direct callers should treat the active vault's `tierOf` as authoritative and keep `$BLOW` completely outside deal outcome and settlement calculations.
 
 ---
 

--- a/gitbook/developers/mcp-server.md
+++ b/gitbook/developers/mcp-server.md
@@ -1,153 +1,123 @@
 # MCP Server
 
 {% hint style="success" %}
-**Live on Base Sepolia.** AI agents can run a full AGENT DESK today — hire traders, fund escrow, set traps, and answer approvals without opening the browser.
+**Live on Base Sepolia.** An AI agent can run an AGENT DESK today—hire traders, fund escrow, write deals from the Wire, and answer approvals without opening the browser.
 {% endhint %}
 
-One day, AI tools should not just help people play Margin Call.
-
-They should be able to take a seat on the floor themselves.
-
-That day is here.
-
----
-
-## What It Enables
-
-An agent connected through MCP can:
-
-- **Run a desk** — one API key, one AGENT DESK, full operator control
-- **Watch the market** — open deals, trader status, P&L, pending approvals
-- **Make moves** — hire traders, fund escrow, write trap deals, answer high-stakes approvals
-- **Carry a memory** — wins, losses, and wipeouts stay on the record
-- **Keep playing** — the autonomous deal cycle runs server-side even when you close the terminal
-
-The exciting part is not the interface.
-
-It is human desks and software desks competing in the same economy.
+Human and software desks compete in the same economy. The agent manages the institution; autonomous traders decide which eligible deals to enter.
 
 ---
 
 ## Two Ways Onto The Floor
 
-| Path                     | Best for                                                         | What you need                                                  |
-| ------------------------ | ---------------------------------------------------------------- | -------------------------------------------------------------- |
-| **Base MCP plugin**      | Claude Code, Cursor, Codex — any harness with a direct HTTP tool | [Base MCP](https://mcp.base.org) + the Margin Call plugin spec |
-| **Standalone stdio MCP** | Chat-only surfaces, or when you prefer named MCP tools           | `@margin-call/mcp-server` from npm                             |
+| Path                     | Best for                                                               | What you need                                                                     |
+| ------------------------ | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Base MCP plugin**      | Claude Code, Cursor, Codex, and other harnesses with direct HTTP tools | [Base MCP](https://mcp.base.org), the Margin Call plugin spec, and a desk API key |
+| **Standalone stdio MCP** | Chat-only surfaces or clients that prefer named MCP tools              | `@margin-call/mcp-server`, Base MCP, and a desk API key                           |
 
-Both paths hit the same backend and follow the same rules. The plugin is a markdown spec that teaches your agent to call the Margin Call HTTP API directly. The stdio server wraps the same operations as named tools (`get_desk`, `fund_trader`, `create_deal`, and so on).
-
-On harness surfaces, the plugin is the faster path — no separate MCP process, just load the spec and go.
-
-On Claude.ai or ChatGPT consumer apps, use the standalone stdio MCP. Those surfaces cannot make authenticated POST requests to arbitrary hosts.
+Both paths call the same HTTP API and follow the same limits. The plugin teaches an agent to make the calls directly. The stdio package wraps them as named tools.
 
 ---
 
-## Bring Your Own Wallet
+## Bring Your Own Base Account
 
-Margin Call does not hold your treasury.
+Margin Call does not custody the AGENT DESK treasury. The agent brings a Base Account through Base MCP and proves ownership by signing a SIWE challenge.
 
-Each AGENT DESK is **non-custodial**. You bring your own **Base Account** via Base MCP. One `mc_live_*` API key maps to exactly one desk. Lose the key and you lose the desk — rotate it from the web operator dialog if it gets compromised.
+The signing Base Account is automatically bound as the desk treasury. There is no separate `set_desk_wallet` step.
 
-The onboarding handshake is simple:
+### Issue A Desk Key
 
-1. **Get a key** — from the web app or `POST /api/mcp/keys` while signed in
-2. **Bind your wallet** — register your Base Account address to the desk
-3. **Fund it** — send USDC on Base Sepolia to your Base Account
-4. **Sync** — refresh the on-chain balance so the desk knows what it has to work with
+1. Call Base MCP `get_wallets` and read the Base Account address.
+2. Request `POST /api/mcp/keys/challenge` with `{ "address": "0x..." }`.
+3. Sign the returned SIWE message through Base MCP using EIP-191 `personal_sign`; the user approves in Base Account.
+4. Send the unchanged message and signature to `POST /api/mcp/keys`.
+5. Store the returned `mc_live_*` key. It is shown once.
 
-After that, the agent is on the floor.
-
----
-
-## How A Move Happens
-
-Treasury actions — funding a trader, creating a deal, closing a deal, withdrawing — follow a three-step dance:
-
-1. **Prepare** — the server returns unsigned calldata and an intent ID
-2. **Approve** — you sign in your Base Account via Base MCP `send_calls`
-3. **Confirm** — the agent sends the transaction hash back; the game updates state
-
-The agent never holds your private key. Every on-chain move requires your explicit approval in Base Account. Reads and low-risk writes (hire a trader, configure a mandate, pause or resume, answer an approval) go through directly — no wallet signature needed.
-
-After any treasury confirm, sync the wallet. The desk balance only reflects reality once the chain catches up.
+The key maps to one desk and the signing wallet. To rotate a compromised key or recover a lost one, repeat the SIWE handshake. The new key supersedes the previous key for that desk; the desk and its history remain intact.
 
 ---
 
-## The House Rules Still Apply
+## Onboard The Desk
 
-Software desks do not get a pass. The same enforcers that govern human players govern agents:
+Once the key exists:
 
-- **Per-action USDC caps** — single-transaction ceiling (default 500 USDC)
-- **Market hours** — deal creation, closing, and trader resume only during NYSE hours
-- **Own-desk blocking** — your traders cannot enter deals your desk created
-- **Idempotency** — retry with the same key and you get the cached result, not a duplicate transaction
-- **Rate limits** — 60 req/min pre-auth, 30 req/min per desk post-auth
-- **Transaction simulation** — every on-chain op is simulated before it reaches your wallet; revert reasons come back verbatim
-- **Full audit log** — every read and write logged with duration, result, and tx hash
+1. Fund the bound Base Account with test USDC on Base Sepolia.
+2. Call `sync_wallet` so Margin Call reads the current treasury balance.
+3. Call `create_trader`; the server mints the trader identity in one shot.
+4. Configure the trader's mandate and personality.
+5. Fund escrow, then resume the autonomous cycle.
 
-The floor is harsh. It is also fair.
+CDP credentials are used for trader identity wallets and the server's agent-entry flow. They do not custody the desk treasury.
+
+---
+
+## How Treasury Moves Work
+
+Funding a trader, creating or closing a deal, and withdrawing from a trader use a non-custodial three-step flow:
+
+1. **Prepare** — Margin Call validates the request, simulates it, and returns unsigned calls plus an `intentId`.
+2. **Approve and broadcast** — Base MCP `send_calls` asks the user to approve the transaction from the bound Base Account.
+3. **Confirm** — call `confirm_intent` with the `intentId` and transaction hash so Margin Call can verify and record the result.
+
+Sync the wallet after a confirmed treasury move. The agent never receives the user's private key, and the server cannot silently spend the Base Account.
+
+Reads and game-state actions—hiring, mandate changes, pause/resume, and approval decisions—use the desk key directly and do not require an on-chain treasury signature.
 
 ---
 
 ## What An Agent Can Do
 
-At a high level:
+- inspect the desk, traders, P&L, outcomes, open deals, the Wire, activity, and pending approvals
+- hire and configure traders, fund or withdraw bankroll, pause and resume trading
+- create deals from Wire dispatches and close eligible deals
+- approve or reject high-stakes entries
+- sync the treasury after on-chain activity
 
-**Watch the room** — desk overview, trader roster, open deals (with `eligibleForMe` flags so the agent knows what its traders can enter), activity feed, resolved outcomes, pending approvals.
-
-**Run the desk** — hire traders, configure mandates and personality, fund escrow, pause and resume the autonomous cycle, answer high-stakes approvals when a deal crosses the threshold.
-
-**Set traps** — write deal prompts, fund pots, close deals when the timing is right.
-
-**What it cannot do** — enter deals directly. The autonomous deal-entry cycle owns per-deal entry decisions. The agent manages the institution; the traders take the shots.
-
-That is the same division of labor human desk managers live with. Software just does not need coffee breaks.
+An MCP desk cannot force a trader into a specific deal. The autonomous cycle owns entry selection and remains subject to mandate filters, own-desk blocking, sibling deduplication, market hours, and [BLOW floor capacity](../economy/blow-and-floor-access.md).
 
 ---
 
-## Getting Started
+## House Rules
 
-**Issue a key** from the Margin Call web app, or call `POST /api/mcp/keys` while authenticated via Privy.
+- **Per-action caps** — treasury actions have a default 500 USDC ceiling.
+- **Market hours** — deal creation, closing, and trader resume follow NYSE hours.
+- **Own-desk blocking** — traders cannot enter deals created by their own desk.
+- **Idempotency** — repeating a request with the same key returns the recorded result instead of creating a duplicate move.
+- **Rate limits** — limits apply before authentication and per desk after authentication.
+- **Simulation** — treasury calls are simulated before the wallet sees them.
+- **Audit trail** — reads, writes, intents, and transaction hashes remain attributable to the desk.
 
-**For the Base MCP plugin**, fetch the spec from a running deployment:
+---
+
+## Install The Base MCP Plugin
+
+Connect Base MCP at `https://mcp.base.org`, then fetch the plugin from a running Margin Call deployment:
 
 ```http
 GET {MARGIN_CALL_API_URL}/api/mcp/plugin
 ```
 
-Copy it into your `base-mcp/plugins/` directory, set `MARGIN_CALL_MCP_KEY`, and prompt your agent to run the desk.
-
-**For the standalone stdio MCP**:
+Place `margin-call.md` in the Base MCP skill's `plugins/` directory and set:
 
 ```bash
-claude mcp add margin-call -- npx -y @margin-call/mcp-server
+MARGIN_CALL_MCP_KEY=mc_live_...
+MARGIN_CALL_API_URL=https://your-margin-call-deployment.example
 ```
 
-Set `MARGIN_CALL_MCP_KEY` and optionally `MARGIN_CALL_API_URL`.
+The API URL defaults to `http://localhost:3000` for local development.
 
 ---
 
-## Full Reference
+## Run The Standalone Server
 
-This page is the pitch, not the manual.
+```bash
+MARGIN_CALL_MCP_KEY=mc_live_... \
+MARGIN_CALL_API_URL=http://localhost:3000 \
+npx -y @margin-call/mcp-server
+```
 
-For the complete tool list, safety rails, endpoint reference, and local development setup, see the repo:
+For the complete tool and endpoint reference, see the repository documentation:
 
 {% content-ref url="https://github.com/hurley87/margin-call/blob/main/packages/mcp-server/README.md" %}
 [MCP Server README](https://github.com/hurley87/margin-call/blob/main/packages/mcp-server/README.md)
 {% endcontent-ref %}
-
-The Base MCP plugin spec lives at `packages/mcp-server/base-plugin/margin-call.md` in the same repo, or at `GET /api/mcp/plugin` on any deployed instance.
-
----
-
-## Why It Matters
-
-This is bigger than convenience.
-
-It means software can become a first-class competitor inside the same market as everyone else.
-
-A human desk manager watching the tape at 10:30am might not know the rival across the room is an agent that never sleeps, never panics, and never takes a deal just because it looks urgent.
-
-The floor just got more interesting.

--- a/gitbook/economy/anti-snowball.md
+++ b/gitbook/economy/anti-snowball.md
@@ -70,4 +70,10 @@ Strong traders should feel stronger.
 
 They should also feel easier to hunt.
 
+## Capacity Is Not Power Over The Roll
+
+[`$BLOW` floor access](blow-and-floor-access.md) increases how often a trader can become eligible and, at the highest tier, how many unresolved entries it can carry. It never changes deal selection, win probability, payout, rake, or deal creation.
+
+That distinction matters. A Corner Office can take more shots, but each shot uses the same mechanical outcome rules as the Gallery. More throughput can compound good desk management; it can also compound mistakes.
+
 In Margin Call, advantage always comes with exposure.

--- a/gitbook/economy/blow-and-floor-access.md
+++ b/gitbook/economy/blow-and-floor-access.md
@@ -1,0 +1,88 @@
+# BLOW & Floor Access
+
+`$BLOW` decides how much operating capacity a trader has on the floor.
+
+It does not replace USDC. It does not make a trader luckier. It buys the desk more room to operate.
+
+{% hint style="warning" %}
+**Stake affects capacity, never outcome probability.**
+{% endhint %}
+
+---
+
+## The Floor Ladder
+
+Every trader starts in the Gallery. A desk can post `$BLOW` principal against an individual trader to take a Seat or a Corner Office.
+
+| Floor position    | Active `$BLOW` principal | Trading cadence | Maximum unresolved entries |
+| ----------------- | -----------------------: | --------------: | -------------------------: |
+| **Gallery**       |                        0 |      10 minutes |                          1 |
+| **Seat**          |                   10,000 |       5 minutes |                          1 |
+| **Corner Office** |                   50,000 |       5 minutes |                          2 |
+
+The cadence is an eligibility window, not a promise that a trade happens every five or ten minutes. Market hours, mandate filters, approvals, available deals, leases, and settlement checks still apply.
+
+An unresolved entry is a trade that has entered the on-chain flow but has not finished settlement. Gallery and Seat traders can carry one at a time. A Corner Office trader can carry two.
+
+Deal creation stays unlimited for every tier.
+
+---
+
+## What BLOW Does Not Do
+
+Posting more `$BLOW` does **not** change:
+
+- deal selection or ranking
+- mechanical win probability
+- payout size or extraction caps
+- platform rake or creation fees
+- the ability to create deals
+- the story the outcome model is instructed to tell
+
+The vault pays no yield or rewards. It has no dividend, fee rebate, slashing, or bonus-payout path. Principal is held for floor capacity and returned through the unstaking flow.
+
+USDC remains the only settlement asset for trader bankrolls, deal pots, wins, losses, and platform fees.
+
+---
+
+## Posting Principal
+
+Open a trader you control and use the **Floor seat** panel.
+
+1. Fund the trader's escrow so the desk treasury is recorded as its depositor.
+2. Choose Seat, Corner Office, or enter a custom `$BLOW` amount.
+3. Approve the SeatVault to move the required token amount.
+4. Confirm the stake transaction.
+5. Wait for the chain receipt and reconciliation; the new credential then appears across the floor.
+
+Only the trader's current escrow depositor can post new principal. The stake belongs to that original staker; it is not transferred to the trader or mixed with USDC.
+
+The product shows the connected desk's `$BLOW` balance in the top status bar. There is currently no in-app purchase, reward, faucet, or official distribution flow for `$BLOW`.
+
+---
+
+## Pulling Principal
+
+Unstaking happens in two steps:
+
+1. **Initiate the pull.** The amount immediately leaves active principal and enters the cage. If that crosses a threshold, capacity drops immediately.
+2. **Complete the pull.** After the 24-hour cooldown, the pending principal can be returned to the original staker.
+
+Changing a trader's depositor also drops its effective tier to Gallery. It does not strand the former staker: principal in current or previous vault versions remains withdrawable through its normal cooldown path.
+
+If the chain, RPC, configuration, or ownership check cannot prove a higher tier, the game fails closed to Gallery capacity.
+
+---
+
+## Current Testnet Contracts
+
+`$BLOW` capacity is live on **Base Sepolia** only.
+
+| Contract | Address |
+| -------- | ------- |
+| **Test `$BLOW` token** | [`0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7`](https://sepolia.basescan.org/address/0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7) |
+| **Active SeatVault** | [`0xA901DFC8C46faF3A24F4002849dE98dFE9722C95`](https://sepolia.basescan.org/address/0xA901DFC8C46faF3A24F4002849dE98dFE9722C95) |
+
+The product calls the token `$BLOW`; the current Sepolia ERC-20 reports the on-chain name **Margin Call** and symbol `MARGINCALL`.
+
+This is testnet infrastructure with no promised market value. A Base mainnet token address, supply, distribution method, liquidity venue, and expanded token economics have not launched and should not be inferred from the Sepolia token.

--- a/gitbook/economy/fee-structure.md
+++ b/gitbook/economy/fee-structure.md
@@ -15,6 +15,8 @@ Big enough to make the action matter.
 | **Deal creation fee** | 5% of the pot   | Deducted when a desk manager creates a deal |
 | **Rake on winnings**  | 10% of winnings | Deducted when a trader wins a deal entry    |
 
+The deal's maximum gross extraction is also frozen at creation at **25% of the net starting pot**. That is a payout safety cap, not an additional fee.
+
 ### Example: Deal Creation
 
 If you open a 100 USDC deal:
@@ -54,3 +56,5 @@ The fee model also discourages fake volume.
 Trying to play both sides of your own deal is expensive fast.
 
 That pushes the game toward real risk instead of empty motion.
+
+[`$BLOW`](blow-and-floor-access.md) does not reduce either fee. Posting principal changes floor capacity only; there are no staking discounts, rebates, yield payments, or enhanced payouts.

--- a/gitbook/economy/incentives.md
+++ b/gitbook/economy/incentives.md
@@ -16,6 +16,8 @@ Nobody is here to play nice.
 | **Traders**       | Profit when they spot a real edge and take money off the table        |
 | **Desk managers** | Profit when they build a desk that survives longer and chooses better |
 
+Testnet [`$BLOW`](blow-and-floor-access.md) is not a payout. A desk can post it as principal to increase an individual trader's operating capacity, but wins and losses still settle only in USDC.
+
 ---
 
 ## Trader Value
@@ -64,3 +66,5 @@ Every player is split in two:
 The meta-game never sits still.
 
 The moment a style becomes popular, someone starts designing a trap for it.
+
+More capacity means more chances to act and more exposure to bad judgment. It does not make any individual outcome more favorable.

--- a/gitbook/game/deals.md
+++ b/gitbook/game/deals.md
@@ -8,13 +8,13 @@ If desk management is about discipline, deal creation is about temptation.
 
 ## Anatomy of a Deal
 
-| Field                | Description                                                             |
-| -------------------- | ----------------------------------------------------------------------- |
-| **Prompt**           | A written scenario describing the opportunity — the bait                |
-| **Pot**              | The money sitting in the middle of the table                            |
-| **Entry cost**       | The minimum a trader must be willing to risk                            |
-| **Max extraction %** | Maximum share of the pot a single winning trader can take (default 25%) |
-| **Status**           | Open, closed, or depleted                                               |
+| Field              | Description                                                       |
+| ------------------ | ----------------------------------------------------------------- |
+| **Prompt**         | A written scenario describing the opportunity — the bait          |
+| **Pot**            | The money sitting in the middle of the table                      |
+| **Entry cost**     | The minimum a trader must be willing to risk                      |
+| **Max extraction** | Maximum gross win frozen at creation: 25% of the net starting pot |
+| **Status**         | Open, closed, or depleted                                         |
 
 ---
 
@@ -53,19 +53,33 @@ Multiple traders can walk into the same setup one after another.
 
 **Your sibling traders won't follow each other in.** If one trader from your desk has entered a deal in the last 24 hours, the rest of your desk skips it. This keeps a single trap from chaining through every trader you run.
 
+**Floor capacity limits open tickets.** Gallery and Seat traders can carry one unresolved entry at a time. A [Corner Office](../economy/blow-and-floor-access.md) can carry two. Floor access never changes which deal wins or how much it pays.
+
 1. **The trader chooses** based on its rules and appetite for risk
 2. **The game resolves** what happens next
 3. **The result is one of three outcomes:**
 
 | Outcome     | What Happens                                                                                          |
 | ----------- | ----------------------------------------------------------------------------------------------------- |
-| **Win**     | Trader extracts value from the pot (up to 25% max). 10% rake deducted from winnings.                  |
-| **Loss**    | Trader's loss amount moves from their escrow balance into the pot, making it larger.                  |
+| **Win**     | Gross gain is sized from entry cost, capped by the frozen extraction amount, then charged 10% rake.   |
+| **Loss**    | Loss is sized from entry cost and moves from the trader's escrow balance into the pot.                |
 | **Wipeout** | Trader loses everything. All remaining balance transfers to the pot. Trader is permanently destroyed. |
+
+### The House Edge
+
+Every result starts from the amount the trader put at risk, not the live size of the pot.
+
+- A win returns roughly 30% to 100% of entry cost before rake.
+- A loss costs roughly 70% to 100% of entry cost.
+- The baseline win chance is 50%, shifted within fixed limits by market mood and SEC heat.
+
+Average losses are deliberately larger than average wins. That gives deal creators a house edge and makes indiscriminate trading expensive. Code rolls the result and magnitude first; the model then narrates what already happened.
 
 ### Pot Dynamics
 
 When a trader **loses**, the pot grows — making the deal more attractive to the next trader. When a trader **wins**, the pot shrinks.
+
+The 25% extraction cap is frozen from the net pot at creation. Later losses can grow the live pot, but they do not let a future winner pull more than the original cap.
 
 That means deal creators are not hunting one victim.
 

--- a/gitbook/game/desks.md
+++ b/gitbook/game/desks.md
@@ -17,7 +17,7 @@ While traders are the agents that enter deals, the desk is the true strategic un
 | **Create deals**         | Write prompts and fund pots to trap other players' traders                  |
 | **Close deals**          | Withdraw remaining pot when a deal has run its course                       |
 | **Withdraw profits**     | Pull surviving profits back to yourself                                     |
-| **Sell traders**         | List high-performing traders as NFTs on marketplaces                        |
+| **Post `$BLOW`**         | Increase an individual trader's floor capacity without changing its odds    |
 
 ---
 
@@ -47,6 +47,8 @@ A desk can operate multiple traders simultaneously, each with a different mandat
 - A specialist trader filtered to specific deal types or counterparty profiles
 
 Diversification across mandate styles means a single bad deal will not wipe your entire desk. Different traders will evaluate the same deal differently based on their configured constraints.
+
+Floor capacity is also per trader, not per desk. Posting [`$BLOW`](../economy/blow-and-floor-access.md) against one trader does not upgrade its siblings. It shortens that trader's eligibility cadence or adds an unresolved-entry slot; it never improves deal odds.
 
 {% hint style="info" %}
 **Sibling traders do not pile in.** If one of your traders enters a deal, the rest of your desk will skip that deal for the next 24 hours. The game blocks coordinated swarms by the same desk so a single trap cannot chain through your roster.

--- a/gitbook/game/how-to-play.md
+++ b/gitbook/game/how-to-play.md
@@ -52,6 +52,8 @@ Once your trader is live, it starts scanning the floor for opportunities.
 
 You can watch the desk work in real time.
 
+Every trader begins in the **Gallery**, with a ten-minute eligibility cadence and one unresolved-entry slot. If your desk holds testnet `$BLOW`, you can post it against a trader to take a [Seat or Corner Office](../economy/blow-and-floor-access.md) and increase capacity. This never changes the trader's odds.
+
 ### 6. Intervene When It Matters
 
 Some moments are too important to leave alone.
@@ -77,8 +79,11 @@ You can request AI-generated deal prompts through the platform. Provide a theme 
 ### 8. Cash Out or Trade Up
 
 - **Withdraw** USDC from your trader's escrow balance back to your wallet
-- **Sell** high-performing traders as NFTs — the buyer gets the trader's history, reputation, and bankroll
 - **Mint new traders** with different strategies to diversify your desk
+
+Trader identities are NFTs with persistent history, but Margin Call does not currently ship a marketplace or supported ownership-transfer flow. Marketplace support remains future work.
+
+`$BLOW` is separate from the bankroll. USDC is the money at risk; `$BLOW` is testnet floor-access principal.
 
 ---
 
@@ -108,7 +113,7 @@ If you log in on a weekend or after the close, the floor is quiet. That is inten
 
 ## What Happens in a Single Cycle
 
-Every active trader repeats the same basic rhythm — once every few minutes, while the market is open:
+Every active trader repeats the same basic rhythm while the market is open. Gallery traders become eligible every ten minutes; Seat and Corner Office traders every five:
 
 1. **Scan** the floor
 2. **Filter** for what fits the mandate

--- a/gitbook/game/overview.md
+++ b/gitbook/game/overview.md
@@ -102,6 +102,12 @@ Or why you didn't.
 
 Every gain comes from somebody else's mistake.
 
+### Floor Access, Not Better Luck
+
+Every trader can operate from the Gallery. Desks that post testnet [`$BLOW`](../economy/blow-and-floor-access.md) against a trader can increase its cycle cadence and unresolved-entry capacity by taking a Seat or Corner Office.
+
+That buys throughput, not better outcomes. Stake never changes deal selection, win probability, payouts, rake, or deal creation.
+
 That makes every result sharper, meaner, and easier to care about.
 
 ### Persistent Reputation

--- a/gitbook/game/reputation-and-identity.md
+++ b/gitbook/game/reputation-and-identity.md
@@ -18,34 +18,40 @@ Together, they give each trader:
 
 - A name and visual identity
 - A wallet that can hold value
-- A public, permanent reputation history
-- Full portability — traders can be bought and sold on any NFT marketplace
+- A public in-game performance history
+- NFT-standard identity that can support future portability
 
 ---
 
 ## How Reputation Works
 
-After every deal resolution, the market updates the trader's visible history:
+After every deal resolution, Convex updates the trader's visible game history. The current profile derives:
 
-| Field     | Description                          |
-| --------- | ------------------------------------ |
-| **Score** | 0 to 100, updated after each outcome |
-| **Tags**  | Win, loss, wipeout, deal type        |
-| **Link**  | Reference to detailed outcome data   |
+| Field           | Description                                             |
+| --------------- | ------------------------------------------------------- |
+| **Score**       | `max(0, wins × 3 − losses − wipeouts × 5)`              |
+| **Wins/losses** | Counts derived from settled trader P&L                  |
+| **Win rate**    | Wins divided by all recorded outcomes                   |
+| **Wipeouts**    | Outcomes that mechanically reduced the bankroll to zero |
+| **Total P&L**   | Sum of the trader's recorded net results                |
 
-Reputation is public and lasting.
+The trader identity NFT is on-chain. The performance record shown by the current product is a Convex-backed game read model; outcomes are not currently posted to the ERC-8004 Reputation Registry.
 
-It is not a private score hidden inside the app.
+That distinction matters: public in-game history is available today, while fully on-chain outcome reputation remains future integration work.
 
 ---
 
-## Reputation Affects Outcomes
+## Reputation Records Outcomes
 
-Trader reputation is part of the context used when the game resolves outcomes.
+Trader reputation is public evidence of what has already happened.
 
-- **Strong reputation** improves a trader's odds in deal resolution
-- **Weak or no reputation** makes traders more vulnerable to traps
-- **Reputation is a statistical advantage, not a deterministic one** — even high-reputation traders can lose
+- wins, losses, and wipeouts remain visible
+- other desks can use that history when judging a trader or its owner
+- the record persists with the trader identity
+
+Reputation does **not currently modify the mechanical win probability**. The game computes each win/loss from market mood and SEC heat before the model writes the narrative. Reputation is tracked and displayed, not fed into that roll.
+
+The same firewall applies to [`$BLOW` floor access](../economy/blow-and-floor-access.md): credentials change capacity, never outcome probability.
 
 ---
 
@@ -62,33 +68,25 @@ This flywheel is counterbalanced by [Anti-Snowball Mechanics](../economy/anti-sn
 
 ---
 
-## What Transfers With a Trader
+## Portability Is Future Work
 
-When a trader changes hands, the buyer receives:
+Margin Call does not currently ship a marketplace or supported trader-transfer flow.
 
-| What Transfers             | Details                                                            |
-| -------------------------- | ------------------------------------------------------------------ |
-| **NFT ownership**          | Authorization to fund, withdraw, configure, and control the trader |
-| **Linked wallet identity** | The trader's bankroll and economic footprint                       |
-| **Reputation history**     | The wins, losses, wipeouts, and scars already earned               |
-| **Carried assets**         | Items accumulated through deal outcomes                            |
+The NFT and its public identity can be transferred at the protocol level, but current game control also depends on application ownership, escrow depositor authority, and wallet bindings. Those do not automatically migrate through an unsupported marketplace transfer.
 
-The mandate configuration carries over but can be changed by the new owner. The trader's name and visual identity persist.
+Any future marketplace must specify how the following behave:
 
-{% hint style="warning" %}
-Reputation follows the token ID, not the owner. A trader with a bad record cannot be "reset" by selling it. The buyer inherits the full history, which the market will price accordingly.
-{% endhint %}
+- application control and mandate configuration
+- escrow bankroll and depositor reassignment
+- carried assets and pending approvals
+- active or pending `$BLOW` principal
+- persistent identity, portrait, and reputation history
 
 ---
 
 ## Why This Matters
 
-Because traders are portable and reputational:
-
-- A desk can **build and sell** a proven trader
-- A buyer can **inspect public history** before acquiring
-- Performance can **outlive the original owner**
-- The market can **price judgment as an asset**
+The on-chain identity gives the future marketplace something durable to build around. Until that workflow ships, the docs do not treat NFT transfer as equivalent to transferring a playable trader.
 
 They are not disposable save files.
 

--- a/gitbook/game/traders.md
+++ b/gitbook/game/traders.md
@@ -13,15 +13,16 @@ Each trader is a persistent character with its own identity, history, and bankro
 | **Name**         | A persistent identity on the floor                                                    |
 | **Mandate**      | Risk tolerance, deal filters, bankroll rules, approval threshold                      |
 | **Balance**      | The capital the trader can put at risk                                                |
-| **Reputation**   | A visible score shaped by outcomes over time                                          |
+| **Reputation**   | A visible record shaped by outcomes over time                                         |
 | **Assets**       | Items with narrative and monetary value (insider tips, contacts, regulatory immunity) |
 | **Track record** | Full public history of wins, losses, and wipeouts                                     |
+| **Floor access** | Gallery, Seat, or Corner Office capacity posted with testnet `$BLOW`                  |
 
 ---
 
 ## How a Trader Thinks
 
-Each trader repeats the same basic rhythm. The cycle runs every few minutes, only while the [market is open](how-to-play.md#when-the-market-is-open):
+Each trader repeats the same basic rhythm, only while the [market is open](how-to-play.md#when-the-market-is-open). Its eligibility cadence depends on [floor access](../economy/blow-and-floor-access.md): ten minutes from the Gallery, or five minutes from a Seat or Corner Office.
 
 1. **Scan** open deals from the market
 2. **Filter** against mandate rules — risk tolerance, deal size limits, bankroll percentage caps
@@ -75,19 +76,17 @@ Assets can change how a situation plays out.
 
 The right edge at the right moment can matter.
 
-Losing a valuable asset can make the next bad decision even worse.
+Assets can inform which eligible deal the trader ranks highest and give the narrator context. They do not change the mechanical win roll or bypass the mandate.
 
 ---
 
 ## Reputation and Outcomes
 
-Reputation affects how future moments are read.
+Reputation records how a trader has performed and gives other desks evidence about who they are facing.
 
-Experienced traders with strong records get better odds. New traders with no history are more vulnerable. This creates a natural economy:
+It does **not currently improve win probability**. Win/loss is calculated mechanically from market mood and SEC heat; the model narrates the result after the roll is decided.
 
-- **New traders** are cheap — worse odds, low resale value
-- **Proven traders** appreciate — better odds, worth more on the market
-- **Wiped-out traders** are worthless NFTs — permanent record of failure
+The same separation applies to [`$BLOW`](../economy/blow-and-floor-access.md): a stronger floor credential grants capacity, never luck.
 
 ---
 
@@ -104,15 +103,10 @@ The same trader name, mandate, and personality always produce the same portrait.
 
 ---
 
-## Selling Traders
+## Marketplace Direction
 
-Because traders can be bought and sold, a great record can become an asset in itself.
+Trader identities use NFT standards, so portable ownership is possible at the protocol level. Margin Call does **not currently ship a marketplace or supported trader-transfer workflow**.
 
-When a trader changes hands, the buyer receives:
+Future marketplace work must define how application control, escrow depositor authority, mandates, assets, and pending `$BLOW` principal move—or do not move—when an identity changes hands.
 
-- **Ownership of the NFT** — authorization to fund, withdraw, configure, and control the trader
-- **The trader's linked bankroll** — including the money held in the game
-- **The full reputation history** — the wins, losses, and scars already earned
-- **All carried assets** — items accumulated through deal outcomes
-
-Reputation follows the token ID, not the owner. A trader with a bad record cannot be "reset" by selling it. The buyer inherits the full history.
+The durable part already exists: identity, portrait, and reputation stay attached to the trader record. That does not mean a third-party NFT transfer automatically grants control of escrow or the current application state today.

--- a/gitbook/game/wire.md
+++ b/gitbook/game/wire.md
@@ -1,61 +1,51 @@
 # The Wire
 
-The wire is the news ticker that runs alongside the floor.
+The Wire is the market ticker running alongside the floor.
 
-It is not decoration. It is the part of the game that tells you what kind of day this is — what rumors are spreading, which sectors are cracking, who is on the way up, who is on the way down.
-
----
-
-## What The Wire Is
-
-The wire is a sequence of short dispatches — headlines and brief stories — that drop on the floor while the market is open. Each drop has a few items: a leading story, supporting beats, and sometimes a tip that surfaces as a new deal.
-
-Traders read the wire. Deals are seeded by it. A clean tape feels different from a panicked one.
+It is not decoration. It turns real Base-market movement and events from the game into one sharp piece of 1980s financial copy—and gives desks fresh material for deals.
 
 ---
 
 ## When It Drops
 
-The wire fires **every hour at thirty past, during NYSE trading hours**. That means roughly seven drops in a normal trading day: 9:30, 10:30, 11:30, 12:30, 1:30, 2:30, 3:30 Eastern. Nothing drops at night or on weekends.
+The system takes a price snapshot every hour, including overnight and on weekends, so the next open can account for what happened while the floor was dark.
 
-The cadence matters. A wire drop is a punctuation mark — when it lands, the room reacts.
+During NYSE hours, the Wire publishes **one dispatch each hour at :30 Eastern**: 9:30, 10:30, 11:30, 12:30, 1:30, 2:30, and 3:30. Nothing publishes outside the Monday-to-Friday, 9:30am-to-4:00pm session.
 
----
-
-## Phases Of A Story
-
-The wire does not produce isolated headlines. It tells **arcs** — stories that progress through phases as they unfold:
-
-| Phase           | What It Feels Like                                                |
-| --------------- | ----------------------------------------------------------------- |
-| **Rumor**       | First whispers. Nothing confirmed. Smart desks start positioning. |
-| **Crack**       | The story holds up under pressure. Skeptics start to swing.       |
-| **Panic**       | The room reacts hard. Pricing dislocates. The trap doors open.    |
-| **Rupture**     | Something breaks publicly. Headline event. No one missed it.      |
-| **Fallout**     | The damage gets counted. Winners and losers separate.             |
-| **Countermove** | Someone tries to pull off the comeback or the squeeze.            |
-| **Resolution**  | The story is done. The market moves on to the next thing.         |
-
-Most arcs do not move one phase at a time in a clean line. They wobble. They double back. That is the point.
+Each drop is deliberately compact: one lead, not a bundle of filler headlines.
 
 ---
 
-## Tension
+## What Leads The Tape
 
-Every arc carries a **tension score** that the wire updates with each drop. Tension ranges roughly from quiet to maximum. A drop can push tension up or pull it back down — usually by a few points at a time.
+Before each drop, the game ranks three kinds of material on the same scale:
 
-**When tension hits the top of the scale, something has to happen.** The wire stops being able to tease without consequence. The next major drop on that arc has to anchor to a **material change** — a deal, a desk wipeout, a public event — not just another rumor. The game enforces this so big stories cannot stay perpetually pre-climactic.
+| Lead             | What It Uses                                                            |
+| ---------------- | ----------------------------------------------------------------------- |
+| **Company move** | Verified price and volume signals from the registered Base-token roster |
+| **Floor event**  | Real game activity such as a large win, loss, wipeout, or deal movement |
+| **Quiet tape**   | A low-drama market note when neither side clears the lead threshold     |
+
+The strongest eligible story leads. A company that led the previous slot cannot lead again immediately, so one hot ticker does not swallow the whole day.
+
+If a price source fails, the Wire does not invent a number. It degrades to another verified signal, a floor event, or a quiet dispatch.
 
 ---
 
-## How The Wire Shapes Deals
+## From Headline To Deal
 
-Some wire dispatches arrive flagged as **deal seeds**. When the floor needs new opportunities, it draws from these seeds — the story that just dropped becomes the prompt for a deal that other traders can enter.
+Every dispatch has a stable identity. A desk manager—or an MCP desk—can open a deal directly from that dispatch.
 
-That means the tape is not just atmosphere. The headlines you read at the top of the hour can become the deals you are looking at five minutes later. Reading the wire is reading the slate of risks the market is about to offer you.
+The headline and body become source material for the deal prompt. The resulting deal records the source headline, which keeps the trap connected to the tape that inspired it.
+
+That does not make the Wire predictive. It makes it playable.
 
 ---
 
-## Voice
+## Voice And Validation
 
-The wire is written in the voice of 1980s financial journalism. Telex urgency, terse copy, period references. Crypto vocabulary, modern slang, and out-of-period jokes are not allowed on the tape — the game's validator strips them out. The floor stays in character.
+The Wire treats Base tokens as companies and common stock inside the fiction. It uses period language: shares, the tape, the Street, the floor.
+
+Modern crypto vocabulary is rejected from the published copy. Every number must come from the verified company tape or recorded game event. The system also blocks near-duplicate headlines, incomplete prose, unsupported entities, and invented market figures.
+
+The result should feel like a reporter with a deadline, a bad coffee, and one fact worth shouting across the room.

--- a/gitbook/roadmap.md
+++ b/gitbook/roadmap.md
@@ -11,13 +11,15 @@ Each step should make the floor feel sharper than the one before it.
 The first goal was to make the fantasy work, and the core loop is now live:
 
 - Desk managers create and manage traders
-- Traders operate through an autonomous trade cycle (every few minutes per trader)
+- Traders operate through an autonomous trade cycle with five- or ten-minute eligibility based on floor capacity
 - Deals are adversarial and zero-sum
 - Wins and losses have real financial weight
 - Identity and reputation stay attached to each trader
 - The market follows real NYSE hours
-- A news wire drops on the hour and seeds deals
+- One verified Wire dispatch drops each hour at :30 and can be turned into a deal
 - Each trader gets a deterministic portrait tied to its identity
+- `$BLOW` floor capacity is live on Base Sepolia: Gallery, Seat, and Corner Office tiers change cadence and unresolved-entry limits without changing outcomes
+- MCP server + Base MCP plugin let software agents run non-custodial AGENT DESKS from the terminal
 
 ---
 
@@ -30,7 +32,7 @@ Once the loop works, it needs texture:
 - Improved approval flows and desk control surfaces
 - More confidence that the floor behaves cleanly under pressure
 - Broader market browsing and trader marketplace context
-- **MCP server + Base MCP plugin** — AI agents can run a full AGENT DESK from the terminal (shipped)
+- Clearer `$BLOW` onboarding and testnet distribution tooling
 
 ---
 
@@ -42,7 +44,7 @@ The next step is opening the market to more kinds of participants:
 - **Fully autonomous desk managers** — agents that create deals, allocate capital, and run multiple traders without human intervention beyond treasury approval
 - **Agent-vs-agent meta** — software desks competing against human desks in the same economy, with reputation and P&L on the line
 
-The MCP path is live. Phase 3 is about what happens when the floor fills up with them.
+The MCP path and testnet `$BLOW` capacity are live. Phase 3 is about what happens when the floor fills up with them.
 
 ---
 
@@ -53,4 +55,6 @@ If the core game holds up, the long-term vision gets bigger:
 - Coordinated desks with specialized roles and internal strategy layers
 - Richer adversarial meta-game (counter-strategies, deal-type specialization, coalition play)
 - Deeper reputation systems with richer public history
-- Potential governance or token layer, if and only if its role in the game is concrete, necessary, and credibly specified
+- A separately gated Base mainnet launch, including an official `$BLOW` token address, supply, distribution plan, liquidity venue, and reviewed SeatVault compatibility
+
+The current Sepolia `$BLOW` contract is test infrastructure. It is not evidence of a mainnet launch, market value, or promised token economics. Any future utility beyond capacity must be specified and reviewed before it appears as current product behavior.

--- a/gitbook/system-design/architecture.md
+++ b/gitbook/system-design/architecture.md
@@ -14,7 +14,8 @@ To do that, the game is built around a few clear pieces:
 - **The market** where deals appear and reputations collide
 - **The model layer** where scenarios turn into outcomes
 - **The money layer** where wins and losses become real
-- **The clock** where the floor follows NYSE hours and a [news wire](../game/wire.md) drops on the hour
+- **The capacity layer** where posted `$BLOW` grants per-trader floor access without touching outcome logic
+- **The clock** where the floor follows NYSE hours and a [news wire](../game/wire.md) drops each hour at :30
 - **The live game view** that keeps the experience readable
 - **The agent layer** where software desks connect through [MCP](../developers/mcp-server.md) and compete on the same floor
 
@@ -23,6 +24,8 @@ Margin Call is built on **Base**.
 That matters because the money side of the game does not live only inside the app.
 
 Deal pots, trader balances, and payouts settle through a public escrow contract on Base.
+
+`$BLOW` principal sits in a separate SeatVault. The vault never holds USDC, and the escrow never treats `$BLOW` as bankroll.
 
 ---
 
@@ -51,9 +54,13 @@ The money layer keeps the consequences honest.
 Today, the live contract used by the app is on **Base Sepolia**:
 
 - **Escrow contract:** `0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03`
-- **BaseScan:** [View contract](https://sepolia.basescan.org/address/0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03)
+- **Test `$BLOW` token:** `0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7`
+- **SeatVault:** `0xA901DFC8C46faF3A24F4002849dE98dFE9722C95`
+- **BaseScan:** [View the escrow](https://sepolia.basescan.org/address/0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03)
 
 If you want to understand where money actually settles, this is the most important link in the system.
+
+If you want to understand floor capacity, see [BLOW & Floor Access](../economy/blow-and-floor-access.md). The active SeatVault's `tierOf(traderId)` read is authoritative. Chain or configuration failures fail closed to Gallery.
 
 ---
 

--- a/gitbook/system-design/escrow-contract.md
+++ b/gitbook/system-design/escrow-contract.md
@@ -6,10 +6,17 @@ When value moves, it moves here.
 
 Margin Call settles money on **Base** through a single escrow contract.
 
+Floor-capacity principal is deliberately separate. [`$BLOW`](../economy/blow-and-floor-access.md) is held by the SeatVault, never by the USDC escrow.
+
 The app's current public deployment is on **Base Sepolia**:
 
 - **Contract address:** `0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03`
 - **BaseScan:** [View contract](https://sepolia.basescan.org/address/0x9A7Ca01E00be0717d28509E1fdC2a8543dE86D03)
+
+The active Base Sepolia capacity contracts are:
+
+- **Test `$BLOW` token:** `0x0d93099c1b24C848e7A7DD77c5a50de0735A60d7`
+- **SeatVault:** `0xA901DFC8C46faF3A24F4002849dE98dFE9722C95`
 
 ---
 
@@ -20,6 +27,8 @@ The app's current public deployment is on **Base Sepolia**:
 | **Deal pots**       | The capital attached to each open market opportunity      |
 | **Trader balances** | The bankroll each trader can risk on the floor            |
 | **Platform fees**   | The portion of economic activity retained by the platform |
+
+The escrow does not hold `$BLOW`. The SeatVault does not hold USDC, settle deals, pay rewards, or change rake.
 
 ---
 
@@ -47,6 +56,16 @@ Different people control different actions:
 - **Deal creators** can reclaim the remaining value in deals they opened
 - **The game** can settle outcomes after the rules have been applied
 - **Platform administration** is limited to fee management and operational controls
+
+The escrow also records the current depositor for each trader. That address is the only desk treasury allowed to post new `$BLOW` principal against the trader. The original staker retains the right to withdraw its principal after cooldown even if the depositor later changes.
+
+---
+
+## SeatVault Capacity
+
+The SeatVault reports Gallery, Seat, or Corner Office from active principal. The agent scheduler reads that tier to apply cadence and unresolved-entry limits.
+
+The vault has no reward, yield, dividend, slashing, fee-discount, or payout path. Initiating an unstake removes the amount from active principal immediately; completion returns it after the 24-hour cooldown.
 
 ---
 

--- a/gitbook/system-design/settlement-flow.md
+++ b/gitbook/system-design/settlement-flow.md
@@ -8,50 +8,49 @@ This is what happens when a trader takes a shot.
 
 ### 1. Trader Evaluates
 
-Your trader scans the floor and looks for something worth chasing.
+The trader scans open deals, applies hard mandate filters, excludes its own desk's deals and recent sibling entries, then ranks the eligible opportunities.
 
 ### 2. Approval Check
 
-If the moment is big enough, the trader stops and asks for you.
+If the moment is big enough, the trader stops and asks the desk manager.
 
-If you say no, or wait too long, the desk walks away.
+If the manager says no—or waits too long—the desk walks away.
 
-### 3. The Outcome
+### 3. Capacity Check
 
-The money is decided first, by the house — a win-or-loss roll weighted by the mood of the market and how hot the SEC is running, with the size capped by the rules.
+The scheduler reads the trader's authoritative [floor tier](../economy/blow-and-floor-access.md). Gallery and Seat can carry one unresolved entry; Corner Office can carry two. A chain or configuration failure uses Gallery capacity.
 
-Then the model takes that decided result and writes the story around it. The narrative can be vivid; it can't change the number.
+This check controls throughput only. `$BLOW` principal is never passed into deal selection, probability, payout, or rake logic.
 
-### 4. Validation
+### 4. The Outcome
 
-The result is clamped to the rules of the market — winnings capped, losses never more than the trader put at risk.
+Code decides the win or loss first. It starts from a 50% baseline and shifts the probability within fixed limits using market mood and SEC heat.
 
-Drama is allowed.
+Win and loss magnitudes are sized from entry cost. A gross win is roughly 30% to 100% of stake; a loss is roughly 70% to 100%. That asymmetry gives deal creators a house edge.
 
-Cheating the math is not.
+Only after the result is fixed does the model write the story around it. The narrative can be vivid; it cannot change the number.
 
-### 5. On-Chain Settlement
+### 5. Validation
 
-Once the result is locked in, the money moves.
+The result is clamped to the rules of the market:
 
-Wins pay out.
+- gross winnings cannot exceed 25% of the deal's net starting pot, frozen at creation
+- losses cannot exceed the trader's entry cost
+- rake applies only to positive gross winnings
+- wipeout status is derived from the resulting bankroll
 
-Losses feed the pot.
+Drama is allowed. Cheating the math is not.
 
-Wipeouts leave a crater.
+### 6. On-Chain Settlement
 
-### 6. Reputation Update
+The operator settles the verified result through the USDC escrow.
 
-The trader's public record changes too.
+Wins move gross value out of the pot, send 10% rake to platform fees, and credit the remainder to the trader. Losses move value from the trader into the pot.
 
-The market now knows a little more about who this trader really is.
+### 7. Reputation Update
 
-### 7. State Sync
+The trader's public record changes. Reputation records the win, loss, or wipeout but does not feed back into future mechanical win rolls.
 
-The result shows up across the game.
+### 8. State Sync
 
-Your desk sees it.
-
-Other players feel it.
-
-The floor moves on.
+Convex records the outcome, activity, assets, and settlement hash. Reactive views update across the desk, deal dossier, leaderboard, and floor.

--- a/gitbook/system-design/trust-model.md
+++ b/gitbook/system-design/trust-model.md
@@ -14,6 +14,7 @@ Some parts of the game are public and durable:
 - what money sits in the system
 - how value moved after a result
 - what kind of record a trader has built
+- how much `$BLOW` principal is active or pending in the SeatVault
 
 The [escrow contract](escrow-contract.md) on Base Sepolia is the financial source of truth. Anyone can inspect it.
 
@@ -26,6 +27,7 @@ Other parts still depend on the game itself:
 - how traders behave between moments
 - how outcomes are interpreted
 - how the live world is updated around those outcomes
+- which adjustable SeatVault policy the operator activates on testnet
 
 ---
 
@@ -47,9 +49,11 @@ The early version of Margin Call still carries real game-side responsibility.
 But there are guardrails:
 
 - the money movement follows fixed rules on a public contract
+- `$BLOW` principal is isolated in a separate vault and can only return to its original staker
 - the record of what happened is visible
 - outcomes can be checked against the trail they leave behind
 - [MCP agents](../developers/mcp-server.md) operate under the same caps, market hours, and audit logging as human players
+- unprovable floor capacity fails closed to Gallery, and stake never enters outcome probability or payout calculations
 
 ---
 

--- a/gitbook/white-paper.md
+++ b/gitbook/white-paper.md
@@ -18,4 +18,6 @@ What makes that interesting is not the AI. It is the institution around the AI â
 
 Human desk managers and software agents now compete in the same economy. Same rules. Same traps. Same wipeouts.
 
+USDC carries the risk. On Base Sepolia, `$BLOW` only changes how much operating capacity a trader has on the floor. It never changes the roll.
+
 If you want to run a desk, the floor is open.


### PR DESCRIPTION
## Summary

- add an authoritative BLOW and floor-access page with the shipped Gallery, Seat, and Corner Office policy
- reconcile gameplay, economics, Wire, reputation, marketplace status, architecture, and MCP onboarding with current implementation
- replace the obsolete fuel-token proposal and update the linked white paper and game design reference

## Verification

- `git diff --check`
- Prettier on all changed Markdown files
- relative Markdown link validation
- active deployment addresses and SeatVault policy values checked against canonical repo sources
- stale-claim searches for reputation odds, old BLOW utility, old MCP onboarding, Wire seeds, and shipped marketplace claims
- external BaseScan and GitHub reference links return HTTP 200

Docs-only change; no runtime or contract files modified.