### PR TITLE
docs: add game token PRD for the permissionless Pack economy

### DIFF
--- a/docs/prd-margin-call-token.md
+++ b/docs/prd-margin-call-token.md
@@ -1,0 +1,192 @@
+# Margin Call: The Game Token
+
+**Status:** Draft for review  
+**Target:** Robinhood Chain testnet, then mainnet with canonical Stock Tokens  
+**Version:** 0.1  
+**Date:** July 26, 2026
+
+## Release boundary
+
+This PRD reverses the "no game token" exclusion in [`docs/prd-margin-call-floor.md`](./prd-margin-call-floor.md), which lists "a game token, staking, cycle-speed purchases, resting-order tiers, buy-and-burn, Morpho yield, supplier APY claims, and monetary leaderboard rewards" as out of scope.
+
+It is a companion to a **permissionless Pack economy** in which any Desk Manager wraps real Stock Tokens into a transferable Pack and other players pay to receive one at random, rather than the single House-operated Window with allowlisted Suppliers described in the Floor PRD. Where the two documents conflict on supply, this one governs the token and assumes the Pack model. The Floor PRD continues to govern custody, the secondary Offer Book, acquisition accounting, the Wire, and the Robinhood-only network boundary.
+
+Prior art in this repository is load-bearing and should be reused rather than rebuilt:
+
+- [`contracts/src/SeatVault.sol`](../contracts/src/SeatVault.sol) — staking against an id for tiers, with two-phase unstake, cooldown, pause, and two-step ownership. Covered by unit, fuzz, invariant, e2e, and integration suites.
+- [`convex/seatVault/`](../convex/seatVault/) and [`convex/agent/capacity.ts`](../convex/agent/capacity.ts) — tier indexing, reconciliation, and capacity-aware agent scheduling.
+- [`docs/trader-fuel-token.md`](./trader-fuel-token.md) — the shipped `$BLOW` capacity token policy and its invariants.
+
+[`contracts/src/MarginCallToken.sol`](../contracts/src/MarginCallToken.sol) is **not** reusable. It is a thirteen-line ERC-20 with an unpermissioned public `mint()` and no supply cap, commented "Test / Sepolia capacity token." It must be replaced.
+
+## Problem Statement
+
+The Floor as specified has one House-operated Window, allowlisted Suppliers, and no token. Two things break under that design.
+
+Supply is capped by business development. Suppliers are onboarded one at a time, they are asked to lock inventory behind a junior surplus claim with a delayed exit, and the PRD forbids describing the return. Total value locked becomes a function of how many partners the House signs rather than how many participants the market attracts.
+
+More fundamentally, **the rip is negative expected value in equity terms and always will be.** A ripper pays a price above the expected value of what they receive. That gap is what pays the creator and the protocol, and it is the only thing that makes supply rational. It is not a flaw to be engineered away. But a game whose sole economic output to participants is a disclosed loss has no way to reward early supply before rip flow exists, no way to retain participants through variance, and no link between protocol revenue and anything a participant can hold.
+
+A permissionless Pack market introduces a fourth problem that does not exist in the Window model. When anyone can create a Pack, the scarce resource is no longer inventory — it is **selection weight**. Something has to meter it, or the pool degenerates into spam.
+
+The design must solve all four without claiming yield, without promising the token has value, and without creating a subsidy that makes wash trading profitable.
+
+## Solution
+
+Introduce a fixed-supply ERC-20 on Robinhood Chain with four functions and no revenue distribution.
+
+**It meters selection weight.** Creators stake against a Pack to raise its selection weight within a published, bounded multiplier band. Staking buys distribution frequency only. It cannot change a Pack's contents, its oracle NAV, or what a ripper receives on unwrap, and every Pack's weight multiplier and independently verifiable NAV are displayed before a rip. This is a deliberate departure from a shipped invariant and is treated separately below.
+
+**It bootstraps supply.** Creators earn emissions proportional to TVL-seconds of _unripped_ Pack inventory valued at oracle. This pays for locked equity directly and tapers as real rip flow takes over.
+
+**It rebates rippers.** Every rip mints to the ripper in proportion to rip spend. This is a disclosed participation rebate, not a return, and it is bounded by a hard invariant so it can never make self-dealing profitable.
+
+**It meters agent capacity.** Staking unlocks agent cycle tiers through the existing SeatVault, unchanged in mechanism.
+
+Value accrual is mechanical and unpromised. Protocol fees are collected in real Stock Tokens — a rip fee in basis points, an unwrap fee in raw underlying units, and a secondary settlement fee. A governance-set share of that revenue funds open-market buyback and burn; the remainder is retained as protocol-owned equity. There is no fee distribution to stakers, no staking yield, and no APY surface anywhere in the product.
+
+Emissions are disciplined by one rule that makes a death spiral structurally impossible: **emissions in any epoch cannot exceed a multiple of the previous epoch's realized fee revenue.** A protocol with no revenue emits nothing.
+
+## Conflict with the shipped `$BLOW` invariant
+
+[`docs/trader-fuel-token.md`](./trader-fuel-token.md) states the shipped invariant plainly:
+
+> **Stake affects capacity, never outcome probability.**
+
+Weight staking violates it. A creator who stakes makes their Pack more likely to be selected, which changes the distribution of outcomes a ripper faces. Calling this "distribution" rather than "odds" would be a rebrand, not a defense.
+
+The departure is proposed deliberately, because in a permissionless market selection weight is the only scarce resource worth metering, and leaving it unmetered invites spam. It is bounded by four mitigations:
+
+1. The multiplier is bounded within a published band and applies to selection frequency only.
+2. Every Pack's exact contents, oracle NAV, staked amount, and current multiplier are visible before payment. The ripper knows the full distribution they are buying into; only the draw is unknown.
+3. Staking never changes contents, unwrap output, or fees. The equity floor under every Pack is invariant to all token state, including during pause.
+4. The house edge is published as an explicit number rather than implied.
+
+Agent capacity staking through SeatVault preserves the original invariant unchanged and is unaffected by this departure.
+
+**This is the single decision in this document most worth rejecting.** If review concludes that outcome-probability neutrality is non-negotiable, the fallback is to meter Pack listings by a flat creation fee or a staked-deposit requirement that grants no weight advantage, at the cost of losing the primary demand sink for the token.
+
+## User Stories
+
+### Creators and supply
+
+1. As a Pack Creator, I want to earn tokens proportional to the oracle value and duration of unripped inventory I have locked, so that supplying equity is rewarded before rip flow can pay me.
+2. As a Pack Creator, I want emissions to stop accruing the moment my Pack is ripped, so that I cannot farm rewards by cycling inventory through myself.
+3. As a Pack Creator, I want to stake against a Pack to raise its selection weight, so that I can compete for rip flow without changing what I am offering.
+4. As a Pack Creator, I want the weight multiplier to be bounded and published, so that staking is a distribution advantage rather than a hidden edge over rippers.
+5. As a Pack Creator, I want unstaking to require a cooldown, so that weight cannot be rented for a single block.
+6. As a Pack Creator, I want my staked position released without penalty when my Pack is ripped, so that capital is not trapped by a position that no longer exists.
+
+### Rippers
+
+7. As a Ripper, I want the expected value of a rip published as an explicit house edge, so that I am choosing to pay a premium rather than being misled about one.
+8. As a Ripper, I want each Pack's contents, oracle NAV, staked amount, and weight multiplier visible before I pay, so that the only unknown is which Pack I receive.
+9. As a Ripper, I want to receive tokens proportional to my rip spend, so that participation is rebated even when a specific rip goes against me.
+10. As a Ripper, I want the rebate described as a rebate and never as a return, yield, or expected profit, so that the product does not make a claim it cannot support.
+11. As a Ripper, I want no rebate accrual on Packs created by my own Desk, so that the emission cannot be farmed by self-dealing.
+12. As a Ripper, I want to unwrap any Pack I receive at any time for its contents less the unwrap fee, so that the token has no bearing on my hard floor.
+
+### Agents
+
+13. As a Desk Manager, I want staked principal to unlock agent cycle tiers through the existing SeatVault, so that automation throughput is metered by committed capital.
+14. As a Desk Manager, I want tier changes to apply to scheduling without restarting or reconfiguring my agents, so that capacity is continuous.
+15. As a Desk Manager, I want a Trader transfer to invalidate the prior owner's tier claim, so that staked capacity does not survive an ownership change unverified.
+
+### Emissions and treasury
+
+16. As a participant, I want a fixed total supply with a published allocation and vesting schedule, so that dilution is knowable in advance.
+17. As a participant, I want per-epoch emissions capped as a multiple of the prior epoch's realized fee revenue, so that the protocol cannot emit into a dead market.
+18. As a participant, I want emissions forgone under that cap to be permanently unissuable, so that a slow epoch reduces total supply rather than deferring it.
+19. As a participant, I want protocol fee revenue collected in real Stock Tokens, so that revenue is denominated in the asset the game is about.
+20. As a participant, I want the buyback and burn share of revenue to be a published mechanical policy rather than a discretionary action, so that treasury behavior is predictable.
+21. As a participant, I want the retained share of fees to accumulate as protocol-owned equity, so that revenue also builds TVL.
+22. As the House, I want the buyback and retention split to be versioned configuration, so that the trade-off between token buy pressure and equity retention can be tuned with data.
+
+### Safety and honesty
+
+23. As the House, I want the value of tokens emitted per rip to be provably less than the rake paid on that rip, so that wash trading is unprofitable by construction rather than by detection.
+24. As the House, I want no staking rewards, no fee sharing, and no yield language anywhere in the contracts or the product, so that the token's utility is access and metering only.
+25. As the House, I want the testnet token to be explicitly valueless and visibly labelled, so that a testnet deployment cannot be mistaken for a live economy.
+26. As an auditor, I want total emitted supply, per-epoch caps, burn totals, staked principal, and treasury holdings reconcilable from onchain events alone, so that supply claims are verifiable.
+
+## Implementation Decisions
+
+### Token
+
+- Fixed maximum supply set at deployment and not increasable. No owner mint.
+- Minting authority is a single non-upgradeable Emitter contract enforcing the epoch schedule and the revenue cap. No other address can mint.
+- Burn is permissionless and irreversible. Treasury buyback burns through the same path.
+- Allocation is published at deployment across supply mining, rip rebates, treasury, and contributors, with contributor and treasury tranches on a cliff and linear vest. Exact percentages are versioned configuration decided before mainnet, not protocol constants.
+- `MarginCallToken.sol` is replaced entirely. Its unpermissioned public `mint()` and absent cap disqualify it from any economic role.
+
+### Emissions
+
+- Time is divided into fixed epochs. The schedule defines a declining maximum issuance per epoch.
+- Actual issuance is `min(scheduled_n, k × realized_fee_revenue_{n-1})`, where revenue is valued at oracle in a common unit and `k` is a governance-set multiple that declines on a published schedule. Starting hypothesis: `k = 3.0`.
+- Any difference between scheduled and actual issuance is permanently forgone. It does not roll forward. This gives the supply curve a deflationary bias in weak epochs and removes any incentive to stall.
+- Supply mining accrues on TVL-seconds of unripped Pack inventory at oracle value. Accrual stops at rip, unwrap, or delist.
+- Rip rebates accrue per rip in proportion to rip spend, subject to the wash-trade invariant, with a per-address per-epoch ceiling.
+- Rebates vest on a short cliff. A ripper who unwraps immediately keeps their equity floor but forfeits unvested rebate.
+
+### The wash-trade invariant
+
+This is the load-bearing safety property and should be treated as a protocol invariant, not a heuristic.
+
+> For every rip, the oracle-referenced value of tokens emitted to the ripper must be strictly less than the rake paid on that rip.
+
+If it holds, ripping your own Pack is unprofitable regardless of volume, because the rake is a real cost and the rebate can never exceed it. This is materially stronger than the Floor PRD's position, which concedes it cannot prevent suspicious trading and can only discount it in leaderboard scoring.
+
+Enforcement is an oracle-referenced cap on the emission rate, recomputed each epoch. This introduces a dependency on a token price reference. On testnet, and in any epoch where the reference is stale or unavailable, the rate falls back to a conservative governance-declared floor. **The invariant fails closed.**
+
+Same-Desk exclusion, already specified for fills in the Floor PRD, additionally applies to rebate accrual: no rebate is earned ripping a Pack your own Desk created.
+
+### Staking and weight
+
+- Pack weight staking is a new vault. Agent capacity staking reuses `SeatVault.sol` and its Convex indexing unchanged.
+- The weight multiplier is bounded — starting hypothesis 1.0x to 2.5x — and is a pure multiplier on selection probability. It never alters Pack contents, oracle NAV, unwrap output, or fees.
+- Every Pack's current multiplier, staked amount, contents, and NAV are displayed before a rip.
+- Unstaking follows the SeatVault pattern: initiate, cooldown, complete. A repeated initiate does not extend an open cooldown. Starting hypothesis for cooldown is seven days.
+- Weight stake is released without cooldown when the backing Pack is ripped.
+
+### Fees and treasury
+
+- Rip fee in basis points on rip price. Unwrap fee in raw underlying units. Secondary settlement fee in the quote asset. All three are collected in real assets, never in the game token.
+- Revenue splits by a versioned parameter into a buyback tranche and a retention tranche. Starting hypothesis 50/50.
+- The buyback tranche swaps to the token on a published venue and burns. Execution is scheduled and rate-limited, not discretionary.
+- **Trade-off to hold explicitly:** the buyback tranche is Stock Token sell volume, which cuts against the volume objective, while the retention tranche grows protocol-owned equity but creates no buy pressure. The split is the dial between those two and should be tuned with data rather than fixed by conviction.
+- Treasury holdings, buyback execution, and burn totals are published and reconcilable from events.
+
+### What the token deliberately does not do
+
+- No staking rewards, no fee distribution, no revenue share, no APY, no "real yield." Utility is access, weight, and capacity.
+- No governance over custody rules, Pack contents, or fee ceilings in v1. Parameters change through the same closed-Window, versioned-configuration discipline the Floor PRD establishes.
+- No effect on unwrap output. The equity floor under every Pack is independent of token state in all conditions, including pause.
+- No requirement to hold the token to rip, create a Pack, or unwrap.
+
+## Testing Decisions
+
+- Follow the LazerForge Foundry conventions already adopted for the Floor: pinned compiler, deterministic block state, metadata-free builds, named profiles, CI fuzzing at 1,024 or more cases, and committed gas snapshots.
+- `SeatVault.t.sol`, `SeatVault.fuzz.t.sol`, and `SeatVault.invariant.t.sol` are direct prior art for the weight vault. Extend rather than rewrite.
+- Invariant campaigns must prove: total minted never exceeds the cap; per-epoch issuance never exceeds `min(schedule, k × prior revenue)`; forgone issuance is unrecoverable; rebate value per rip is always below rake paid; staked principal is always fully withdrawable after cooldown; weight multipliers stay within the published band; and Pack unwrap output is invariant to all token state.
+- Fuzz across epoch boundaries, zero-revenue epochs, stale token price references, concurrent stake and unstake, rip during cooldown, and a Pack ripped while weight-staked.
+- Adversarial tests must prove self-dealing is unprofitable at arbitrary volume, that a creator cannot farm supply mining by ripping their own inventory, and that an emission-rate oracle failure fails closed to the conservative floor rather than open.
+- Convex tests cover epoch accounting idempotency, rebate vesting, tier reconciliation on Trader transfer, and that no product surface renders yield or APY language.
+
+## Out of Scope
+
+- Mainnet token launch, liquidity provisioning, listings, market making, and any price or value claim.
+- Fee sharing, staking yield, revenue distribution to holders, and vote-escrow lockup multipliers.
+- Governance over custody, contents, or fee ceilings.
+- Buying odds, buying NAV, buying information, or any token mechanic that changes what a ripper receives after selection.
+- Cross-chain deployment, bridging, and non-Robinhood-Chain venues.
+- Retroactive airdrop to legacy Base desks, deals, or `$BLOW` positions.
+
+## Further Notes
+
+The `$BLOW` naming in [`gitbook/economy/blow-and-floor-access.md`](../gitbook/economy/blow-and-floor-access.md) and `docs/trader-fuel-token.md` is inconsistent with the `MARGINCALL` symbol in the deployed contract. Pick one before deployment.
+
+The single most important number in this document is `k`, the revenue multiple on emissions. It is what separates this design from every game token that emitted its way into a death spiral. Set it conservatively, decline it on a published schedule, and never raise it in response to weak demand — a protocol that emits harder when revenue falls is the exact failure mode this rule exists to prevent.
+
+The wash-trade invariant is the strongest claim here and the one most worth attacking in review. If it holds, the leaderboard integrity concerns the Floor PRD concedes it cannot solve become largely moot on the token dimension, because the subsidy an attacker would farm is bounded below the cost of farming it.
+
+The rip being negative expected value is stated deliberately and should never be softened in product copy. The honest description of this economy is that Pack creators distribute equity at a premium to spot and rippers pay that premium for entertainment and a bounded rebate. That is a real business, it is what gacha has always been, and it drives the metric the product cares about: Stock Tokens moving from existing holders to new holders, continuously, with the creator side buying on the open market to restock.

