### PR TITLE
Floor (#250): Trader identity, token-bound account, and epoch-scoped delegation

### DIFF
--- a/contracts/script/DeployFloorTrader.s.sol
+++ b/contracts/script/DeployFloorTrader.s.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {TraderAccount} from "../src/TraderAccount.sol";
+import {TraderDelegation} from "../src/TraderDelegation.sol";
+import {TraderIdentity} from "../src/TraderIdentity.sol";
+
+/// @notice Deploy the Floor Trader identity set to Robinhood Chain testnet.
+/// @dev The three contracts deploy together because TraderDelegation is bound
+///      to a TraderIdentity address at construction, and an account
+///      implementation is only meaningful alongside the collection it serves.
+///      Splitting them across runs invites a delegation contract pointed at a
+///      stale collection.
+///
+/// Env:
+///   TRADER_NAME (optional, default "Margin Call Trader")
+///   TRADER_SYMBOL (optional, default "MCTRADER")
+///   TRADER_BASE_URI (required — the metadata endpoint, with trailing slash)
+contract DeployFloorTrader is Script {
+    string internal constant DEFAULT_NAME = "Margin Call Trader";
+    string internal constant DEFAULT_SYMBOL = "MCTRADER";
+
+    function run() external {
+        string memory name = vm.envOr("TRADER_NAME", string(DEFAULT_NAME));
+        string memory symbol = vm.envOr("TRADER_SYMBOL", string(DEFAULT_SYMBOL));
+        string memory baseURI = vm.envString("TRADER_BASE_URI");
+
+        vm.startBroadcast();
+        TraderIdentity identity = new TraderIdentity(name, symbol, baseURI);
+        TraderAccount accountImplementation = new TraderAccount();
+        TraderDelegation delegation = new TraderDelegation(address(identity));
+        vm.stopBroadcast();
+
+        console2.log("TraderIdentity deployed at:", address(identity));
+        console2.log("TraderAccount deployed at:", address(accountImplementation));
+        console2.log("TraderDelegation deployed at:", address(delegation));
+        console2.log("Name:", name);
+        console2.log("Symbol:", symbol);
+        console2.log("Base URI:", baseURI);
+    }
+}

--- a/contracts/src/TraderAccount.sol
+++ b/contracts/src/TraderAccount.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import {IERC6551Account, IERC6551Executable} from "./interfaces/IERC6551.sol";
+
+/// @notice ERC-6551 token bound account implementation for Trader identities.
+/// @dev Deployed once and used as the implementation behind every Trader's
+///      account proxy, which the canonical ERC-6551 registry creates. Because a
+///      cross-chain implementation address cannot be assumed to hold code, this
+///      is deployed and verified per network rather than reused by address.
+///
+///      Authority is read live from the controlling NFT on every call, so
+///      control follows a standard ERC-721 transfer with no migration step and
+///      no residual power for the previous owner. There is no admin, no
+///      upgrade path, and no House key: only the current NFT owner can move
+///      what the account holds.
+contract TraderAccount is IERC165, IERC1271, IERC6551Account, IERC6551Executable, IERC721Receiver {
+    /// @dev Offset of the token data appended to the proxy's runtime code:
+    ///      ERC-1167 header (10) + implementation (20) + footer (15) + salt (32).
+    uint256 private constant TOKEN_DATA_OFFSET = 0x4d;
+    uint256 private constant TOKEN_DATA_LENGTH = 0x60;
+
+    /// @dev Runtime size of a registry-created proxy: the 0x4d bytes preceding
+    ///      the token data plus chainId, tokenContract, and tokenId.
+    uint256 private constant PROXY_RUNTIME_LENGTH = 0xad;
+
+    uint256 public state;
+
+    event TransactionExecuted(address indexed to, uint256 value, bytes data, uint256 state);
+
+    receive() external payable {}
+
+    /// @notice Execute a call from the account.
+    /// @dev Restricted to the current NFT owner. Delegated agent keys never get
+    ///      raw account control; they authorize typed protocol intents instead,
+    ///      so a compromised agent key cannot drain the account.
+    function execute(address to, uint256 value, bytes calldata data, uint8 operation)
+        external
+        payable
+        returns (bytes memory result)
+    {
+        require(_isValidSigner(msg.sender), "Not trader owner");
+        require(operation == 0, "Unsupported operation");
+
+        ++state;
+
+        bool success;
+        (success, result) = to.call{value: value}(data);
+        if (!success) {
+            assembly {
+                revert(add(result, 0x20), mload(result))
+            }
+        }
+
+        emit TransactionExecuted(to, value, data, state);
+    }
+
+    /// @notice Identity of the NFT that controls this account.
+    /// @dev Read from the proxy's own runtime code. Anything that is not a
+    ///      registry-created proxy — the bare implementation most of all —
+    ///      reports no binding rather than reverting or decoding whatever
+    ///      happens to sit at that offset. Callers get an ownerless account,
+    ///      which denies every authority check.
+    function token() public view returns (uint256 chainId, address tokenContract, uint256 tokenId) {
+        if (address(this).code.length != PROXY_RUNTIME_LENGTH) {
+            return (0, address(0), 0);
+        }
+
+        bytes memory footer = new bytes(TOKEN_DATA_LENGTH);
+        assembly {
+            extcodecopy(address(), add(footer, 0x20), TOKEN_DATA_OFFSET, TOKEN_DATA_LENGTH)
+        }
+        return abi.decode(footer, (uint256, address, uint256));
+    }
+
+    /// @notice Current controller of the account, or zero when it has none.
+    function owner() public view returns (address) {
+        (uint256 chainId, address tokenContract, uint256 tokenId) = token();
+        // A Trader bound on another chain has no owner here. Failing closed
+        // matters: a zero owner must never be treated as a valid signer.
+        if (chainId != block.chainid || tokenContract == address(0)) {
+            return address(0);
+        }
+        return IERC721(tokenContract).ownerOf(tokenId);
+    }
+
+    function isValidSigner(address signer, bytes calldata) external view returns (bytes4) {
+        if (_isValidSigner(signer)) {
+            return IERC6551Account.isValidSigner.selector;
+        }
+        return bytes4(0);
+    }
+
+    /// @notice ERC-1271 validation against the current NFT owner.
+    /// @dev Because the owner is resolved live, a signature from a previous
+    ///      owner stops validating the moment the Trader is transferred.
+    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4) {
+        address currentOwner = owner();
+        if (currentOwner == address(0)) {
+            return bytes4(0);
+        }
+        if (SignatureChecker.isValidSignatureNow(currentOwner, hash, signature)) {
+            return IERC1271.isValidSignature.selector;
+        }
+        return bytes4(0);
+    }
+
+    /// @dev Accepts Lots and other ERC-721s, but refuses the account's own
+    ///      controlling token: letting an account own itself would strand it
+    ///      with no reachable owner.
+    function onERC721Received(address, address, uint256 receivedTokenId, bytes memory) external view returns (bytes4) {
+        (uint256 chainId, address tokenContract, uint256 tokenId) = token();
+        if (chainId == block.chainid && tokenContract == msg.sender && tokenId == receivedTokenId) {
+            revert("Ownership cycle");
+        }
+        return IERC721Receiver.onERC721Received.selector;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC6551Account).interfaceId
+            || interfaceId == type(IERC6551Executable).interfaceId || interfaceId == type(IERC1271).interfaceId
+            || interfaceId == type(IERC721Receiver).interfaceId;
+    }
+
+    function _isValidSigner(address signer) internal view returns (bool) {
+        address currentOwner = owner();
+        return currentOwner != address(0) && signer == currentOwner;
+    }
+}

--- a/contracts/src/TraderDelegation.sol
+++ b/contracts/src/TraderDelegation.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {TraderIdentity} from "./TraderIdentity.sol";
+
+/// @notice Delegated agent authority for Trader identities, scoped to an
+///         authority epoch.
+/// @dev Agent keys never receive raw token-bound-account control. They are
+///      authorized only for named protocol actions against named contracts, so
+///      a compromised key cannot make arbitrary calls from the account.
+///
+///      Every grant records the Trader's authority epoch. Because a transfer
+///      advances that epoch, a sale retires every delegated key at once —
+///      without an unbounded loop and without needing the departing owner to
+///      cooperate in a revocation. Grants are likewise inert while the Trader
+///      is unclaimed, which is what keeps automation paused until the new owner
+///      has reviewed it.
+///
+///      Spend limits are deliberately absent. A per-fill or daily cap can only
+///      be enforced where the spend is observed, so those live with the
+///      settlement contract rather than being recorded here as a control this
+///      contract cannot apply.
+contract TraderDelegation {
+    uint256 public constant ACTION_QUOTE = 1 << 0;
+    uint256 public constant ACTION_FILL = 1 << 1;
+    uint256 public constant ACTION_CANCEL = 1 << 2;
+    uint256 public constant ACTION_CRACK = 1 << 3;
+
+    /// @dev Every currently defined action. Grants may not request bits outside
+    ///      this set, so a later action cannot be pre-authorized by a grant
+    ///      written before it existed.
+    uint256 public constant ACTION_ALL = ACTION_QUOTE | ACTION_FILL | ACTION_CANCEL | ACTION_CRACK;
+
+    /// @dev Upper bound on how long a single grant may live. Bounds the blast
+    ///      radius of a leaked key for an owner who stops paying attention.
+    uint64 public constant MAX_DELEGATION_DURATION = 30 days;
+
+    struct Delegation {
+        uint64 epoch;
+        uint64 generation;
+        uint64 expiresAt;
+        uint256 actions;
+    }
+
+    TraderIdentity public immutable identity;
+
+    mapping(uint256 => mapping(address => Delegation)) private _delegations;
+    mapping(uint256 => uint64) private _generation;
+    mapping(bytes32 => bool) private _targets;
+
+    event DelegationGranted(
+        uint256 indexed tokenId, address indexed agentKey, uint64 epoch, uint64 expiresAt, uint256 actions
+    );
+    event DelegationTargetAllowed(uint256 indexed tokenId, address indexed agentKey, address indexed target);
+    event DelegationRevoked(uint256 indexed tokenId, address indexed agentKey);
+    event DelegationsRevokedAll(uint256 indexed tokenId, uint64 generation);
+
+    constructor(address identity_) {
+        require(identity_ != address(0), "Zero identity");
+        identity = TraderIdentity(identity_);
+    }
+
+    modifier onlyTraderOwner(uint256 tokenId) {
+        require(msg.sender == identity.ownerOf(tokenId), "Not trader owner");
+        _;
+    }
+
+    /// @notice Authorize `agentKey` to take `actions` against `targets`.
+    /// @dev Overwrites any previous grant for the same key. Only the current
+    ///      owner of a claimed Trader may grant.
+    function grant(uint256 tokenId, address agentKey, uint256 actions, address[] calldata targets, uint64 expiresAt)
+        external
+        onlyTraderOwner(tokenId)
+    {
+        require(agentKey != address(0), "Zero agent key");
+        require(identity.isClaimed(tokenId), "Trader unclaimed");
+        require(actions != 0 && actions & ~ACTION_ALL == 0, "Invalid actions");
+        require(targets.length != 0, "No targets");
+        require(expiresAt > block.timestamp, "Expiry in past");
+        require(expiresAt <= block.timestamp + MAX_DELEGATION_DURATION, "Expiry too far");
+
+        uint64 epoch = identity.authorityEpoch(tokenId);
+        uint64 generation = _generation[tokenId];
+
+        _delegations[tokenId][agentKey] =
+            Delegation({epoch: epoch, generation: generation, expiresAt: expiresAt, actions: actions});
+
+        for (uint256 i = 0; i < targets.length; i++) {
+            address target = targets[i];
+            require(target != address(0), "Zero target");
+            _targets[_targetKey(tokenId, agentKey, epoch, generation, target)] = true;
+            emit DelegationTargetAllowed(tokenId, agentKey, target);
+        }
+
+        emit DelegationGranted(tokenId, agentKey, epoch, expiresAt, actions);
+    }
+
+    /// @notice Revoke a single agent key immediately.
+    function revoke(uint256 tokenId, address agentKey) external onlyTraderOwner(tokenId) {
+        require(_delegations[tokenId][agentKey].expiresAt != 0, "No delegation");
+        delete _delegations[tokenId][agentKey];
+        emit DelegationRevoked(tokenId, agentKey);
+    }
+
+    /// @notice Revoke every agent key for a Trader in one transaction.
+    /// @dev Advances a generation counter rather than iterating keys, so the
+    ///      cost does not grow with the number of grants.
+    function revokeAll(uint256 tokenId) external onlyTraderOwner(tokenId) {
+        uint64 generation = _generation[tokenId] + 1;
+        _generation[tokenId] = generation;
+        emit DelegationsRevokedAll(tokenId, generation);
+    }
+
+    /// @notice Whether `agentKey` may take `action` against `target` right now.
+    function isAuthorized(uint256 tokenId, address agentKey, uint256 action, address target)
+        public
+        view
+        returns (bool)
+    {
+        Delegation storage d = _delegations[tokenId][agentKey];
+
+        if (d.expiresAt == 0 || block.timestamp >= d.expiresAt) return false;
+        if (action == 0 || d.actions & action != action) return false;
+        if (d.generation != _generation[tokenId]) return false;
+        if (d.epoch != identity.authorityEpoch(tokenId)) return false;
+        if (!identity.isClaimed(tokenId)) return false;
+
+        return _targets[_targetKey(tokenId, agentKey, d.epoch, d.generation, target)];
+    }
+
+    /// @notice Revert-on-failure form for protocol contracts.
+    function assertAuthorized(uint256 tokenId, address agentKey, uint256 action, address target) external view {
+        require(isAuthorized(tokenId, agentKey, action, target), "Agent not authorized");
+    }
+
+    function delegationOf(uint256 tokenId, address agentKey) external view returns (Delegation memory) {
+        return _delegations[tokenId][agentKey];
+    }
+
+    function generationOf(uint256 tokenId) external view returns (uint64) {
+        return _generation[tokenId];
+    }
+
+    function isTargetAllowed(uint256 tokenId, address agentKey, address target) external view returns (bool) {
+        Delegation storage d = _delegations[tokenId][agentKey];
+        return _targets[_targetKey(tokenId, agentKey, d.epoch, d.generation, target)];
+    }
+
+    function _targetKey(uint256 tokenId, address agentKey, uint64 epoch, uint64 generation, address target)
+        private
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(tokenId, agentKey, epoch, generation, target));
+    }
+}

