### PR TITLE
Cinematic 1987 redesign: juiced landing + live market pulse

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,7 +81,7 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
-  /* Trading floor palette */
+  /* Trading floor palette — semantic game tokens */
   --t-bg: #090b10;
   --t-surface: #11161f;
   --t-panel: rgba(17, 22, 31, 0.82);
@@ -102,6 +102,15 @@
   --t-green-hot: #92f5b8;
   --t-red-hot: #ff9d93;
   --t-amber-hot: #ffd58a;
+
+  /* Urgency / market-state accents */
+  --t-urgency: #f0a35a;
+  --t-threat: #ff6b5c;
+  --t-safe: #6fd99a;
+  --t-focus-ring: rgba(214, 166, 96, 0.55);
+  --t-hero-scrim: rgba(5, 7, 10, 0.88);
+  --t-type-label: 0.6875rem; /* 11px — readable micro-labels */
+  --t-type-body: 0.875rem;
 
   /* ── MOTION TOKENS — keep in sync with src/lib/motion-tokens.ts ── */
   --mc-dur-fast: 120ms;
@@ -674,6 +683,12 @@
   }
   button:not(:disabled):active {
     transform: scale(0.97);
+  }
+  a:focus-visible,
+  button:focus-visible,
+  [role="button"]:focus-visible {
+    outline: 2px solid var(--t-focus-ring);
+    outline-offset: 2px;
   }
   @media (prefers-reduced-motion: reduce) {
     button:not(:disabled):active {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,22 @@ const plexSans = IBM_Plex_Sans_Condensed({
 
 export const metadata: Metadata = {
   title: "MARGIN CALL // DESK_OS v2.1",
-  description: "Wall Street Agent Trading Game",
+  description:
+    "Run a hostile 1987 Wall Street desk. Fund AI traders, write deals on the Wire, and wipe rival agents — zero-sum USDC on Base.",
+  openGraph: {
+    title: "MARGIN CALL",
+    description: "AI-powered PvP trading game. Hire. Fund. Bait. Collect.",
+    images: [
+      { url: "/banner.png", width: 1200, height: 630, alt: "Margin Call" },
+    ],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "MARGIN CALL",
+    description: "AI-powered PvP trading game set on 1980s Wall Street.",
+    images: ["/banner.png"],
+  },
   other: {
     "base:app_id": "69a85de978b3a616c1d0428c",
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,12 +45,13 @@ import {
 } from "@/components/feed-line";
 import { PendingApprovalCard } from "@/components/pending-approval-card";
 import { TraderAvatar } from "@/components/trader-avatar";
-import { pickFunTraits, type FunTrait } from "@/lib/portrait-traits";
 import { AgentDeskBadge } from "@/components/agent-desk-badge";
 import { FloorCredential } from "@/components/seat-tier-badge";
 import { SeatUpgradeDialog } from "@/components/seat-upgrade-dialog";
-import { ConnectMcpDialog } from "@/components/connect-mcp-dialog";
 import { IntroSequence } from "@/components/intro-sequence";
+import { LandingScreen } from "@/components/landing/landing-screen";
+import { MarketStatusStrip } from "@/components/desk/market-status-strip";
+import { MobileMarketPulse } from "@/components/desk/mobile-market-pulse";
 import { ConvexIdentityDebug } from "@/components/convex-identity-debug";
 import { LiveGameToasts } from "@/components/live-game-toasts";
 import { MomentLayer } from "@/components/moments/moment-overlay";
@@ -82,8 +83,8 @@ import {
   useLeaderboard,
   type LeaderboardTrader,
 } from "@/hooks/use-leaderboard";
-import { useLandingRoster } from "@/hooks/use-landing-roster";
 import { useSfx } from "@/hooks/use-sfx";
+import { useMarketPulse } from "@/hooks/use-market-pulse";
 import {
   usePortfolio,
   type Portfolio,
@@ -109,6 +110,8 @@ import {
 } from "@/lib/utils";
 import { AnimatedNumber } from "@/components/animated-number";
 import { SkeletonRows } from "@/components/ui/skeleton-line";
+import { PanelHeader } from "@/components/ui/desk-panel";
+import { StatusChip } from "@/components/ui/status-chip";
 import { TickerTape } from "@/components/ticker-tape";
 import { staggerDelay } from "@/lib/motion-tokens";
 import {
@@ -146,11 +149,7 @@ const FALLBACK_WIRE_ITEMS = [
 ] as const;
 
 type WireCategory =
-  | "deal_seed"
-  | "breaking"
-  | "market_update"
-  | "market"
-  | "rumor";
+  "deal_seed" | "breaking" | "market_update" | "market" | "rumor";
 
 const CATEGORY_RAIL: Record<WireCategory, string> = {
   deal_seed: "bg-[var(--t-red)]",
@@ -260,184 +259,6 @@ export default function Home() {
       <Dashboard deskWalletAddress={deskManager.wallet_address} />
       {process.env.NODE_ENV === "development" && <ConvexIdentityDebug />}
     </>
-  );
-}
-
-/** Fallback roster shown before any real portraits have finished generating. */
-const SAMPLE_TRADER_NAMES = [
-  "Vic Sterling",
-  "Dana Cross",
-  "Rex Malloy",
-  "Sable Quinn",
-];
-
-type RosterTile = {
-  key: string;
-  name: string;
-  src: string | null;
-  imageStatus: "pending" | "generating" | "ready" | "error";
-  traits: FunTrait[];
-  effectiveTier?: "Gallery" | "Seat" | "CornerOffice";
-};
-
-/** Tier → chip color, mirroring the persona-traits palette. */
-const TRAIT_CHIP_TONE: Record<string, string> = {
-  Common: "border-[var(--t-divider)] text-[var(--t-muted)]",
-  Uncommon: "border-[var(--t-green)]/50 text-[var(--t-green)]",
-  Rare: "border-[var(--t-blue)]/60 text-[var(--t-blue)]",
-  Legendary: "border-[var(--t-amber)]/60 text-[var(--t-amber-hot)]",
-};
-
-/**
- * Unauthenticated landing screen. Renders the hero, the "first run" checklist,
- * and a live roster of real trader portraits (from a lightweight public query)
- * next to a "mint your own" slot so it's clear the player creates their own 1-of-1
- * AI trader. Each tile surfaces a couple of fun persona traits.
- */
-function LandingScreen({ onLogin }: { onLogin: () => void }) {
-  const { data: landingRoster } = useLandingRoster();
-
-  const galleryTiles = useMemo<RosterTile[]>(() => {
-    if (!landingRoster || landingRoster.length === 0) {
-      return SAMPLE_TRADER_NAMES.map((name) => ({
-        key: name,
-        name,
-        src: null,
-        imageStatus: "pending" as const,
-        traits: [],
-      }));
-    }
-
-    return landingRoster.map((t) => ({
-      key: t.id,
-      name: t.name,
-      src: t.profileImageUrl,
-      imageStatus: "ready" as const,
-      traits: t.traits ? pickFunTraits(t.traits) : [],
-      effectiveTier: t.effectiveTier,
-    }));
-  }, [landingRoster]);
-
-  return (
-    <div className="flex min-h-screen flex-col justify-center gap-8 bg-[var(--t-bg)] px-5 py-8 font-mono text-[var(--t-text)]">
-      <div className="mx-auto grid w-full max-w-4xl gap-7 md:grid-cols-[minmax(0,1.25fr)_minmax(17rem,0.75fr)] md:items-end">
-        <section className="min-w-0">
-          <p className="mb-3 text-[10px] font-bold uppercase tracking-[0.22em] text-[var(--t-green)]">
-            DESK_OS 1987 // PRIVATE WIRE
-          </p>
-          <h1 className="font-[family-name:var(--font-plex-sans)] text-4xl font-black uppercase leading-none tracking-wide text-[var(--t-accent)] sm:text-5xl">
-            MARGIN CALL
-          </h1>
-          <p className="mt-3 max-w-[42rem] text-sm leading-6 text-[var(--t-green)]/90 sm:text-base">
-            Run a hostile Wall Street desk. Fund your wallet, mint a 1-of-1 AI
-            trader, then write deals that lure rival agents into bad rooms.
-          </p>
-        </section>
-
-        <section className="terminal-panel px-4 py-4">
-          <h2 className="font-[family-name:var(--font-plex-sans)] text-sm font-black uppercase tracking-[0.16em] text-[var(--t-amber)]">
-            First run
-          </h2>
-          <ol className="mt-4 grid gap-3 text-xs uppercase tracking-[0.14em] text-[var(--t-muted)]">
-            {[
-              "Enter by email",
-              "Fund desk wallet",
-              "Mint your AI trader",
-              "Create first deal",
-            ].map((step, index) => (
-              <li key={step} className="flex items-center gap-3">
-                <span className="grid h-7 w-7 shrink-0 place-items-center border border-[var(--t-divider)] text-[var(--t-accent)]">
-                  {String(index + 1).padStart(2, "0")}
-                </span>
-                <span>{step}</span>
-              </li>
-            ))}
-          </ol>
-        </section>
-      </div>
-
-      <section className="mx-auto w-full max-w-4xl">
-        <div className="mb-3 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-          <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-[var(--t-green)]">
-            THE FLOOR // LIVE ROSTER
-          </p>
-          <p className="text-[10px] uppercase tracking-widest text-[var(--t-muted)]">
-            Every trader is a 1-of-1, minted onchain from your desk
-          </p>
-        </div>
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
-          {galleryTiles.map((tile) => (
-            <figure
-              key={tile.key}
-              className="terminal-panel flex flex-col overflow-hidden"
-            >
-              <div className="relative aspect-square">
-                <TraderAvatar
-                  name={tile.name}
-                  src={tile.src}
-                  imageStatus={tile.imageStatus}
-                  size="lg"
-                />
-              </div>
-              <figcaption className="flex flex-col gap-1.5 border-t border-[var(--t-divider)] px-2 py-2">
-                <span className="flex min-w-0 items-center gap-1.5">
-                  <span className="truncate text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
-                    {tile.name}
-                  </span>
-                  {tile.effectiveTier ? (
-                    <FloorCredential tier={tile.effectiveTier} compact />
-                  ) : null}
-                </span>
-                {tile.traits.length > 0 && (
-                  <span className="flex flex-wrap gap-1">
-                    {tile.traits.map((trait) => (
-                      <span
-                        key={trait.key}
-                        className={cn(
-                          "truncate border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em]",
-                          TRAIT_CHIP_TONE[trait.tier] ?? TRAIT_CHIP_TONE.Common
-                        )}
-                      >
-                        {trait.label}
-                      </span>
-                    ))}
-                  </span>
-                )}
-              </figcaption>
-            </figure>
-          ))}
-
-          <button
-            type="button"
-            onClick={onLogin}
-            className="group flex flex-col overflow-hidden border border-dashed border-[var(--t-accent)]/50 bg-[var(--t-accent-soft)] text-left transition-colors hover:border-[var(--t-accent)] focus:border-[var(--t-accent)] focus:outline-none"
-          >
-            <div className="relative flex aspect-square items-center justify-center">
-              <span className="font-[family-name:var(--font-plex-sans)] text-4xl font-black text-[var(--t-accent)]/70 transition-colors group-hover:text-[var(--t-accent)]">
-                +
-              </span>
-              <div className="pointer-events-none absolute inset-0 crt-line-grid opacity-30" />
-            </div>
-            <span className="truncate border-t border-dashed border-[var(--t-accent)]/40 px-2 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
-              Mint your trader
-            </span>
-          </button>
-        </div>
-      </section>
-
-      <div className="mx-auto flex w-full max-w-4xl flex-col items-start gap-3 sm:flex-row sm:items-center">
-        <button
-          onClick={onLogin}
-          className="min-h-11 border border-[var(--t-border)] bg-[var(--t-panel-strong)] px-6 py-3 font-mono text-sm font-black uppercase tracking-wider text-[var(--t-accent)] transition-colors hover:border-[var(--t-accent)] hover:text-[var(--t-text)] focus:border-[var(--t-accent)] focus:outline-none"
-        >
-          {">"} Enter by email<span className="cursor-blink">█</span>
-        </button>
-        <ConnectMcpDialog />
-        <p className="text-[11px] uppercase tracking-widest text-[var(--t-muted)]">
-          Email OTP access, or connect your AI agent via MCP.
-        </p>
-      </div>
-    </div>
   );
 }
 
@@ -578,13 +399,14 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
         dealsLoading={myDealsLoading}
         approvalsCount={pendingApprovals.length}
       />
+      <MarketStatusStrip />
 
-      <main className="mx-auto flex min-h-0 w-full flex-1 flex-col gap-2 overflow-hidden px-2 pb-2 xl:grid xl:min-h-0 xl:max-w-[112rem] xl:grid-cols-[22rem_minmax(36rem,1fr)_28rem] xl:pb-3">
+      <main className="mx-auto flex min-h-0 w-full flex-1 flex-col gap-2 overflow-hidden px-2 pb-2 lg:grid lg:min-h-0 lg:max-w-[112rem] lg:grid-cols-[20rem_minmax(28rem,1fr)_24rem] lg:pb-3 xl:grid-cols-[22rem_minmax(36rem,1fr)_28rem]">
         <div
           className={cn(
             "min-h-0 flex-1 flex-col overflow-hidden",
             mobileTab === "wire" ? "flex" : "hidden",
-            "xl:contents"
+            "lg:contents"
           )}
         >
           <NewswirePanel
@@ -601,14 +423,14 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
           className={cn(
             "grid min-h-0 flex-1 gap-2 overflow-hidden",
             mobileTab === "desk" || mobileTab === "feed" ? "grid" : "hidden",
-            "xl:grid xl:min-h-0 xl:grid-rows-[minmax(22rem,23rem)_minmax(0,1fr)]"
+            "lg:grid lg:min-h-0 lg:grid-rows-[minmax(18rem,20rem)_minmax(0,1fr)] xl:grid-rows-[minmax(22rem,23rem)_minmax(0,1fr)]"
           )}
         >
           <div
             className={cn(
               "min-h-0 flex-1 flex-col overflow-hidden",
               mobileTab === "desk" ? "flex" : "hidden",
-              "xl:flex xl:min-h-0"
+              "lg:flex lg:min-h-0"
             )}
           >
             <TradingDeskPanel
@@ -635,7 +457,7 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
             className={cn(
               "min-h-0 flex-1 flex-col overflow-hidden",
               mobileTab === "feed" ? "flex" : "hidden",
-              "xl:flex xl:min-h-0"
+              "lg:flex lg:min-h-0"
             )}
           >
             <TraderFeedPanel
@@ -661,7 +483,7 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
           className={cn(
             "min-h-0 flex-1 flex-col gap-2 overflow-hidden",
             mobileTab === "floor" ? "flex" : "hidden",
-            "xl:grid xl:min-h-0 xl:grid-rows-[minmax(0,1.6fr)_minmax(0,1fr)]"
+            "lg:grid lg:min-h-0 lg:grid-rows-[minmax(0,1.6fr)_minmax(0,1fr)]"
           )}
         >
           <MarketPlayersPanel
@@ -681,6 +503,7 @@ function Dashboard({ deskWalletAddress }: { deskWalletAddress: string }) {
       </main>
 
       <TickerTape pnl={pnl} approvalsCount={pendingApprovals.length} />
+      <MobileMarketPulse pnl={pnl} approvalsCount={pendingApprovals.length} />
 
       <MobileFooterNav
         activeTab={mobileTab}
@@ -837,7 +660,7 @@ function TopStatusBar({
 
   return (
     <header className="z-40 shrink-0 bg-[#050706]/95 px-2 pt-2 shadow-[0_1px_0_0_rgba(255,255,255,0.04)] backdrop-blur-sm">
-      <div className="border border-[var(--t-divider)] bg-[#070b09]/90 px-2 py-2 xl:hidden">
+      <div className="border border-[var(--t-divider)] bg-[#070b09]/90 px-2 py-2 lg:hidden">
         <div className="flex items-center gap-2">
           <div className="min-w-0 flex-1">
             <h1 className="truncate font-[family-name:var(--font-plex-sans)] text-sm font-black uppercase tracking-wide text-[var(--t-accent)]">
@@ -897,7 +720,7 @@ function TopStatusBar({
         </div>
       </div>
 
-      <div className="hidden gap-2 xl:grid xl:grid-cols-[18rem_14rem_minmax(42rem,1fr)_max-content]">
+      <div className="hidden gap-2 lg:grid lg:grid-cols-[14rem_12rem_minmax(0,1fr)_max-content] xl:grid-cols-[18rem_14rem_minmax(42rem,1fr)_max-content]">
         <div className="terminal-panel px-3 py-2">
           <h1 className="font-[family-name:var(--font-plex-sans)] text-2xl font-black leading-none tracking-wide text-[var(--t-accent)]">
             MARGIN CALL
@@ -1160,6 +983,7 @@ export function DeskCommandStrip({
       value: `${approvalsCount}`,
       tone: approvalsCount > 0 ? "amber" : "green",
       status: approvalsCount > 0 ? "Needs call" : "Clear",
+      urgent: approvalsCount > 0,
     },
   ] as const;
 
@@ -1169,7 +993,12 @@ export function DeskCommandStrip({
         {steps.map((step, index) => (
           <div
             key={step.label}
-            className="grid min-h-12 min-w-[11rem] shrink-0 grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 border border-[var(--t-divider)] bg-[#070b09]/90 px-3 py-2 xl:min-h-14 xl:min-w-0"
+            className={cn(
+              "grid min-h-12 min-w-[11rem] shrink-0 grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-3 border bg-[#070b09]/90 px-3 py-2 xl:min-h-14 xl:min-w-0",
+              "urgent" in step && step.urgent
+                ? "border-[var(--t-amber)]/55 shadow-[inset_0_0_0_1px_rgba(235,193,122,0.12)]"
+                : "border-[var(--t-divider)]"
+            )}
           >
             <span
               className={cn(
@@ -1189,6 +1018,12 @@ export function DeskCommandStrip({
                   STEP_TONE_STATUS[step.tone]
                 )}
               >
+                {"urgent" in step && step.urgent ? (
+                  <span
+                    aria-hidden
+                    className="live-pulse mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-[var(--t-amber)]"
+                  />
+                ) : null}
                 {step.status}
               </p>
             </div>
@@ -1394,6 +1229,8 @@ function NewswirePanel({
     | Array<{
         createdAt: string;
         isFlash?: boolean;
+        mood?: string;
+        topArcTension?: number | null;
         subjects?: Array<{ type: "trader" | "deal" | "manager"; id: string }>;
         dispatches: Array<{
           headline: string;
@@ -1417,6 +1254,7 @@ function NewswirePanel({
   onOpenDeal: (dealId: string) => void;
   onOpenTrader: (traderId: string) => void;
 }) {
+  const pulse = useMarketPulse();
   const [dealDialog, setDealDialog] = useState<NewswireCreateDialog | null>(
     null
   );
@@ -1493,15 +1331,25 @@ function NewswirePanel({
           canShowOpenDealsList ? () => setOpenDealsListOpen(true) : undefined
         }
         action={
-          <button
-            type="button"
-            onClick={() => setHelpOpen(true)}
-            title="How deals work"
-            aria-label="How deals work"
-            className="grid h-7 w-7 place-items-center border border-[var(--t-divider)] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)]"
-          >
-            <HelpCircle className="h-3.5 w-3.5" />
-          </button>
+          <div className="flex items-center gap-1.5">
+            {!pulse.isLoading ? (
+              <StatusChip
+                tone={pulse.heatTone}
+                className="hidden sm:inline-flex"
+              >
+                SEC {pulse.heatLabel}
+              </StatusChip>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => setHelpOpen(true)}
+              title="How deals work"
+              aria-label="How deals work"
+              className="grid h-7 w-7 place-items-center border border-[var(--t-divider)] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none"
+            >
+              <HelpCircle className="h-3.5 w-3.5" />
+            </button>
+          </div>
         }
       />
       <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
@@ -1626,7 +1474,7 @@ export function HowDealsWorkBrief({ onClose }: { onClose: () => void }) {
             [
               "03",
               "Let agents trade",
-              "GPT resolves each agent against the scenario.",
+              "Odds are rolled from market mood + SEC heat; the model only narrates.",
             ],
           ].map(([step, title, body]) => (
             <section
@@ -3009,47 +2857,6 @@ function MarketPlayersPanel({
         </div>
       )}
     </aside>
-  );
-}
-
-function PanelHeader({
-  title,
-  meta,
-  metaAriaLabel,
-  onMetaClick,
-  action,
-}: {
-  title: string;
-  meta?: string;
-  metaAriaLabel?: string;
-  onMetaClick?: () => void;
-  action?: ReactNode;
-}) {
-  return (
-    <div className="flex min-h-10 items-center justify-between gap-3 border-b border-[var(--t-divider)] bg-[#0b100d] px-3 py-2">
-      <h2 className="truncate font-[family-name:var(--font-plex-sans)] text-sm font-black uppercase tracking-[0.14em] text-[var(--t-accent)]">
-        {title}
-      </h2>
-      <div className="flex shrink-0 items-center gap-2">
-        {meta &&
-          (onMetaClick ? (
-            <button
-              type="button"
-              onClick={onMetaClick}
-              title={metaAriaLabel ?? meta}
-              aria-label={metaAriaLabel ?? meta}
-              className="border border-[var(--t-divider)] px-2 py-1 text-[10px] uppercase tracking-wider text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] focus:border-[var(--t-accent)] focus:text-[var(--t-accent)] focus:outline-none"
-            >
-              {meta}
-            </button>
-          ) : (
-            <span className="border border-[var(--t-divider)] px-2 py-1 text-[10px] uppercase tracking-wider text-[var(--t-muted)]">
-              {meta}
-            </span>
-          ))}
-        {action}
-      </div>
-    </div>
   );
 }
 

--- a/src/app/page.ui.test.tsx
+++ b/src/app/page.ui.test.tsx
@@ -60,6 +60,7 @@ describe("HowDealsWorkBrief", () => {
     expect(html).toContain("Desk brief");
     expect(html).toContain("How Deals Work");
     expect(html).toContain("Pick a wire");
+    expect(html).toContain("market mood + SEC heat");
     expect(html).toContain("Deal economics");
     expect(html).toContain("Sizing tactics");
     expect(html).toContain("Rule of thumb");

--- a/src/components/desk/market-status-strip.tsx
+++ b/src/components/desk/market-status-strip.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { StatusChip } from "@/components/ui/status-chip";
+import { useMarketHours } from "@/hooks/use-market-hours";
+import { useMarketPulse } from "@/hooks/use-market-pulse";
+import { cn } from "@/lib/utils";
+
+/**
+ * Compact live market threat strip for the signed-in desk — mood, SEC heat,
+ * and session clock. Sits under the command strip / above the main grid.
+ */
+export function MarketStatusStrip({
+  className,
+  compact = false,
+}: {
+  className?: string;
+  compact?: boolean;
+}) {
+  const pulse = useMarketPulse();
+  const hours = useMarketHours();
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2 border-b border-[var(--t-bronze)]/70 bg-[#080b0f]/90 px-2 py-1.5 xl:px-3",
+        className
+      )}
+    >
+      <StatusChip tone={hours.isOpen ? "live" : "warn"} pulse={hours.isOpen}>
+        {hours.isOpen ? "Floor open" : "Floor closed"} · {hours.countdownLabel}
+      </StatusChip>
+      {!pulse.isLoading ? (
+        <>
+          <StatusChip tone={pulse.moodTone}>Mood {pulse.moodLabel}</StatusChip>
+          <StatusChip tone={pulse.heatTone}>
+            SEC heat {pulse.heatLabel}
+            {typeof pulse.tension === "number"
+              ? ` · ${pulse.tension.toFixed(0)}`
+              : ""}
+          </StatusChip>
+          {pulse.isFlash ? (
+            <StatusChip tone="danger" pulse>
+              Flash tape
+            </StatusChip>
+          ) : null}
+          {!compact && pulse.headline ? (
+            <p className="min-w-0 flex-1 truncate text-[11px] uppercase tracking-[0.12em] text-[var(--t-muted)]">
+              <span className="text-[var(--t-amber)]">Wire</span>{" "}
+              {pulse.headline}
+            </p>
+          ) : null}
+        </>
+      ) : (
+        <span className="text-[11px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
+          Syncing tape…
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/desk/mobile-market-pulse.tsx
+++ b/src/components/desk/mobile-market-pulse.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { MarketValue } from "@/components/ui/market-value";
+import { StatusChip } from "@/components/ui/status-chip";
+import { useMarketPulse } from "@/hooks/use-market-pulse";
+import { cn, formatSignedMoney } from "@/lib/utils";
+
+/**
+ * Mobile-only P&L / approvals / heat pulse — desktop already has TickerTape.
+ */
+export function MobileMarketPulse({
+  pnl,
+  approvalsCount,
+  className,
+}: {
+  pnl: number;
+  approvalsCount: number;
+  className?: string;
+}) {
+  const pulse = useMarketPulse();
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center gap-3 overflow-x-auto border-t border-[var(--t-bronze)] bg-[#050706]/95 px-3 py-2 text-[11px] uppercase tracking-wider text-[var(--t-muted)] lg:hidden",
+        className
+      )}
+    >
+      <span className="shrink-0">
+        P&L <MarketValue value={pnl} format={formatSignedMoney} live />
+      </span>
+      <span className="shrink-0">
+        Appr{" "}
+        <span
+          className={
+            approvalsCount > 0
+              ? "font-bold text-[var(--t-amber)]"
+              : "text-[var(--t-green)]"
+          }
+        >
+          {approvalsCount}
+        </span>
+      </span>
+      {!pulse.isLoading ? (
+        <StatusChip tone={pulse.heatTone} className="shrink-0">
+          SEC {pulse.heatLabel}
+        </StatusChip>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/intro-sequence.tsx
+++ b/src/components/intro-sequence.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Volume2, VolumeX } from "lucide-react";
 
+import { GameButton } from "@/components/ui/game-button";
 import { useSfx } from "@/hooks/use-sfx";
 import { cn } from "@/lib/utils";
 
@@ -55,7 +56,6 @@ export function IntroSequence({
   onComplete: (triggerLogin: boolean) => void;
 }) {
   const [screen, setScreen] = useState<Screen>(0);
-  const [checks, setChecks] = useState<boolean[]>(() => RULES.map(() => false));
   const [muted, setMuted] = useState(false);
   const [musicStarted, setMusicStarted] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -95,17 +95,6 @@ export function IntroSequence({
     }
   }
 
-  function toggleCheck(index: number) {
-    setChecks((current) => {
-      const next = [...current];
-      next[index] = !next[index];
-      return next;
-    });
-    sfx.playApprovalPing();
-  }
-
-  const allChecked = useMemo(() => checks.every(Boolean), [checks]);
-
   function finish(triggerLogin: boolean) {
     if (typeof window !== "undefined") {
       localStorage.setItem("mc-intro-seen", "true");
@@ -123,7 +112,7 @@ export function IntroSequence({
         <button
           type="button"
           onClick={() => finish(false)}
-          className="text-[10px] font-bold uppercase tracking-[0.22em] text-[var(--t-muted)] transition-colors hover:text-[var(--t-accent)]"
+          className="text-[11px] font-bold uppercase tracking-[0.22em] text-[var(--t-muted)] transition-colors hover:text-[var(--t-accent)] focus-visible:text-[var(--t-accent)] focus-visible:outline-none"
         >
           [ SKIP INTRO ]
         </button>
@@ -132,7 +121,7 @@ export function IntroSequence({
           onClick={toggleMute}
           aria-label={muted ? "Unmute music" : "Mute music"}
           title={muted ? "Unmute music" : "Mute music"}
-          className="grid h-9 w-9 place-items-center border border-[var(--t-divider)] text-[var(--t-accent)] transition-colors hover:border-[var(--t-accent)] hover:bg-[var(--t-accent-soft)] hover:text-[var(--t-text)]"
+          className="grid h-9 w-9 place-items-center border border-[var(--t-divider)] text-[var(--t-accent)] transition-colors hover:border-[var(--t-accent)] hover:bg-[var(--t-accent-soft)] hover:text-[var(--t-text)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none"
         >
           {muted ? (
             <VolumeX className="h-4 w-4" />
@@ -142,22 +131,15 @@ export function IntroSequence({
         </button>
       </header>
 
-      <main className="flex flex-1 items-center justify-center px-5 py-8 sm:px-8">
+      <main className="flex flex-1 items-center justify-center overflow-y-auto px-5 py-8 sm:px-8">
         <div className="mx-auto w-full max-w-3xl">
           {screen === 0 && <SceneSet onAdvance={advance} />}
           {screen === 1 && <HowItWorks onAdvance={advance} />}
-          {screen === 2 && (
-            <RulesAndAgree
-              checks={checks}
-              onToggle={toggleCheck}
-              allChecked={allChecked}
-              onAgree={() => finish(true)}
-            />
-          )}
+          {screen === 2 && <RulesAndAgree onContinue={() => finish(false)} />}
         </div>
       </main>
 
-      <footer className="flex items-center justify-center gap-2 px-4 pb-6 text-[10px] uppercase tracking-[0.22em] text-[var(--t-muted)] sm:pb-8">
+      <footer className="flex items-center justify-center gap-2 px-4 pb-6 text-[11px] uppercase tracking-[0.22em] text-[var(--t-muted)] sm:pb-8">
         {[0, 1, 2].map((i) => (
           <span
             key={i}
@@ -174,36 +156,10 @@ export function IntroSequence({
   );
 }
 
-function PrimaryButton({
-  onClick,
-  disabled,
-  children,
-}: {
-  onClick: () => void;
-  disabled?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "group inline-flex min-h-12 items-center gap-2 border bg-[var(--t-panel-strong)] px-6 py-3 font-mono text-sm font-black uppercase tracking-[0.18em] transition-colors focus:outline-none",
-        disabled
-          ? "cursor-not-allowed border-[var(--t-divider)] text-[var(--t-muted)] opacity-60"
-          : "border-[var(--t-accent)] text-[var(--t-accent)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)] focus:bg-[var(--t-accent)] focus:text-[var(--t-bg)]"
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
 function SceneSet({ onAdvance }: { onAdvance: () => void }) {
   return (
     <div className="mc-crt-reveal flex flex-col gap-6 sm:gap-8">
-      <p className="text-[10px] font-bold uppercase tracking-[0.32em] text-[var(--t-green)]">
+      <p className="text-[11px] font-bold uppercase tracking-[0.32em] text-[var(--t-green)]">
         New York · October 1987 · 04:58 ET
       </p>
       <h1 className="font-[family-name:var(--font-plex-sans)] text-5xl font-black uppercase leading-[0.95] tracking-tight text-[var(--t-accent)] sm:text-7xl">
@@ -227,12 +183,12 @@ function SceneSet({ onAdvance }: { onAdvance: () => void }) {
         </p>
       </div>
       <div className="pt-4">
-        <PrimaryButton onClick={onAdvance}>
+        <GameButton onClick={onAdvance} size="lg">
           {">"} Step onto the floor
           <span className="cursor-blink">█</span>
-        </PrimaryButton>
-        <p className="mt-3 text-[10px] uppercase tracking-[0.22em] text-[var(--t-muted)]">
-          Audio starts on click. Click the speaker icon to mute.
+        </GameButton>
+        <p className="mt-3 text-[11px] uppercase tracking-[0.22em] text-[var(--t-muted)]">
+          Audio starts on click. Mute anytime from the speaker icon.
         </p>
       </div>
     </div>
@@ -243,7 +199,7 @@ function HowItWorks({ onAdvance }: { onAdvance: () => void }) {
   return (
     <div className="flex flex-col gap-6 sm:gap-8">
       <div className="flex flex-col gap-2">
-        <p className="text-[10px] font-bold uppercase tracking-[0.32em] text-[var(--t-green)]">
+        <p className="text-[11px] font-bold uppercase tracking-[0.32em] text-[var(--t-green)]">
           The game · how your desk earns
         </p>
         <h2 className="font-[family-name:var(--font-plex-sans)] text-4xl font-black uppercase leading-tight tracking-tight text-[var(--t-accent)] sm:text-5xl">
@@ -267,92 +223,48 @@ function HowItWorks({ onAdvance }: { onAdvance: () => void }) {
         ))}
       </ol>
       <div className="pt-2">
-        <PrimaryButton onClick={onAdvance}>
+        <GameButton onClick={onAdvance} size="lg">
           {">"} Show me the rules
           <span className="cursor-blink">█</span>
-        </PrimaryButton>
+        </GameButton>
       </div>
     </div>
   );
 }
 
-function RulesAndAgree({
-  checks,
-  onToggle,
-  allChecked,
-  onAgree,
-}: {
-  checks: boolean[];
-  onToggle: (index: number) => void;
-  allChecked: boolean;
-  onAgree: () => void;
-}) {
+function RulesAndAgree({ onContinue }: { onContinue: () => void }) {
   return (
     <div className="flex flex-col gap-6 sm:gap-8">
       <div className="flex flex-col gap-2">
-        <p className="text-[10px] font-bold uppercase tracking-[0.32em] text-[var(--t-amber)]">
-          The fine print · check every box
+        <p className="text-[11px] font-bold uppercase tracking-[0.32em] text-[var(--t-amber)]">
+          The fine print · read it once
         </p>
         <h2 className="font-[family-name:var(--font-plex-sans)] text-4xl font-black uppercase leading-tight tracking-tight text-[var(--t-accent)] sm:text-5xl">
           Sign on the dotted line.
         </h2>
       </div>
       <ul className="space-y-3">
-        {RULES.map((rule, i) => {
-          const checked = checks[i];
-          return (
-            <li key={rule.title}>
-              <button
-                type="button"
-                onClick={() => onToggle(i)}
-                aria-pressed={checked}
-                className={cn(
-                  "group flex w-full items-start gap-4 border px-4 py-3 text-left transition-colors focus:outline-none",
-                  checked
-                    ? "border-[var(--t-green)] bg-[var(--t-green)]/[0.06]"
-                    : "border-[var(--t-divider)] bg-[var(--t-panel-strong)] hover:border-[var(--t-accent)]"
-                )}
-              >
-                <span
-                  className={cn(
-                    "mt-0.5 grid h-6 w-6 shrink-0 place-items-center border font-mono text-xs font-black",
-                    checked
-                      ? "border-[var(--t-green)] bg-[var(--t-green)] text-[var(--t-bg)]"
-                      : "border-[var(--t-divider)] text-[var(--t-muted)] group-hover:border-[var(--t-accent)] group-hover:text-[var(--t-accent)]"
-                  )}
-                  aria-hidden
-                >
-                  {checked ? "✓" : ""}
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span
-                    className={cn(
-                      "block font-[family-name:var(--font-plex-sans)] text-base font-black uppercase tracking-wide",
-                      checked
-                        ? "text-[var(--t-green)]"
-                        : "text-[var(--t-accent)]"
-                    )}
-                  >
-                    {rule.title}
-                  </span>
-                  <span className="mt-1 block text-sm leading-6 text-[var(--t-text)]/90">
-                    {rule.body}
-                  </span>
-                </span>
-              </button>
-            </li>
-          );
-        })}
+        {RULES.map((rule) => (
+          <li
+            key={rule.title}
+            className="border border-[var(--t-divider)] bg-[var(--t-panel-strong)] px-4 py-3"
+          >
+            <p className="font-[family-name:var(--font-plex-sans)] text-base font-black uppercase tracking-wide text-[var(--t-accent)]">
+              {rule.title}
+            </p>
+            <p className="mt-1 text-sm leading-6 text-[var(--t-text)]/90">
+              {rule.body}
+            </p>
+          </li>
+        ))}
       </ul>
       <div className="pt-2">
-        <PrimaryButton onClick={onAgree} disabled={!allChecked}>
-          {">"} I&apos;m in
+        <GameButton onClick={onContinue} size="lg">
+          {">"} I&apos;m in — show me the floor
           <span className="cursor-blink">█</span>
-        </PrimaryButton>
-        <p className="mt-3 text-[10px] uppercase tracking-[0.22em] text-[var(--t-muted)]">
-          {allChecked
-            ? "Email OTP on the next screen. Welcome to the desk."
-            : "Acknowledge every rule to continue."}
+        </GameButton>
+        <p className="mt-3 text-[11px] uppercase tracking-[0.22em] text-[var(--t-muted)]">
+          Next: live roster and enter by email when you&apos;re ready.
         </p>
       </div>
     </div>

--- a/src/components/intro-sequence.ui.test.tsx
+++ b/src/components/intro-sequence.ui.test.tsx
@@ -1,0 +1,26 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-sfx", () => ({
+  useSfx: () => ({
+    playStinger: vi.fn(),
+    playWin: vi.fn(),
+    playApprovalPing: vi.fn(),
+    enabled: true,
+    toggleEnabled: vi.fn(),
+  }),
+}));
+
+import { IntroSequence } from "@/components/intro-sequence";
+
+describe("IntroSequence", () => {
+  it("opens on the cinematic prologue with skip and mute controls", () => {
+    const html = renderToStaticMarkup(<IntroSequence onComplete={() => {}} />);
+
+    expect(html).toContain("The year is 1987");
+    expect(html).toContain("SKIP INTRO");
+    expect(html).toContain("Mute music");
+    expect(html).toContain("Step onto the floor");
+    expect(html).not.toContain("Acknowledge every rule");
+  });
+});

--- a/src/components/landing/landing-screen.tsx
+++ b/src/components/landing/landing-screen.tsx
@@ -1,0 +1,373 @@
+"use client";
+
+import { useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+import { ConnectMcpDialog } from "@/components/connect-mcp-dialog";
+import { FloorCredential } from "@/components/seat-tier-badge";
+import { TraderAvatar } from "@/components/trader-avatar";
+import { GameButton } from "@/components/ui/game-button";
+import { StatusChip } from "@/components/ui/status-chip";
+import { useLandingRoster } from "@/hooks/use-landing-roster";
+import { useMarketHours } from "@/hooks/use-market-hours";
+import { useMarketPulse } from "@/hooks/use-market-pulse";
+import { pickFunTraits, type FunTrait } from "@/lib/portrait-traits";
+import { cn } from "@/lib/utils";
+
+const SAMPLE_TRADER_NAMES = [
+  "Vic Sterling",
+  "Dana Cross",
+  "Rex Malloy",
+  "Sable Quinn",
+];
+
+const LOOP_STEPS = [
+  {
+    tag: "Hire",
+    body: "Mint a 1-of-1 AI trader. It runs on its own clock.",
+  },
+  {
+    tag: "Fund",
+    body: "Drop USDC into escrow. Set the leash — risk, size, approvals.",
+  },
+  {
+    tag: "Bait",
+    body: "Write deals on the Wire. Lure rival agents into bad rooms.",
+  },
+  {
+    tag: "Collect",
+    body: "When they wipe, your desk eats. Zero-sum. No referees.",
+  },
+] as const;
+
+const TRAIT_CHIP_TONE: Record<string, string> = {
+  Common: "border-[var(--t-divider)] text-[var(--t-muted)]",
+  Uncommon: "border-[var(--t-green)]/50 text-[var(--t-green)]",
+  Rare: "border-[var(--t-blue)]/60 text-[var(--t-blue)]",
+  Legendary: "border-[var(--t-amber)]/60 text-[var(--t-amber-hot)]",
+};
+
+type RosterTile = {
+  key: string;
+  id: string | null;
+  name: string;
+  src: string | null;
+  imageStatus: "pending" | "generating" | "ready" | "error";
+  traits: FunTrait[];
+  effectiveTier?: "Gallery" | "Seat" | "CornerOffice";
+};
+
+/**
+ * Public cinematic landing — full-bleed hero, live roster proof, short loop,
+ * then convert via Privy email or MCP.
+ */
+export function LandingScreen({ onLogin }: { onLogin: () => void }) {
+  const { data: landingRoster } = useLandingRoster();
+  const pulse = useMarketPulse();
+  const marketHours = useMarketHours();
+
+  const galleryTiles = useMemo<RosterTile[]>(() => {
+    if (!landingRoster || landingRoster.length === 0) {
+      return SAMPLE_TRADER_NAMES.map((name) => ({
+        key: name,
+        id: null,
+        name,
+        src: null,
+        imageStatus: "pending" as const,
+        traits: [],
+      }));
+    }
+
+    return landingRoster.map((t) => ({
+      key: t.id,
+      id: t.id,
+      name: t.name,
+      src: t.profileImageUrl,
+      imageStatus: "ready" as const,
+      traits: t.traits ? pickFunTraits(t.traits) : [],
+      effectiveTier: t.effectiveTier,
+    }));
+  }, [landingRoster]);
+
+  return (
+    <div className="bg-[var(--t-bg)] font-mono text-[var(--t-text)]">
+      <LandingHero
+        onLogin={onLogin}
+        marketOpen={marketHours.isOpen}
+        countdownLabel={marketHours.countdownLabel}
+        moodLabel={pulse.moodLabel}
+        moodTone={pulse.moodTone}
+        heatLabel={pulse.heatLabel}
+        heatTone={pulse.heatTone}
+        headline={pulse.headline}
+        isPulseLoading={pulse.isLoading}
+      />
+
+      <section className="relative border-t border-[var(--t-bronze)] px-5 py-14 sm:px-8">
+        <div className="mx-auto w-full max-w-5xl">
+          <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-[var(--t-green)]">
+                The floor // live roster
+              </p>
+              <h2 className="mt-2 font-[family-name:var(--font-plex-sans)] text-2xl font-black uppercase tracking-wide text-[var(--t-accent)] sm:text-3xl">
+                Real desks. Real portraits.
+              </h2>
+            </div>
+            <p className="max-w-sm text-xs uppercase tracking-[0.14em] text-[var(--t-muted)]">
+              Every trader is a 1-of-1, minted onchain from a desk.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-5">
+            {galleryTiles.map((tile) => {
+              const body = (
+                <>
+                  <div className="relative aspect-square">
+                    <TraderAvatar
+                      name={tile.name}
+                      src={tile.src}
+                      imageStatus={tile.imageStatus}
+                      size="lg"
+                    />
+                  </div>
+                  <figcaption className="flex flex-col gap-1.5 border-t border-[var(--t-divider)] px-2 py-2">
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate text-[11px] font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+                        {tile.name}
+                      </span>
+                      {tile.effectiveTier ? (
+                        <FloorCredential tier={tile.effectiveTier} compact />
+                      ) : null}
+                    </span>
+                    {tile.traits.length > 0 && (
+                      <span className="flex flex-wrap gap-1">
+                        {tile.traits.map((trait) => (
+                          <span
+                            key={trait.key}
+                            className={cn(
+                              "truncate border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.1em]",
+                              TRAIT_CHIP_TONE[trait.tier] ??
+                                TRAIT_CHIP_TONE.Common
+                            )}
+                          >
+                            {trait.label}
+                          </span>
+                        ))}
+                      </span>
+                    )}
+                  </figcaption>
+                </>
+              );
+
+              if (tile.id) {
+                return (
+                  <Link
+                    key={tile.key}
+                    href={`/traders/${tile.id}`}
+                    className="terminal-panel flex flex-col overflow-hidden transition-colors hover:border-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none"
+                  >
+                    {body}
+                  </Link>
+                );
+              }
+
+              return (
+                <figure
+                  key={tile.key}
+                  className="terminal-panel flex flex-col overflow-hidden"
+                >
+                  {body}
+                </figure>
+              );
+            })}
+
+            <button
+              type="button"
+              onClick={onLogin}
+              className="group flex flex-col overflow-hidden border border-dashed border-[var(--t-accent)]/50 bg-[var(--t-accent-soft)] text-left transition-colors hover:border-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none"
+            >
+              <div className="relative flex aspect-square items-center justify-center">
+                <span className="font-[family-name:var(--font-plex-sans)] text-4xl font-black text-[var(--t-accent)]/70 transition-colors group-hover:text-[var(--t-accent)]">
+                  +
+                </span>
+                <div className="pointer-events-none absolute inset-0 crt-line-grid opacity-30" />
+              </div>
+              <span className="truncate border-t border-dashed border-[var(--t-accent)]/40 px-2 py-1.5 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+                Mint your trader
+              </span>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-[var(--t-bronze)] bg-[var(--t-surface)]/40 px-5 py-14 sm:px-8">
+        <div className="mx-auto w-full max-w-5xl">
+          <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-[var(--t-amber)]">
+            How your desk earns
+          </p>
+          <h2 className="mt-2 font-[family-name:var(--font-plex-sans)] text-2xl font-black uppercase tracking-wide text-[var(--t-accent)] sm:text-3xl">
+            Hire. Fund. Bait. Collect.
+          </h2>
+          <ol className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {LOOP_STEPS.map((step, index) => (
+              <li
+                key={step.tag}
+                className="mc-crt-reveal border border-[var(--t-divider)] bg-[#070b09]/80 px-4 py-4"
+                style={{ animationDelay: `${index * 80}ms` }}
+              >
+                <p className="text-[10px] uppercase tracking-[0.2em] text-[var(--t-muted)]">
+                  {String(index + 1).padStart(2, "0")}
+                </p>
+                <p className="mt-2 font-[family-name:var(--font-plex-sans)] text-lg font-black uppercase tracking-[0.14em] text-[var(--t-green)]">
+                  {step.tag}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-[var(--t-text)]/90">
+                  {step.body}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      {pulse.headline ? (
+        <section className="border-t border-[var(--t-bronze)] px-5 py-12 sm:px-8">
+          <div className="mx-auto w-full max-w-5xl">
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-[var(--t-green)]">
+              The wire // live
+            </p>
+            <article className="terminal-panel mt-4 px-4 py-5 sm:px-6">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusChip tone={pulse.moodTone} pulse>
+                  Mood {pulse.moodLabel}
+                </StatusChip>
+                <StatusChip tone={pulse.heatTone}>
+                  SEC heat {pulse.heatLabel}
+                </StatusChip>
+              </div>
+              <h3 className="mt-4 font-[family-name:var(--font-plex-sans)] text-xl font-black uppercase leading-tight tracking-wide text-[var(--t-amber)] sm:text-2xl">
+                {pulse.headline}
+              </h3>
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--t-muted)]">
+                Desk managers turn wire pressure into deals. Rival agents walk
+                in. Someone pays the room.
+              </p>
+            </article>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="border-t border-[var(--t-bronze)] px-5 py-16 sm:px-8">
+        <div className="mx-auto flex w-full max-w-5xl flex-col items-start gap-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-[family-name:var(--font-plex-sans)] text-3xl font-black uppercase tracking-wide text-[var(--t-accent)]">
+              Step onto the floor
+            </h2>
+            <p className="mt-2 max-w-md text-sm text-[var(--t-muted)]">
+              Email OTP gets you a desk wallet. Or connect an AI agent via MCP.
+            </p>
+          </div>
+          <div className="flex flex-col items-start gap-3 sm:items-end">
+            <GameButton onClick={onLogin} size="lg">
+              {">"} Enter by email
+              <span className="cursor-blink">█</span>
+            </GameButton>
+            <ConnectMcpDialog />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LandingHero({
+  onLogin,
+  marketOpen,
+  countdownLabel,
+  moodLabel,
+  moodTone: moodToneValue,
+  heatLabel,
+  heatTone: heatToneValue,
+  headline,
+  isPulseLoading,
+}: {
+  onLogin: () => void;
+  marketOpen: boolean;
+  countdownLabel: string;
+  moodLabel: string;
+  moodTone: "live" | "accent" | "warn" | "danger" | "neutral";
+  heatLabel: string;
+  heatTone: "live" | "accent" | "warn" | "danger" | "neutral";
+  headline: string | null;
+  isPulseLoading: boolean;
+}) {
+  return (
+    <section className="relative isolate min-h-[calc(100svh)] overflow-hidden">
+      <Image
+        src="/banner.png"
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover object-[58%_42%] sm:object-[62%_40%]"
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-[linear-gradient(105deg,rgba(5,7,10,0.94)_0%,rgba(5,7,10,0.82)_38%,rgba(5,7,10,0.45)_62%,rgba(5,7,10,0.72)_100%)]"
+      />
+      <div
+        aria-hidden
+        className="absolute inset-0 bg-[radial-gradient(circle_at_20%_80%,rgba(214,166,96,0.14),transparent_42%)]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 crt-line-grid opacity-[0.12]"
+      />
+
+      <div className="relative z-10 flex min-h-[calc(100svh)] flex-col">
+        <div className="flex flex-wrap items-center justify-between gap-3 px-5 pt-5 sm:px-8 sm:pt-6">
+          <StatusChip tone={marketOpen ? "live" : "warn"} pulse={marketOpen}>
+            {marketOpen
+              ? `NYSE open · ${countdownLabel}`
+              : `NYSE closed · ${countdownLabel}`}
+          </StatusChip>
+          <div className="flex flex-wrap items-center gap-2">
+            {!isPulseLoading ? (
+              <>
+                <StatusChip tone={moodToneValue}>Mood {moodLabel}</StatusChip>
+                <StatusChip tone={heatToneValue}>SEC {heatLabel}</StatusChip>
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mc-crt-reveal flex flex-1 flex-col justify-end px-5 pb-10 pt-16 sm:px-8 sm:pb-14 md:max-w-[38rem] lg:max-w-[42rem]">
+          <p className="text-[11px] font-bold uppercase tracking-[0.28em] text-[var(--t-green)]">
+            Desk_OS 1987 // private wire
+          </p>
+          <h1 className="mt-3 font-[family-name:var(--font-plex-sans)] text-[clamp(3.25rem,12vw,6.5rem)] font-black uppercase leading-[0.88] tracking-tight text-[var(--t-accent)]">
+            Margin Call
+          </h1>
+          <p className="mt-4 max-w-[28rem] text-base leading-7 text-[var(--t-text)]/92 sm:text-lg">
+            Run a hostile Wall Street desk. Fund AI traders. Write deals that
+            wipe the room.
+          </p>
+          {headline ? (
+            <p className="mt-3 line-clamp-2 max-w-[30rem] text-xs uppercase tracking-[0.14em] text-[var(--t-amber)]/90">
+              Wire: {headline}
+            </p>
+          ) : null}
+          <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+            <GameButton onClick={onLogin} size="lg">
+              {">"} Enter by email
+              <span className="cursor-blink">█</span>
+            </GameButton>
+            <ConnectMcpDialog />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/landing-screen.ui.test.tsx
+++ b/src/components/landing/landing-screen.ui.test.tsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-landing-roster", () => ({
+  useLandingRoster: () => ({
+    data: [
+      {
+        id: "trader_abc",
+        name: "Vic Sterling",
+        profileImageUrl: "https://example.com/vic.png",
+        traits: null,
+        effectiveTier: "Seat",
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-market-pulse", () => ({
+  useMarketPulse: () => ({
+    mood: "nervous",
+    moodLabel: "nervous",
+    moodTone: "warn",
+    heatBand: "hot",
+    heatLabel: "Elevated",
+    heatTone: "warn",
+    tension: 7,
+    isFlash: false,
+    headline: "Junk desks scramble as treasury whispers heat up",
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-market-hours", () => ({
+  useMarketHours: () => ({
+    isOpen: true,
+    countdownLabel: "1:02:00",
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: (props: { alt?: string; src?: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={props.alt ?? ""} src={props.src} />
+  ),
+}));
+
+vi.mock("@/components/connect-mcp-dialog", () => ({
+  ConnectMcpDialog: () => <button type="button">Connect via MCP</button>,
+}));
+
+import { LandingScreen } from "@/components/landing/landing-screen";
+
+describe("LandingScreen", () => {
+  it("renders cinematic brand hero, live roster link, and email CTA", () => {
+    const html = renderToStaticMarkup(<LandingScreen onLogin={() => {}} />);
+
+    expect(html).toContain("Margin Call");
+    expect(html).toContain("Run a hostile Wall Street desk");
+    expect(html).toContain("Enter by email");
+    expect(html).toContain("/traders/trader_abc");
+    expect(html).toContain("Vic Sterling");
+    expect(html).toContain("Hire. Fund. Bait. Collect.");
+    expect(html).toContain("Junk desks scramble");
+    expect(html).toContain("banner.png");
+    expect(html).toContain("SEC Elevated");
+  });
+});

--- a/src/components/mobile-footer-nav.tsx
+++ b/src/components/mobile-footer-nav.tsx
@@ -31,7 +31,7 @@ export function MobileFooterNav({
   return (
     <nav
       aria-label="Main navigation"
-      className="fixed inset-x-0 bottom-0 z-50 border-t border-[var(--t-bronze)] bg-[#050706]/98 pb-[env(safe-area-inset-bottom)] backdrop-blur-sm xl:hidden"
+      className="fixed inset-x-0 bottom-0 z-50 border-t border-[var(--t-bronze)] bg-[#050706]/98 pb-[env(safe-area-inset-bottom)] backdrop-blur-sm lg:hidden"
     >
       <div className="mx-auto grid h-16 max-w-lg grid-cols-4">
         {TABS.map(({ id, label, icon: Icon }) => {

--- a/src/components/pending-approval-card.tsx
+++ b/src/components/pending-approval-card.tsx
@@ -12,13 +12,20 @@ function getPendingApprovalState(expiresAtIso: string) {
   );
 
   if (minutesLeft <= 0) {
-    return { isExpired: true, label: "EXPIRED", color: "text-[var(--t-red)]" };
+    return {
+      isExpired: true,
+      isUrgent: false,
+      label: "EXPIRED",
+      color: "text-[var(--t-red)]",
+    };
   }
 
+  const isUrgent = minutesLeft < 5;
   return {
     isExpired: false,
-    label: `${minutesLeft}m`,
-    color: minutesLeft < 5 ? "text-[var(--t-red)]" : "text-[var(--t-amber)]",
+    isUrgent,
+    label: `${minutesLeft}m left`,
+    color: isUrgent ? "text-[var(--t-red-hot)]" : "text-[var(--t-amber)]",
   };
 }
 
@@ -31,7 +38,13 @@ export function PendingApprovalCard({
   const expiry = getPendingApprovalState(approval.expires_at);
 
   return (
-    <div className="bg-[var(--t-bg)] px-3 py-3">
+    <div
+      className={
+        expiry.isUrgent
+          ? "border border-[var(--t-red)]/45 bg-[var(--t-red)]/[0.07] px-3 py-3 shadow-[inset_3px_0_0_0_var(--t-red-hot)]"
+          : "border border-[var(--t-amber)]/30 bg-[var(--t-amber)]/[0.05] px-3 py-3 shadow-[inset_3px_0_0_0_var(--t-amber)]"
+      }
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 flex-1 items-start gap-2">
           <TraderAvatar
@@ -42,6 +55,9 @@ export function PendingApprovalCard({
           />
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span className="font-bold uppercase tracking-wider text-[var(--t-accent)]">
+                Needs call
+              </span>
               <span className="text-[var(--t-accent)]">
                 {approval.trader_name}
               </span>
@@ -49,7 +65,12 @@ export function PendingApprovalCard({
                 ${approval.entry_cost_usdc.toFixed(2)} into $
                 {approval.deal_pot_usdc.toFixed(2)} pot
               </span>
-              <span className={`text-[10px] ${expiry.color}`}>
+              <span
+                className={`text-[11px] font-bold uppercase tracking-wider ${expiry.color}`}
+              >
+                {expiry.isUrgent ? (
+                  <span className="live-pulse mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--t-red-hot)]" />
+                ) : null}
                 {expiry.label}
               </span>
             </div>
@@ -65,7 +86,7 @@ export function PendingApprovalCard({
               onClick={() =>
                 mutate({ approvalId: approval.id, action: "approve" })
               }
-              className="min-h-10 border border-[var(--t-border)] px-3 py-1 text-[var(--t-green)] transition-colors hover:border-[var(--t-green)] focus:border-[var(--t-green)] focus:outline-none"
+              className="min-h-10 border border-[var(--t-border)] px-3 py-1 text-[var(--t-green)] transition-colors hover:border-[var(--t-green)] focus-visible:border-[var(--t-green)] focus-visible:outline-none"
             >
               APPROVE
             </button>
@@ -74,7 +95,7 @@ export function PendingApprovalCard({
               onClick={() =>
                 mutate({ approvalId: approval.id, action: "reject" })
               }
-              className="min-h-10 border border-[var(--t-border)] px-3 py-1 text-[var(--t-red)] transition-colors hover:border-[var(--t-red)] focus:border-[var(--t-red)] focus:outline-none"
+              className="min-h-10 border border-[var(--t-border)] px-3 py-1 text-[var(--t-red)] transition-colors hover:border-[var(--t-red)] focus-visible:border-[var(--t-red)] focus-visible:outline-none"
             >
               DENY
             </button>

--- a/src/components/ticker-tape.tsx
+++ b/src/components/ticker-tape.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { AnimatedNumber } from "@/components/animated-number";
 import { useGlobalActivity } from "@/hooks/use-global-activity";
+import { useMarketPulse } from "@/hooks/use-market-pulse";
 import { MARQUEE } from "@/lib/motion-tokens";
 import { buildTickerItems, type TickerItem } from "@/lib/ticker-tape";
 import { cn, formatSignedMoney } from "@/lib/utils";
@@ -19,19 +20,12 @@ const KIND_CLASS: Record<TickerItem["kind"], string> = {
 };
 
 // Period-flavor filler so the tape never runs dry on a quiet floor.
-const STATIC_FILLER: TickerItem[] = [
+const ERA_FILLER = [
   "DOW 2,503.45 +1.28%",
   "S&P 500 336.21 +1.14%",
   "10Y YIELD 8.42%",
   "OIL (WTI) $18.74 -1.24",
-  "SEC HEAT MODERATE",
-].map((text, index) => ({
-  id: `filler:${index}`,
-  kind: "enter",
-  text,
-  createdAt: 0,
-  isFiller: true,
-}));
+] as const;
 
 /** Tile the headline list until the marquee track is wide enough to loop. */
 const MIN_TRACK_ENTRIES = 12;
@@ -49,6 +43,7 @@ export function TickerTape({
   approvalsCount: number;
 }) {
   const { data: globalActivity } = useGlobalActivity();
+  const pulse = useMarketPulse();
   const recentDeals = useQuery(api.deals.listRecentCreatedForToasts, {
     limit: 8,
   });
@@ -64,11 +59,23 @@ export function TickerTape({
         createdAt: deal.createdAt,
       })),
     });
-    const merged = [...live, ...STATIC_FILLER];
+    const fillerTexts = [
+      ...ERA_FILLER,
+      `SEC HEAT ${pulse.heatLabel.toUpperCase()}`,
+      `MOOD ${pulse.moodLabel.toUpperCase()}`,
+    ];
+    const filler: TickerItem[] = fillerTexts.map((text, index) => ({
+      id: `filler:${index}`,
+      kind: "enter" as const,
+      text,
+      createdAt: 0,
+      isFiller: true,
+    }));
+    const merged = [...live, ...filler];
     const tiled = [...merged];
     while (tiled.length < MIN_TRACK_ENTRIES) tiled.push(...merged);
     return tiled;
-  }, [globalActivity, recentDeals]);
+  }, [globalActivity, recentDeals, pulse.heatLabel, pulse.moodLabel]);
 
   const durationSeconds = Math.max(
     MARQUEE.minSeconds,
@@ -76,7 +83,7 @@ export function TickerTape({
   );
 
   return (
-    <footer className="z-30 hidden shrink-0 border-t border-[var(--t-bronze)] bg-[#050706]/95 text-[11px] uppercase tracking-wider text-[var(--t-muted)] xl:block">
+    <footer className="z-30 hidden shrink-0 border-t border-[var(--t-bronze)] bg-[#050706]/95 text-[11px] uppercase tracking-wider text-[var(--t-muted)] lg:block">
       <div className="mx-auto flex max-w-[112rem] items-stretch">
         <div className="relative z-10 flex shrink-0 items-center gap-5 bg-[#050706] px-3 py-2 shadow-[8px_0_12px_-6px_rgba(0,0,0,0.9)]">
           <span>

--- a/src/components/ui/desk-panel.tsx
+++ b/src/components/ui/desk-panel.tsx
@@ -1,0 +1,67 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function DeskPanel({
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLElement> & { children: ReactNode }) {
+  return (
+    <section className={cn("terminal-panel", className)} {...props}>
+      {children}
+    </section>
+  );
+}
+
+export function PanelHeader({
+  title,
+  meta,
+  action,
+  metaAriaLabel,
+  onMetaClick,
+  className,
+}: {
+  title: string;
+  meta?: string;
+  action?: ReactNode;
+  metaAriaLabel?: string;
+  onMetaClick?: () => void;
+  className?: string;
+}) {
+  const metaNode = meta ? (
+    onMetaClick ? (
+      <button
+        type="button"
+        onClick={onMetaClick}
+        aria-label={metaAriaLabel ?? meta}
+        className="border border-[var(--t-divider)] px-2 py-0.5 text-[10px] uppercase tracking-wider text-[var(--t-muted)] transition-colors hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:text-[var(--t-accent)] focus-visible:outline-none"
+      >
+        {meta}
+      </button>
+    ) : (
+      <span className="border border-[var(--t-divider)] px-2 py-0.5 text-[10px] uppercase tracking-wider text-[var(--t-muted)]">
+        {meta}
+      </span>
+    )
+  ) : null;
+
+  return (
+    <header
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-3 border-b border-[var(--t-divider)] bg-[#0b100d]/90 px-3 py-2.5",
+        className
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <h2 className="truncate font-[family-name:var(--font-plex-sans)] text-sm font-black uppercase tracking-[0.14em] text-[var(--t-accent)]">
+          {title}
+        </h2>
+        {metaNode}
+      </div>
+      {action ? (
+        <div className="flex shrink-0 items-center gap-2">{action}</div>
+      ) : null}
+    </header>
+  );
+}

--- a/src/components/ui/desk-panel.ui.test.tsx
+++ b/src/components/ui/desk-panel.ui.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { DeskPanel, PanelHeader } from "@/components/ui/desk-panel";
+import { GameButton } from "@/components/ui/game-button";
+import { StatusChip } from "@/components/ui/status-chip";
+
+describe("game UI primitives", () => {
+  it("renders DeskPanel and PanelHeader chrome", () => {
+    const html = renderToStaticMarkup(
+      <DeskPanel>
+        <PanelHeader title="The Wire" meta="3 OPEN DEALS" />
+      </DeskPanel>
+    );
+    expect(html).toContain("terminal-panel");
+    expect(html).toContain("The Wire");
+    expect(html).toContain("3 OPEN DEALS");
+  });
+
+  it("renders GameButton primary CTA", () => {
+    const html = renderToStaticMarkup(
+      <GameButton onClick={() => {}}>{">"} Enter by email</GameButton>
+    );
+    expect(html).toContain("Enter by email");
+    expect(html).toContain("border-[var(--t-accent)]");
+  });
+
+  it("renders StatusChip with live pulse affordance", () => {
+    const html = renderToStaticMarkup(
+      <StatusChip tone="live" pulse>
+        Floor open
+      </StatusChip>
+    );
+    expect(html).toContain("Floor open");
+    expect(html).toContain("live-pulse");
+  });
+});

--- a/src/components/ui/game-button.tsx
+++ b/src/components/ui/game-button.tsx
@@ -1,0 +1,57 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const gameButtonVariants = cva(
+  "inline-flex min-h-11 items-center justify-center gap-2 border font-mono text-sm font-black uppercase tracking-[0.16em] transition-[color,background-color,border-color,transform] duration-[var(--mc-dur-fast)] ease-[var(--mc-ease-snap)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--t-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50 active:enabled:scale-[0.97]",
+  {
+    variants: {
+      variant: {
+        primary:
+          "border-[var(--t-accent)] bg-[var(--t-panel-strong)] text-[var(--t-accent)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]",
+        secondary:
+          "border-[var(--t-divider)] bg-transparent text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)]",
+        ghost:
+          "border-transparent bg-transparent text-[var(--t-muted)] hover:text-[var(--t-accent)]",
+        danger:
+          "border-[var(--t-red)]/60 bg-[var(--t-red)]/10 text-[var(--t-red)] hover:border-[var(--t-red)] hover:bg-[var(--t-red)]/20",
+      },
+      size: {
+        default: "px-6 py-3",
+        sm: "min-h-9 px-3 py-2 text-[11px] tracking-[0.14em]",
+        lg: "min-h-12 px-8 py-3.5 text-base",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "default",
+    },
+  }
+);
+
+export type GameButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof gameButtonVariants> & {
+    children: ReactNode;
+  };
+
+export function GameButton({
+  className,
+  variant,
+  size,
+  children,
+  type = "button",
+  ...props
+}: GameButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(gameButtonVariants({ variant, size }), className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export { gameButtonVariants };

--- a/src/components/ui/market-value.tsx
+++ b/src/components/ui/market-value.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+
+import { AnimatedNumber } from "@/components/animated-number";
+import { cn } from "@/lib/utils";
+
+export function MarketValue({
+  value,
+  format,
+  live = false,
+  className,
+  tone = "auto",
+}: {
+  value: number;
+  format: (n: number) => string;
+  live?: boolean;
+  className?: string;
+  tone?: "auto" | "neutral" | "up" | "down";
+}) {
+  const resolvedTone =
+    tone === "auto"
+      ? value > 0
+        ? "up"
+        : value < 0
+          ? "down"
+          : "neutral"
+      : tone;
+
+  return (
+    <AnimatedNumber
+      value={value}
+      format={format}
+      live={live}
+      className={cn(
+        "mc-live-value tabular-nums",
+        resolvedTone === "up" && "text-[var(--t-green)]",
+        resolvedTone === "down" && "text-[var(--t-red)]",
+        resolvedTone === "neutral" && "text-[var(--t-text)]",
+        className
+      )}
+    />
+  );
+}
+
+export function MarketLabel({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("min-w-0", className)}>
+      <p className="text-[10px] uppercase tracking-[0.16em] text-[var(--t-muted)]">
+        {label}
+      </p>
+      <div className="mt-0.5 text-sm font-bold tabular-nums text-[var(--t-text)]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/status-chip.tsx
+++ b/src/components/ui/status-chip.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const statusChipVariants = cva(
+  "inline-flex items-center gap-1.5 border px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.14em]",
+  {
+    variants: {
+      tone: {
+        neutral: "border-[var(--t-divider)] text-[var(--t-muted)]",
+        accent: "border-[var(--t-accent)]/50 text-[var(--t-accent)]",
+        live: "border-[var(--t-green)]/50 text-[var(--t-green)]",
+        warn: "border-[var(--t-amber)]/50 text-[var(--t-amber)]",
+        danger: "border-[var(--t-red)]/50 text-[var(--t-red)]",
+      },
+    },
+    defaultVariants: {
+      tone: "neutral",
+    },
+  }
+);
+
+export function StatusChip({
+  tone,
+  pulse = false,
+  className,
+  children,
+}: VariantProps<typeof statusChipVariants> & {
+  pulse?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span className={cn(statusChipVariants({ tone }), className)}>
+      {pulse ? (
+        <span
+          aria-hidden
+          className="live-pulse inline-block h-1.5 w-1.5 rounded-full bg-current"
+        />
+      ) : null}
+      {children}
+    </span>
+  );
+}
+
+export { statusChipVariants };

--- a/src/hooks/use-market-pulse.ts
+++ b/src/hooks/use-market-pulse.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "convex/react";
+
+import { api } from "../../convex/_generated/api";
+import {
+  formatMoodLabel,
+  heatBandFromTension,
+  heatLabel,
+  heatTone,
+  moodTone,
+  type HeatBand,
+} from "@/lib/market-pulse";
+
+export type MarketPulse = {
+  mood: string;
+  moodLabel: string;
+  moodTone: ReturnType<typeof moodTone>;
+  heatBand: HeatBand;
+  heatLabel: string;
+  heatTone: ReturnType<typeof heatTone>;
+  tension: number | null;
+  isFlash: boolean;
+  headline: string | null;
+  isLoading: boolean;
+};
+
+/** Latest wire drop mood + tension for status chrome (public-safe). */
+export function useMarketPulse(): MarketPulse {
+  const drops = useQuery(api.marketNarratives.feedDrops, { limit: 1 });
+
+  return useMemo(() => {
+    const latest = drops?.[0];
+    const mood = latest?.mood ?? "unknown";
+    const tension =
+      typeof latest?.topArcTension === "number" ? latest.topArcTension : null;
+    const band = heatBandFromTension(tension);
+    const headline =
+      latest?.dispatches?.[0]?.headline ?? latest?.dropTitle ?? null;
+
+    return {
+      mood,
+      moodLabel: formatMoodLabel(mood),
+      moodTone: moodTone(mood),
+      heatBand: band,
+      heatLabel: heatLabel(band),
+      heatTone: heatTone(band),
+      tension,
+      isFlash: Boolean(latest?.isFlash),
+      headline,
+      isLoading: drops === undefined,
+    };
+  }, [drops]);
+}

--- a/src/lib/market-pulse.test.ts
+++ b/src/lib/market-pulse.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatMoodLabel,
+  heatBandFromTension,
+  heatLabel,
+  heatTone,
+  moodTone,
+} from "@/lib/market-pulse";
+
+describe("market-pulse helpers", () => {
+  it("maps mood to UI tones", () => {
+    expect(moodTone("electric")).toBe("live");
+    expect(moodTone("grim")).toBe("danger");
+    expect(moodTone("nervous")).toBe("warn");
+    expect(moodTone("bored")).toBe("neutral");
+  });
+
+  it("bands tension into SEC heat labels", () => {
+    expect(heatBandFromTension(1)).toBe("cool");
+    expect(heatBandFromTension(4)).toBe("warm");
+    expect(heatBandFromTension(7)).toBe("hot");
+    expect(heatBandFromTension(9)).toBe("critical");
+    expect(heatLabel("critical")).toBe("Critical");
+    expect(heatTone("cool")).toBe("live");
+  });
+
+  it("formats mood labels for display", () => {
+    expect(formatMoodLabel("unknown")).toBe("Quiet tape");
+    expect(formatMoodLabel("electric")).toBe("electric");
+  });
+});

--- a/src/lib/market-pulse.ts
+++ b/src/lib/market-pulse.ts
@@ -1,0 +1,90 @@
+/**
+ * Display helpers for live market mood / SEC-heat atmosphere.
+ * Odds use mood + heat mechanically; the UI only narrates that state.
+ */
+
+export type MarketMood =
+  | "electric"
+  | "greedy"
+  | "bored"
+  | "hungover"
+  | "nervous"
+  | "grim"
+  | "tense"
+  | "unknown"
+  | string;
+
+export type HeatBand = "cool" | "warm" | "hot" | "critical";
+
+/** Map narrative mood → UI tone for chips and status bars. */
+export function moodTone(
+  mood: MarketMood
+): "live" | "accent" | "warn" | "danger" | "neutral" {
+  switch (mood) {
+    case "electric":
+    case "greedy":
+      return "live";
+    case "bored":
+    case "hungover":
+      return "neutral";
+    case "nervous":
+    case "tense":
+      return "warn";
+    case "grim":
+      return "danger";
+    default:
+      return "accent";
+  }
+}
+
+/** Arc tension (0–10) → SEC heat band for display. */
+export function heatBandFromTension(
+  tension: number | null | undefined
+): HeatBand {
+  const t = tension ?? 5;
+  if (t >= 8) return "critical";
+  if (t >= 6) return "hot";
+  if (t >= 3.5) return "warm";
+  return "cool";
+}
+
+export function heatLabel(band: HeatBand): string {
+  switch (band) {
+    case "cool":
+      return "Cool";
+    case "warm":
+      return "Moderate";
+    case "hot":
+      return "Elevated";
+    case "critical":
+      return "Critical";
+    default: {
+      const _exhaustive: never = band;
+      return _exhaustive;
+    }
+  }
+}
+
+export function heatTone(
+  band: HeatBand
+): "live" | "accent" | "warn" | "danger" | "neutral" {
+  switch (band) {
+    case "cool":
+      return "live";
+    case "warm":
+      return "accent";
+    case "hot":
+      return "warn";
+    case "critical":
+      return "danger";
+    default: {
+      const _exhaustive: never = band;
+      return _exhaustive;
+    }
+  }
+}
+
+export function formatMoodLabel(mood: MarketMood): string {
+  if (!mood || mood === "unknown") return "Quiet tape";
+  return mood.replace(/_/g, " ");
+}

--- a/src/lib/privy/config.ts
+++ b/src/lib/privy/config.ts
@@ -20,7 +20,7 @@ export const privyConfig: PrivyClientConfig = {
   loginMethods: ["email"],
   appearance: {
     theme: "dark",
-    accentColor: "#22c55e",
+    accentColor: "#d6a660",
   },
   embeddedWallets: {
     ethereum: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Phased visual redesign to make Margin Call feel more like a 1987 financial thriller—especially before signup—without changing game mechanics.

### Public homepage
- Full-bleed hero using `banner.png` with brand-first hierarchy and live NYSE / mood / SEC heat chips
- Live roster tiles now link to public trader dossiers; mint CTA + email OTP remain primary conversion
- Short scroll narrative: roster proof → Hire/Fund/Bait/Collect → Wire teaser → final CTA
- Intro is a faster cinematic prologue (no 4-checkbox gate); handoff copy matches landing

### Design system
- Shared primitives: `GameButton`, `DeskPanel`/`PanelHeader`, `StatusChip`, `MarketValue`
- Semantic urgency/market tokens + focus-visible defaults in `globals.css`
- Privy accent aligned to brass gold; OG/Twitter metadata uses the banner

### Signed-in desk
- `MarketStatusStrip` surfaces live mood + SEC heat from Wire world state
- Mobile P&L / approvals / heat pulse (desktop keeps ticker tape)
- Approval cards and command-strip approvals get urgency treatment
- Deal brief clarifies mechanical odds (mood + SEC heat), not “GPT resolves”
- Intermediate `lg` breakpoint for the three-column desk layout

### Tests
- New coverage for landing, intro, market-pulse helpers, and UI primitives
- Existing page UI tests updated for mechanical-odds copy

## Notes
- `/music.mp3` is present in this workspace and kept for the intro
- One pre-existing Convex trading-hours test failure remains unrelated to this UI work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1420de7-b0c3-4f1a-988e-a5d251bbc671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1420de7-b0c3-4f1a-988e-a5d251bbc671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