--- a/docs/prd-margin-call-token.md
+++ b/docs/prd-margin-call-token.md
@@ -9,20 +9,20 @@
 
 Margin Call V1 is a fixed-price Pack-ripping game operated through persistent Trader identities. Packs are the immediate game object; Traders are the long game.
 
-Creators permissionlessly fund auditable Packs of approved tokenized-stock ERC-20s. A Desk Manager funds a Trader with the configured rip-payment asset and assigns it to a named pool or tier. Every funded, eligible Trader may Rip exactly one Pack in each hourly window at that pool's fixed price. The protocol selects uniformly at random: every eligible Pack has an equal chance regardless of oracle NAV, game-token balance, creator identity, or any other Pack attribute. Selection immediately completes the Rip and delivers the Pack to the Trader. There is no discretionary buy, hold-unripped, resell, or market-timing decision in V1.
+Creators permissionlessly fund auditable Packs of approved tokenized-stock ERC-20s. A Desk Manager funds a Trader with the configured USD stablecoin and assigns it to a named pool or tier. Every funded, eligible Trader may Rip exactly one Pack in each hourly window at that pool's fixed price. The protocol selects uniformly at random: every eligible Pack has an equal chance regardless of oracle NAV, game-token balance, creator identity, or any other Pack attribute. Selection immediately completes the Rip and delivers the Pack to the Trader. There is no discretionary buy, hold-unripped, resell, or market-timing decision in V1.
 
-The game token's primary active V1 incentive at launch is bounded creator emissions. A future ripper participation-reward configuration exists but is disabled with a value of zero at launch. The token is not the rip-payment asset, does not change Pack selection odds, and does not buy faster Trader cadence in V1. The product makes no promise that the token will appreciate or that any participant will earn a profit.
+The game token has a fixed maximum supply of `1,000,000,000` tokens and a finite 15-day launch-emission season. Creator emissions receive `150,000,000` tokens (15%) through published fixed hourly-epoch budgets, and confirmed-Rip participation rewards receive a separate `150,000,000` tokens (15%) through published fixed reward pots. The remaining `700,000,000` tokens (70%) are non-emitting and unallocated in V1. The launch allocations are independent of Rip-fee revenue. The token is not the Rip-payment stablecoin, does not change Pack selection odds, and does not buy faster Trader cadence. The product makes no promise that the token will appreciate or that any participant will earn a profit.
 
 Rips are disclosed negative-expected-value entertainment: creators fund possible above-price outcomes, receive the fixed Rip proceeds when selected, and farm a pro rata share of bounded emissions while eligible inventory remains active, without any return promise.
 
-The initial V1 configuration charges `$25` per Rip: a 10% protocol fee retains `$2.50` in the rip-payment asset, the creator receives fixed proceeds of `$22.50`, the selected Pack transfers to the Trader with control of its full recorded basket, and unwrap or redemption carries no additional fee.
+The initial V1 configuration charges `$25` in the configured USD stablecoin per Rip: a 10% protocol fee retains `$2.50` of that stablecoin as protocol revenue, the creator receives fixed stablecoin proceeds of `$22.50`, the selected Pack transfers to the Trader with control of its full recorded basket, and unwrap or redemption carries no additional fee.
 
 ## V1 game loop
 
 1. A creator mints and fully funds a Pack with an approved basket of tokenized-stock ERC-20s.
 2. The protocol records the Pack's immutable basket accounting and publishes its contents, oracle NAV, fees, and redemption terms.
-3. The Pack enters and remains in a named fixed-price pool or tier only while satisfying objective asset, funding, freshness, anti-spam, and current pool NAV-bound rules.
-4. A Desk Manager funds a Trader's ERC-6551 account with the configured rip-payment asset, chooses one eligible pool, and enables its deterministic schedule.
+3. The Pack enters and remains in a named fixed-price pool or tier only while satisfying objective asset, funding, freshness, anti-spam, and pool NAV-bound rules at required eligibility checkpoints.
+4. A Desk Manager funds a Trader's ERC-6551 account with the configured USD stablecoin, chooses one eligible pool, and enables its deterministic schedule.
 5. Once per hourly window, an enabled Trader with sufficient funds may spend exactly one fixed Rip Price. It cannot spend more often, exceed its balance, or choose among eligible Packs.
 6. The protocol selects uniformly at random from the eligible set, giving every eligible Pack an equal chance. Selection immediately completes the Rip, transfers the Pack and control of its full recorded basket to the Trader, settles fixed creator proceeds and the protocol fee, and stops that Pack's creator emissions; V1 does not create an unopened-Pack decision point.
 7. The confirmed Rip, payment, selected Pack, basket, NAV snapshot, fees, and Trader history are publicly auditable. The manager may later refill or pause the Trader.
@@ -37,7 +37,7 @@ If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, 
 - A TokenPacks-style custody contract directly holds and accounts for every Pack's basket. A Pack is not an ERC-6551 token-bound account.
 - Transferring the Pack transfers the right to its recorded basket. In V1 the current holder can unwrap or redeem the full recorded basket with no protocol deduction.
 - Pack contents and oracle NAV are public and auditable before selection and after transfer. The whitelist resolves canonical addresses from Robinhood's [Token Contracts](https://docs.robinhood.com/chain/contracts/) page and may reconcile metadata through the [Stock Token APIs](https://docs.robinhood.com/chain/stock-token-apis/). Custody accounting uses raw token units; displayed NAV never replaces the recorded basket.