--- a/contracts/src/TraderIdentity.sol
+++ b/contracts/src/TraderIdentity.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @notice Transferable Trader identity for The Floor.
+/// @dev Non-upgradeable by design: custody rules must not change beneath active
+///      positions. Ownership is a standard, permissionlessly transferable
+///      ERC-721 with no lockup, so a Trader can be sold on any external
+///      marketplace.
+///
+///      Every transfer advances the token's authority epoch. Downstream
+///      contracts bind delegated agent keys and signed offers to an epoch, so
+///      advancing it retires the previous owner's authority without needing an
+///      explicit revocation from them. A transfer also clears the claim flag:
+///      the new owner must claim the Trader before automation may resume.
+contract TraderIdentity is ERC721 {
+    address public owner;
+    address public pendingOwner;
+
+    string private _baseTokenURI;
+
+    uint256 private _nextTokenId = 1;
+
+    mapping(uint256 => uint64) private _authorityEpoch;
+    mapping(uint256 => bool) private _claimed;
+
+    event TraderCreated(uint256 indexed tokenId, address indexed traderOwner);
+    event AuthorityEpochAdvanced(
+        uint256 indexed tokenId, address indexed previousOwner, address indexed newOwner, uint64 epoch
+    );
+    event TraderClaimed(uint256 indexed tokenId, address indexed traderOwner, uint64 epoch);
+    event BaseURIUpdated(string baseURI);
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    constructor(string memory name_, string memory symbol_, string memory baseTokenURI_) ERC721(name_, symbol_) {
+        _baseTokenURI = baseTokenURI_;
+        owner = msg.sender;
+    }
+
+    /// @notice Create a Trader owned by `to`.
+    /// @dev Permissionless: the House sponsors gas but must not gate identity
+    ///      creation, so a desk's ownership is never shared with the House.
+    ///      The creator is the first owner and needs no separate claim.
+    function mint(address to) external returns (uint256 tokenId) {
+        require(to != address(0), "Zero owner");
+
+        tokenId = _nextTokenId++;
+        _authorityEpoch[tokenId] = 1;
+        _claimed[tokenId] = true;
+
+        _safeMint(to, tokenId);
+
+        emit TraderCreated(tokenId, to);
+    }
+
+    /// @notice Claim a Trader received by transfer, re-enabling automation.
+    function claim(uint256 tokenId) external {
+        address traderOwner = _requireOwned(tokenId);
+        require(msg.sender == traderOwner, "Not trader owner");
+        require(!_claimed[tokenId], "Already claimed");
+
+        _claimed[tokenId] = true;
+
+        emit TraderClaimed(tokenId, traderOwner, _authorityEpoch[tokenId]);
+    }
+
+    /// @notice Current authority epoch, or zero if the Trader does not exist.
+    function authorityEpoch(uint256 tokenId) external view returns (uint64) {
+        return _authorityEpoch[tokenId];
+    }
+
+    /// @notice Whether the current owner has claimed the Trader.
+    function isClaimed(uint256 tokenId) external view returns (bool) {
+        return _claimed[tokenId];
+    }
+
+    /// @notice Owner, epoch, and claim state in one read for indexers and UI.
+    function traderState(uint256 tokenId) external view returns (address traderOwner, uint64 epoch, bool claimed_) {
+        traderOwner = _requireOwned(tokenId);
+        return (traderOwner, _authorityEpoch[tokenId], _claimed[tokenId]);
+    }
+
+    function totalMinted() external view returns (uint256) {
+        return _nextTokenId - 1;
+    }
+
+    function setBaseURI(string calldata baseTokenURI_) external onlyOwner {
+        _baseTokenURI = baseTokenURI_;
+        emit BaseURIUpdated(baseTokenURI_);
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "Zero owner");
+        pendingOwner = newOwner;
+        emit OwnershipTransferStarted(owner, newOwner);
+    }
+
+    function acceptOwnership() external {
+        require(msg.sender == pendingOwner, "Not pending owner");
+        address previousOwner = owner;
+        owner = pendingOwner;
+        pendingOwner = address(0);
+        emit OwnershipTransferred(previousOwner, owner);
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return _baseTokenURI;
+    }
+
+    /// @dev Advances the authority epoch on every ownership change. A
+    ///      self-transfer still advances it: treating a real transfer as a
+    ///      no-op would leave the decision of whether authority survives up to
+    ///      the caller, and failing closed is the safer default.
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+        address from = super._update(to, tokenId, auth);
+
+        if (from != address(0)) {
+            uint64 epoch = _authorityEpoch[tokenId] + 1;
+            _authorityEpoch[tokenId] = epoch;
+            _claimed[tokenId] = false;
+            emit AuthorityEpochAdvanced(tokenId, from, to, epoch);
+        }
+
+        return from;
+    }
+}

