### PR TITLE
Floor (#250): align the Foundry harness with LazerForge conventions

### DIFF
--- a/contracts/REPRODUCIBILITY.md
+++ b/contracts/REPRODUCIBILITY.md
@@ -1,17 +1,54 @@
 # Contract build reproducibility
 
-Pinned compiler and dependency settings for `MarginCallEscrow`, `SeatVault`, and
-`MarginCallToken`. A clean clone with these pins should produce identical bytecode
-when built with the same Foundry version.
+Pinned compiler, chain-state, and dependency settings for the contract
+workspace. A clean clone with these pins should produce identical bytecode when
+built with the same Foundry version.
+
+The configuration follows [LazerForge](https://github.com/LazerTechnologies/LazerForge)
+conventions, adapted to this repository rather than imported wholesale.
+Deviations are listed at the bottom of this file.
 
 ## Toolchain
 
-| Component         | Pin                 | Where                                                                                                        |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Foundry (forge)   | `v1.4.3`            | [`.github/actions/setup-foundry/action.yml`](../.github/actions/setup-foundry/action.yml), local `foundryup` |
-| Solidity (`solc`) | `0.8.28`            | [`foundry.toml`](foundry.toml) `solc_version`                                                                |
-| EVM target        | `cancun`            | [`foundry.toml`](foundry.toml) `evm_version`                                                                 |
-| Optimizer         | enabled, `200` runs | [`foundry.toml`](foundry.toml)                                                                               |
+| Component         | Pin                        | Where                                                                                                        |
+| ----------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Foundry (forge)   | `v1.4.3`                   | [`.github/actions/setup-foundry/action.yml`](../.github/actions/setup-foundry/action.yml), local `foundryup` |
+| Solidity (`solc`) | `0.8.28`, auto-detect off  | [`foundry.toml`](foundry.toml) `solc_version`, `auto_detect_solc`                                            |
+| EVM target        | `cancun`                   | [`foundry.toml`](foundry.toml) `evm_version`                                                                 |
+| Optimizer         | enabled, `99_999_999` runs | [`foundry.toml`](foundry.toml)                                                                               |
+| Metadata          | stripped                   | [`foundry.toml`](foundry.toml) `bytecode_hash = "none"`, `cbor_metadata = false`                             |
+
+## Deterministic chain state
+
+Tests run against a fixed, realistic chain state instead of block 1:
+
+| Setting           | Value           | Source                                                    |
+| ----------------- | --------------- | --------------------------------------------------------- |
+| `block_number`    | `93_499_334`    | Robinhood Chain testnet (46630) head, observed 2026-07-26 |
+| `block_timestamp` | `1_785_024_629` | Timestamp of that block (2026-07-26T00:10:29Z)            |
+
+Update both together, and only to a matching real block, so time-dependent
+tests stay honest about the network they target.
+
+## Profiles
+
+| Profile   | Purpose                                  | Notable settings                      |
+| --------- | ---------------------------------------- | ------------------------------------- |
+| `default` | Fast local development                   | fuzz 256, invariant 64 × 32           |
+| `ci`      | Complete non-fork suite                  | fuzz 512, invariant 128 × 32          |
+| `ci-fuzz` | Higher-run campaign                      | fuzz 1024, invariant 256 × 64         |
+| `gas`     | Gas analysis and snapshots               | `via_ir`, optimizer 1,000,000 runs    |
+| `legacy`  | Reproduce deployed Base Sepolia bytecode | optimizer 200 runs, metadata retained |
+
+```bash
+forge test                                        # default
+FOUNDRY_PROFILE=ci forge test                     # CI suite
+FOUNDRY_PROFILE=ci-fuzz forge test                # fuzz/invariant campaign
+FOUNDRY_PROFILE=gas forge snapshot                # gas analysis
+```
+
+RPC endpoints come from the environment (`ROBINHOOD_TESTNET_RPC_URL`,
+`BASE_SEPOLIA_RPC_URL`) via `[rpc_endpoints]`; no URL is hard-coded.
 
 ## Forge libraries
 
@@ -37,4 +74,25 @@ cd contracts && forge build
 # Compare bytecode hashes under out/*.sol/*.json "deployedBytecode.object"
 ```
 
-Contract source pragmas remain `^0.8.20`; `foundry.toml` forces solc `0.8.28` for every build.
+Contract source pragmas remain `^0.8.20`; `foundry.toml` forces solc `0.8.28`
+for every build.
+
+## Documented deviations from LazerForge
+
+- **Remappings** cover only the dependencies this repo installs. LazerForge
+  ships Solady and Uniswap remappings that would not resolve here.
+- **`evm_version = "cancun"`** rather than LazerForge's `prague`. Robinhood
+  Chain testnet is an Arbitrum Nitro L2; Cancun is the pin this workspace
+  already shipped and verified against.
+- **No `via_ir-out` pre-compile step.** LazerForge pre-compiles via-IR and
+  deploys with `vm.getCode`. Contracts here fit comfortably without it —
+  `MarginCallEscrow` is the largest at 14,979 B runtime, leaving 9,597 B of
+  EIP-170 margin at 99,999,999 optimizer runs — so via-IR is confined to the
+  `gas` profile.
+- **A `legacy` profile exists** because the Base Sepolia deal-game contracts
+  were deployed before metadata stripping and the optimizer-runs increase.
+  Their bytecode no longer reproduces under `default`, so
+  `pnpm deploy:*` and `pnpm verify:*` for those contracts pass
+  `LEGACY_FOUNDRY_PROFILE` (see [`scripts/deploy-utils.ts`](../scripts/deploy-utils.ts)).
+  The profile and its callers are removed with the rest of the legacy path in
+  [#262](https://github.com/hurley87/margin-call/issues/262).

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,17 +1,70 @@
+# Margin Call contract workspace.
+#
+# Conventions follow LazerForge (https://github.com/LazerTechnologies/LazerForge):
+# explicit compiler selection, deterministic chain state, metadata-free builds,
+# named profiles, CI fuzzing, gas analysis, and env-supplied RPC endpoints.
+# Deviations and their reasons are recorded in REPRODUCIBILITY.md.
+
 [profile.default]
 src = "src"
 out = "out"
 libs = ["lib"]
 remappings = [
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+    "forge-std/=lib/forge-std/src/",
 ]
+
+# Never let the toolchain pick a compiler for us.
+auto_detect_solc = false
 solc_version = "0.8.28"
 evm_version = "cancun"
 optimizer = true
-optimizer_runs = 200
-fuzz = { runs = 512 }
-invariant = { runs = 256, depth = 32 }
+optimizer_runs = 99_999_999
 
-[profile.ci]
+# Keep metadata out of the bytecode so builds are reproducible.
+bytecode_hash = "none"
+cbor_metadata = false
+
+# Robinhood Chain testnet (46630) head observed at 2026-07-26T00:10:29Z.
+# Tests run against a realistic, fixed chain state rather than block 1.
+block_number = 93_499_334
+block_timestamp = 1_785_024_629
+
+# Local development is fast; CI runs the larger campaigns.
 fuzz = { runs = 256 }
-invariant = { runs = 128, depth = 15 }
+invariant = { runs = 64, depth = 32 }
+
+# Complete non-fork suite.
+[profile.ci]
+fuzz = { runs = 512 }
+invariant = { runs = 128, depth = 32 }
+
+# Higher-run fuzz and invariant campaign.
+[profile.ci-fuzz]
+fuzz = { runs = 1024 }
+invariant = { runs = 256, depth = 64 }
+
+# Gas analysis and snapshots.
+[profile.gas]
+via_ir = true
+optimizer_runs = 1_000_000
+
+# Reproduces bytecode for the legacy deal-game contracts already deployed to
+# Base Sepolia, which were built before metadata was stripped. Not a Floor
+# build target; removed with the rest of the legacy path in #262.
+[profile.legacy]
+optimizer_runs = 200
+bytecode_hash = "ipfs"
+cbor_metadata = true
+
+[fmt]
+line_length = 120
+tab_width = 4
+bracket_spacing = false
+int_types = "long"
+quote_style = "double"
+number_underscore = "preserve"
+
+[rpc_endpoints]
+robinhood_testnet = "${ROBINHOOD_TESTNET_RPC_URL}"
+base_sepolia = "${BASE_SEPOLIA_RPC_URL}"

--- a/scripts/deploy-escrow.ts
+++ b/scripts/deploy-escrow.ts
@@ -18,6 +18,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import {
   appendDeploymentRecord,
   broadcastRecordFields,
+  LEGACY_FOUNDRY_PROFILE,
   loadEnvLocal,
   patchEnvLocal,
   readLatestBroadcastCreate,
@@ -79,6 +80,7 @@ function main() {
       DEPOSITOR_BINDER_ADDRESS: depositorBinder,
       ENTRY_TIMEOUT_SECONDS: entryTimeoutSeconds,
     },
+    foundryProfile: LEGACY_FOUNDRY_PROFILE,
   });
 
   const broadcast = readLatestBroadcastCreate({

--- a/scripts/deploy-margincall-token.ts
+++ b/scripts/deploy-margincall-token.ts
@@ -11,6 +11,7 @@
  */
 import {
   appendDeploymentRecord,
+  LEGACY_FOUNDRY_PROFILE,
   loadEnvLocal,
   patchEnvLocal,
   requireGate1Approval,
@@ -37,6 +38,7 @@ function main() {
     privateKey: operatorKey,
     addressLabel: "MARGINCALL",
     env: { INITIAL_MINT: env.INITIAL_MINT ?? "1000000000000000000000000" },
+    foundryProfile: LEGACY_FOUNDRY_PROFILE,
   });
 
   patchEnvLocal("MARGINCALL_TOKEN", address);

--- a/scripts/deploy-seat-vault.ts
+++ b/scripts/deploy-seat-vault.ts
@@ -20,6 +20,7 @@
 import {
   appendDeploymentRecord,
   broadcastRecordFields,
+  LEGACY_FOUNDRY_PROFILE,
   loadEnvLocal,
   patchEnvLocal,
   readLatestBroadcastCreate,
@@ -90,6 +91,7 @@ function main() {
     privateKey: operatorKey,
     addressLabel: "SeatVault",
     env: forgeEnv,
+    foundryProfile: LEGACY_FOUNDRY_PROFILE,
   });
 
   const broadcast = readLatestBroadcastCreate({

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -13,6 +13,14 @@ export const DEPLOYMENTS_DIR = join(CONTRACTS_DIR, "deployments");
 
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
 
+/**
+ * Foundry profile that reproduces the bytecode of the Base Sepolia deal-game
+ * contracts, which were built before the default profile stripped metadata and
+ * raised optimizer runs. Legacy deploy and verify calls must pass this or
+ * Basescan will reject the recompiled source.
+ */
+export const LEGACY_FOUNDRY_PROFILE = "legacy";
+
 export function loadEnvLocal(): Record<string, string> {
   if (!existsSync(ENV_LOCAL)) {
     throw new Error(
@@ -182,6 +190,7 @@ export function runForgeDeploy(opts: {
   privateKey: string;
   addressLabel: string;
   env?: Record<string, string>;
+  foundryProfile?: string;
 }): { address: string; output: string } {
   const output = execFileSync(
     "forge",
@@ -197,7 +206,13 @@ export function runForgeDeploy(opts: {
     ],
     {
       cwd: CONTRACTS_DIR,
-      env: { ...process.env, ...opts.env },
+      env: {
+        ...process.env,
+        ...opts.env,
+        ...(opts.foundryProfile
+          ? { FOUNDRY_PROFILE: opts.foundryProfile }
+          : {}),
+      },
       encoding: "utf8",
     }
   );
@@ -245,6 +260,7 @@ export function runForgeVerify(opts: {
   constructorArgsHex: string;
   etherscanApiKey: string;
   chainId?: number;
+  foundryProfile?: string;
 }): string {
   const chainId = opts.chainId ?? BASE_SEPOLIA_CHAIN_ID;
   return execFileSync(
@@ -263,6 +279,12 @@ export function runForgeVerify(opts: {
     ],
     {
       cwd: CONTRACTS_DIR,
+      env: {
+        ...process.env,
+        ...(opts.foundryProfile
+          ? { FOUNDRY_PROFILE: opts.foundryProfile }
+          : {}),
+      },
       encoding: "utf8",
     }
   );

--- a/scripts/verify-contracts.ts
+++ b/scripts/verify-contracts.ts
@@ -24,6 +24,7 @@
  */
 import {
   castAbiEncode,
+  LEGACY_FOUNDRY_PROFILE,
   loadEnvLocal,
   requireAddress,
   runForgeVerify,
@@ -78,6 +79,7 @@ function verifyContract(opts: {
     contractPath: opts.contractPath,
     constructorArgsHex: opts.constructorArgsHex,
     etherscanApiKey: opts.key,
+    foundryProfile: LEGACY_FOUNDRY_PROFILE,
   });
   console.log(output);
   console.log(


### PR DESCRIPTION
First of two PRs for [#250](https://github.com/hurley87/margin-call/issues/250). This one only satisfies the harness acceptance criterion, so the Trader NFT / ERC-6551 work lands on a reproducible, deterministic base. No contract source changes.

## Summary

- **Pinned and metadata-free builds.** Compiler auto-detection off, metadata and CBOR stripped, optimizer runs raised to LazerForge's level.
- **Deterministic chain state.** `block_number` / `block_timestamp` pinned to a real Robinhood Chain testnet head (block 93,499,334 at 2026-07-26T00:10:29Z, read live from the public RPC) so time-dependent tests run against realistic state instead of block 1.
- **Named profiles.** `default` (fast local), `ci` (complete non-fork suite), `ci-fuzz` (1,024 fuzz runs), `gas` (via-IR at 1M runs), and `legacy`.
- **Env-supplied RPCs.** `[rpc_endpoints]` reads `ROBINHOOD_TESTNET_RPC_URL` and `BASE_SEPOLIA_RPC_URL`; no hard-coded URLs.
- **`[fmt]` pinned to Foundry defaults**, so the convention is explicit with zero reformat churn.

## Why the `legacy` profile exists

Stripping metadata means the Base Sepolia deal-game contracts already deployed on-chain no longer reproduce under `default`, which would have silently broken `pnpm verify:escrow`. The `legacy` profile preserves the old 200-run, metadata-retaining build, and `runForgeDeploy` / `runForgeVerify` gained a `foundryProfile` option that the four legacy Base Sepolia scripts pass. Base Sepolia is not a Floor regression gate, but breaking the tool without saying so would be worse than keeping it working. Profile and callers are removed with the rest of the legacy path in #262.

## Documented deviations from LazerForge

Recorded in `contracts/REPRODUCIBILITY.md`:

- Remappings cover only the dependencies this repo installs (no Solady / Uniswap).
- `evm_version = "cancun"` rather than `prague` — Robinhood Chain testnet is an Arbitrum Nitro L2 and Cancun is the pin this workspace already verified against.
- No `via_ir-out` pre-compile step. `MarginCallEscrow` is the largest contract at 14,979 B runtime with 9,597 B of EIP-170 margin at 99,999,999 runs, so via-IR stays confined to the `gas` profile.

## Test plan

- [x] `forge test` (default) — 132 passed
- [x] `FOUNDRY_PROFILE=ci forge test --no-match-path 'test/fork/**'` — 132 passed
- [x] `FOUNDRY_PROFILE=ci-fuzz forge test --no-match-path 'test/fork/**'` — 132 passed
- [x] `FOUNDRY_PROFILE=gas forge build` and `FOUNDRY_PROFILE=legacy forge build` — both succeed
- [x] `forge fmt --check` clean, no reformat churn
- [x] `tsc --noEmit` and ESLint clean on the changed scripts
- [x] Fork test still skips cleanly with no `BASE_SEPOLIA_RPC_URL`
- [ ] CI green

## Follow-up

CI wiring for the `ci-fuzz` job, `.gas-snapshot`, and coverage is deliberately held for the feature PR, so the snapshot is generated once against final bytecode rather than regenerated as the Trader contracts land.

Made with [Cursor](https://cursor.com)