-- Pack NAV and creator-emission eligibility use the approved onchain Chainlink feed for each whitelisted Stock Token, following Robinhood Chain's [oracle and price-feed guidance](https://docs.robinhood.com/chain/oracles-and-price-feeds/). Calculations normalize token and feed decimals and fail closed on invalid, paused, missing, or stale data. When canonical testnet token or feed coverage is unavailable, clearly labelled Test Assets and controlled feed doubles validate the same accounting and failure semantics.
+- Pack NAV and creator-emission eligibility use the approved onchain Chainlink feed for each whitelisted Stock Token, following Robinhood Chain's [oracle and price-feed guidance](https://docs.robinhood.com/chain/oracles-and-price-feeds/). Fresh values are checked at defined hourly-epoch boundaries and relevant Pack interactions, including Rip, top-up, and claim. Calculations normalize token and feed decimals and fail closed on invalid, paused, missing, or stale data. When canonical testnet token or feed coverage is unavailable, clearly labelled Test Assets and controlled feed doubles validate the same accounting and failure semantics.
 
 ### Trader: the persistent desk
 
@@ -51,16 +51,16 @@ If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, 
 - Any participant may create and list as many fully funded Packs as they can support.
 - Creation and active-pool eligibility do not depend on a creator allowlist. Eligibility follows objective published rules for approved assets, complete funding, oracle freshness, public contents and NAV, protocol fees or bonds, and anti-spam limits.
 - Under the initial `$25` configuration, a creator receives fixed proceeds of `$22.50` when their Pack is selected, even when the Pack's NAV is higher than the Rip Price.
-- A creator farms a pro rata share of bounded emissions based on verified Pack NAV and active eligibility time. Accrual stops when the Pack is selected, redeemed, delisted, or becomes ineligible.
+- A creator accrues a pro rata share of each hourly epoch's published fixed emission budget, weighted by verified USD Pack NAV and eligible time established at fresh-oracle checkpoints. Rewards can be claimed at any time without changing the Pack's ongoing eligibility or accrual. Accrual stops when the Pack is selected, redeemed, delisted, or becomes ineligible.
 - Creator copy must disclose maximum immediate downside and must not describe emissions, token price, or pool participation as a return promise.
 
 ### Pool and protocol
 
-- Each pool or tier has a stable public name, one rip-payment asset, one fixed Rip Price, approved asset rules, fees, and published minimum and maximum oracle NAV bounds.
-- The initial V1 Rip Price is `$25`. Its 10% Rip fee retains `$2.50` as protocol revenue in the rip-payment asset and settles `$22.50` as fixed creator proceeds. The fee is versioned, evented pool configuration that may be adjusted prospectively based on testnet results rather than an immutable universal constant.
+- Each pool or tier has a stable public name, one configured USD stablecoin, one fixed Rip Price, approved Stock Token rules, fees, and published minimum and maximum USD oracle NAV bounds. Pack NAV and bounds are denominated in USD; Rip Price, creator proceeds, and protocol fees are denominated and settled in that stablecoin.
+- The initial V1 Rip Price is `$25`. Its 10% Rip fee retains `$2.50` as protocol revenue in the configured stablecoin and settles `$22.50` as fixed creator proceeds in that stablecoin. The fee is versioned, evented pool configuration that may be adjusted prospectively based on testnet results rather than an immutable universal constant.
 - The initial `$25` pool's starting hypothesis is a `$15` minimum NAV and `$100` maximum NAV. These are versioned, evented pool configuration, not immutable universal constants.
 - The V1 unwrap or redemption fee is zero. The disclosed Rip fee is the only player-facing protocol fee.
-- NAV bounds are continuously enforced for active eligibility, and the maximum protects pool risk rather than serving only as a listing-time check. A Pack outside either bound leaves the eligible selection set and stops creator emissions until price movement or a permitted top-up returns it within bounds; its redemption right remains intact.
+- NAV bounds are enforced for active eligibility using fresh oracle data at defined hourly-epoch boundaries and relevant Pack interactions, including Rip, top-up, and claim; the maximum protects pool risk rather than serving only as a listing-time check. A Pack outside either bound leaves the eligible selection set and stops creator emissions until a later checkpoint confirms that price movement or a permitted top-up has returned it within bounds; its redemption right remains intact.
 - Bound changes apply prospectively to new listings or a new pool version and never silently rewrite the bounds governing existing active Packs.
 - Selection within a pool is uniform: oracle NAV, game-token balance, creator identity, and all other Pack attributes have zero selection weight.
 - V1 may launch with one pool. Additional fixed-price pools are configuration expansions, not variable pricing within a pool.
@@ -69,19 +69,21 @@ If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, 
 
 ## Game-token role in V1
 
-The game token is a fixed-maximum-supply ERC-20 whose primary active V1 use at launch is:
+The game token is a fixed-maximum-supply ERC-20 with `1,000,000,000` tokens allocated for V1 as follows:
 
-- **Creator emissions:** eligible creators farm a pro rata share of a capped allocation based on verified Pack NAV and active eligibility time. Selection, redemption, delisting, or loss of eligibility stops accrual.
+- **Creator emissions — 15%:** `150,000,000` tokens are emitted over the 15-day launch season through a published fixed hourly-epoch schedule and distributed pro rata based on verified USD Pack NAV multiplied by eligible time. Selection, redemption, delisting, or loss of eligibility stops accrual.
+- **Rip participation rewards — 15%:** `150,000,000` tokens are divided among published fixed daily pots of `10,000,000` tokens, or an equivalent fixed-epoch schedule with the same total cap. Each pot is shared among confirmed qualifying Rips in that epoch; the protocol never mints an uncapped fixed amount per Rip.
+- **Unallocated — 70%:** `700,000,000` tokens remain non-emitting, unallocated, and unavailable for use in V1. Any future use requires separate approval and does not imply a market, liquidity, buyback, external distribution, price support, treasury access, or return guarantee.
 
-The contract retains a future ripper participation-reward configuration set to zero at launch. The owner may later set it only within an immutable deployment-time maximum and a bounded published budget; every configuration change is evented and auditable. It is a participation reward, never a return, yield, appreciation, or guarantee.
+Only confirmed, settled Rips qualify for the participation pot. Failed, pending, or retried intents and same-Desk Rips do not qualify. Multiple Traders and automated paid Rips may qualify under the same hard per-Trader cadence and settlement rules; V1 does not add a broad identity-based Sybil gate. The owner may update the participation-reward configuration only within the immutable deployment-time maximum and the `150,000,000`-token season allocation, and every change must be evented and auditable. The configured reward remains below the disclosed game cost and is never a return, yield, appreciation, or guarantee.
 
-At V1 launch, the token is earned-only and transfer-restricted. Normal external wallet-to-wallet `transfer` and `transferFrom` are disabled; user balances are earned only through eligible creator emissions and, if later enabled, the bounded participation reward. Protocol mints, burns, and strictly required internal movements remain allowed.
+At V1 launch, the token is earned-only and transfer-restricted. Normal external wallet-to-wallet `transfer` and `transferFrom` are disabled; user balances are earned only through eligible creator emissions and qualifying Rip participation rewards. Protocol mints, burns, and strictly required internal movements remain allowed.
 
-The contract retains a separately approved path to enable ordinary ERC-20 transfers through an explicit, evented, time-delayed, preferably irreversible switch. Enabling transfers does not itself create external buying; a market or liquidity venue requires a separate decision. Mainnet and external-market opening remain outside V1, with no price, return, availability, or transfer-enablement promise.
+The contract retains a separately approved path to enable ordinary ERC-20 transfers through an explicit, evented, time-delayed, preferably irreversible switch. Enabling transfers does not itself create external buying; a market or liquidity venue requires a separate decision. Any stablecoin-fee-funded market buy, buyback, or liquidity program is post-V1 and separately approved; buying through an approved pool is distinct from adding two-sided liquidity, and neither creates a price target, floor, redemption right, or return promise. Mainnet and external-market opening remain outside V1, with no price, return, availability, or transfer-enablement promise.
 
 The token is not required to Rip, create, or redeem a Pack. It does not affect Pack contents, NAV, unwrap output, selection odds, Trader cadence, or the fixed Rip Price.
 
-Protocol fee revenue remains held in the rip-payment asset and gates or funds future bounded creator-emission budgets; the fee does not directly pay newly minted game tokens on each Rip. A zero-revenue period creates no new ongoing emission budget, and unused budget does not accumulate for later release. A finite bootstrap allocation, if approved, must be published separately and cannot be represented as revenue-backed. Exact allocations, vesting, emission rates, and any mainnet token launch remain approval-gated decisions.
+Creator emissions and Rip participation rewards are minted from their separate fixed-supply allocations under the published launch schedules. Stablecoin protocol revenue neither gates nor funds either token budget and does not directly pay or mint either reward. Any mainnet token launch remains an approval-gated decision.
 
 Creator emissions stop when inventory leaves eligible supply. All creator-emission totals, Pack eligibility inputs, and claims must be reproducible from confirmed records. The token pays no staking yield, fee share, revenue distribution, APY, or guaranteed benefit.
 
@@ -91,38 +93,39 @@ Creator emissions stop when inventory leaves eligible supply. All creator-emissi
 - A Pack can be selected at most once and its fixed Rip payment settles at most once. Failure and retry paths reconcile the same intent and never create a second Rip.
 - Every funded, eligible Trader can complete at most one Rip in an hourly window. Ownership transfer, pause, insufficient balance, or ineligibility fails closed.
 - Pack selection is uniform across the published eligible set. Every eligible Pack has equal odds; oracle NAV, game-token holdings or stake, creator identity, and Pack attributes never add selection weight.
-- Pool NAV bounds are continuously enforced. An out-of-bounds Pack leaves selection and creator-emission eligibility until it returns within bounds, without losing its redemption right; versioned bound changes apply prospectively rather than rewriting active-Pack terms.
+- Pool NAV bounds are enforced with fresh oracle data at defined epoch boundaries and relevant Pack interactions. An out-of-bounds Pack leaves selection and creator-emission eligibility until a later checkpoint confirms its return within bounds, without losing its redemption right; versioned bound changes apply prospectively rather than rewriting active-Pack terms.
 - The fixed Rip Price, selected Pack, basket, NAV snapshot, payment, fees, and terminal state are preserved in confirmed audit records.
-- Initial settlement conserves the full `$25` payment: `$22.50` goes to the creator and `$2.50` remains protocol revenue in the rip-payment asset, while the selected Pack transfers to the Trader with control of its full recorded basket and its creator emissions stop.
+- Initial settlement conserves the full `$25` stablecoin payment: `$22.50` goes to the creator and `$2.50` remains protocol revenue in the configured stablecoin, while the selected Pack transfers to the Trader with control of its full recorded basket and its creator emissions stop.
 - Redemption releases the selected Pack's full recorded raw-token basket with zero protocol fee. Stale or unavailable oracle data makes NAV-dependent eligibility fail closed; oracle or scheduler failure cannot rewrite custody or permanently block the defined exit.