--- a/contracts/src/interfaces/IERC6551.sol
+++ b/contracts/src/interfaces/IERC6551.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice ERC-6551 token bound account registry.
+/// @dev The canonical registry is deployed at a fixed CREATE2 address on every
+///      supported chain. Its presence on Robinhood Chain testnet was verified
+///      in issue #248; see contracts/deployments/robinhood-testnet.dependencies.json.
+interface IERC6551Registry {
+    event ERC6551AccountCreated(
+        address account,
+        address indexed implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address indexed tokenContract,
+        uint256 indexed tokenId
+    );
+
+    error AccountCreationFailed();
+
+    function createAccount(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external returns (address account);
+
+    function account(address implementation, bytes32 salt, uint256 chainId, address tokenContract, uint256 tokenId)
+        external
+        view
+        returns (address account);
+}
+
+/// @notice ERC-6551 token bound account.
+interface IERC6551Account {
+    receive() external payable;
+
+    /// @notice Identity of the NFT that controls this account.
+    function token() external view returns (uint256 chainId, address tokenContract, uint256 tokenId);
+
+    /// @notice Monotonic counter that changes whenever account state changes.
+    function state() external view returns (uint256);
+
+    /// @return magicValue `IERC6551Account.isValidSigner.selector` when valid.
+    function isValidSigner(address signer, bytes calldata context) external view returns (bytes4 magicValue);
+}
+
+/// @notice ERC-6551 execution interface.
+interface IERC6551Executable {
+    /// @param operation Only `0` (CALL) is required by the standard.
+    function execute(address to, uint256 value, bytes calldata data, uint8 operation)
+        external
+        payable
+        returns (bytes memory);
+}

--- a/contracts/test/TraderAccount.t.sol
+++ b/contracts/test/TraderAccount.t.sol
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {TraderAccount} from "../src/TraderAccount.sol";
+import {TraderIdentity} from "../src/TraderIdentity.sol";
+import {IERC6551Account, IERC6551Executable} from "../src/interfaces/IERC6551.sol";
+import {MockERC6551Registry} from "./mocks/MockERC6551Registry.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+
+contract RevertingTarget {
+    error Nope(uint256 code);
+
+    function boom() external pure {
+        revert Nope(42);
+    }
+
+    function boomString() external pure {
+        revert("target failed");
+    }
+}
+
+contract Counter {
+    uint256 public value;
+
+    function bump(uint256 by) external payable {
+        value += by;
+    }
+}
+
+contract TraderAccountTest is Test {
+    MockERC6551Registry public registry;
+    TraderAccount public implementation;
+    TraderIdentity public identity;
+    TraderAccount public account;
+
+    uint256 public tokenId;
+
+    address manager;
+    uint256 managerKey;
+    address buyer;
+    uint256 buyerKey;
+    address attacker = makeAddr("attacker");
+
+    bytes32 constant SALT = bytes32(0);
+
+    function setUp() public {
+        (manager, managerKey) = makeAddrAndKey("manager");
+        (buyer, buyerKey) = makeAddrAndKey("buyer");
+
+        registry = new MockERC6551Registry();
+        implementation = new TraderAccount();
+        identity = new TraderIdentity("Margin Call Trader", "MCTRADER", "https://margincall.test/t/");
+
+        vm.prank(manager);
+        tokenId = identity.mint(manager);
+
+        account = TraderAccount(payable(_createAccount(tokenId)));
+    }
+
+    function _createAccount(uint256 tokenId_) internal returns (address) {
+        return registry.createAccount(address(implementation), SALT, block.chainid, address(identity), tokenId_);
+    }
+
+    function _transferTrader(address from, address to) internal {
+        vm.prank(from);
+        identity.transferFrom(from, to, tokenId);
+    }
+
+    // ========== Registry binding ==========
+
+    function test_createAccount_isDeterministic() public view {
+        address predicted = registry.account(address(implementation), SALT, block.chainid, address(identity), tokenId);
+        assertEq(predicted, address(account));
+    }
+
+    function test_createAccount_isIdempotent() public {
+        address again = _createAccount(tokenId);
+        assertEq(again, address(account));
+    }
+
+    function test_token_decodesBoundIdentity() public view {
+        (uint256 chainId, address tokenContract, uint256 boundTokenId) = account.token();
+        assertEq(chainId, block.chainid);
+        assertEq(tokenContract, address(identity));
+        assertEq(boundTokenId, tokenId);
+    }
+
+    function test_accountsAreDistinctPerTrader() public {
+        vm.prank(manager);
+        uint256 second = identity.mint(manager);
+        address secondAccount = _createAccount(second);
+
+        assertTrue(secondAccount != address(account));
+        (,, uint256 boundTokenId) = TraderAccount(payable(secondAccount)).token();
+        assertEq(boundTokenId, second);
+    }
+
+    // ========== Ownership follows the NFT ==========
+
+    function test_owner_isCurrentTokenOwner() public view {
+        assertEq(account.owner(), manager);
+    }
+
+    function test_owner_followsTransferWithNoMigrationStep() public {
+        _transferTrader(manager, buyer);
+        assertEq(account.owner(), buyer);
+    }
+
+    function test_owner_isZeroWhenImplementationCalledDirectly() public view {
+        // The bare implementation has no appended token data, so it must not
+        // resolve an owner and must not be executable.
+        assertEq(implementation.owner(), address(0));
+    }
+
+    // ========== Execute authorization ==========
+
+    function test_execute_ownerCanCall() public {
+        Counter counter = new Counter();
+
+        vm.prank(manager);
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (5)), 0);
+
+        assertEq(counter.value(), 5);
+    }
+
+    function test_execute_incrementsState() public {
+        Counter counter = new Counter();
+        assertEq(account.state(), 0);
+
+        vm.prank(manager);
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+        assertEq(account.state(), 1);
+
+        vm.prank(manager);
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+        assertEq(account.state(), 2);
+    }
+
+    function test_execute_forwardsValue() public {
+        Counter counter = new Counter();
+        vm.deal(address(account), 1 ether);
+
+        vm.prank(manager);
+        account.execute(address(counter), 0.4 ether, abi.encodeCall(Counter.bump, (1)), 0);
+
+        assertEq(address(counter).balance, 0.4 ether);
+        assertEq(address(account).balance, 0.6 ether);
+    }
+
+    function test_execute_movesHeldTokens() public {
+        MockERC20 usdg = new MockERC20("Margin Call Test USDG", "tUSDG", 6);
+        usdg.mint(address(account), 1_000e6);
+
+        vm.prank(manager);
+        account.execute(address(usdg), 0, abi.encodeCall(IERC20.transfer, (buyer, 250e6)), 0);
+
+        assertEq(usdg.balanceOf(buyer), 250e6);
+        assertEq(usdg.balanceOf(address(account)), 750e6);
+    }
+
+    function test_execute_revertsForNonOwner() public {
+        Counter counter = new Counter();
+
+        vm.prank(attacker);
+        vm.expectRevert("Not trader owner");
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+    }
+
+    function test_execute_revertsForPreviousOwnerAfterTransfer() public {
+        Counter counter = new Counter();
+        _transferTrader(manager, buyer);
+
+        vm.prank(manager);
+        vm.expectRevert("Not trader owner");
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+    }
+
+    function test_execute_newOwnerControlsAfterTransfer() public {
+        Counter counter = new Counter();
+        _transferTrader(manager, buyer);
+
+        vm.prank(buyer);
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (7)), 0);
+
+        assertEq(counter.value(), 7);
+    }
+
+    function test_execute_revertsOnUnsupportedOperation() public {
+        Counter counter = new Counter();
+
+        vm.prank(manager);
+        vm.expectRevert("Unsupported operation");
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 1);
+    }
+
+    function test_execute_revertsOnBareImplementation() public {
+        Counter counter = new Counter();
+
+        vm.prank(manager);
+        vm.expectRevert("Not trader owner");
+        implementation.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+    }
+
+    function test_execute_bubblesCustomErrorFromTarget() public {
+        RevertingTarget target = new RevertingTarget();
+
+        vm.prank(manager);
+        vm.expectRevert(abi.encodeWithSelector(RevertingTarget.Nope.selector, uint256(42)));
+        account.execute(address(target), 0, abi.encodeCall(RevertingTarget.boom, ()), 0);
+    }
+
+    function test_execute_bubblesStringRevertFromTarget() public {
+        RevertingTarget target = new RevertingTarget();
+
+        vm.prank(manager);
+        vm.expectRevert("target failed");
+        account.execute(address(target), 0, abi.encodeCall(RevertingTarget.boomString, ()), 0);
+    }
+
+    // ========== Signer and signature validation ==========
+
+    function test_isValidSigner_returnsMagicValueForOwner() public view {
+        assertEq(account.isValidSigner(manager, ""), IERC6551Account.isValidSigner.selector);
+    }
+
+    function test_isValidSigner_rejectsStranger() public view {
+        assertEq(account.isValidSigner(attacker, ""), bytes4(0));
+    }
+
+    function test_isValidSigner_rejectsZeroAddress() public view {
+        assertEq(account.isValidSigner(address(0), ""), bytes4(0));
+    }
+
+    function test_isValidSigner_followsTransfer() public {
+        _transferTrader(manager, buyer);
+
+        assertEq(account.isValidSigner(buyer, ""), IERC6551Account.isValidSigner.selector);
+        assertEq(account.isValidSigner(manager, ""), bytes4(0));
+    }
+
+    function test_isValidSignature_acceptsOwnerSignature() public view {
+        bytes32 digest = keccak256("floor offer");
+        bytes memory signature = _sign(managerKey, digest);
+
+        assertEq(account.isValidSignature(digest, signature), IERC1271.isValidSignature.selector);
+    }
+
+    function test_isValidSignature_rejectsStrangerSignature() public view {
+        bytes32 digest = keccak256("floor offer");
+        bytes memory signature = _sign(buyerKey, digest);
+
+        assertEq(account.isValidSignature(digest, signature), bytes4(0));
+    }
+
+    function test_isValidSignature_previousOwnerSignatureDiesOnTransfer() public {
+        bytes32 digest = keccak256("floor offer");
+        bytes memory signature = _sign(managerKey, digest);
+        assertEq(account.isValidSignature(digest, signature), IERC1271.isValidSignature.selector);
+
+        _transferTrader(manager, buyer);
+
+        assertEq(account.isValidSignature(digest, signature), bytes4(0));
+        assertEq(account.isValidSignature(digest, _sign(buyerKey, digest)), IERC1271.isValidSignature.selector);
+    }
+
+    function test_isValidSignature_rejectsWhenNoOwnerResolvable() public view {
+        // Guards against ECDSA recovery of address(0) validating against an
+        // ownerless account.
+        bytes32 digest = keccak256("floor offer");
+        assertEq(implementation.isValidSignature(digest, _sign(managerKey, digest)), bytes4(0));
+        assertEq(implementation.isValidSignature(digest, hex""), bytes4(0));
+    }
+
+    function test_isValidSignature_rejectsMalformedSignature() public view {
+        assertEq(account.isValidSignature(keccak256("x"), hex"1234"), bytes4(0));
+    }
+
+    // ========== Receiving assets ==========
+
+    function test_receive_acceptsNativeValue() public {
+        vm.deal(manager, 1 ether);
+        vm.prank(manager);
+        (bool ok,) = address(account).call{value: 1 ether}("");
+
+        assertTrue(ok);
+        assertEq(address(account).balance, 1 ether);
+    }
+
+    function test_onERC721Received_acceptsForeignCollection() public {
+        TraderIdentity lots = new TraderIdentity("Lot", "LOT", "https://margincall.test/lot/");
+        vm.prank(manager);
+        uint256 lotId = lots.mint(manager);
+
+        vm.prank(manager);
+        lots.safeTransferFrom(manager, address(account), lotId);
+
+        assertEq(lots.ownerOf(lotId), address(account));
+    }
+
+    function test_onERC721Received_rejectsOwnControllingToken() public {
+        vm.prank(manager);
+        vm.expectRevert("Ownership cycle");
+        identity.safeTransferFrom(manager, address(account), tokenId);
+    }
+
+    function test_onERC721Received_acceptsAnotherTraderToken() public {
+        vm.prank(manager);
+        uint256 other = identity.mint(manager);
+
+        vm.prank(manager);
+        identity.safeTransferFrom(manager, address(account), other);
+
+        assertEq(identity.ownerOf(other), address(account));
+    }
+
+    // ========== Introspection ==========
+
+    function test_supportsInterface_advertisesAccountInterfaces() public view {
+        assertTrue(account.supportsInterface(type(IERC6551Account).interfaceId));
+        assertTrue(account.supportsInterface(type(IERC6551Executable).interfaceId));
+        assertTrue(account.supportsInterface(type(IERC1271).interfaceId));
+        assertTrue(account.supportsInterface(type(IERC721Receiver).interfaceId));
+        assertFalse(account.supportsInterface(bytes4(0xdeadbeef)));
+    }
+
+    // ========== Fuzz ==========
+
+    function testFuzz_onlyCurrentOwnerCanExecute(address caller) public {
+        vm.assume(caller != manager);
+        Counter counter = new Counter();
+
+        vm.prank(caller);
+        vm.expectRevert("Not trader owner");
+        account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+    }
+
+    function testFuzz_controlTracksOwnerAcrossTransfers(uint8 hops) public {
+        hops = uint8(bound(hops, 1, 16));
+        Counter counter = new Counter();
+
+        address current = manager;
+        for (uint256 i = 0; i < hops; i++) {
+            address next = address(uint160(uint256(keccak256(abi.encode("hop", i)))));
+            vm.assume(next != address(0) && next != current);
+
+            vm.prank(current);
+            identity.transferFrom(current, next, tokenId);
+
+            // The account it just left must be inert for the previous owner.
+            vm.prank(current);
+            vm.expectRevert("Not trader owner");
+            account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+
+            vm.prank(next);
+            account.execute(address(counter), 0, abi.encodeCall(Counter.bump, (1)), 0);
+
+            current = next;
+        }
+
+        assertEq(account.owner(), current);
+        assertEq(counter.value(), hops);
+    }
+
+    function _sign(uint256 key, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
+        return abi.encodePacked(r, s, v);
+    }
+}