-- Creator emissions come only from a bounded published budget and are never described as offsetting creator loss or promising a return.
-- Rip-fee revenue remains in the rip-payment asset and gates future bounded emission budgets; it is not a direct per-Rip payment of newly minted game tokens.
-- A nonzero ripper participation reward applies only after one confirmed, settled Rip, excludes same-Desk Rips, and remains below the disclosed game cost. Failed, pending, or retried intents never qualify.
+- The fixed supply is `1,000,000,000` tokens. Creator emissions and Rip participation rewards can never exceed their separate `150,000,000`-token launch-season allocations; the remaining `700,000,000` tokens do not emit or become available in V1.
+- Creator emissions follow the published fixed hourly-epoch budget, remain independent of Rip-fee revenue, and are never described as offsetting creator loss or promising a return.
+- Rip-fee revenue remains in the configured USD stablecoin as protocol revenue; it does not gate, fund, directly pay, or mint either V1 token reward.
+- A Rip participation pot is shared only among confirmed, settled qualifying Rips in its fixed epoch and cannot become an uncapped per-Rip mint. Same-Desk Rips and failed, pending, or retried intents never qualify, and the configured reward remains below the disclosed game cost.
 - Ordinary external token transfers fail closed at launch. Any later transfer-enablement transition is separately approved, evented, time-delayed, bounded to enabling transferability rather than promising a market, and preferably irreversible.
 - Testnet assets and tokens are visibly labelled as valueless test assets. V1 makes no mainnet, yield, appreciation, or guaranteed-profit claim.
 
 ## V1 acceptance path
 
-On Robinhood Chain testnet, independent participants can create and fully fund eligible Packs, inspect their backing and NAV, create or acquire Traders, fund those Traders with the configured rip-payment asset, and observe the following without hidden operator edits:
+On Robinhood Chain testnet, independent participants can create and fully fund eligible Packs, inspect their backing and USD NAV, create or acquire Traders, fund those Traders with the configured USD stablecoin, and observe the following without hidden operator edits:
 
 - an enabled Trader completes no more than one fixed-price Rip in an hourly window;
 - selection comes from the published eligible Pack set;
 - the selected Pack and fixed proceeds settle exactly once;
-- confirmed history and creator-emission accounting reflect the same event;
+- confirmed history, creator-emission accounting, and qualifying-Rip reward accounting reflect the same event and remain within their separate published launch allocations;
 - pause, insufficient funds, stale eligibility data, and ownership transfer fail closed; and
 - the current Pack holder can exercise the disclosed transfer and redemption rights.
 
 ## Open decisions before implementation planning
 
-- The V1 pool name, fixed rip-payment asset, approved Stock Token set, oracle freshness limits, objective anti-spam eligibility rules, whether the `$15` / `$100` NAV-bound hypothesis becomes launch configuration, and the criteria for prospective changes to the initial 10% Rip fee after testnet results.
+- The V1 pool name, exact USD stablecoin, approved Stock Token set, oracle freshness and eligibility-checkpoint rules, objective anti-spam eligibility rules, whether the `$15` / `$100` USD NAV-bound hypothesis becomes launch configuration, and the criteria for prospective changes to the initial 10% Rip fee after testnet results.
 - The random-selection mechanism, audit evidence, outage behavior, and required consumer disclosures.
-- The fixed token cap, bootstrap allocation if any, ongoing creator-emission budget, vesting and claim rules, and the immutable ripper-reward maximum and published budget.
+- The launch-season start and end boundaries, exact epoch timestamps, integer-rounding and empty-pot treatment, creator and ripper claim rules, and permitted configuration changes within the fixed allocations and immutable maximums.
 - Permitted Pack top-up rules, exact pool-version transition behavior, the transfer-enablement delay, whether that switch is strictly irreversible, and any separately approved external venue or liquidity plan.
 - The Pack redemption workflow, including whether V1 exposes manual redemption in the application or only preserves the protocol right.
 - Regulatory and consumer-protection review for paid random selection backed by tokenized financial assets.
 
 ## Relationship to existing Floor documents
 
-Mainnet launch remains outside V1. If separately approved, it is a fresh deployment of the same reviewed contract logic with separately verified production configuration: canonical token addresses, Chainlink feed map and freshness limits, whitelist, fees, and roles. No testnet Pack, Trader, game-token, or other state migrates.
+Mainnet launch remains outside V1. If separately approved, it is a fresh deployment of the same reviewed contract logic with separately verified production configuration: canonical Stock Token and USD stablecoin addresses, Chainlink feed map and freshness limits, whitelist, fees, and roles. No testnet Pack, Trader, game-token, or other state migrates.
 
 This PRD supersedes conflicting Pack-supply, Supplier-allowlist, secondary-market, and autonomous-Trader assumptions in [`docs/prd-margin-call-floor.md`](./prd-margin-call-floor.md) for this proposal. The Floor documents remain useful for the Robinhood-only network boundary, confirmed-intent finality, custody conservation, pause-and-exit asymmetry, event-derived Wire facts, and testnet labelling.

--- a/docs/prd-margin-call-token.md
+++ b/docs/prd-margin-call-token.md
@@ -9,7 +9,7 @@
 
 Margin Call V1 is a fixed-price Pack-ripping game operated through persistent Trader identities. Packs are the immediate game object; Traders are the long game.
 
-Creators permissionlessly fund auditable Packs of approved tokenized-stock ERC-20s. A Desk Manager funds a Trader with the configured rip-payment asset and assigns it to a named pool or tier. Every funded, eligible Trader may Rip exactly one Pack in each hourly window at that pool's fixed price. The protocol randomly selects an eligible Pack, immediately completes the Rip, and delivers the Pack to the Trader. There is no discretionary buy, hold-unripped, resell, or market-timing decision in V1.
+Creators permissionlessly fund auditable Packs of approved tokenized-stock ERC-20s. A Desk Manager funds a Trader with the configured rip-payment asset and assigns it to a named pool or tier. Every funded, eligible Trader may Rip exactly one Pack in each hourly window at that pool's fixed price. The protocol selects uniformly at random: every eligible Pack has an equal chance regardless of oracle NAV, game-token balance, creator identity, or any other Pack attribute. Selection immediately completes the Rip and delivers the Pack to the Trader. There is no discretionary buy, hold-unripped, resell, or market-timing decision in V1.
 
 The game token's primary active V1 incentive at launch is bounded creator emissions. A future ripper participation-reward configuration exists but is disabled with a value of zero at launch. The token is not the rip-payment asset, does not change Pack selection odds, and does not buy faster Trader cadence in V1. The product makes no promise that the token will appreciate or that any participant will earn a profit.
 
@@ -19,10 +19,10 @@ Rips are disclosed negative-expected-value entertainment: creators fund possible
 
 1. A creator mints and fully funds a Pack with an approved basket of tokenized-stock ERC-20s.
 2. The protocol records the Pack's immutable basket accounting and publishes its contents, oracle NAV, fees, and redemption terms.
-3. The Pack enters a named fixed-price pool or tier only after satisfying objective asset, funding, freshness, and anti-spam eligibility rules.
+3. The Pack enters and remains in a named fixed-price pool or tier only while satisfying objective asset, funding, freshness, anti-spam, and current pool NAV-bound rules.
 4. A Desk Manager funds a Trader's ERC-6551 account with the configured rip-payment asset, chooses one eligible pool, and enables its deterministic schedule.
 5. Once per hourly window, an enabled Trader with sufficient funds may spend exactly one fixed Rip Price. It cannot spend more often, exceed its balance, or choose among eligible Packs.
-6. The protocol selects one eligible Pack using the pool's published random-selection rule. Selection immediately completes the Rip and delivers the Pack to the Trader; V1 does not create an unopened-Pack decision point.
+6. The protocol selects uniformly at random from the eligible set, giving every eligible Pack an equal chance. Selection immediately completes the Rip and delivers the Pack to the Trader; V1 does not create an unopened-Pack decision point.
 7. The confirmed Rip, payment, selected Pack, basket, NAV snapshot, fees, and Trader history are publicly auditable. The manager may later refill or pause the Trader.
 
 If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, it does nothing for that window. Missed windows do not accumulate and cannot be replayed as a burst.
@@ -54,7 +54,11 @@ If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, 
 
 ### Pool and protocol
 
-- Each pool or tier has a stable public name, one rip-payment asset, one fixed Rip Price, approved asset rules, eligibility rules, fees, and a published selection method.
+- Each pool or tier has a stable public name, one rip-payment asset, one fixed Rip Price, approved asset rules, fees, and published minimum and maximum oracle NAV bounds.
+- The initial `$25` pool's starting hypothesis is a `$15` minimum NAV and `$100` maximum NAV. These are versioned, evented pool configuration, not immutable universal constants.
+- NAV bounds are continuously enforced for active eligibility, and the maximum protects pool risk rather than serving only as a listing-time check. A Pack outside either bound leaves the eligible selection set and stops creator emissions until price movement or a permitted top-up returns it within bounds; its redemption right remains intact.
+- Bound changes apply prospectively to new listings or a new pool version and never silently rewrite the bounds governing existing active Packs.
+- Selection within a pool is uniform: oracle NAV, game-token balance, creator identity, and all other Pack attributes have zero selection weight.
 - V1 may launch with one pool. Additional fixed-price pools are configuration expansions, not variable pricing within a pool.
 - The protocol validates funding and eligibility, enforces one Rip per Trader per hourly window, selects the Pack, settles the fixed payment, and records finality exactly once.
 - The House may operate the selection and scheduling infrastructure and can affect liveness. It cannot create an unfunded Pack, alter a selected basket, charge a different price, reuse a Rip, bypass frequency limits, or block the Pack holder's disclosed exit.
@@ -67,7 +71,11 @@ The game token is a fixed-maximum-supply ERC-20 whose primary active V1 use at l
 
 The contract retains a future ripper participation-reward configuration set to zero at launch. The owner may later set it only within an immutable deployment-time maximum and a bounded published budget; every configuration change is evented and auditable. It is a participation reward, never a return, yield, appreciation, or guarantee.
 
-The token is not required to Rip, create, transfer, or redeem a Pack. It does not affect Pack contents, NAV, unwrap output, selection odds, Trader cadence, or the fixed Rip Price.
+At V1 launch, the token is earned-only and transfer-restricted. Normal external wallet-to-wallet `transfer` and `transferFrom` are disabled; user balances are earned only through eligible creator emissions and, if later enabled, the bounded participation reward. Protocol mints, burns, and strictly required internal movements remain allowed.
+
+The contract retains a separately approved path to enable ordinary ERC-20 transfers through an explicit, evented, time-delayed, preferably irreversible switch. Enabling transfers does not itself create external buying; a market or liquidity venue requires a separate decision. Mainnet and external-market opening remain outside V1, with no price, return, availability, or transfer-enablement promise.
+
+The token is not required to Rip, create, or redeem a Pack. It does not affect Pack contents, NAV, unwrap output, selection odds, Trader cadence, or the fixed Rip Price.
 
 Ongoing emissions are gated by prior realized protocol fees: a zero-revenue period creates no new ongoing emission budget, and unused budget does not accumulate for later release. A finite bootstrap allocation, if approved, must be published separately and cannot be represented as revenue-backed. Exact allocations, vesting, emission rates, and any mainnet token launch remain approval-gated decisions.
 
@@ -78,11 +86,13 @@ Creator emissions stop when inventory leaves eligible supply. All creator-emissi
 - Every active Pack is fully backed by its recorded basket; fee assets and protocol-owned assets are never counted as Pack backing.
 - A Pack can be selected at most once and its fixed Rip payment settles at most once. Failure and retry paths reconcile the same intent and never create a second Rip.
 - Every funded, eligible Trader can complete at most one Rip in an hourly window. Ownership transfer, pause, insufficient balance, or ineligibility fails closed.
-- Pack selection uses only the published eligible set and random-selection rule. Game-token holdings or stake never change V1 odds.
+- Pack selection is uniform across the published eligible set. Every eligible Pack has equal odds; oracle NAV, game-token holdings or stake, creator identity, and Pack attributes never add selection weight.
+- Pool NAV bounds are continuously enforced. An out-of-bounds Pack leaves selection and creator-emission eligibility until it returns within bounds, without losing its redemption right; versioned bound changes apply prospectively rather than rewriting active-Pack terms.
 - The fixed Rip Price, selected Pack, basket, NAV snapshot, payment, fees, and terminal state are preserved in confirmed audit records.
 - Redemption releases only the selected Pack's recorded raw-token basket less disclosed fees. Stale or unavailable oracle data makes NAV-dependent eligibility fail closed; oracle or scheduler failure cannot rewrite custody or permanently block the defined exit.
 - Creator emissions come only from a bounded published budget and are never described as offsetting creator loss or promising a return.
 - A nonzero ripper participation reward applies only after one confirmed, settled Rip, excludes same-Desk Rips, and remains below the disclosed game cost. Failed, pending, or retried intents never qualify.
+- Ordinary external token transfers fail closed at launch. Any later transfer-enablement transition is separately approved, evented, time-delayed, bounded to enabling transferability rather than promising a market, and preferably irreversible.
 - Testnet assets and tokens are visibly labelled as valueless test assets. V1 makes no mainnet, yield, appreciation, or guaranteed-profit claim.
 
 ## V1 acceptance path
@@ -98,9 +108,10 @@ On Robinhood Chain testnet, independent participants can create and fully fund e
 
 ## Open decisions before implementation planning
 
-- The V1 pool name, fixed rip-payment asset, fixed Rip Price, approved Stock Token set, fee schedule, oracle freshness limits, and objective anti-spam eligibility rules.
+- The V1 pool name, fixed rip-payment asset, approved Stock Token set, fee schedule, oracle freshness limits, objective anti-spam eligibility rules, and whether the `$25` / `$15` / `$100` starting hypotheses become launch configuration.
 - The random-selection mechanism, audit evidence, outage behavior, and required consumer disclosures.
 - The fixed token cap, bootstrap allocation if any, ongoing creator-emission budget, vesting and claim rules, and the immutable ripper-reward maximum and published budget.
+- Permitted Pack top-up rules, exact pool-version transition behavior, the transfer-enablement delay, whether that switch is strictly irreversible, and any separately approved external venue or liquidity plan.
 - The exact Pack redemption rules and fees, including whether V1 exposes manual redemption in the application or only preserves the protocol right.
 - Regulatory and consumer-protection review for paid random selection backed by tokenized financial assets.
 

--- a/docs/prd-margin-call-token.md
+++ b/docs/prd-margin-call-token.md
@@ -1,192 +1,111 @@
-# Margin Call: The Game Token
+# Margin Call: The Game Token and Pack Economy
 
-**Status:** Draft for review  
-**Target:** Robinhood Chain testnet, then mainnet with canonical Stock Tokens  
-**Version:** 0.1  
-**Date:** July 26, 2026
+- **Status:** Draft for review
+- **Target:** Robinhood Chain testnet
+- **Version:** 0.2
+- **Date:** July 26, 2026
 
-## Release boundary
+## Product decision
 
-This PRD reverses the "no game token" exclusion in [`docs/prd-margin-call-floor.md`](./prd-margin-call-floor.md), which lists "a game token, staking, cycle-speed purchases, resting-order tiers, buy-and-burn, Morpho yield, supplier APY claims, and monetary leaderboard rewards" as out of scope.
+Margin Call V1 is a fixed-price Pack-ripping game operated through persistent Trader identities. Packs are the immediate game object; Traders are the long game.
 
-It is a companion to a **permissionless Pack economy** in which any Desk Manager wraps real Stock Tokens into a transferable Pack and other players pay to receive one at random, rather than the single House-operated Window with allowlisted Suppliers described in the Floor PRD. Where the two documents conflict on supply, this one governs the token and assumes the Pack model. The Floor PRD continues to govern custody, the secondary Offer Book, acquisition accounting, the Wire, and the Robinhood-only network boundary.
+Creators permissionlessly fund auditable Packs of approved tokenized-stock ERC-20s. A Desk Manager funds a Trader with the configured rip-payment asset and assigns it to a named pool or tier. Every funded, eligible Trader may Rip exactly one Pack in each hourly window at that pool's fixed price. The protocol randomly selects an eligible Pack, immediately completes the Rip, and delivers the Pack to the Trader. There is no discretionary buy, hold-unripped, resell, or market-timing decision in V1.
 
-Prior art in this repository is load-bearing and should be reused rather than rebuilt:
+The game token's primary active V1 incentive at launch is bounded creator emissions. A future ripper participation-reward configuration exists but is disabled with a value of zero at launch. The token is not the rip-payment asset, does not change Pack selection odds, and does not buy faster Trader cadence in V1. The product makes no promise that the token will appreciate or that any participant will earn a profit.
 
-- [`contracts/src/SeatVault.sol`](../contracts/src/SeatVault.sol) — staking against an id for tiers, with two-phase unstake, cooldown, pause, and two-step ownership. Covered by unit, fuzz, invariant, e2e, and integration suites.
-- [`convex/seatVault/`](../convex/seatVault/) and [`convex/agent/capacity.ts`](../convex/agent/capacity.ts) — tier indexing, reconciliation, and capacity-aware agent scheduling.
-- [`docs/trader-fuel-token.md`](./trader-fuel-token.md) — the shipped `$BLOW` capacity token policy and its invariants.
+Rips are disclosed negative-expected-value entertainment: creators fund possible above-price outcomes, receive the fixed Rip proceeds when selected, and farm a pro rata share of bounded emissions while eligible inventory remains active, without any return promise.
 
-[`contracts/src/MarginCallToken.sol`](../contracts/src/MarginCallToken.sol) is **not** reusable. It is a thirteen-line ERC-20 with an unpermissioned public `mint()` and no supply cap, commented "Test / Sepolia capacity token." It must be replaced.
+## V1 game loop
 
-## Problem Statement
+1. A creator mints and fully funds a Pack with an approved basket of tokenized-stock ERC-20s.
+2. The protocol records the Pack's immutable basket accounting and publishes its contents, oracle NAV, fees, and redemption terms.
+3. The Pack enters a named fixed-price pool or tier only after satisfying objective asset, funding, freshness, and anti-spam eligibility rules.
+4. A Desk Manager funds a Trader's ERC-6551 account with the configured rip-payment asset, chooses one eligible pool, and enables its deterministic schedule.
+5. Once per hourly window, an enabled Trader with sufficient funds may spend exactly one fixed Rip Price. It cannot spend more often, exceed its balance, or choose among eligible Packs.
+6. The protocol selects one eligible Pack using the pool's published random-selection rule. Selection immediately completes the Rip and delivers the Pack to the Trader; V1 does not create an unopened-Pack decision point.
+7. The confirmed Rip, payment, selected Pack, basket, NAV snapshot, fees, and Trader history are publicly auditable. The manager may later refill or pause the Trader.
 
-The Floor as specified has one House-operated Window, allowlisted Suppliers, and no token. Two things break under that design.
+If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, it does nothing for that window. Missed windows do not accumulate and cannot be replayed as a burst.
 
-Supply is capped by business development. Suppliers are onboarded one at a time, they are asked to lock inventory behind a junior surplus claim with a delayed exit, and the PRD forbids describing the return. Total value locked becomes a function of how many partners the House signs rather than how many participants the market attracts.
+## Architecture and roles
 
-More fundamentally, **the rip is negative expected value in equity terms and always will be.** A ripper pays a price above the expected value of what they receive. That gap is what pays the creator and the protocol, and it is the only thing that makes supply rational. It is not a flaw to be engineered away. But a game whose sole economic output to participants is a disclosed loss has no way to reward early supply before rip flow exists, no way to retain participants through variance, and no link between protocol revenue and anything a participant can hold.
+### Pack: the immediate object
 
-A permissionless Pack market introduces a fourth problem that does not exist in the Window model. When anyone can create a Pack, the scarce resource is no longer inventory — it is **selection weight**. Something has to meter it, or the pool degenerates into spam.
+- A Pack is a transferable ERC-721 backed by a recorded basket of approved ERC-20 tokenized stocks.
+- A TokenPacks-style custody contract directly holds and accounts for every Pack's basket. A Pack is not an ERC-6551 token-bound account.
+- Transferring the Pack transfers the right to its recorded basket. The current holder can ultimately unwrap or redeem that basket subject to disclosed protocol rules and fees.
+- Pack contents and oracle NAV are public and auditable before selection and after transfer. The whitelist resolves canonical addresses from Robinhood's [Token Contracts](https://docs.robinhood.com/chain/contracts/) page and may reconcile metadata through the [Stock Token APIs](https://docs.robinhood.com/chain/stock-token-apis/). Custody accounting uses raw token units; displayed NAV never replaces the recorded basket.
+- Pack NAV and creator-emission eligibility use the approved onchain Chainlink feed for each whitelisted Stock Token, following Robinhood Chain's [oracle and price-feed guidance](https://docs.robinhood.com/chain/oracles-and-price-feeds/). Calculations normalize token and feed decimals and fail closed on invalid, paused, missing, or stale data. When canonical testnet token or feed coverage is unavailable, clearly labelled Test Assets and controlled feed doubles validate the same accounting and failure semantics.
 
-The design must solve all four without claiming yield, without promising the token has value, and without creating a subsidy that makes wash trading profitable.
+### Trader: the persistent desk
 
-## Solution
+- A Trader is a transferable ERC-721 identity with an ERC-6551 token-bound account; transferring it carries its portfolio and public history.
+- In V1 the Trader is clockwork automation, not an autonomous market agent. Its only scheduled choice is already made by the manager: rip one Pack from one named pool when the hourly window opens and hard eligibility checks pass.
+- The Desk Manager can fund, refill, configure the named pool, enable, and pause the Trader. The Trader cannot change its own pool, cadence, budget, or permissions.
+- Ownership changes revoke prior automation authority and leave the Trader paused until the new owner claims and re-enables it.
 
-Introduce a fixed-supply ERC-20 on Robinhood Chain with four functions and no revenue distribution.
+### Creator: permissionless supply
 