--- a/contracts/test/TraderDelegation.t.sol
+++ b/contracts/test/TraderDelegation.t.sol
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {TraderDelegation} from "../src/TraderDelegation.sol";
+import {TraderIdentity} from "../src/TraderIdentity.sol";
+
+contract TraderDelegationTest is Test {
+    TraderIdentity public identity;
+    TraderDelegation public delegation;
+
+    address manager = makeAddr("manager");
+    address buyer = makeAddr("buyer");
+    address attacker = makeAddr("attacker");
+    address agent = makeAddr("agent");
+    address otherAgent = makeAddr("otherAgent");
+    address settlement = makeAddr("settlement");
+    address otherContract = makeAddr("otherContract");
+
+    uint256 public tokenId;
+    uint64 expiry;
+
+    // Cached because reading a public constant is itself an external call,
+    // which would consume a pending vm.prank before the call under test.
+    uint256 ACTION_QUOTE;
+    uint256 ACTION_FILL;
+    uint256 ACTION_CANCEL;
+    uint256 ACTION_CRACK;
+    uint256 ACTION_ALL;
+    uint64 MAX_DURATION;
+
+    event DelegationGranted(
+        uint256 indexed tokenId, address indexed agentKey, uint64 epoch, uint64 expiresAt, uint256 actions
+    );
+    event DelegationRevoked(uint256 indexed tokenId, address indexed agentKey);
+    event DelegationsRevokedAll(uint256 indexed tokenId, uint64 generation);
+
+    function setUp() public {
+        identity = new TraderIdentity("Margin Call Trader", "MCTRADER", "https://margincall.test/t/");
+        delegation = new TraderDelegation(address(identity));
+
+        vm.prank(manager);
+        tokenId = identity.mint(manager);
+
+        expiry = uint64(block.timestamp + 1 hours);
+
+        ACTION_QUOTE = delegation.ACTION_QUOTE();
+        ACTION_FILL = delegation.ACTION_FILL();
+        ACTION_CANCEL = delegation.ACTION_CANCEL();
+        ACTION_CRACK = delegation.ACTION_CRACK();
+        ACTION_ALL = delegation.ACTION_ALL();
+        MAX_DURATION = delegation.MAX_DELEGATION_DURATION();
+    }
+
+    function _targets() internal view returns (address[] memory targets) {
+        targets = new address[](1);
+        targets[0] = settlement;
+    }
+
+    function _grant(address who, uint256 actions) internal {
+        vm.prank(who);
+        delegation.grant(tokenId, agent, actions, _targets(), expiry);
+    }
+
+    function _grantFill() internal {
+        _grant(manager, ACTION_FILL);
+    }
+
+    function _fillAuthorized() internal view returns (bool) {
+        return delegation.isAuthorized(tokenId, agent, ACTION_FILL, settlement);
+    }
+
+    // ========== Granting ==========
+
+    function test_grant_authorizesNamedActionOnNamedTarget() public {
+        _grantFill();
+        assertTrue(_fillAuthorized());
+    }
+
+    function test_grant_recordsCurrentEpochAndGeneration() public {
+        _grantFill();
+
+        TraderDelegation.Delegation memory d = delegation.delegationOf(tokenId, agent);
+        assertEq(d.epoch, identity.authorityEpoch(tokenId));
+        assertEq(d.generation, delegation.generationOf(tokenId));
+        assertEq(d.expiresAt, expiry);
+        assertEq(d.actions, ACTION_FILL);
+    }
+
+    function test_grant_emitsGranted() public {
+        vm.expectEmit(true, true, false, true);
+        emit DelegationGranted(tokenId, agent, 1, expiry, ACTION_FILL);
+        _grantFill();
+    }
+
+    function test_grant_supportsMultipleActions() public {
+        _grant(manager, ACTION_QUOTE | ACTION_CANCEL);
+
+        assertTrue(delegation.isAuthorized(tokenId, agent, ACTION_QUOTE, settlement));
+        assertTrue(delegation.isAuthorized(tokenId, agent, ACTION_CANCEL, settlement));
+        assertFalse(_fillAuthorized());
+        assertFalse(delegation.isAuthorized(tokenId, agent, ACTION_CRACK, settlement));
+    }
+
+    function test_grant_overwritesPreviousGrantForSameKey() public {
+        _grant(manager, ACTION_FILL);
+        _grant(manager, ACTION_QUOTE);
+
+        assertFalse(_fillAuthorized());
+        assertTrue(delegation.isAuthorized(tokenId, agent, ACTION_QUOTE, settlement));
+    }
+
+    function test_grant_keysAreIndependent() public {
+        _grantFill();
+
+        assertTrue(_fillAuthorized());
+        assertFalse(delegation.isAuthorized(tokenId, otherAgent, ACTION_FILL, settlement));
+    }
+
+    function test_grant_revertsForNonOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not trader owner");
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), expiry);
+    }
+
+    function test_grant_revertsForZeroAgentKey() public {
+        vm.prank(manager);
+        vm.expectRevert("Zero agent key");
+        delegation.grant(tokenId, address(0), ACTION_FILL, _targets(), expiry);
+    }
+
+    function test_grant_revertsForZeroActions() public {
+        vm.prank(manager);
+        vm.expectRevert("Invalid actions");
+        delegation.grant(tokenId, agent, 0, _targets(), expiry);
+    }
+
+    function test_grant_revertsForUndefinedActionBits() public {
+        vm.prank(manager);
+        vm.expectRevert("Invalid actions");
+        delegation.grant(tokenId, agent, 1 << 9, _targets(), expiry);
+    }
+
+    function test_grant_revertsForEmptyTargets() public {
+        address[] memory empty = new address[](0);
+
+        vm.prank(manager);
+        vm.expectRevert("No targets");
+        delegation.grant(tokenId, agent, ACTION_FILL, empty, expiry);
+    }
+
+    function test_grant_revertsForZeroTarget() public {
+        address[] memory targets = new address[](1);
+
+        vm.prank(manager);
+        vm.expectRevert("Zero target");
+        delegation.grant(tokenId, agent, ACTION_FILL, targets, expiry);
+    }
+
+    function test_grant_revertsForPastExpiry() public {
+        vm.prank(manager);
+        vm.expectRevert("Expiry in past");
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), uint64(block.timestamp));
+    }
+
+    function test_grant_revertsBeyondMaximumDuration() public {
+        uint64 tooFar = uint64(block.timestamp + MAX_DURATION + 1);
+
+        vm.prank(manager);
+        vm.expectRevert("Expiry too far");
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), tooFar);
+    }
+
+    function test_grant_revertsWhileTraderUnclaimed() public {
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+
+        vm.prank(buyer);
+        vm.expectRevert("Trader unclaimed");
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), expiry);
+    }
+
+    // ========== Scope boundaries ==========
+
+    function test_isAuthorized_rejectsUnlistedTarget() public {
+        _grantFill();
+        assertFalse(delegation.isAuthorized(tokenId, agent, ACTION_FILL, otherContract));
+    }
+
+    function test_isAuthorized_rejectsUngrantedAction() public {
+        _grantFill();
+        assertFalse(delegation.isAuthorized(tokenId, agent, ACTION_CRACK, settlement));
+    }
+
+    function test_isAuthorized_rejectsZeroAction() public {
+        _grantFill();
+        assertFalse(delegation.isAuthorized(tokenId, agent, 0, settlement));
+    }
+
+    function test_isAuthorized_requiresEveryRequestedActionBit() public {
+        _grant(manager, ACTION_FILL);
+
+        uint256 both = ACTION_FILL | ACTION_CRACK;
+        assertFalse(delegation.isAuthorized(tokenId, agent, both, settlement));
+    }
+
+    function test_isAuthorized_falseForNeverGrantedKey() public view {
+        assertFalse(delegation.isAuthorized(tokenId, otherAgent, ACTION_FILL, settlement));
+    }
+
+    function test_isAuthorized_falseAfterExpiry() public {
+        _grantFill();
+        assertTrue(_fillAuthorized());
+
+        vm.warp(expiry);
+        assertFalse(_fillAuthorized());
+    }
+
+    function test_isAuthorized_trueUpToTheSecondBeforeExpiry() public {
+        _grantFill();
+        vm.warp(expiry - 1);
+        assertTrue(_fillAuthorized());
+    }
+
+    function test_assertAuthorized_revertsWhenUnauthorized() public {
+        _grantFill();
+
+        vm.expectRevert("Agent not authorized");
+        delegation.assertAuthorized(tokenId, agent, ACTION_FILL, otherContract);
+    }
+
+    function test_assertAuthorized_passesWhenAuthorized() public {
+        _grantFill();
+        delegation.assertAuthorized(tokenId, agent, ACTION_FILL, settlement);
+    }
+
+    // ========== Transfer invalidation ==========
+
+    function test_transfer_killsEveryDelegatedKey() public {
+        _grantFill();
+        vm.prank(manager);
+        delegation.grant(tokenId, otherAgent, ACTION_CRACK, _targets(), expiry);
+
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+
+        assertFalse(_fillAuthorized());
+        assertFalse(delegation.isAuthorized(tokenId, otherAgent, ACTION_CRACK, settlement));
+    }
+
+    function test_transfer_killsKeysWithoutAnyRevokeTransaction() public {
+        _grantFill();
+
+        // The departing owner never cooperates; the epoch change is enough.
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+
+        vm.prank(buyer);
+        identity.claim(tokenId);
+
+        assertFalse(_fillAuthorized());
+    }
+
+    function test_transfer_previousOwnerCannotRegrant() public {
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+
+        vm.prank(manager);
+        vm.expectRevert("Not trader owner");
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), expiry);
+    }
+
+    function test_transfer_backToOriginalOwnerDoesNotRevivePriorKeys() public {
+        _grantFill();
+
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+        vm.prank(buyer);
+        identity.claim(tokenId);
+        vm.prank(buyer);
+        identity.transferFrom(buyer, manager, tokenId);
+        vm.prank(manager);
+        identity.claim(tokenId);
+
+        // Epoch advanced twice; the original grant stays dead.
+        assertFalse(_fillAuthorized());
+    }
+
+    function test_newOwner_canGrantAfterClaiming() public {
+        _grantFill();
+
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+        vm.prank(buyer);
+        identity.claim(tokenId);
+
+        vm.prank(buyer);
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), expiry);
+
+        assertTrue(_fillAuthorized());
+    }
+
+    // ========== Claim gating ==========
+
+    function test_unclaimedTrader_hasNoAuthorizedKeys() public {
+        _grantFill();
+
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+        vm.prank(buyer);
+        identity.claim(tokenId);
+        vm.prank(buyer);
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), expiry);
+        assertTrue(_fillAuthorized());
+
+        // A further transfer both advances the epoch and unclaims the Trader.
+        vm.prank(buyer);
+        identity.transferFrom(buyer, attacker, tokenId);
+        assertFalse(identity.isClaimed(tokenId));
+        assertFalse(_fillAuthorized());
+    }
+
+    // ========== Revocation ==========
+
+    function test_revoke_disablesSingleKey() public {
+        _grantFill();
+        vm.prank(manager);
+        delegation.grant(tokenId, otherAgent, ACTION_FILL, _targets(), expiry);
+
+        vm.prank(manager);
+        delegation.revoke(tokenId, agent);
+
+        assertFalse(_fillAuthorized());
+        assertTrue(delegation.isAuthorized(tokenId, otherAgent, ACTION_FILL, settlement));
+    }
+
+    function test_revoke_emitsRevoked() public {
+        _grantFill();
+
+        vm.expectEmit(true, true, false, false);
+        emit DelegationRevoked(tokenId, agent);
+        vm.prank(manager);
+        delegation.revoke(tokenId, agent);
+    }
+
+    function test_revoke_revertsForNonOwner() public {
+        _grantFill();
+
+        vm.prank(attacker);
+        vm.expectRevert("Not trader owner");
+        delegation.revoke(tokenId, agent);
+    }
+
+    function test_revoke_revertsWhenNothingGranted() public {
+        vm.prank(manager);
+        vm.expectRevert("No delegation");
+        delegation.revoke(tokenId, agent);
+    }
+
+    function test_revoke_thenRegrantWorks() public {
+        _grantFill();
+        vm.prank(manager);
+        delegation.revoke(tokenId, agent);
+        _grantFill();
+
+        assertTrue(_fillAuthorized());
+    }
+
+    function test_revokeAll_disablesEveryKeyAtOnce() public {
+        _grantFill();
+        vm.prank(manager);
+        delegation.grant(tokenId, otherAgent, ACTION_CRACK, _targets(), expiry);
+
+        vm.prank(manager);
+        delegation.revokeAll(tokenId);
+
+        assertFalse(_fillAuthorized());
+        assertFalse(delegation.isAuthorized(tokenId, otherAgent, ACTION_CRACK, settlement));
+    }
+
+    function test_revokeAll_emitsWithNewGeneration() public {
+        vm.expectEmit(true, false, false, true);
+        emit DelegationsRevokedAll(tokenId, 1);
+        vm.prank(manager);
+        delegation.revokeAll(tokenId);
+    }
+
+    function test_revokeAll_allowsFreshGrantsAfterwards() public {
+        _grantFill();
+        vm.prank(manager);
+        delegation.revokeAll(tokenId);
+        _grantFill();
+
+        assertTrue(_fillAuthorized());
+    }
+
+    function test_revokeAll_revertsForNonOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not trader owner");
+        delegation.revokeAll(tokenId);
+    }
+
+    function test_revokeAll_isScopedToOneTrader() public {
+        vm.prank(manager);
+        uint256 second = identity.mint(manager);
+
+        _grantFill();
+        vm.prank(manager);
+        delegation.grant(second, agent, ACTION_FILL, _targets(), expiry);
+
+        vm.prank(manager);
+        delegation.revokeAll(tokenId);
+
+        assertFalse(_fillAuthorized());
+        assertTrue(delegation.isAuthorized(second, agent, ACTION_FILL, settlement));
+    }
+
+    // ========== Construction ==========
+
+    function test_constructor_revertsForZeroIdentity() public {
+        vm.expectRevert("Zero identity");
+        new TraderDelegation(address(0));
+    }
+
+    // ========== Fuzz ==========
+
+    function testFuzz_onlyTraderOwnerCanGrant(address caller) public {
+        vm.assume(caller != manager);
+
+        vm.prank(caller);
+        vm.expectRevert("Not trader owner");
+        delegation.grant(tokenId, agent, ACTION_FILL, _targets(), expiry);
+    }
+
+    function testFuzz_noKeySurvivesATransfer(address agentKey, uint8 actionSeed) public {
+        vm.assume(agentKey != address(0));
+        uint256 actions = uint256(bound(actionSeed, 1, ACTION_ALL));
+
+        vm.prank(manager);
+        delegation.grant(tokenId, agentKey, actions, _targets(), expiry);
+
+        vm.prank(manager);
+        identity.transferFrom(manager, buyer, tokenId);
+
+        for (uint256 bit = 0; bit < 4; bit++) {
+            assertFalse(delegation.isAuthorized(tokenId, agentKey, 1 << bit, settlement));
+        }
+    }
+
+    function testFuzz_authorizationNeverLeaksToOtherTargets(address target) public {
+        vm.assume(target != settlement);
+        _grantFill();
+
+        assertFalse(delegation.isAuthorized(tokenId, agent, ACTION_FILL, target));
+    }
+}