-**It meters selection weight.** Creators stake against a Pack to raise its selection weight within a published, bounded multiplier band. Staking buys distribution frequency only. It cannot change a Pack's contents, its oracle NAV, or what a ripper receives on unwrap, and every Pack's weight multiplier and independently verifiable NAV are displayed before a rip. This is a deliberate departure from a shipped invariant and is treated separately below.
+- Any participant may create and list as many fully funded Packs as they can support.
+- Creation and active-pool eligibility do not depend on a creator allowlist. Eligibility follows objective published rules for approved assets, complete funding, oracle freshness, public contents and NAV, protocol fees or bonds, and anti-spam limits.
+- A creator receives the fixed Rip proceeds when their Pack is selected, less disclosed fees, even when the Pack's NAV is higher than the Rip Price.
+- A creator farms a pro rata share of bounded emissions based on verified Pack NAV and active eligibility time. Accrual stops when the Pack is selected, redeemed, delisted, or becomes ineligible.
+- Creator copy must disclose maximum immediate downside and must not describe emissions, token price, or pool participation as a return promise.
 
-**It bootstraps supply.** Creators earn emissions proportional to TVL-seconds of _unripped_ Pack inventory valued at oracle. This pays for locked equity directly and tapers as real rip flow takes over.
+### Pool and protocol
 
-**It rebates rippers.** Every rip mints to the ripper in proportion to rip spend. This is a disclosed participation rebate, not a return, and it is bounded by a hard invariant so it can never make self-dealing profitable.
+- Each pool or tier has a stable public name, one rip-payment asset, one fixed Rip Price, approved asset rules, eligibility rules, fees, and a published selection method.
+- V1 may launch with one pool. Additional fixed-price pools are configuration expansions, not variable pricing within a pool.
+- The protocol validates funding and eligibility, enforces one Rip per Trader per hourly window, selects the Pack, settles the fixed payment, and records finality exactly once.
+- The House may operate the selection and scheduling infrastructure and can affect liveness. It cannot create an unfunded Pack, alter a selected basket, charge a different price, reuse a Rip, bypass frequency limits, or block the Pack holder's disclosed exit.
 
-**It meters agent capacity.** Staking unlocks agent cycle tiers through the existing SeatVault, unchanged in mechanism.
+## Game-token role in V1
 
-Value accrual is mechanical and unpromised. Protocol fees are collected in real Stock Tokens — a rip fee in basis points, an unwrap fee in raw underlying units, and a secondary settlement fee. A governance-set share of that revenue funds open-market buyback and burn; the remainder is retained as protocol-owned equity. There is no fee distribution to stakers, no staking yield, and no APY surface anywhere in the product.
+The game token is a fixed-maximum-supply ERC-20 whose primary active V1 use at launch is:
 
-Emissions are disciplined by one rule that makes a death spiral structurally impossible: **emissions in any epoch cannot exceed a multiple of the previous epoch's realized fee revenue.** A protocol with no revenue emits nothing.
+- **Creator emissions:** eligible creators farm a pro rata share of a capped allocation based on verified Pack NAV and active eligibility time. Selection, redemption, delisting, or loss of eligibility stops accrual.
 
-## Conflict with the shipped `$BLOW` invariant
+The contract retains a future ripper participation-reward configuration set to zero at launch. The owner may later set it only within an immutable deployment-time maximum and a bounded published budget; every configuration change is evented and auditable. It is a participation reward, never a return, yield, appreciation, or guarantee.
 
-[`docs/trader-fuel-token.md`](./trader-fuel-token.md) states the shipped invariant plainly:
+The token is not required to Rip, create, transfer, or redeem a Pack. It does not affect Pack contents, NAV, unwrap output, selection odds, Trader cadence, or the fixed Rip Price.
 
-> **Stake affects capacity, never outcome probability.**
+Ongoing emissions are gated by prior realized protocol fees: a zero-revenue period creates no new ongoing emission budget, and unused budget does not accumulate for later release. A finite bootstrap allocation, if approved, must be published separately and cannot be represented as revenue-backed. Exact allocations, vesting, emission rates, and any mainnet token launch remain approval-gated decisions.
 
-Weight staking violates it. A creator who stakes makes their Pack more likely to be selected, which changes the distribution of outcomes a ripper faces. Calling this "distribution" rather than "odds" would be a rebrand, not a defense.
+Creator emissions stop when inventory leaves eligible supply. All creator-emission totals, Pack eligibility inputs, and claims must be reproducible from confirmed records. The token pays no staking yield, fee share, revenue distribution, APY, or guaranteed benefit.
 
-The departure is proposed deliberately, because in a permissionless market selection weight is the only scarce resource worth metering, and leaving it unmetered invites spam. It is bounded by four mitigations:
+## Safety and accounting invariants
 
-1. The multiplier is bounded within a published band and applies to selection frequency only.
-2. Every Pack's exact contents, oracle NAV, staked amount, and current multiplier are visible before payment. The ripper knows the full distribution they are buying into; only the draw is unknown.
-3. Staking never changes contents, unwrap output, or fees. The equity floor under every Pack is invariant to all token state, including during pause.
-4. The house edge is published as an explicit number rather than implied.
+- Every active Pack is fully backed by its recorded basket; fee assets and protocol-owned assets are never counted as Pack backing.
+- A Pack can be selected at most once and its fixed Rip payment settles at most once. Failure and retry paths reconcile the same intent and never create a second Rip.
+- Every funded, eligible Trader can complete at most one Rip in an hourly window. Ownership transfer, pause, insufficient balance, or ineligibility fails closed.
+- Pack selection uses only the published eligible set and random-selection rule. Game-token holdings or stake never change V1 odds.
+- The fixed Rip Price, selected Pack, basket, NAV snapshot, payment, fees, and terminal state are preserved in confirmed audit records.
+- Redemption releases only the selected Pack's recorded raw-token basket less disclosed fees. Stale or unavailable oracle data makes NAV-dependent eligibility fail closed; oracle or scheduler failure cannot rewrite custody or permanently block the defined exit.
+- Creator emissions come only from a bounded published budget and are never described as offsetting creator loss or promising a return.
+- A nonzero ripper participation reward applies only after one confirmed, settled Rip, excludes same-Desk Rips, and remains below the disclosed game cost. Failed, pending, or retried intents never qualify.
+- Testnet assets and tokens are visibly labelled as valueless test assets. V1 makes no mainnet, yield, appreciation, or guaranteed-profit claim.
 
-Agent capacity staking through SeatVault preserves the original invariant unchanged and is unaffected by this departure.
+## V1 acceptance path
 
-**This is the single decision in this document most worth rejecting.** If review concludes that outcome-probability neutrality is non-negotiable, the fallback is to meter Pack listings by a flat creation fee or a staked-deposit requirement that grants no weight advantage, at the cost of losing the primary demand sink for the token.
+On Robinhood Chain testnet, independent participants can create and fully fund eligible Packs, inspect their backing and NAV, create or acquire Traders, fund those Traders with the configured rip-payment asset, and observe the following without hidden operator edits:
 
-## User Stories
+- an enabled Trader completes no more than one fixed-price Rip in an hourly window;
+- selection comes from the published eligible Pack set;
+- the selected Pack and fixed proceeds settle exactly once;
+- confirmed history and creator-emission accounting reflect the same event;
+- pause, insufficient funds, stale eligibility data, and ownership transfer fail closed; and
+- the current Pack holder can exercise the disclosed transfer and redemption rights.
 
-### Creators and supply
+## Open decisions before implementation planning
 
-1. As a Pack Creator, I want to earn tokens proportional to the oracle value and duration of unripped inventory I have locked, so that supplying equity is rewarded before rip flow can pay me.
-2. As a Pack Creator, I want emissions to stop accruing the moment my Pack is ripped, so that I cannot farm rewards by cycling inventory through myself.
-3. As a Pack Creator, I want to stake against a Pack to raise its selection weight, so that I can compete for rip flow without changing what I am offering.
-4. As a Pack Creator, I want the weight multiplier to be bounded and published, so that staking is a distribution advantage rather than a hidden edge over rippers.
-5. As a Pack Creator, I want unstaking to require a cooldown, so that weight cannot be rented for a single block.
-6. As a Pack Creator, I want my staked position released without penalty when my Pack is ripped, so that capital is not trapped by a position that no longer exists.
+- The V1 pool name, fixed rip-payment asset, fixed Rip Price, approved Stock Token set, fee schedule, oracle freshness limits, and objective anti-spam eligibility rules.
+- The random-selection mechanism, audit evidence, outage behavior, and required consumer disclosures.
+- The fixed token cap, bootstrap allocation if any, ongoing creator-emission budget, vesting and claim rules, and the immutable ripper-reward maximum and published budget.
+- The exact Pack redemption rules and fees, including whether V1 exposes manual redemption in the application or only preserves the protocol right.
+- Regulatory and consumer-protection review for paid random selection backed by tokenized financial assets.
 
-### Rippers
+## Relationship to existing Floor documents
 
-7. As a Ripper, I want the expected value of a rip published as an explicit house edge, so that I am choosing to pay a premium rather than being misled about one.
-8. As a Ripper, I want each Pack's contents, oracle NAV, staked amount, and weight multiplier visible before I pay, so that the only unknown is which Pack I receive.
-9. As a Ripper, I want to receive tokens proportional to my rip spend, so that participation is rebated even when a specific rip goes against me.
-10. As a Ripper, I want the rebate described as a rebate and never as a return, yield, or expected profit, so that the product does not make a claim it cannot support.
-11. As a Ripper, I want no rebate accrual on Packs created by my own Desk, so that the emission cannot be farmed by self-dealing.
-12. As a Ripper, I want to unwrap any Pack I receive at any time for its contents less the unwrap fee, so that the token has no bearing on my hard floor.
+Mainnet launch remains outside V1. If separately approved, it is a fresh deployment of the same reviewed contract logic with separately verified production configuration: canonical token addresses, Chainlink feed map and freshness limits, whitelist, fees, and roles. No testnet Pack, Trader, game-token, or other state migrates.
 
-### Agents
-
-13. As a Desk Manager, I want staked principal to unlock agent cycle tiers through the existing SeatVault, so that automation throughput is metered by committed capital.
-14. As a Desk Manager, I want tier changes to apply to scheduling without restarting or reconfiguring my agents, so that capacity is continuous.
-15. As a Desk Manager, I want a Trader transfer to invalidate the prior owner's tier claim, so that staked capacity does not survive an ownership change unverified.
-
-### Emissions and treasury
-
-16. As a participant, I want a fixed total supply with a published allocation and vesting schedule, so that dilution is knowable in advance.
-17. As a participant, I want per-epoch emissions capped as a multiple of the prior epoch's realized fee revenue, so that the protocol cannot emit into a dead market.
-18. As a participant, I want emissions forgone under that cap to be permanently unissuable, so that a slow epoch reduces total supply rather than deferring it.
-19. As a participant, I want protocol fee revenue collected in real Stock Tokens, so that revenue is denominated in the asset the game is about.
-20. As a participant, I want the buyback and burn share of revenue to be a published mechanical policy rather than a discretionary action, so that treasury behavior is predictable.
-21. As a participant, I want the retained share of fees to accumulate as protocol-owned equity, so that revenue also builds TVL.
-22. As the House, I want the buyback and retention split to be versioned configuration, so that the trade-off between token buy pressure and equity retention can be tuned with data.
-
-### Safety and honesty
-
-23. As the House, I want the value of tokens emitted per rip to be provably less than the rake paid on that rip, so that wash trading is unprofitable by construction rather than by detection.
-24. As the House, I want no staking rewards, no fee sharing, and no yield language anywhere in the contracts or the product, so that the token's utility is access and metering only.
-25. As the House, I want the testnet token to be explicitly valueless and visibly labelled, so that a testnet deployment cannot be mistaken for a live economy.
-26. As an auditor, I want total emitted supply, per-epoch caps, burn totals, staked principal, and treasury holdings reconcilable from onchain events alone, so that supply claims are verifiable.
-
-## Implementation Decisions
-
-### Token
-
-- Fixed maximum supply set at deployment and not increasable. No owner mint.
-- Minting authority is a single non-upgradeable Emitter contract enforcing the epoch schedule and the revenue cap. No other address can mint.
-- Burn is permissionless and irreversible. Treasury buyback burns through the same path.
-- Allocation is published at deployment across supply mining, rip rebates, treasury, and contributors, with contributor and treasury tranches on a cliff and linear vest. Exact percentages are versioned configuration decided before mainnet, not protocol constants.
-- `MarginCallToken.sol` is replaced entirely. Its unpermissioned public `mint()` and absent cap disqualify it from any economic role.
-
-### Emissions
-
-- Time is divided into fixed epochs. The schedule defines a declining maximum issuance per epoch.
-- Actual issuance is `min(scheduled_n, k × realized_fee_revenue_{n-1})`, where revenue is valued at oracle in a common unit and `k` is a governance-set multiple that declines on a published schedule. Starting hypothesis: `k = 3.0`.
-- Any difference between scheduled and actual issuance is permanently forgone. It does not roll forward. This gives the supply curve a deflationary bias in weak epochs and removes any incentive to stall.
-- Supply mining accrues on TVL-seconds of unripped Pack inventory at oracle value. Accrual stops at rip, unwrap, or delist.
-- Rip rebates accrue per rip in proportion to rip spend, subject to the wash-trade invariant, with a per-address per-epoch ceiling.
-- Rebates vest on a short cliff. A ripper who unwraps immediately keeps their equity floor but forfeits unvested rebate.
-
-### The wash-trade invariant
-
-This is the load-bearing safety property and should be treated as a protocol invariant, not a heuristic.
-
-> For every rip, the oracle-referenced value of tokens emitted to the ripper must be strictly less than the rake paid on that rip.
-
-If it holds, ripping your own Pack is unprofitable regardless of volume, because the rake is a real cost and the rebate can never exceed it. This is materially stronger than the Floor PRD's position, which concedes it cannot prevent suspicious trading and can only discount it in leaderboard scoring.
-
-Enforcement is an oracle-referenced cap on the emission rate, recomputed each epoch. This introduces a dependency on a token price reference. On testnet, and in any epoch where the reference is stale or unavailable, the rate falls back to a conservative governance-declared floor. **The invariant fails closed.**
-
-Same-Desk exclusion, already specified for fills in the Floor PRD, additionally applies to rebate accrual: no rebate is earned ripping a Pack your own Desk created.
-
-### Staking and weight
-
-- Pack weight staking is a new vault. Agent capacity staking reuses `SeatVault.sol` and its Convex indexing unchanged.
-- The weight multiplier is bounded — starting hypothesis 1.0x to 2.5x — and is a pure multiplier on selection probability. It never alters Pack contents, oracle NAV, unwrap output, or fees.
-- Every Pack's current multiplier, staked amount, contents, and NAV are displayed before a rip.
-- Unstaking follows the SeatVault pattern: initiate, cooldown, complete. A repeated initiate does not extend an open cooldown. Starting hypothesis for cooldown is seven days.
-- Weight stake is released without cooldown when the backing Pack is ripped.
-
-### Fees and treasury
-
-- Rip fee in basis points on rip price. Unwrap fee in raw underlying units. Secondary settlement fee in the quote asset. All three are collected in real assets, never in the game token.
-- Revenue splits by a versioned parameter into a buyback tranche and a retention tranche. Starting hypothesis 50/50.
-- The buyback tranche swaps to the token on a published venue and burns. Execution is scheduled and rate-limited, not discretionary.
-- **Trade-off to hold explicitly:** the buyback tranche is Stock Token sell volume, which cuts against the volume objective, while the retention tranche grows protocol-owned equity but creates no buy pressure. The split is the dial between those two and should be tuned with data rather than fixed by conviction.
-- Treasury holdings, buyback execution, and burn totals are published and reconcilable from events.
-
-### What the token deliberately does not do
-
-- No staking rewards, no fee distribution, no revenue share, no APY, no "real yield." Utility is access, weight, and capacity.
-- No governance over custody rules, Pack contents, or fee ceilings in v1. Parameters change through the same closed-Window, versioned-configuration discipline the Floor PRD establishes.
-- No effect on unwrap output. The equity floor under every Pack is independent of token state in all conditions, including pause.
-- No requirement to hold the token to rip, create a Pack, or unwrap.
-
-## Testing Decisions
-
-- Follow the LazerForge Foundry conventions already adopted for the Floor: pinned compiler, deterministic block state, metadata-free builds, named profiles, CI fuzzing at 1,024 or more cases, and committed gas snapshots.
-- `SeatVault.t.sol`, `SeatVault.fuzz.t.sol`, and `SeatVault.invariant.t.sol` are direct prior art for the weight vault. Extend rather than rewrite.
-- Invariant campaigns must prove: total minted never exceeds the cap; per-epoch issuance never exceeds `min(schedule, k × prior revenue)`; forgone issuance is unrecoverable; rebate value per rip is always below rake paid; staked principal is always fully withdrawable after cooldown; weight multipliers stay within the published band; and Pack unwrap output is invariant to all token state.
-- Fuzz across epoch boundaries, zero-revenue epochs, stale token price references, concurrent stake and unstake, rip during cooldown, and a Pack ripped while weight-staked.
-- Adversarial tests must prove self-dealing is unprofitable at arbitrary volume, that a creator cannot farm supply mining by ripping their own inventory, and that an emission-rate oracle failure fails closed to the conservative floor rather than open.
-- Convex tests cover epoch accounting idempotency, rebate vesting, tier reconciliation on Trader transfer, and that no product surface renders yield or APY language.
-
-## Out of Scope
-
-- Mainnet token launch, liquidity provisioning, listings, market making, and any price or value claim.
-- Fee sharing, staking yield, revenue distribution to holders, and vote-escrow lockup multipliers.
-- Governance over custody, contents, or fee ceilings.
-- Buying odds, buying NAV, buying information, or any token mechanic that changes what a ripper receives after selection.
-- Cross-chain deployment, bridging, and non-Robinhood-Chain venues.
-- Retroactive airdrop to legacy Base desks, deals, or `$BLOW` positions.
-
-## Further Notes
-
-The `$BLOW` naming in [`gitbook/economy/blow-and-floor-access.md`](../gitbook/economy/blow-and-floor-access.md) and `docs/trader-fuel-token.md` is inconsistent with the `MARGINCALL` symbol in the deployed contract. Pick one before deployment.
-
-The single most important number in this document is `k`, the revenue multiple on emissions. It is what separates this design from every game token that emitted its way into a death spiral. Set it conservatively, decline it on a published schedule, and never raise it in response to weak demand — a protocol that emits harder when revenue falls is the exact failure mode this rule exists to prevent.
-
-The wash-trade invariant is the strongest claim here and the one most worth attacking in review. If it holds, the leaderboard integrity concerns the Floor PRD concedes it cannot solve become largely moot on the token dimension, because the subsidy an attacker would farm is bounded below the cost of farming it.
-
-The rip being negative expected value is stated deliberately and should never be softened in product copy. The honest description of this economy is that Pack creators distribute equity at a premium to spot and rippers pay that premium for entertainment and a bounded rebate. That is a real business, it is what gacha has always been, and it drives the metric the product cares about: Stock Tokens moving from existing holders to new holders, continuously, with the creator side buying on the open market to restock.
+This PRD supersedes conflicting Pack-supply, Supplier-allowlist, secondary-market, and autonomous-Trader assumptions in [`docs/prd-margin-call-floor.md`](./prd-margin-call-floor.md) for this proposal. The Floor documents remain useful for the Robinhood-only network boundary, confirmed-intent finality, custody conservation, pause-and-exit asymmetry, event-derived Wire facts, and testnet labelling.

--- a/docs/prd-margin-call-token.md
+++ b/docs/prd-margin-call-token.md
@@ -15,6 +15,8 @@ The game token's primary active V1 incentive at launch is bounded creator emissi
 
 Rips are disclosed negative-expected-value entertainment: creators fund possible above-price outcomes, receive the fixed Rip proceeds when selected, and farm a pro rata share of bounded emissions while eligible inventory remains active, without any return promise.
 
+The initial V1 configuration charges `$25` per Rip: a 10% protocol fee retains `$2.50` in the rip-payment asset, the creator receives fixed proceeds of `$22.50`, the selected Pack transfers to the Trader with control of its full recorded basket, and unwrap or redemption carries no additional fee.
+
 ## V1 game loop
 
 1. A creator mints and fully funds a Pack with an approved basket of tokenized-stock ERC-20s.
@@ -22,7 +24,7 @@ Rips are disclosed negative-expected-value entertainment: creators fund possible
 3. The Pack enters and remains in a named fixed-price pool or tier only while satisfying objective asset, funding, freshness, anti-spam, and current pool NAV-bound rules.
 4. A Desk Manager funds a Trader's ERC-6551 account with the configured rip-payment asset, chooses one eligible pool, and enables its deterministic schedule.
 5. Once per hourly window, an enabled Trader with sufficient funds may spend exactly one fixed Rip Price. It cannot spend more often, exceed its balance, or choose among eligible Packs.
-6. The protocol selects uniformly at random from the eligible set, giving every eligible Pack an equal chance. Selection immediately completes the Rip and delivers the Pack to the Trader; V1 does not create an unopened-Pack decision point.
+6. The protocol selects uniformly at random from the eligible set, giving every eligible Pack an equal chance. Selection immediately completes the Rip, transfers the Pack and control of its full recorded basket to the Trader, settles fixed creator proceeds and the protocol fee, and stops that Pack's creator emissions; V1 does not create an unopened-Pack decision point.
 7. The confirmed Rip, payment, selected Pack, basket, NAV snapshot, fees, and Trader history are publicly auditable. The manager may later refill or pause the Trader.
 
 If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, it does nothing for that window. Missed windows do not accumulate and cannot be replayed as a burst.
@@ -33,7 +35,7 @@ If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, 
 
 - A Pack is a transferable ERC-721 backed by a recorded basket of approved ERC-20 tokenized stocks.
 - A TokenPacks-style custody contract directly holds and accounts for every Pack's basket. A Pack is not an ERC-6551 token-bound account.