--- a/contracts/test/TraderIdentity.t.sol
+++ b/contracts/test/TraderIdentity.t.sol
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {TraderIdentity} from "../src/TraderIdentity.sol";
+
+contract TraderIdentityTest is Test {
+    TraderIdentity public identity;
+
+    address house = address(this);
+    address manager = makeAddr("manager");
+    address buyer = makeAddr("buyer");
+    address attacker = makeAddr("attacker");
+
+    string constant BASE_URI = "https://margincall.test/api/floor/trader/";
+
+    event TraderCreated(uint256 indexed tokenId, address indexed traderOwner);
+    event AuthorityEpochAdvanced(
+        uint256 indexed tokenId, address indexed previousOwner, address indexed newOwner, uint64 epoch
+    );
+    event TraderClaimed(uint256 indexed tokenId, address indexed traderOwner, uint64 epoch);
+
+    function setUp() public {
+        identity = new TraderIdentity("Margin Call Trader", "MCTRADER", BASE_URI);
+    }
+
+    function _mint(address to) internal returns (uint256) {
+        vm.prank(to);
+        return identity.mint(to);
+    }
+
+    function _transfer(address from, address to, uint256 tokenId) internal {
+        vm.prank(from);
+        identity.transferFrom(from, to, tokenId);
+    }
+
+    // ========== Creation ==========
+
+    function test_mint_assignsOwnershipAndFirstEpoch() public {
+        uint256 tokenId = _mint(manager);
+
+        assertEq(tokenId, 1);
+        assertEq(identity.ownerOf(tokenId), manager);
+        assertEq(identity.authorityEpoch(tokenId), 1);
+        assertEq(identity.balanceOf(manager), 1);
+    }
+
+    function test_mint_creatorNeedsNoClaim() public {
+        uint256 tokenId = _mint(manager);
+        assertTrue(identity.isClaimed(tokenId));
+    }
+
+    function test_mint_isPermissionlessAndCanMintToAnother() public {
+        vm.prank(attacker);
+        uint256 tokenId = identity.mint(manager);
+        assertEq(identity.ownerOf(tokenId), manager);
+    }
+
+    function test_mint_incrementsTokenIds() public {
+        assertEq(_mint(manager), 1);
+        assertEq(_mint(manager), 2);
+        assertEq(_mint(buyer), 3);
+        assertEq(identity.totalMinted(), 3);
+    }
+
+    function test_mint_revertsZeroOwner() public {
+        vm.expectRevert("Zero owner");
+        identity.mint(address(0));
+    }
+
+    function test_mint_emitsTraderCreated() public {
+        vm.expectEmit(true, true, false, true);
+        emit TraderCreated(1, manager);
+        identity.mint(manager);
+    }
+
+    // ========== Transfer advances authority ==========
+
+    function test_transfer_advancesAuthorityEpoch() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        assertEq(identity.ownerOf(tokenId), buyer);
+        assertEq(identity.authorityEpoch(tokenId), 2);
+    }
+
+    function test_transfer_clearsClaim() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        assertFalse(identity.isClaimed(tokenId));
+    }
+
+    function test_transfer_emitsAuthorityEpochAdvanced() public {
+        uint256 tokenId = _mint(manager);
+
+        vm.expectEmit(true, true, true, true);
+        emit AuthorityEpochAdvanced(tokenId, manager, buyer, 2);
+        _transfer(manager, buyer, tokenId);
+    }
+
+    function test_transfer_repeatedAdvancesEachTime() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+        vm.prank(buyer);
+        identity.claim(tokenId);
+        _transfer(buyer, attacker, tokenId);
+
+        assertEq(identity.authorityEpoch(tokenId), 3);
+        assertFalse(identity.isClaimed(tokenId));
+    }
+
+    function test_transfer_selfTransferStillAdvancesEpoch() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, manager, tokenId);
+
+        assertEq(identity.authorityEpoch(tokenId), 2);
+        assertFalse(identity.isClaimed(tokenId));
+    }
+
+    function test_transfer_epochsAreIndependentPerToken() public {
+        uint256 first = _mint(manager);
+        uint256 second = _mint(manager);
+
+        _transfer(manager, buyer, first);
+
+        assertEq(identity.authorityEpoch(first), 2);
+        assertEq(identity.authorityEpoch(second), 1);
+        assertTrue(identity.isClaimed(second));
+    }
+
+    function test_transfer_isPermissionlessForOwner() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+        assertEq(identity.ownerOf(tokenId), buyer);
+    }
+
+    function test_transfer_revertsForNonOwner() public {
+        uint256 tokenId = _mint(manager);
+
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721InsufficientApproval.selector, attacker, tokenId));
+        identity.transferFrom(manager, attacker, tokenId);
+    }
+
+    function test_transfer_byApprovedOperatorStillAdvancesEpoch() public {
+        uint256 tokenId = _mint(manager);
+
+        vm.prank(manager);
+        identity.approve(buyer, tokenId);
+
+        vm.prank(buyer);
+        identity.transferFrom(manager, buyer, tokenId);
+
+        assertEq(identity.authorityEpoch(tokenId), 2);
+        assertFalse(identity.isClaimed(tokenId));
+    }
+
+    // ========== Claim ==========
+
+    function test_claim_restoresClaimFlag() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        vm.prank(buyer);
+        identity.claim(tokenId);
+
+        assertTrue(identity.isClaimed(tokenId));
+    }
+
+    function test_claim_emitsWithCurrentEpoch() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        vm.expectEmit(true, true, false, true);
+        emit TraderClaimed(tokenId, buyer, 2);
+        vm.prank(buyer);
+        identity.claim(tokenId);
+    }
+
+    function test_claim_doesNotAdvanceEpoch() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        vm.prank(buyer);
+        identity.claim(tokenId);
+
+        assertEq(identity.authorityEpoch(tokenId), 2);
+    }
+
+    function test_claim_revertsForPreviousOwner() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        vm.prank(manager);
+        vm.expectRevert("Not trader owner");
+        identity.claim(tokenId);
+    }
+
+    function test_claim_revertsForStranger() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        vm.prank(attacker);
+        vm.expectRevert("Not trader owner");
+        identity.claim(tokenId);
+    }
+
+    function test_claim_revertsWhenAlreadyClaimed() public {
+        uint256 tokenId = _mint(manager);
+
+        vm.prank(manager);
+        vm.expectRevert("Already claimed");
+        identity.claim(tokenId);
+    }
+
+    function test_claim_revertsForNonexistentTrader() public {
+        vm.prank(manager);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, uint256(99)));
+        identity.claim(99);
+    }
+
+    function test_claim_isRequiredAgainAfterEachTransfer() public {
+        uint256 tokenId = _mint(manager);
+
+        _transfer(manager, buyer, tokenId);
+        vm.prank(buyer);
+        identity.claim(tokenId);
+        assertTrue(identity.isClaimed(tokenId));
+
+        _transfer(buyer, attacker, tokenId);
+        assertFalse(identity.isClaimed(tokenId));
+    }
+
+    // ========== Views ==========
+
+    function test_traderState_returnsOwnerEpochAndClaim() public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        (address traderOwner, uint64 epoch, bool claimed) = identity.traderState(tokenId);
+        assertEq(traderOwner, buyer);
+        assertEq(epoch, 2);
+        assertFalse(claimed);
+    }
+
+    function test_traderState_revertsForNonexistentTrader() public {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, uint256(7)));
+        identity.traderState(7);
+    }
+
+    function test_authorityEpoch_isZeroForNonexistentTrader() public view {
+        assertEq(identity.authorityEpoch(1234), 0);
+    }
+
+    function test_tokenURI_usesBaseURI() public {
+        uint256 tokenId = _mint(manager);
+        assertEq(identity.tokenURI(tokenId), string.concat(BASE_URI, "1"));
+    }
+
+    function test_tokenURI_revertsForNonexistentTrader() public {
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, uint256(1)));
+        identity.tokenURI(1);
+    }
+
+    // ========== Admin ==========
+
+    function test_setBaseURI_updatesMetadataEndpoint() public {
+        uint256 tokenId = _mint(manager);
+        identity.setBaseURI("https://margincall.test/v2/");
+        assertEq(identity.tokenURI(tokenId), "https://margincall.test/v2/1");
+    }
+
+    function test_setBaseURI_revertsForNonOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert("Not owner");
+        identity.setBaseURI("https://evil.test/");
+    }
+
+    function test_setBaseURI_cannotFreezeOrRestrictTransfers() public {
+        uint256 tokenId = _mint(manager);
+        identity.setBaseURI("https://margincall.test/v2/");
+
+        // Admin holds metadata only; custody stays permissionless.
+        _transfer(manager, buyer, tokenId);
+        assertEq(identity.ownerOf(tokenId), buyer);
+    }
+
+    function test_transferOwnership_isTwoStep() public {
+        identity.transferOwnership(manager);
+        assertEq(identity.owner(), house);
+        assertEq(identity.pendingOwner(), manager);
+
+        vm.prank(manager);
+        identity.acceptOwnership();
+
+        assertEq(identity.owner(), manager);
+        assertEq(identity.pendingOwner(), address(0));
+    }
+
+    function test_transferOwnership_revertsZeroOwner() public {
+        vm.expectRevert("Zero owner");
+        identity.transferOwnership(address(0));
+    }
+
+    function test_acceptOwnership_revertsForNonPendingOwner() public {
+        identity.transferOwnership(manager);
+
+        vm.prank(attacker);
+        vm.expectRevert("Not pending owner");
+        identity.acceptOwnership();
+    }
+
+    // ========== Fuzz ==========
+
+    function testFuzz_transferChainAdvancesEpochOncePerHop(uint8 hops) public {
+        hops = uint8(bound(hops, 1, 32));
+        uint256 tokenId = _mint(manager);
+
+        address current = manager;
+        for (uint256 i = 0; i < hops; i++) {
+            address next = address(uint160(uint256(keccak256(abi.encode(i, tokenId)))));
+            vm.assume(next != address(0));
+            _transfer(current, next, tokenId);
+            current = next;
+        }
+
+        assertEq(identity.authorityEpoch(tokenId), uint64(hops) + 1);
+        assertEq(identity.ownerOf(tokenId), current);
+        assertFalse(identity.isClaimed(tokenId));
+    }
+
+    function testFuzz_onlyCurrentOwnerCanClaim(address caller) public {
+        uint256 tokenId = _mint(manager);
+        _transfer(manager, buyer, tokenId);
+
+        vm.assume(caller != buyer);
+        vm.prank(caller);
+        vm.expectRevert("Not trader owner");
+        identity.claim(tokenId);
+    }
+}