-- Transferring the Pack transfers the right to its recorded basket. The current holder can ultimately unwrap or redeem that basket subject to disclosed protocol rules and fees.
+- Transferring the Pack transfers the right to its recorded basket. In V1 the current holder can unwrap or redeem the full recorded basket with no protocol deduction.
 - Pack contents and oracle NAV are public and auditable before selection and after transfer. The whitelist resolves canonical addresses from Robinhood's [Token Contracts](https://docs.robinhood.com/chain/contracts/) page and may reconcile metadata through the [Stock Token APIs](https://docs.robinhood.com/chain/stock-token-apis/). Custody accounting uses raw token units; displayed NAV never replaces the recorded basket.
 - Pack NAV and creator-emission eligibility use the approved onchain Chainlink feed for each whitelisted Stock Token, following Robinhood Chain's [oracle and price-feed guidance](https://docs.robinhood.com/chain/oracles-and-price-feeds/). Calculations normalize token and feed decimals and fail closed on invalid, paused, missing, or stale data. When canonical testnet token or feed coverage is unavailable, clearly labelled Test Assets and controlled feed doubles validate the same accounting and failure semantics.
 
@@ -48,14 +50,16 @@ If a Trader is unfunded, paused, ineligible, or the pool cannot safely execute, 
 
 - Any participant may create and list as many fully funded Packs as they can support.
 - Creation and active-pool eligibility do not depend on a creator allowlist. Eligibility follows objective published rules for approved assets, complete funding, oracle freshness, public contents and NAV, protocol fees or bonds, and anti-spam limits.
-- A creator receives the fixed Rip proceeds when their Pack is selected, less disclosed fees, even when the Pack's NAV is higher than the Rip Price.
+- Under the initial `$25` configuration, a creator receives fixed proceeds of `$22.50` when their Pack is selected, even when the Pack's NAV is higher than the Rip Price.
 - A creator farms a pro rata share of bounded emissions based on verified Pack NAV and active eligibility time. Accrual stops when the Pack is selected, redeemed, delisted, or becomes ineligible.
 - Creator copy must disclose maximum immediate downside and must not describe emissions, token price, or pool participation as a return promise.
 
 ### Pool and protocol
 
 - Each pool or tier has a stable public name, one rip-payment asset, one fixed Rip Price, approved asset rules, fees, and published minimum and maximum oracle NAV bounds.
+- The initial V1 Rip Price is `$25`. Its 10% Rip fee retains `$2.50` as protocol revenue in the rip-payment asset and settles `$22.50` as fixed creator proceeds. The fee is versioned, evented pool configuration that may be adjusted prospectively based on testnet results rather than an immutable universal constant.
 - The initial `$25` pool's starting hypothesis is a `$15` minimum NAV and `$100` maximum NAV. These are versioned, evented pool configuration, not immutable universal constants.
+- The V1 unwrap or redemption fee is zero. The disclosed Rip fee is the only player-facing protocol fee.
 - NAV bounds are continuously enforced for active eligibility, and the maximum protects pool risk rather than serving only as a listing-time check. A Pack outside either bound leaves the eligible selection set and stops creator emissions until price movement or a permitted top-up returns it within bounds; its redemption right remains intact.
 - Bound changes apply prospectively to new listings or a new pool version and never silently rewrite the bounds governing existing active Packs.
 - Selection within a pool is uniform: oracle NAV, game-token balance, creator identity, and all other Pack attributes have zero selection weight.
@@ -77,7 +81,7 @@ The contract retains a separately approved path to enable ordinary ERC-20 transf
 
 The token is not required to Rip, create, or redeem a Pack. It does not affect Pack contents, NAV, unwrap output, selection odds, Trader cadence, or the fixed Rip Price.
 
-Ongoing emissions are gated by prior realized protocol fees: a zero-revenue period creates no new ongoing emission budget, and unused budget does not accumulate for later release. A finite bootstrap allocation, if approved, must be published separately and cannot be represented as revenue-backed. Exact allocations, vesting, emission rates, and any mainnet token launch remain approval-gated decisions.
+Protocol fee revenue remains held in the rip-payment asset and gates or funds future bounded creator-emission budgets; the fee does not directly pay newly minted game tokens on each Rip. A zero-revenue period creates no new ongoing emission budget, and unused budget does not accumulate for later release. A finite bootstrap allocation, if approved, must be published separately and cannot be represented as revenue-backed. Exact allocations, vesting, emission rates, and any mainnet token launch remain approval-gated decisions.
 
 Creator emissions stop when inventory leaves eligible supply. All creator-emission totals, Pack eligibility inputs, and claims must be reproducible from confirmed records. The token pays no staking yield, fee share, revenue distribution, APY, or guaranteed benefit.
 
@@ -89,8 +93,10 @@ Creator emissions stop when inventory leaves eligible supply. All creator-emissi
 - Pack selection is uniform across the published eligible set. Every eligible Pack has equal odds; oracle NAV, game-token holdings or stake, creator identity, and Pack attributes never add selection weight.
 - Pool NAV bounds are continuously enforced. An out-of-bounds Pack leaves selection and creator-emission eligibility until it returns within bounds, without losing its redemption right; versioned bound changes apply prospectively rather than rewriting active-Pack terms.
 - The fixed Rip Price, selected Pack, basket, NAV snapshot, payment, fees, and terminal state are preserved in confirmed audit records.
-- Redemption releases only the selected Pack's recorded raw-token basket less disclosed fees. Stale or unavailable oracle data makes NAV-dependent eligibility fail closed; oracle or scheduler failure cannot rewrite custody or permanently block the defined exit.
+- Initial settlement conserves the full `$25` payment: `$22.50` goes to the creator and `$2.50` remains protocol revenue in the rip-payment asset, while the selected Pack transfers to the Trader with control of its full recorded basket and its creator emissions stop.
+- Redemption releases the selected Pack's full recorded raw-token basket with zero protocol fee. Stale or unavailable oracle data makes NAV-dependent eligibility fail closed; oracle or scheduler failure cannot rewrite custody or permanently block the defined exit.
 - Creator emissions come only from a bounded published budget and are never described as offsetting creator loss or promising a return.
+- Rip-fee revenue remains in the rip-payment asset and gates future bounded emission budgets; it is not a direct per-Rip payment of newly minted game tokens.
 - A nonzero ripper participation reward applies only after one confirmed, settled Rip, excludes same-Desk Rips, and remains below the disclosed game cost. Failed, pending, or retried intents never qualify.
 - Ordinary external token transfers fail closed at launch. Any later transfer-enablement transition is separately approved, evented, time-delayed, bounded to enabling transferability rather than promising a market, and preferably irreversible.
 - Testnet assets and tokens are visibly labelled as valueless test assets. V1 makes no mainnet, yield, appreciation, or guaranteed-profit claim.
@@ -108,11 +114,11 @@ On Robinhood Chain testnet, independent participants can create and fully fund e
 
 ## Open decisions before implementation planning
 
-- The V1 pool name, fixed rip-payment asset, approved Stock Token set, fee schedule, oracle freshness limits, objective anti-spam eligibility rules, and whether the `$25` / `$15` / `$100` starting hypotheses become launch configuration.
+- The V1 pool name, fixed rip-payment asset, approved Stock Token set, oracle freshness limits, objective anti-spam eligibility rules, whether the `$15` / `$100` NAV-bound hypothesis becomes launch configuration, and the criteria for prospective changes to the initial 10% Rip fee after testnet results.
 - The random-selection mechanism, audit evidence, outage behavior, and required consumer disclosures.
 - The fixed token cap, bootstrap allocation if any, ongoing creator-emission budget, vesting and claim rules, and the immutable ripper-reward maximum and published budget.
 - Permitted Pack top-up rules, exact pool-version transition behavior, the transfer-enablement delay, whether that switch is strictly irreversible, and any separately approved external venue or liquidity plan.
-- The exact Pack redemption rules and fees, including whether V1 exposes manual redemption in the application or only preserves the protocol right.
+- The Pack redemption workflow, including whether V1 exposes manual redemption in the application or only preserves the protocol right.
 - Regulatory and consumer-protection review for paid random selection backed by tokenized financial assets.
 
 ## Relationship to existing Floor documents


### PR DESCRIPTION
## Summary

Adds `docs/prd-margin-call-token.md`, reversing the "no game token" exclusion in the Floor PRD (#247).

The PRD starts from an assumption the Floor PRD avoids stating: **the rip is negative expected value in equity terms and always will be.** That gap is what pays the creator and the protocol, so it isn't a flaw to engineer away — but a game whose only economic output to participants is a disclosed loss can't reward early supply, can't retain through variance, and gives protocol revenue nothing to attach to.

It also assumes the **permissionless Pack economy** (any Desk Manager wraps real Stock Tokens into a transferable Pack) rather than the single House-operated Window with allowlisted Suppliers. In that market the scarce resource stops being inventory and becomes selection weight, which is the fourth thing the token meters.

The token has four jobs and no revenue distribution: meter selection weight, pay for early supply via TVL-seconds of unripped inventory, rebate rippers, and gate agent capacity through the existing SeatVault.

## Two decisions carry the design

- **Emissions are capped at a multiple of the prior epoch's realized fee revenue** (`min(schedule, k x prior revenue)`), with the shortfall permanently forgone rather than rolled forward. A protocol with no revenue emits nothing. This is the anti-death-spiral rule.
- **Per-rip rebate value must stay strictly below the rake paid on that rip.** If it holds, self-dealing is unprofitable at any volume — by construction rather than by detection. That's materially stronger than the Floor PRD, which concedes it can only discount suspicious trading in leaderboard scoring. Enforcement is an oracle-referenced emission-rate cap that fails closed.

## Conflict this PR records rather than hides

`docs/trader-fuel-token.md` states the shipped invariant as **"Stake affects capacity, never outcome probability."** Weight staking violates it — a creator who stakes changes the distribution a ripper faces, and calling that "distribution" instead of "odds" would be a rebrand, not a defense.

The PRD proposes the departure deliberately, bounds it with four mitigations (published multiplier band, full pre-rip disclosure of contents/NAV/multiplier, no effect on unwrap output in any state including pause, published house edge), and names the fallback if review rejects it: meter listings with a flat fee or a no-advantage deposit, at the cost of losing the token's primary demand sink.

**This is the decision most worth arguing about in review.**

## Reuse, not rebuild

- `contracts/src/SeatVault.sol` and its unit/fuzz/invariant/e2e/integration suites are prior art for the weight vault; agent capacity staking reuses it unchanged and preserves the original invariant.
- `contracts/src/MarginCallToken.sol` is flagged as **not reusable** — 13 lines, unpermissioned public `mint()`, no supply cap, commented "Test / Sepolia capacity token."

## Test plan

Docs-only; no code paths touched.

- [x] Prettier clean (`npx prettier --check`)
- [x] All 10 relative links resolve
- [x] Header hard-breaks match the Floor PRD convention
- [ ] Decide the weight-staking departure vs. the no-advantage fallback
- [ ] Set the starting value and decline schedule for `k`
- [ ] Resolve `$BLOW` vs. `MARGINCALL` naming before any deployment

Made with [Cursor](https://cursor.com)