--- a/contracts/test/mocks/MockERC6551Registry.sol
+++ b/contracts/test/mocks/MockERC6551Registry.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {IERC6551Registry} from "../../src/interfaces/IERC6551.sol";
+
+/// @notice Local stand-in for the canonical ERC-6551 registry.
+/// @dev Reproduces the canonical proxy bytecode layout exactly — ERC-1167
+///      header, implementation, footer, then salt/chainId/tokenContract/tokenId
+///      appended as four words — so an account's `token()` decodes the same
+///      here as it does against the real registry. Tests that rely on that
+///      layout would silently pass against a looser double.
+contract MockERC6551Registry is IERC6551Registry {
+    function createAccount(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) external returns (address) {
+        bytes memory creationCode = _creationCode(implementation, salt, chainId, tokenContract, tokenId);
+        address computed = Create2.computeAddress(salt, keccak256(creationCode), address(this));
+
+        if (computed.code.length != 0) {
+            return computed;
+        }
+
+        address deployed = Create2.deploy(0, salt, creationCode);
+        if (deployed != computed) {
+            revert AccountCreationFailed();
+        }
+
+        emit ERC6551AccountCreated(deployed, implementation, salt, chainId, tokenContract, tokenId);
+        return deployed;
+    }
+
+    function account(address implementation, bytes32 salt, uint256 chainId, address tokenContract, uint256 tokenId)
+        external
+        view
+        returns (address)
+    {
+        bytes memory creationCode = _creationCode(implementation, salt, chainId, tokenContract, tokenId);
+        return Create2.computeAddress(salt, keccak256(creationCode), address(this));
+    }
+
+    function _creationCode(
+        address implementation,
+        bytes32 salt,
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            hex"3d60ad80600a3d3981f3363d3d373d3d3d363d73",
+            implementation,
+            hex"5af43d82803e903d91602b57fd5bf3",
+            abi.encode(salt, chainId, tokenContract, tokenId)
+        );
+    }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "deploy:escrow": "tsx scripts/deploy-escrow.ts",
     "deploy:margincall-token": "tsx scripts/deploy-margincall-token.ts",
     "deploy:seat-vault": "tsx scripts/deploy-seat-vault.ts",
+    "deploy:floor-trader": "tsx scripts/deploy-floor-trader.ts",
     "verify:escrow": "tsx scripts/verify-contracts.ts --target=escrow",
     "verify:seat-vault": "tsx scripts/verify-contracts.ts --target=seat-vault",
     "verify:contracts": "tsx scripts/verify-contracts.ts --target=all",

--- a/scripts/deploy-floor-trader.ts
+++ b/scripts/deploy-floor-trader.ts
@@ -1,0 +1,163 @@
+/**
+ * Deploy the Floor Trader identity set to Robinhood Chain testnet.
+ *
+ * Deploys TraderIdentity, the TraderAccount ERC-6551 implementation, and
+ * TraderDelegation in one broadcast, records the result, and repoints the
+ * dependency matrix at the freshly deployed account implementation.
+ *
+ * Requires in .env.local or the shell:
+ *   OPERATOR_PRIVATE_KEY
+ *   ROBINHOOD_TESTNET_RPC_URL
+ *   TRADER_BASE_URI
+ *   MARGIN_CALL_FLOOR_DEPLOY_APPROVED=1
+ *
+ * Optional: TRADER_NAME, TRADER_SYMBOL
+ *
+ * Usage: pnpm deploy:floor-trader
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { createPublicClient, http } from "viem";
+import {
+  appendDeploymentRecord,
+  broadcastRecordFields,
+  loadEnvLocal,
+  readLatestBroadcastCreate,
+  requireFloorDeployApproval,
+  runForgeDeployMany,
+} from "./deploy-utils";
+import {
+  DEPENDENCIES_JSON_PATH,
+  ERC6551_REGISTRY_ADDRESS,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+} from "./floor/dependencies";
+import { assertAllowedChainId } from "./floor/preflight-checks";
+import { TRADER_DEPLOYMENTS_FILENAME } from "./floor/trader-deployment";
+
+const DEFAULT_NAME = "Margin Call Trader";
+const DEFAULT_SYMBOL = "MCTRADER";
+
+function requireRpcUrl(env: Record<string, string>): string {
+  const url = env.ROBINHOOD_TESTNET_RPC_URL?.trim();
+  if (!url) {
+    throw new Error(
+      "ROBINHOOD_TESTNET_RPC_URL missing — set it in .env.local or the shell (no silent public fallback)"
+    );
+  }
+  if (/mainnet\.chain\.robinhood\.com/i.test(url)) {
+    throw new Error(
+      "ROBINHOOD_TESTNET_RPC_URL points at Robinhood mainnet — refusing to deploy"
+    );
+  }
+  return url;
+}
+
+/**
+ * Point the dependency matrix at the implementation we just deployed. Left
+ * unpinned, every Trader account would resolve against a null implementation.
+ */
+function pinAccountImplementation(address: string): void {
+  const raw = readFileSync(DEPENDENCIES_JSON_PATH, "utf8");
+  const packet = JSON.parse(raw) as {
+    dependencies: Array<{ id: string; address: string | null; label: string }>;
+  };
+
+  const entry = packet.dependencies.find(
+    (d) => d.id === "erc6551-account-implementation"
+  );
+  if (!entry) {
+    throw new Error(
+      "erc6551-account-implementation missing from the dependency matrix"
+    );
+  }
+
+  entry.address = address;
+  entry.label = "Margin Call Test Asset — TBA account implementation";
+  writeFileSync(DEPENDENCIES_JSON_PATH, `${JSON.stringify(packet, null, 2)}\n`);
+}
+
+async function main() {
+  const env = loadEnvLocal();
+  requireFloorDeployApproval(env);
+
+  const rpcUrl = requireRpcUrl(env);
+  const operatorKey = env.OPERATOR_PRIVATE_KEY;
+  if (!operatorKey) {
+    throw new Error("OPERATOR_PRIVATE_KEY missing in .env.local");
+  }
+
+  const baseUri = env.TRADER_BASE_URI?.trim();
+  if (!baseUri) {
+    throw new Error(
+      "TRADER_BASE_URI missing — the Trader collection needs a stable metadata endpoint"
+    );
+  }
+  if (!baseUri.endsWith("/")) {
+    throw new Error(
+      "TRADER_BASE_URI must end with a slash — tokenURI appends the token id directly"
+    );
+  }
+
+  // Confirm the endpoint before broadcasting rather than discovering after the
+  // fact that the collection was deployed against the wrong chain.
+  const client = createPublicClient({ transport: http(rpcUrl) });
+  const chainId = await client.getChainId();
+  assertAllowedChainId(chainId);
+
+  const name = env.TRADER_NAME ?? DEFAULT_NAME;
+  const symbol = env.TRADER_SYMBOL ?? DEFAULT_SYMBOL;
+
+  console.log(`Deploying Floor Trader identity set to chain ${chainId}…`);
+
+  const { addresses } = runForgeDeployMany({
+    scriptTarget: "script/DeployFloorTrader.s.sol:DeployFloorTrader",
+    rpcUrl,
+    privateKey: operatorKey,
+    addressLabels: ["TraderIdentity", "TraderAccount", "TraderDelegation"],
+    env: {
+      TRADER_NAME: name,
+      TRADER_SYMBOL: symbol,
+      TRADER_BASE_URI: baseUri,
+    },
+  });
+
+  const identity = addresses.TraderIdentity as string;
+  const accountImplementation = addresses.TraderAccount as string;
+  const delegation = addresses.TraderDelegation as string;
+
+  const broadcast = readLatestBroadcastCreate({
+    scriptFileName: "DeployFloorTrader.s.sol",
+    chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+  });
+
+  const version = appendDeploymentRecord(TRADER_DEPLOYMENTS_FILENAME, {
+    chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+    identity,
+    accountImplementation,
+    delegation,
+    registry: ERC6551_REGISTRY_ADDRESS,
+    name,
+    symbol,
+    baseUri,
+    deployedAt: new Date().toISOString(),
+    ...broadcastRecordFields(broadcast),
+  });
+
+  pinAccountImplementation(accountImplementation);
+
+  console.log(`\nRecorded deployment v${version}:`);
+  console.log(`  TraderIdentity   ${identity}`);
+  console.log(`  TraderAccount    ${accountImplementation}`);
+  console.log(`  TraderDelegation ${delegation}`);
+  console.log(
+    `\nPinned erc6551-account-implementation in the dependency matrix.`
+  );
+  console.log(
+    `Next: record the address in docs/floor/robinhood-testnet-dependency-packet.md (pnpm test enforces it), then run pnpm floor:preflight:live.`
+  );
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Floor Trader deploy failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -54,6 +54,11 @@ export function loadEnvLocal(): Record<string, string> {
     "SEAT_THRESHOLD",
     "CORNER_THRESHOLD",
     "UNSTAKE_COOLDOWN",
+    "ROBINHOOD_TESTNET_RPC_URL",
+    "MARGIN_CALL_FLOOR_DEPLOY_APPROVED",
+    "TRADER_NAME",
+    "TRADER_SYMBOL",
+    "TRADER_BASE_URI",
   ]) {
     const value = process.env[key];
     if (value !== undefined && value !== "") {
@@ -95,6 +100,20 @@ export function requireGate1Approval(env: Record<string, string>) {
   if (env.MARGIN_CALL_DEPLOY_GATE1_APPROVED !== "1") {
     throw new Error(
       "Gate 1 not approved — refusing broadcast. Sign docs/security/base-sepolia-deploy-packet-211.md, then set MARGIN_CALL_DEPLOY_GATE1_APPROVED=1 for this shell only (see #211)."
+    );
+  }
+}
+
+/**
+ * Hard stop unless a Floor deployment is explicitly approved for this shell.
+ * Separate from Gate 1, which covers the Base Sepolia deal-game contracts: an
+ * operator approved to redeploy those has not thereby approved putting a new
+ * Trader collection on Robinhood Chain testnet.
+ */
+export function requireFloorDeployApproval(env: Record<string, string>) {
+  if (env.MARGIN_CALL_FLOOR_DEPLOY_APPROVED !== "1") {
+    throw new Error(
+      "Floor deploy not approved — refusing broadcast. Review docs/floor/chain-and-intent-boundaries.md, then set MARGIN_CALL_FLOOR_DEPLOY_APPROVED=1 for this shell only."
     );
   }
 }
@@ -225,6 +244,66 @@ export function runForgeDeploy(opts: {
     throw new Error("Could not parse deployed address from forge output");
   }
   return { address: match[1] as string, output };
+}
+
+/**
+ * Run a Foundry deploy script that creates several contracts in one broadcast
+ * and return every labelled address. Fails if any label is missing rather than
+ * returning a partial set, since a half-parsed multi-contract deployment would
+ * be recorded as if it were complete.
+ */
+export function runForgeDeployMany(opts: {
+  scriptTarget: string;
+  rpcUrl: string;
+  privateKey: string;
+  addressLabels: string[];
+  env?: Record<string, string>;
+  foundryProfile?: string;
+}): { addresses: Record<string, string>; output: string } {
+  const output = execFileSync(
+    "forge",
+    [
+      "script",
+      opts.scriptTarget,
+      "--rpc-url",
+      opts.rpcUrl,
+      "--private-key",
+      opts.privateKey,
+      "--broadcast",
+      "-vv",
+    ],
+    {
+      cwd: CONTRACTS_DIR,
+      env: {
+        ...process.env,
+        ...opts.env,
+        ...(opts.foundryProfile
+          ? { FOUNDRY_PROFILE: opts.foundryProfile }
+          : {}),
+      },
+      encoding: "utf8",
+    }
+  );
+  console.log(output);
+
+  const addresses: Record<string, string> = {};
+  const missing: string[] = [];
+  for (const label of opts.addressLabels) {
+    const match = output.match(
+      new RegExp(`${label} deployed at:\\s*(0x[a-fA-F0-9]{40})`)
+    );
+    if (match) {
+      addresses[label] = match[1] as string;
+    } else {
+      missing.push(label);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Could not parse deployed address for: ${missing.join(", ")}`
+    );
+  }
+  return { addresses, output };
 }
 
 export function appendDeploymentRecord<T extends Record<string, unknown>>(

--- a/scripts/floor/preflight-checks.ts
+++ b/scripts/floor/preflight-checks.ts
@@ -11,6 +11,7 @@ import {
   isForbiddenRobinhoodMainnetChainId,
   isRobinhoodTestnetChainId,
 } from "./dependencies";
+import type { FloorTraderDeployment } from "./trader-deployment";
 
 export type PreflightFinding = {
   code: string;
@@ -129,21 +130,104 @@ export function isFeedStale(opts: {
   return age > heartbeatSeconds + graceSeconds;
 }
 
+/**
+ * Any entry that pins an address must have bytecode there, whatever its status.
+ * A pinned address with no code is a dead pointer regardless of whether it
+ * names a canonical asset or a Floor-deployed one, and the Trader account
+ * implementation is recorded as a fallback precisely because we deploy it
+ * ourselves.
+ */
 export function checkBytecodeExpectation(opts: {
   entry: DependencyEntry;
   code: string | null | undefined;
 }): PreflightFinding | null {
   const { entry, code } = opts;
-  if (entry.status !== "canonical") return null;
+  if (entry.status !== "canonical" && entry.address === null) return null;
   if (!hasContractBytecode(code)) {
     return {
       code: "bytecode-missing",
       severity: "error",
       dependencyId: entry.id,
-      message: `Canonical dependency "${entry.id}" expected bytecode at ${entry.address ?? "unknown"} but eth_getCode was empty`,
+      message: `Dependency "${entry.id}" (status=${entry.status}) expected bytecode at ${entry.address ?? "unknown"} but eth_getCode was empty`,
     };
   }
   return null;
+}
+
+export const TRADER_ACCOUNT_IMPLEMENTATION_ID =
+  "erc6551-account-implementation";
+
+function sameAddress(a: string | null, b: string | null): boolean {
+  if (a === null || b === null) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Keep the dependency matrix and the recorded Floor Trader deployment from
+ * drifting apart. A pinned account implementation that no deployment record
+ * accounts for, or one that names a different address than the contract we
+ * actually deployed, would send every Trader's token-bound account to the
+ * wrong implementation.
+ */
+export function checkTraderDeploymentConsistency(opts: {
+  deps: RobinhoodTestnetDependencies;
+  deployment: FloorTraderDeployment | null;
+}): PreflightFinding[] {
+  const { deps, deployment } = opts;
+  const findings: PreflightFinding[] = [];
+
+  const entry = deps.dependencies.find(
+    (d) => d.id === TRADER_ACCOUNT_IMPLEMENTATION_ID
+  );
+  if (!entry) {
+    findings.push({
+      code: "account-implementation-entry-missing",
+      severity: "error",
+      dependencyId: TRADER_ACCOUNT_IMPLEMENTATION_ID,
+      message: `Dependency matrix must contain "${TRADER_ACCOUNT_IMPLEMENTATION_ID}"`,
+    });
+    return findings;
+  }
+
+  if (deployment === null) {
+    if (entry.address !== null) {
+      findings.push({
+        code: "account-implementation-unrecorded",
+        severity: "error",
+        dependencyId: entry.id,
+        message: `Matrix pins account implementation ${entry.address} but no Floor Trader deployment is recorded`,
+      });
+    }
+    return findings;
+  }
+
+  if (entry.address === null) {
+    findings.push({
+      code: "account-implementation-address-missing",
+      severity: "error",
+      dependencyId: entry.id,
+      message: `Floor Trader deployment v${deployment.version} deployed account implementation ${deployment.accountImplementation} but the matrix still pins null`,
+    });
+  } else if (!sameAddress(entry.address, deployment.accountImplementation)) {
+    findings.push({
+      code: "account-implementation-drift",
+      severity: "error",
+      dependencyId: entry.id,
+      message: `Matrix pins account implementation ${entry.address} but deployment v${deployment.version} recorded ${deployment.accountImplementation}`,
+    });
+  }
+
+  const registry = deps.dependencies.find((d) => d.id === "erc6551-registry");
+  if (registry && !sameAddress(registry.address, deployment.registry)) {
+    findings.push({
+      code: "registry-drift",
+      severity: "error",
+      dependencyId: "erc6551-registry",
+      message: `Floor Trader deployment v${deployment.version} used registry ${deployment.registry} but the matrix pins ${registry.address ?? "null"}`,
+    });
+  }
+
+  return findings;
 }
 
 export function assertAllowedChainId(chainId: string | number): void {
@@ -164,7 +248,8 @@ export function assertAllowedChainId(chainId: string | number): void {
  * By default, any error-severity finding means the matrix is not shippable.
  */
 export function runOfflinePreflight(
-  deps: RobinhoodTestnetDependencies
+  deps: RobinhoodTestnetDependencies,
+  opts: { traderDeployment?: FloorTraderDeployment | null } = {}
 ): PreflightFinding[] {
   const findings: PreflightFinding[] = [];
 
@@ -216,6 +301,13 @@ export function runOfflinePreflight(
         "erc6551-registry must be present as a canonical dependency with an address",
     });
   }
+
+  findings.push(
+    ...checkTraderDeploymentConsistency({
+      deps,
+      deployment: opts.traderDeployment ?? null,
+    })
+  );
 
   return findings;
 }

--- a/scripts/floor/preflight-robinhood-testnet.ts
+++ b/scripts/floor/preflight-robinhood-testnet.ts
@@ -35,6 +35,7 @@ import {
   type PreflightFinding,
 } from "./preflight-checks";
 import { loadFloorEnvLocal } from "./load-env";
+import { loadActiveFloorTraderDeployment } from "./trader-deployment";
 
 const ROOT = join(import.meta.dirname, "../..");
 const EVIDENCE_DIR = join(ROOT, ".floor-evidence");
@@ -327,7 +328,9 @@ async function main() {
   const rpcUrl = requireRpcUrl();
   const deps = loadRobinhoodTestnetDependencies();
 
-  const offlineFindings = runOfflinePreflight(deps);
+  const offlineFindings = runOfflinePreflight(deps, {
+    traderDeployment: loadActiveFloorTraderDeployment(),
+  });
   if (offlinePreflightHasErrors(offlineFindings)) {
     console.error("Offline preflight failed:");
     for (const f of offlineFindings) {

--- a/scripts/floor/preflight.ts
+++ b/scripts/floor/preflight.ts
@@ -7,10 +7,12 @@ import {
   offlinePreflightHasErrors,
   runOfflinePreflight,
 } from "./preflight-checks";
+import { loadActiveFloorTraderDeployment } from "./trader-deployment";
 
 function main() {
   const deps = loadRobinhoodTestnetDependencies();
-  const findings = runOfflinePreflight(deps);
+  const traderDeployment = loadActiveFloorTraderDeployment();
+  const findings = runOfflinePreflight(deps, { traderDeployment });
 
   console.log(
     JSON.stringify(
@@ -18,6 +20,7 @@ function main() {
         ok: !offlinePreflightHasErrors(findings),
         chainId: deps.network.chainId,
         dependencyCount: deps.dependencies.length,
+        traderDeploymentVersion: traderDeployment?.version ?? null,
         findings,
       },
       null,

--- a/scripts/floor/trader-deployment.ts
+++ b/scripts/floor/trader-deployment.ts
@@ -1,0 +1,59 @@
+/**
+ * Typed loader for contracts/deployments/robinhood-testnet.traders.json.
+ * Environment-free: no RPC, no env reads.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import { ROBINHOOD_TESTNET_CHAIN_ID } from "./dependencies";
+
+const ROOT = join(import.meta.dirname, "../..");
+
+export const TRADER_DEPLOYMENTS_FILENAME =
+  "robinhood-testnet.traders.json" as const;
+
+export const TRADER_DEPLOYMENTS_JSON_PATH = join(
+  ROOT,
+  "contracts/deployments",
+  TRADER_DEPLOYMENTS_FILENAME
+);
+
+const AddressSchema = z
+  .string()
+  .regex(/^0x[a-fA-F0-9]{40}$/, "must be a 0x-prefixed 20-byte address");
+
+const FloorTraderDeploymentSchema = z.object({
+  version: z.number().int().positive(),
+  chainId: z.literal(ROBINHOOD_TESTNET_CHAIN_ID),
+  identity: AddressSchema,
+  accountImplementation: AddressSchema,
+  delegation: AddressSchema,
+  registry: AddressSchema,
+  name: z.string().min(1),
+  symbol: z.string().min(1),
+  baseUri: z.string().min(1),
+  deployedAt: z.string().min(1),
+  txHash: z.string().optional(),
+  blockNumber: z.number().int().nonnegative().optional(),
+});
+
+export type FloorTraderDeployment = z.infer<typeof FloorTraderDeploymentSchema>;
+
+const FloorTraderDeploymentsSchema = z.array(FloorTraderDeploymentSchema);
+
+/** Load every recorded Floor Trader deployment, oldest first. */
+export function loadFloorTraderDeployments(
+  path: string = TRADER_DEPLOYMENTS_JSON_PATH
+): FloorTraderDeployment[] {
+  if (!existsSync(path)) return [];
+  const raw = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  return FloorTraderDeploymentsSchema.parse(raw);
+}
+
+/** The deployment the app should be pointed at, or null before the first one. */
+export function loadActiveFloorTraderDeployment(
+  path: string = TRADER_DEPLOYMENTS_JSON_PATH
+): FloorTraderDeployment | null {
+  const all = loadFloorTraderDeployments(path);
+  return all.length > 0 ? (all[all.length - 1] as FloorTraderDeployment) : null;
+}

--- a/tests/floor/trader-deployment.test.ts
+++ b/tests/floor/trader-deployment.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  ERC6551_REGISTRY_ADDRESS,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+  loadRobinhoodTestnetDependencies,
+  type DependencyEntry,
+  type RobinhoodTestnetDependencies,
+} from "../../scripts/floor/dependencies";
+import {
+  TRADER_ACCOUNT_IMPLEMENTATION_ID,
+  checkBytecodeExpectation,
+  checkTraderDeploymentConsistency,
+  offlinePreflightHasErrors,
+  runOfflinePreflight,
+} from "../../scripts/floor/preflight-checks";
+import {
+  loadActiveFloorTraderDeployment,
+  loadFloorTraderDeployments,
+  type FloorTraderDeployment,
+} from "../../scripts/floor/trader-deployment";
+
+const IDENTITY = "0x1111111111111111111111111111111111111111";
+const ACCOUNT_IMPL = "0x2222222222222222222222222222222222222222";
+const DELEGATION = "0x3333333333333333333333333333333333333333";
+
+function deployment(
+  overrides: Partial<FloorTraderDeployment> = {}
+): FloorTraderDeployment {
+  return {
+    version: 1,
+    chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+    identity: IDENTITY,
+    accountImplementation: ACCOUNT_IMPL,
+    delegation: DELEGATION,
+    registry: ERC6551_REGISTRY_ADDRESS,
+    name: "Margin Call Trader",
+    symbol: "MCTRADER",
+    baseUri: "https://margincall.test/api/floor/trader/",
+    deployedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+/** The committed matrix with the account implementation address overridden. */
+function depsWithAccountImplementation(
+  address: string | null
+): RobinhoodTestnetDependencies {
+  const deps = loadRobinhoodTestnetDependencies();
+  return {
+    ...deps,
+    dependencies: deps.dependencies.map((entry) =>
+      entry.id === TRADER_ACCOUNT_IMPLEMENTATION_ID
+        ? { ...entry, address }
+        : entry
+    ),
+  };
+}
+
+function entry(
+  overrides: Partial<DependencyEntry> & Pick<DependencyEntry, "id" | "status">
+): DependencyEntry {
+  return {
+    kind: "test",
+    label: "Margin Call Test Asset — fixture",
+    address: null,
+    expectedInterfaces: [],
+    ...overrides,
+  };
+}
+
+describe("loadFloorTraderDeployments", () => {
+  it("treats a missing record file as no deployments", () => {
+    expect(loadFloorTraderDeployments("/nonexistent/traders.json")).toEqual([]);
+    expect(loadActiveFloorTraderDeployment("/nonexistent/traders.json")).toBe(
+      null
+    );
+  });
+});
+
+describe("checkTraderDeploymentConsistency", () => {
+  it("passes when nothing is deployed and nothing is pinned", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(null),
+      deployment: null,
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("rejects a pinned implementation with no deployment record", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(ACCOUNT_IMPL),
+      deployment: null,
+    });
+    expect(findings.map((f) => f.code)).toContain(
+      "account-implementation-unrecorded"
+    );
+  });
+
+  it("rejects a deployment the matrix never pinned", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(null),
+      deployment: deployment(),
+    });
+    expect(findings.map((f) => f.code)).toContain(
+      "account-implementation-address-missing"
+    );
+  });
+
+  it("rejects a matrix pinned at a different implementation", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(
+        "0x9999999999999999999999999999999999999999"
+      ),
+      deployment: deployment(),
+    });
+    expect(findings.map((f) => f.code)).toContain(
+      "account-implementation-drift"
+    );
+  });
+
+  it("accepts a matrix that matches the deployment", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(ACCOUNT_IMPL),
+      deployment: deployment(),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("matches addresses regardless of checksum casing", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(ACCOUNT_IMPL.toUpperCase()),
+      deployment: deployment(),
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("rejects a deployment made against a different registry", () => {
+    const findings = checkTraderDeploymentConsistency({
+      deps: depsWithAccountImplementation(ACCOUNT_IMPL),
+      deployment: deployment({
+        registry: "0x4444444444444444444444444444444444444444",
+      }),
+    });
+    expect(findings.map((f) => f.code)).toContain("registry-drift");
+  });
+});
+
+describe("runOfflinePreflight with a trader deployment", () => {
+  it("still passes for the committed matrix with no deployment", () => {
+    const deps = loadRobinhoodTestnetDependencies();
+    expect(offlinePreflightHasErrors(runOfflinePreflight(deps))).toBe(false);
+  });
+
+  it("fails when the deployment and matrix disagree", () => {
+    const findings = runOfflinePreflight(depsWithAccountImplementation(null), {
+      traderDeployment: deployment(),
+    });
+    expect(offlinePreflightHasErrors(findings)).toBe(true);
+  });
+
+  it("passes once the matrix pins the deployed implementation", () => {
+    const findings = runOfflinePreflight(
+      depsWithAccountImplementation(ACCOUNT_IMPL),
+      { traderDeployment: deployment() }
+    );
+    expect(offlinePreflightHasErrors(findings)).toBe(false);
+  });
+});
+
+describe("checkBytecodeExpectation covers Floor-deployed addresses", () => {
+  it("errors when a pinned fallback address has no bytecode", () => {
+    const finding = checkBytecodeExpectation({
+      entry: entry({
+        id: TRADER_ACCOUNT_IMPLEMENTATION_ID,
+        status: "test-asset-fallback",
+        address: ACCOUNT_IMPL,
+      }),
+      code: "0x",
+    });
+    expect(finding?.code).toBe("bytecode-missing");
+  });
+
+  it("stays quiet for a pinned fallback address that has bytecode", () => {
+    expect(
+      checkBytecodeExpectation({
+        entry: entry({
+          id: TRADER_ACCOUNT_IMPLEMENTATION_ID,
+          status: "test-asset-fallback",
+          address: ACCOUNT_IMPL,
+        }),
+        code: "0x6080604052",
+      })
+    ).toBeNull();
+  });
+
+  it("stays quiet for an unpinned fallback", () => {
+    expect(
+      checkBytecodeExpectation({
+        entry: entry({ id: "usdg", status: "test-asset-fallback" }),
+        code: "0x",
+      })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Phase B of #250 — the contracts only. Convex integration, claim UI, and the live deployment follow separately.

## What this adds

**`TraderIdentity`** — a standard, permissionlessly transferable ERC-721. No lockup, so a desk can sell a Trader on any external marketplace, and non-upgradeable so custody rules cannot change beneath active positions. Minting is permissionless: the House sponsors gas but must not gate identity creation, since a desk's ownership is not shared with the House. Admin rights cover the metadata endpoint only and cannot restrict or freeze a transfer.

Each token carries an **authority epoch** that advances on every ownership change, and a claim flag that a transfer clears.

**`TraderAccount`** — an ERC-6551 token-bound account holding the Trader's balances and inventory. Authority is resolved live from the controlling NFT on every call, so control follows a transfer with no migration step and no residual power for the previous owner. No admin, no upgrade path, no House key.

**`TraderDelegation`** — delegated agent keys, authorized only for named protocol actions against named contracts. Agent keys never get raw account control, so a compromised key cannot make arbitrary calls from the account.

**Deploy script and preflight wiring** — `pnpm deploy:floor-trader` puts all three on Robinhood Chain testnet in one broadcast and records the result.

## How a transfer retires authority

This is the part worth reviewing closely. Rather than iterating over grants at transfer time, every grant records the epoch it was issued under, and `isAuthorized` compares against the current epoch. A sale therefore retires every delegated key at once, in the transfer itself:

- no unbounded loop that could run out of gas as grants accumulate
- no dependence on the departing owner signing a revocation
- grants stay inert while the Trader is unclaimed, which is what holds automation paused until the new owner has reviewed it

Revoking everything at once uses the same trick with a per-Trader generation counter, so its cost does not grow with the number of grants.

## Security decisions worth a look

- **Ownerless accounts fail closed.** `TraderAccount.token()` reads its binding from the proxy's own runtime code. Anything that is not a registry-created proxy reports no binding rather than decoding whatever sits at that offset. A zero owner is then never accepted as a signer — without that guard, ECDSA recovery of the zero address would validate signatures against an ownerless account.
- **Self-transfers still advance the epoch.** Treating a real transfer as a no-op would leave it to the caller whether authority survives; failing closed is the safer default.
- **Ownership cycles are rejected.** An account that received its own controlling token would have no reachable owner.
- **Grants cannot pre-authorize future actions.** A grant may not request action bits that are not yet defined, so a key issued today cannot cover an action added later.
- **Spend caps are deliberately absent.** Per-fill and daily caps can only be enforced where the spend is observed, so they belong to the settlement contract rather than sitting in the delegation record as a control it cannot apply.

## Preflight now has teeth it was missing

Two gaps closed:

- Any dependency pinning an address must have bytecode there, not only `canonical` ones. The account implementation is recorded as a fallback precisely because we deploy it ourselves, so until now a dead pointer there would have passed.
- The dependency matrix must agree with the recorded deployment. An implementation pinned with no deployment behind it, or one naming a different address than we deployed, would send every Trader's token-bound account to the wrong implementation.

The deploy driver also refuses to broadcast unless a Floor deployment is separately approved for the shell. Gate 1 covers the Base Sepolia deal-game contracts, and an operator approved to redeploy those has not thereby approved putting a new Trader collection on Robinhood Chain testnet. It reads the chain id before broadcasting and rejects a mainnet RPC outright.

## Not in this PR

Convex ownership projection and claim gating, the custody/claim UI, and the live testnet deployment. The contracts are not deployed, so the dependency matrix still pins `null` for the account implementation — `pnpm floor:preflight` passes in that state and will fail the moment the two sides disagree.

## Test plan

- [x] `forge test` — 246 passing, 114 of them new across the three contracts
- [x] Transfer chains, self-transfers, operator-approved transfers, and claim-after-each-hop covered by unit and fuzz tests
- [x] Registry double reproduces the canonical ERC-6551 proxy bytecode layout exactly, so `token()` decoding is exercised against the real layout rather than a looser stand-in
- [x] `forge fmt --check`, `forge build --sizes` (all three well under EIP-170)
- [x] `pnpm vitest run` — 713 passing
- [x] `pnpm floor:preflight` — ok
- [x] `npx tsc --noEmit`, ESLint clean on changed files
- [ ] Slither runs in CI (not installed locally)

Made with [Cursor](https://cursor.com)