### PR TITLE
Pack custody contract — mint, top-up, redeem, unwrap (#275)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,13 @@ MOCKUSD_ADMIN=
 MOCKUSD_MINTER=
 MOCKUSD_ADDRESS=             # Filled by `pnpm deploy:mockusd`
 NEXT_PUBLIC_MOCKUSD_ADDRESS= # Same address for the client
+# Optional PackCustody constructor / role overrides (defaults: admin = deployer,
+# whitelist = the five approved Stock Tokens in docs/prd-margin-call-token.md)
+PACKCUSTODY_ADMIN=
+PACKCUSTODY_WHITELIST_ADMIN=
+PACKCUSTODY_WHITELIST=           # Comma-separated asset addresses
+PACKCUSTODY_ADDRESS=             # Filled by `pnpm deploy:packcustody`
+NEXT_PUBLIC_PACKCUSTODY_ADDRESS= # Same address for the client
 
 # Legacy deal-game addresses (optional — rebuild pending)
 # See docs/base-sepolia-configuration.md. Removed at #262.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -122,13 +122,82 @@ Writes `contracts/deployments/robinhood-testnet.packcustody.json` (address, admi
 - **MockUSD (testnet, verified):** [`0xAA555fD042F33B5AF485171015AeAF11eD49EF3D`](https://explorer.testnet.chain.robinhood.com/address/0xAA555fD042F33B5AF485171015AeAF11eD49EF3D#code)
 - Deployment record: [`deployments/robinhood-testnet.mockusd.json`](./deployments/robinhood-testnet.mockusd.json)
 - Tx: [`0x9a2c19d5…`](https://explorer.testnet.chain.robinhood.com/tx/0x9a2c19d5e97a12eb86f7ec5dd3e74bcf30bd099d11a763d57f390fde2af7f4c2)
-- Verify after deploy: `pnpm verify:mockusd` (Blockscout; workspace uses `optimizer_runs = 1_000_000`).
+- **PackCustody (testnet, verified):** [`0x413e82F990DE796CC279c180F711d720A7Ee7728`](https://explorer.testnet.chain.robinhood.com/address/0x413e82F990DE796CC279c180F711d720A7Ee7728#code)
+- Deployment record: [`deployments/robinhood-testnet.packcustody.json`](./deployments/robinhood-testnet.packcustody.json)
+- Tx: [`0x6532824d…`](https://explorer.testnet.chain.robinhood.com/tx/0x6532824d0202d16b693a55fab1ff2bffa2a87f718037ca3930a3b0d89f11b9e6)
+- Verify after deploy: `pnpm verify:mockusd` / `pnpm verify:packcustody` (Blockscout; workspace uses `optimizer_runs = 1_000_000`).
+
+> **Gas note.** Robinhood Chain bills L1 calldata as extra gas, and for a contract deployment
+> that component dominates and drifts with the L1 base fee. Forge's default 130% headroom is
+> not enough — the first PackCustody attempt burned its whole limit and reverted out of gas.
+> `runForgeDeploy` now passes `--gas-estimate-multiplier 400`; only gas actually used is billed.
+
+## Demo the Pack lifecycle with `cast`
+
+Everything below runs against the deployed contracts with tokens from the
+[Robinhood faucet](https://faucet.testnet.chain.robinhood.com) — no app required.
+
+```bash
+export RPC=https://rpc.testnet.chain.robinhood.com
+export PACKS=0x413e82F990DE796CC279c180F711d720A7Ee7728
+export AMZN=0x5884aD2f920c162CFBbACc88C9C51AA75eC09E02
+export PLTR=0x1FBE1a0e43594b3455993B5dE5Fd0A7A266298d0
+export KEY=0x…            # a faucet-funded creator
+export ME=$(cast wallet address --private-key $KEY)
+```
+
+Read the pool's entry rules:
+
+```bash
+cast call $PACKS "whitelistedAssets()(address[])" --rpc-url $RPC
+cast call $PACKS "isWhitelisted(address)(bool)" $AMZN --rpc-url $RPC   # true
+```
+
+Approve, then mint a fully funded Pack. Amounts are raw token units:
+
+```bash
+cast send $AMZN "approve(address,uint256)" $PACKS 1000000000000000000 --private-key $KEY --rpc-url $RPC
+cast send $PLTR "approve(address,uint256)" $PACKS 5000000 --private-key $KEY --rpc-url $RPC
+
+cast send $PACKS "mint(address[],uint256[])" "[$AMZN,$PLTR]" "[1000000000000000000,5000000]" \
+  --private-key $KEY --rpc-url $RPC
+
+export ID=$(cast call $PACKS "totalMinted()(uint256)" --rpc-url $RPC)
+cast call $PACKS "basketOf(uint256)((address,uint256)[])" $ID --rpc-url $RPC
+cast call $PACKS "isListed(uint256)(bool)" $ID --rpc-url $RPC        # true
+```
+
+Top it up (creator only, additions only):
+
+```bash
+cast send $AMZN "approve(address,uint256)" $PACKS 500000000000000000 --private-key $KEY --rpc-url $RPC
+cast send $PACKS "topUp(uint256,address[],uint256[])" $ID "[$AMZN]" "[500000000000000000]" \
+  --private-key $KEY --rpc-url $RPC
+cast call $PACKS "basketAmountOf(uint256,address)(uint256)" $ID $AMZN --rpc-url $RPC   # 1.5e18
+```
+
+Then take either exit. While the Pack is still yours, delist and redeem:
+
+```bash
+cast send $PACKS "delistAndRedeem(uint256)" $ID --private-key $KEY --rpc-url $RPC
+```
+
+Or transfer it — standing in for Rip settlement — and let the new holder unwrap:
+
+```bash
+cast send $PACKS "transferFrom(address,address,uint256)" $ME $BUYER $ID --private-key $KEY --rpc-url $RPC
+cast call $PACKS "isListed(uint256)(bool)" $ID --rpc-url $RPC        # false
+cast send $PACKS "unwrap(uint256)" $ID --private-key $BUYER_KEY --rpc-url $RPC
+```
+
+Both paths return the entire recorded basket and burn the Pack. Compare the token balances
+before and after: nothing is deducted on either path.
 
 ## Layout
 
 ```
 contracts/
-  src/            # Deployable contracts (MockUSD today; PackCustody et al. later)
+  src/            # Deployable contracts (MockUSD, PackCustody; RipEngine et al. later)
   test/           # Forge unit / fuzz / invariant suites
   script/         # Deploy scripts + LazerForge Utils
   deployments/    # Recorded, reproducible addresses (committed)

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -59,6 +59,19 @@ Protocol-deployed mock USD stablecoin for the Season:
 
 This is a **valueless test asset**. It has no USD backing and nothing about it carries over to mainnet.
 
+## PackCustody
+
+ERC-721 Packs backed by a recorded basket of whitelisted Stock Tokens held directly by the contract (issue [#275](https://github.com/hurley87/margin-call/issues/275)):
+
+- Name / symbol: `Margin Call Pack (Test Asset)` / `PACK`
+- `mint` deposits the whole basket in one transaction; a Pack can never exist unfunded
+- Custody accounting is raw token units, recorded from the balance actually received
+- `topUp` is creator-only and additions-only, while the Pack is still listed
+- `delistAndRedeem` (creator, while listed) and `unwrap` (holder, once transferred) both release the full basket at **zero protocol fee**
+- `WHITELIST_ADMIN_ROLE` governs deposits only — de-whitelisting an asset never blocks redemption
+
+Oracle NAV, eligibility, and Rip selection live in later contracts; custody knows nothing about them.
+
 ## Deploy (Robinhood Chain testnet)
 
 1. Fund a deployer with testnet ETH from the [Robinhood faucet](https://faucet.testnet.chain.robinhood.com).
@@ -86,6 +99,22 @@ This is a **valueless test asset**. It has no USD backing and nothing about it c
    ```bash
    pnpm verify:mockusd
    ```
+
+### PackCustody
+
+Same flow, with the whitelist defaulting to the five approved Stock Tokens from the PRD launch configuration:
+
+```bash
+# Optional overrides in .env.local:
+#   PACKCUSTODY_ADMIN=0x…            # defaults to deployer
+#   PACKCUSTODY_WHITELIST_ADMIN=0x…  # granted WHITELIST_ADMIN_ROLE when admin == deployer
+#   PACKCUSTODY_WHITELIST=0x…,0x…    # comma-separated; overrides the launch five
+
+pnpm deploy:packcustody
+pnpm verify:packcustody
+```
+
+Writes `contracts/deployments/robinhood-testnet.packcustody.json` (address, admin, whitelist, build fingerprint, tx hash) and patches `PACKCUSTODY_ADDRESS` / `NEXT_PUBLIC_PACKCUSTODY_ADDRESS` in `.env.local`.
 
 ### Explorer
 

--- a/contracts/deployments/robinhood-testnet.packcustody.json
+++ b/contracts/deployments/robinhood-testnet.packcustody.json
@@ -1,0 +1,25 @@
+{
+  "address": "0x413e82F990DE796CC279c180F711d720A7Ee7728",
+  "admin": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
+  "blockNumber": 94393734,
+  "bytecodeHash": "none",
+  "cborMetadata": false,
+  "chainId": 46630,
+  "deployer": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
+  "evmVersion": "cancun",
+  "name": "Margin Call Pack (Test Asset)",
+  "optimizerRuns": 1000000,
+  "solc": "0.8.28",
+  "symbol": "PACK",
+  "timestamp": 1785240970,
+  "version": 1,
+  "whitelist": [
+    "0x5884aD2f920c162CFBbACc88C9C51AA75eC09E02",
+    "0x71178BAc73cBeb415514eB542a8995b82669778d",
+    "0x3b8262A63d25f0477c4DDE23F83cfe22Cb768C93",
+    "0x1FBE1a0e43594b3455993B5dE5Fd0A7A266298d0",
+    "0xC9f9c86933092BbbfFF3CCb4b105A4A94bf3Bd4E"
+  ],
+  "txHash": "0x6532824d0202d16b693a55fab1ff2bffa2a87f718037ca3930a3b0d89f11b9e6",
+  "deployedAt": "2026-07-28T12:16:16.371Z"
+}

--- a/contracts/script/DeployPackCustody.s.sol
+++ b/contracts/script/DeployPackCustody.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {console2} from "forge-std/console2.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {Utils} from "./utils/Utils.sol";
+
+/// @notice Deploy PackCustody to Robinhood Chain testnet and record the address.
+/// @dev Signing: set DEPLOYER_PRIVATE_KEY, or export it from a Foundry keystore
+///      (`cast wallet private-key --account <name>`). Env:
+///        PACKCUSTODY_ADMIN           — optional; defaults to the deployer
+///        PACKCUSTODY_WHITELIST_ADMIN — optional; granted WHITELIST_ADMIN_ROLE when
+///                                      admin == deployer
+///        PACKCUSTODY_WHITELIST       — optional; comma-separated assets, defaults to the
+///                                      five approved Stock Tokens below
+contract DeployPackCustody is Utils {
+    uint256 internal constant ROBINHOOD_TESTNET_CHAIN_ID = 46_630;
+
+    function run() external {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        address admin = vm.envOr("PACKCUSTODY_ADMIN", deployer);
+        address whitelistAdmin = vm.envOr("PACKCUSTODY_WHITELIST_ADMIN", address(0));
+        address[] memory assets = vm.envOr("PACKCUSTODY_WHITELIST", ",", launchWhitelist());
+
+        vm.startBroadcast(deployerKey);
+        PackCustody custody = new PackCustody(admin, assets);
+        if (whitelistAdmin != address(0)) {
+            require(admin == deployer, "DeployPackCustody: deployer must be admin to grant whitelist admin");
+            // Use the role constant directly so we don't broadcast a view call.
+            custody.grantRole(keccak256("WHITELIST_ADMIN_ROLE"), whitelistAdmin);
+        }
+        vm.stopBroadcast();
+
+        console2.log("PackCustody deployed at:", address(custody));
+        console2.log("Admin:", admin);
+        console2.log("Deployer:", deployer);
+        if (whitelistAdmin != address(0)) {
+            console2.log("Whitelist admin:", whitelistAdmin);
+        }
+        for (uint256 i; i < assets.length; ++i) {
+            console2.log("Whitelisted:", assets[i]);
+        }
+
+        _writeRecord(address(custody), deployer, admin, whitelistAdmin, assets);
+    }
+
+    /// @notice The five approved testnet Stock Tokens from the PRD launch configuration.
+    /// @dev Public so the verify tooling can re-derive the constructor arguments.
+    function launchWhitelist() public pure returns (address[] memory assets) {
+        assets = new address[](5);
+        assets[0] = 0x5884aD2f920c162CFBbACc88C9C51AA75eC09E02; // AMZN
+        assets[1] = 0x71178BAc73cBeb415514eB542a8995b82669778d; // AMD
+        assets[2] = 0x3b8262A63d25f0477c4DDE23F83cfe22Cb768C93; // NFLX
+        assets[3] = 0x1FBE1a0e43594b3455993B5dE5Fd0A7A266298d0; // PLTR
+        assets[4] = 0xC9f9c86933092BbbfFF3CCb4b105A4A94bf3Bd4E; // TSLA
+    }
+
+    function _writeRecord(
+        address custody,
+        address deployer,
+        address admin,
+        address whitelistAdmin,
+        address[] memory assets
+    ) internal {
+        string memory obj = "packcustody";
+        vm.serializeUint(obj, "version", 1);
+        vm.serializeUint(obj, "chainId", block.chainid);
+        vm.serializeAddress(obj, "address", custody);
+        vm.serializeAddress(obj, "deployer", deployer);
+        vm.serializeAddress(obj, "admin", admin);
+        if (whitelistAdmin != address(0)) {
+            vm.serializeAddress(obj, "whitelistAdmin", whitelistAdmin);
+        }
+        vm.serializeAddress(obj, "whitelist", assets);
+        vm.serializeUint(obj, "blockNumber", block.number);
+        vm.serializeUint(obj, "timestamp", block.timestamp);
+        vm.serializeString(obj, "name", "Margin Call Pack (Test Asset)");
+        vm.serializeString(obj, "symbol", "PACK");
+        // Build fingerprint — matches foundry.toml default profile pins.
+        vm.serializeString(obj, "solc", "0.8.28");
+        vm.serializeString(obj, "evmVersion", "cancun");
+        vm.serializeUint(obj, "optimizerRuns", 1_000_000);
+        vm.serializeString(obj, "bytecodeHash", "none");
+        string memory finalJson = vm.serializeBool(obj, "cborMetadata", false);
+
+        string memory fileName = block.chainid == ROBINHOOD_TESTNET_CHAIN_ID
+            ? "robinhood-testnet.packcustody"
+            : string.concat("chain-", vm.toString(block.chainid), ".packcustody");
+
+        writeOutput(finalJson, fileName);
+        console2.log("Wrote deployment record:", getOutputPath(fileName));
+    }
+}

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title PackCustody
+/// @notice ERC-721 Packs backed by a recorded basket of whitelisted Stock Tokens held
+///         directly by this contract.
+/// @dev Custody accounting is in raw token units; oracle NAV and selection eligibility are
+///      computed elsewhere and never gate the assets recorded here. Packs are plain
+///      custody-backed ERC-721s, not token-bound accounts (ADR-0004).
+contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    /// @notice One recorded position in a Pack's basket.
+    struct BasketEntry {
+        address asset;
+        uint256 amount;
+    }
+
+    /// @notice Role permitted to change which assets may be deposited.
+    bytes32 public constant WHITELIST_ADMIN_ROLE = keccak256("WHITELIST_ADMIN_ROLE");
+
+    /// @notice Whether an asset may be deposited into a Pack.
+    /// @dev Entry control only. Assets already recorded in a basket stay redeemable whatever
+    ///      this says later, so de-whitelisting can never strand a creator's capital.
+    mapping(address asset => bool whitelisted) public isWhitelisted;
+
+    /// @notice The account that minted a Pack, and the only account that may top it up.
+    mapping(uint256 tokenId => address creator) public creatorOf;
+
+    address[] private _whitelist;
+
+    /// @dev Distinct assets recorded for a Pack. Bounded by the whitelist size because
+    ///      deposits require whitelist membership and duplicate mint entries are rejected.
+    mapping(uint256 tokenId => address[] assets) private _basketAssets;
+
+    mapping(uint256 tokenId => mapping(address asset => uint256 amount)) private _basketAmounts;
+
+    uint256 private _lastTokenId;
+
+    /// @notice Emitted once per Pack, with the amounts actually received into custody.
+    event PackMinted(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+
+    /// @notice Emitted when an asset becomes depositable.
+    event AssetWhitelisted(address indexed asset);
+
+    error ZeroAddress();
+    error EmptyWhitelist();
+    error AlreadyWhitelisted(address asset);
+    error EmptyBasket();
+    error LengthMismatch();
+    error AssetNotWhitelisted(address asset);
+    error DuplicateAsset(address asset);
+    error ZeroAmount(address asset);
+    error NoAssetsReceived(address asset);
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE (can grant/revoke WHITELIST_ADMIN_ROLE).
+    /// @param initialWhitelist Assets depositable at launch — the five approved Stock Tokens.
+    constructor(address admin, address[] memory initialWhitelist) ERC721("Margin Call Pack (Test Asset)", "PACK") {
+        if (admin == address(0)) revert ZeroAddress();
+        if (initialWhitelist.length == 0) revert EmptyWhitelist();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+
+        for (uint256 i; i < initialWhitelist.length; ++i) {
+            address asset = initialWhitelist[i];
+            if (asset == address(0)) revert ZeroAddress();
+            if (isWhitelisted[asset]) revert AlreadyWhitelisted(asset);
+
+            isWhitelisted[asset] = true;
+            _whitelist.push(asset);
+            emit AssetWhitelisted(asset);
+        }
+    }
+
+    /// @notice Mint a Pack, depositing its full basket in the same transaction.
+    /// @dev The caller must have approved this contract for every asset. Recorded amounts are
+    ///      what custody actually received, so a fee-on-transfer asset records its net amount.
+    /// @param assets Distinct whitelisted assets to deposit.
+    /// @param amounts Raw token units to deposit, positionally matched to `assets`.
+    /// @return tokenId The newly minted Pack.
+    function mint(address[] calldata assets, uint256[] calldata amounts)
+        external
+        nonReentrant
+        returns (uint256 tokenId)
+    {
+        if (assets.length == 0) revert EmptyBasket();
+        if (assets.length != amounts.length) revert LengthMismatch();
+
+        tokenId = ++_lastTokenId;
+        creatorOf[tokenId] = msg.sender;
+
+        uint256[] memory received = new uint256[](assets.length);
+        for (uint256 i; i < assets.length; ++i) {
+            // The Pack is new, so any recorded amount can only come from this call.
+            if (_basketAmounts[tokenId][assets[i]] != 0) revert DuplicateAsset(assets[i]);
+            received[i] = _deposit(tokenId, assets[i], amounts[i]);
+        }
+
+        _safeMint(msg.sender, tokenId);
+
+        emit PackMinted(tokenId, msg.sender, assets, received);
+    }
+
+    /// @notice The full recorded basket of a Pack, in raw token units.
+    function basketOf(uint256 tokenId) external view returns (BasketEntry[] memory basket) {
+        address[] storage assets = _basketAssets[tokenId];
+        basket = new BasketEntry[](assets.length);
+        for (uint256 i; i < assets.length; ++i) {
+            basket[i] = BasketEntry({asset: assets[i], amount: _basketAmounts[tokenId][assets[i]]});
+        }
+    }
+
+    /// @notice Distinct assets recorded for a Pack.
+    function basketAssetsOf(uint256 tokenId) external view returns (address[] memory) {
+        return _basketAssets[tokenId];
+    }
+
+    /// @notice Raw token units of a single asset recorded for a Pack.
+    function basketAmountOf(uint256 tokenId, address asset) external view returns (uint256) {
+        return _basketAmounts[tokenId][asset];
+    }
+
+    /// @notice Assets currently depositable into new and existing Packs.
+    function whitelistedAssets() external view returns (address[] memory) {
+        return _whitelist;
+    }
+
+    /// @notice Total Packs minted, including any since burned. Doubles as the last token id.
+    function totalMinted() external view returns (uint256) {
+        return _lastTokenId;
+    }
+
+    /// @inheritdoc ERC721
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, AccessControl) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Pulls `amount` of `asset` into custody and records what actually arrived.
+    function _deposit(uint256 tokenId, address asset, uint256 amount) internal returns (uint256 received) {
+        if (!isWhitelisted[asset]) revert AssetNotWhitelisted(asset);
+        if (amount == 0) revert ZeroAmount(asset);
+
+        IERC20 token = IERC20(asset);
+        uint256 balanceBefore = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        received = token.balanceOf(address(this)) - balanceBefore;
+        if (received == 0) revert NoAssetsReceived(asset);
+
+        if (_basketAmounts[tokenId][asset] == 0) {
+            _basketAssets[tokenId].push(asset);
+        }
+        _basketAmounts[tokenId][asset] += received;
+    }
+}

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -56,6 +56,9 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @notice Emitted the first time a Pack leaves its creator, retiring it from the pool.
     event PackUnlisted(uint256 indexed tokenId);
 
+    /// @notice Emitted when a creator delists a Pack and takes its full basket back.
+    event PackRedeemed(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+
     /// @notice Emitted when an asset becomes depositable.
     event AssetWhitelisted(address indexed asset);
 
@@ -139,6 +142,18 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
         emit PackToppedUp(tokenId, msg.sender, assets, received);
     }
 
+    /// @notice Delist a Pack and take its entire basket back, at no protocol fee.
+    /// @dev Creator-only while listed. Available at any moment — the exit right is never
+    ///      delayed — so creator capital can never be trapped. Burns the Pack.
+    function delistAndRedeem(uint256 tokenId) external nonReentrant {
+        if (!isListed(tokenId)) revert PackNotListed(tokenId);
+        if (creatorOf[tokenId] != msg.sender) revert NotPackCreator(tokenId, msg.sender);
+
+        (address[] memory assets, uint256[] memory amounts) = _release(tokenId, msg.sender);
+
+        emit PackRedeemed(tokenId, msg.sender, assets, amounts);
+    }
+
     /// @notice Whether a Pack is still held by its creator and can be topped up or delisted.
     function isListed(uint256 tokenId) public view returns (bool) {
         return _ownerOf(tokenId) != address(0) && !_unlisted[tokenId];
@@ -207,6 +222,32 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @inheritdoc ERC721
     function supportsInterface(bytes4 interfaceId) public view override(ERC721, AccessControl) returns (bool) {
         return super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Burns the Pack and pays its whole recorded basket to `to`, with no deduction of
+    ///      any kind. Accounting is cleared before any token moves, so a hostile asset that
+    ///      re-enters finds nothing left to release even before the guard rejects it.
+    function _release(uint256 tokenId, address to)
+        internal
+        returns (address[] memory assets, uint256[] memory amounts)
+    {
+        assets = _basketAssets[tokenId];
+        amounts = new uint256[](assets.length);
+
+        for (uint256 i; i < assets.length; ++i) {
+            amounts[i] = _basketAmounts[tokenId][assets[i]];
+            delete _basketAmounts[tokenId][assets[i]];
+        }
+
+        delete _basketAssets[tokenId];
+        delete creatorOf[tokenId];
+        delete _unlisted[tokenId];
+
+        _burn(tokenId);
+
+        for (uint256 i; i < assets.length; ++i) {
+            IERC20(assets[i]).safeTransfer(to, amounts[i]);
+        }
     }
 
     /// @dev Latches the Pack out of the pool on its first move to a new holder. Mints, burns,

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -41,10 +41,20 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
 
     mapping(uint256 tokenId => mapping(address asset => uint256 amount)) private _basketAmounts;
 
+    /// @dev Latched the first time a Pack leaves its creator. One way: a Pack that has been
+    ///      ripped or sold never rejoins the pool, so the lifecycle only ever moves forward.
+    mapping(uint256 tokenId => bool unlisted) private _unlisted;
+
     uint256 private _lastTokenId;
 
     /// @notice Emitted once per Pack, with the amounts actually received into custody.
     event PackMinted(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+
+    /// @notice Emitted when a creator adds assets to a listed Pack.
+    event PackToppedUp(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+
+    /// @notice Emitted the first time a Pack leaves its creator, retiring it from the pool.
+    event PackUnlisted(uint256 indexed tokenId);
 
     /// @notice Emitted when an asset becomes depositable.
     event AssetWhitelisted(address indexed asset);
@@ -62,6 +72,8 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     error DuplicateAsset(address asset);
     error ZeroAmount(address asset);
     error NoAssetsReceived(address asset);
+    error NotPackCreator(uint256 tokenId, address caller);
+    error PackNotListed(uint256 tokenId);
 
     /// @param admin Address granted DEFAULT_ADMIN_ROLE (can grant/revoke WHITELIST_ADMIN_ROLE).
     /// @param initialWhitelist Assets depositable at launch — the five approved Stock Tokens.
@@ -93,22 +105,43 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
         nonReentrant
         returns (uint256 tokenId)
     {
-        if (assets.length == 0) revert EmptyBasket();
-        if (assets.length != amounts.length) revert LengthMismatch();
+        _validateDeposit(assets, amounts);
 
         tokenId = ++_lastTokenId;
         creatorOf[tokenId] = msg.sender;
 
         uint256[] memory received = new uint256[](assets.length);
         for (uint256 i; i < assets.length; ++i) {
-            // The Pack is new, so any recorded amount can only come from this call.
-            if (_basketAmounts[tokenId][assets[i]] != 0) revert DuplicateAsset(assets[i]);
             received[i] = _deposit(tokenId, assets[i], amounts[i]);
         }
 
         _safeMint(msg.sender, tokenId);
 
         emit PackMinted(tokenId, msg.sender, assets, received);
+    }
+
+    /// @notice Add assets to a listed Pack. Additions only — nothing can be withdrawn here.
+    /// @dev Creator-only, and only while the Pack is still in the pool. A published NAV can
+    ///      therefore rise between checkpoints but can never be hollowed out.
+    /// @param tokenId The Pack to top up.
+    /// @param assets Distinct whitelisted assets to add, new to the basket or already in it.
+    /// @param amounts Raw token units to add, positionally matched to `assets`.
+    function topUp(uint256 tokenId, address[] calldata assets, uint256[] calldata amounts) external nonReentrant {
+        _validateDeposit(assets, amounts);
+        if (!isListed(tokenId)) revert PackNotListed(tokenId);
+        if (creatorOf[tokenId] != msg.sender) revert NotPackCreator(tokenId, msg.sender);
+
+        uint256[] memory received = new uint256[](assets.length);
+        for (uint256 i; i < assets.length; ++i) {
+            received[i] = _deposit(tokenId, assets[i], amounts[i]);
+        }
+
+        emit PackToppedUp(tokenId, msg.sender, assets, received);
+    }
+
+    /// @notice Whether a Pack is still held by its creator and can be topped up or delisted.
+    function isListed(uint256 tokenId) public view returns (bool) {
+        return _ownerOf(tokenId) != address(0) && !_unlisted[tokenId];
     }
 
     /// @notice Allow an asset to be deposited into new and existing Packs.
@@ -174,6 +207,29 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @inheritdoc ERC721
     function supportsInterface(bytes4 interfaceId) public view override(ERC721, AccessControl) returns (bool) {
         return super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Latches the Pack out of the pool on its first move to a new holder. Mints, burns,
+    ///      and self-transfers are not departures.
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address from) {
+        from = super._update(to, tokenId, auth);
+
+        if (from != address(0) && to != address(0) && to != from && !_unlisted[tokenId]) {
+            _unlisted[tokenId] = true;
+            emit PackUnlisted(tokenId);
+        }
+    }
+
+    /// @dev Shared shape check for mint and top-up: non-empty, aligned, and free of duplicates.
+    function _validateDeposit(address[] calldata assets, uint256[] calldata amounts) internal pure {
+        if (assets.length == 0) revert EmptyBasket();
+        if (assets.length != amounts.length) revert LengthMismatch();
+
+        for (uint256 i; i < assets.length; ++i) {
+            for (uint256 j; j < i; ++j) {
+                if (assets[i] == assets[j]) revert DuplicateAsset(assets[i]);
+            }
+        }
     }
 
     /// @dev Pulls `amount` of `asset` into custody and records what actually arrived.

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -59,6 +59,9 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @notice Emitted when a creator delists a Pack and takes its full basket back.
     event PackRedeemed(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
 
+    /// @notice Emitted when a holder unwraps a Pack that has left its creator.
+    event PackUnwrapped(uint256 indexed tokenId, address indexed holder, address[] assets, uint256[] amounts);
+
     /// @notice Emitted when an asset becomes depositable.
     event AssetWhitelisted(address indexed asset);
 
@@ -76,7 +79,9 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     error ZeroAmount(address asset);
     error NoAssetsReceived(address asset);
     error NotPackCreator(uint256 tokenId, address caller);
+    error NotPackHolder(uint256 tokenId, address caller);
     error PackNotListed(uint256 tokenId);
+    error PackStillListed(uint256 tokenId);
 
     /// @param admin Address granted DEFAULT_ADMIN_ROLE (can grant/revoke WHITELIST_ADMIN_ROLE).
     /// @param initialWhitelist Assets depositable at launch — the five approved Stock Tokens.
@@ -152,6 +157,19 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
         (address[] memory assets, uint256[] memory amounts) = _release(tokenId, msg.sender);
 
         emit PackRedeemed(tokenId, msg.sender, assets, amounts);
+    }
+
+    /// @notice Take the entire basket out of a Pack that has left its creator, at no protocol
+    ///         fee. Available to whoever holds the Pack, however they came by it.
+    /// @dev Burns the Pack. The disclosed exit for a ripped or purchased Pack; the creator's
+    ///      equivalent while the Pack is still in the pool is `delistAndRedeem`.
+    function unwrap(uint256 tokenId) external nonReentrant {
+        if (_ownerOf(tokenId) != msg.sender) revert NotPackHolder(tokenId, msg.sender);
+        if (isListed(tokenId)) revert PackStillListed(tokenId);
+
+        (address[] memory assets, uint256[] memory amounts) = _release(tokenId, msg.sender);
+
+        emit PackUnwrapped(tokenId, msg.sender, assets, amounts);
     }
 
     /// @notice Whether a Pack is still held by its creator and can be topped up or delisted.

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -49,6 +49,10 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @notice Emitted when an asset becomes depositable.
     event AssetWhitelisted(address indexed asset);
 
+    /// @notice Emitted when an asset stops being depositable.
+    /// @dev Baskets already holding the asset are unaffected and stay fully redeemable.
+    event AssetRemovedFromWhitelist(address indexed asset);
+
     error ZeroAddress();
     error EmptyWhitelist();
     error AlreadyWhitelisted(address asset);
@@ -105,6 +109,37 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
         _safeMint(msg.sender, tokenId);
 
         emit PackMinted(tokenId, msg.sender, assets, received);
+    }
+
+    /// @notice Allow an asset to be deposited into new and existing Packs.
+    function addAsset(address asset) external onlyRole(WHITELIST_ADMIN_ROLE) {
+        if (asset == address(0)) revert ZeroAddress();
+        if (isWhitelisted[asset]) revert AlreadyWhitelisted(asset);
+
+        isWhitelisted[asset] = true;
+        _whitelist.push(asset);
+
+        emit AssetWhitelisted(asset);
+    }
+
+    /// @notice Stop an asset from being deposited into any Pack.
+    /// @dev Entry control only. Packs already holding `asset` keep it in their recorded basket
+    ///      and release it in full on redeem and unwrap, so removal can never strand capital.
+    function removeAsset(address asset) external onlyRole(WHITELIST_ADMIN_ROLE) {
+        if (!isWhitelisted[asset]) revert AssetNotWhitelisted(asset);
+
+        isWhitelisted[asset] = false;
+
+        uint256 length = _whitelist.length;
+        for (uint256 i; i < length; ++i) {
+            if (_whitelist[i] == asset) {
+                _whitelist[i] = _whitelist[length - 1];
+                _whitelist.pop();
+                break;
+            }
+        }
+
+        emit AssetRemovedFromWhitelist(asset);
     }
 
     /// @notice The full recorded basket of a Pack, in raw token units.

--- a/contracts/test/PackCustody.fuzz.t.sol
+++ b/contracts/test/PackCustody.fuzz.t.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {PackCustody} from "../src/PackCustody.sol";
+import {MockStockToken} from "./mocks/MockStockToken.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice Conservation over arbitrary baskets: whatever went in comes back out, across every
+///         combination of the whitelisted assets and their differing decimals.
+contract PackCustodyFuzzTest is PackCustodyFixture {
+    /// @dev Builds a basket from a bitmask over the whitelist, so every subset gets exercised.
+    function _maskedBasket(uint8 maskSeed, uint256 amountSeed)
+        internal
+        view
+        returns (address[] memory assets, uint256[] memory amounts)
+    {
+        uint256 mask = bound(uint256(maskSeed), 1, (1 << 5) - 1);
+
+        uint256 count;
+        for (uint256 i; i < 5; ++i) {
+            if (mask & (1 << i) != 0) ++count;
+        }
+
+        assets = new address[](count);
+        amounts = new uint256[](count);
+
+        uint256 cursor;
+        for (uint256 i; i < 5; ++i) {
+            if (mask & (1 << i) == 0) continue;
+
+            address asset = whitelist[i];
+            uint256 unit = 10 ** MockStockToken(asset).decimals();
+            uint256 raw = uint256(keccak256(abi.encode(amountSeed, i)));
+
+            assets[cursor] = asset;
+            // Bounded well below the funded balance so top-ups always have headroom.
+            amounts[cursor] = bound(raw, 1, 1000 * unit);
+            ++cursor;
+        }
+    }
+
+    function _balances(address who) internal view returns (uint256[5] memory out) {
+        for (uint256 i; i < 5; ++i) {
+            out[i] = MockStockToken(whitelist[i]).balanceOf(who);
+        }
+    }
+
+    function _assertBalances(address who, uint256[5] memory expected) internal view {
+        for (uint256 i; i < 5; ++i) {
+            assertEq(MockStockToken(whitelist[i]).balanceOf(who), expected[i]);
+        }
+    }
+
+    // ========== Deposit accounting ==========
+
+    function testFuzz_mintRecordsExactlyWhatCustodyReceived(uint8 maskSeed, uint256 amountSeed) public {
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
+        assertEq(basket.length, assets.length);
+
+        for (uint256 i; i < assets.length; ++i) {
+            assertEq(basket[i].asset, assets[i]);
+            assertEq(basket[i].amount, amounts[i]);
+            assertEq(MockStockToken(assets[i]).balanceOf(address(packs)), amounts[i]);
+        }
+    }
+
+    // ========== Round trips ==========
+
+    function testFuzz_mintThenRedeemIsABalanceNeutralRoundTrip(uint8 maskSeed, uint256 amountSeed) public {
+        uint256[5] memory start = _balances(creator);
+
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.startPrank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+        packs.delistAndRedeem(tokenId);
+        vm.stopPrank();
+
+        _assertBalances(creator, start);
+        for (uint256 i; i < 5; ++i) {
+            assertEq(MockStockToken(whitelist[i]).balanceOf(address(packs)), 0);
+        }
+    }
+
+    function testFuzz_mintTransferUnwrapMovesTheWholeBasketToTheHolder(uint8 maskSeed, uint256 amountSeed) public {
+        uint256[5] memory creatorStart = _balances(creator);
+        uint256[5] memory buyerStart = _balances(buyer);
+
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.startPrank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+        packs.transferFrom(creator, buyer, tokenId);
+        vm.stopPrank();
+
+        vm.prank(buyer);
+        packs.unwrap(tokenId);
+
+        // Every unit the creator spent arrives with the holder, and none is retained.
+        for (uint256 i; i < 5; ++i) {
+            address asset = whitelist[i];
+            uint256 spent = creatorStart[i] - MockStockToken(asset).balanceOf(creator);
+            uint256 gained = MockStockToken(asset).balanceOf(buyer) - buyerStart[i];
+
+            assertEq(gained, spent);
+            assertEq(MockStockToken(asset).balanceOf(address(packs)), 0);
+        }
+    }
+
+    function testFuzz_topUpsAccumulateAndRedeemReturnsTheTotal(
+        uint8 mintMask,
+        uint256 mintSeed,
+        uint8 topUpMask,
+        uint256 topUpSeed
+    ) public {
+        uint256[5] memory start = _balances(creator);
+
+        (address[] memory mintAssets, uint256[] memory mintAmounts) = _maskedBasket(mintMask, mintSeed);
+        (address[] memory addAssets, uint256[] memory addAmounts) = _maskedBasket(topUpMask, topUpSeed);
+
+        vm.startPrank(creator);
+        uint256 tokenId = packs.mint(mintAssets, mintAmounts);
+        packs.topUp(tokenId, addAssets, addAmounts);
+
+        // Every deposit is still recorded, summed per asset.
+        for (uint256 i; i < addAssets.length; ++i) {
+            uint256 expected = addAmounts[i];
+            for (uint256 j; j < mintAssets.length; ++j) {
+                if (mintAssets[j] == addAssets[i]) expected += mintAmounts[j];
+            }
+            assertEq(packs.basketAmountOf(tokenId, addAssets[i]), expected);
+        }
+
+        packs.delistAndRedeem(tokenId);
+        vm.stopPrank();
+
+        _assertBalances(creator, start);
+    }
+
+    function testFuzz_repeatedTopUpsNeverReduceARecordedAmount(uint8 maskSeed, uint256 amountSeed, uint8 rounds)
+        public
+    {
+        uint256 roundCount = bound(uint256(rounds), 1, 8);
+
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.startPrank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        uint256[] memory previous = new uint256[](assets.length);
+        for (uint256 i; i < assets.length; ++i) {
+            previous[i] = packs.basketAmountOf(tokenId, assets[i]);
+        }
+
+        for (uint256 round; round < roundCount; ++round) {
+            packs.topUp(tokenId, assets, amounts);
+
+            for (uint256 i; i < assets.length; ++i) {
+                uint256 current = packs.basketAmountOf(tokenId, assets[i]);
+                assertGe(current, previous[i]);
+                previous[i] = current;
+            }
+        }
+        vm.stopPrank();
+    }
+
+    // ========== Isolation ==========
+
+    function testFuzz_packsDoNotDrawOnEachOthersCustody(uint8 maskSeed, uint256 amountSeed) public {
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.prank(creator);
+        uint256 first = packs.mint(assets, amounts);
+
+        vm.prank(otherCreator);
+        uint256 second = packs.mint(assets, amounts);
+
+        uint256[5] memory otherStart = _balances(otherCreator);
+
+        vm.prank(creator);
+        packs.delistAndRedeem(first);
+
+        // Redeeming one Pack leaves the other's recorded basket and its backing intact.
+        for (uint256 i; i < assets.length; ++i) {
+            assertEq(packs.basketAmountOf(second, assets[i]), amounts[i]);
+            assertEq(MockStockToken(assets[i]).balanceOf(address(packs)), amounts[i]);
+        }
+
+        vm.prank(otherCreator);
+        packs.delistAndRedeem(second);
+
+        for (uint256 i; i < assets.length; ++i) {
+            assertEq(MockStockToken(assets[i]).balanceOf(address(packs)), 0);
+        }
+        for (uint256 i; i < 5; ++i) {
+            assertGe(MockStockToken(whitelist[i]).balanceOf(otherCreator), otherStart[i]);
+        }
+    }
+}

--- a/contracts/test/PackCustody.invariant.t.sol
+++ b/contracts/test/PackCustody.invariant.t.sol
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {MockStockToken} from "./mocks/MockStockToken.sol";
+
+/// @notice Drives every external Pack action through the public ABI and keeps an independent
+///         additions-only mirror of what each basket should hold.
+contract PackCustodyHandler is Test {
+    PackCustody public immutable PACKS;
+    address public immutable WHITELIST_ADMIN;
+
+    address[] public assets;
+    address[] public actors;
+
+    uint256[] public livePacks;
+    mapping(uint256 tokenId => uint256 index) internal _livePackIndex;
+    mapping(uint256 tokenId => bool live) internal _isLive;
+
+    /// @dev Cumulative units pulled into and paid out of custody, per asset.
+    mapping(address asset => uint256 amount) public ghostDeposited;
+    mapping(address asset => uint256 amount) public ghostReleased;
+
+    /// @dev What each live Pack should hold, built only ever by addition.
+    mapping(uint256 tokenId => mapping(address asset => uint256 amount)) public ghostBasket;
+    mapping(uint256 tokenId => address[] assets) internal _ghostPackAssets;
+
+    /// @dev Packs seen out of the pool, to prove unlisting never reverses.
+    mapping(uint256 tokenId => bool seen) public ghostSeenUnlisted;
+
+    uint256[] public terminatedPacks;
+
+    constructor(PackCustody packs_, address[] memory assets_, address whitelistAdmin_) {
+        PACKS = packs_;
+        WHITELIST_ADMIN = whitelistAdmin_;
+        assets = assets_;
+
+        actors.push(makeAddr("handlerActor0"));
+        actors.push(makeAddr("handlerActor1"));
+        actors.push(makeAddr("handlerActor2"));
+        actors.push(makeAddr("handlerActor3"));
+
+        for (uint256 a; a < actors.length; ++a) {
+            for (uint256 i; i < assets.length; ++i) {
+                MockStockToken token = MockStockToken(assets[i]);
+                token.mint(actors[a], 1_000_000_000 * (10 ** token.decimals()));
+
+                vm.prank(actors[a]);
+                token.approve(address(PACKS), type(uint256).max);
+            }
+        }
+    }
+
+    // ========== Actions ==========
+
+    function mintPack(uint256 actorSeed, uint256 maskSeed, uint256 amountSeed) external {
+        address actor = _actor(actorSeed);
+        (address[] memory picked, uint256[] memory amounts) = _pickDepositable(maskSeed, amountSeed);
+        if (picked.length == 0) return;
+
+        vm.prank(actor);
+        uint256 tokenId = PACKS.mint(picked, amounts);
+
+        _trackLive(tokenId);
+        _recordDeposits(tokenId, picked, amounts);
+    }
+
+    function topUpPack(uint256 packSeed, uint256 maskSeed, uint256 amountSeed) external {
+        if (livePacks.length == 0) return;
+        uint256 tokenId = livePacks[bound(packSeed, 0, livePacks.length - 1)];
+        if (!PACKS.isListed(tokenId)) return;
+
+        (address[] memory picked, uint256[] memory amounts) = _pickDepositable(maskSeed, amountSeed);
+        if (picked.length == 0) return;
+
+        vm.prank(PACKS.creatorOf(tokenId));
+        PACKS.topUp(tokenId, picked, amounts);
+
+        _recordDeposits(tokenId, picked, amounts);
+    }
+
+    function transferPack(uint256 packSeed, uint256 actorSeed) external {
+        if (livePacks.length == 0) return;
+        uint256 tokenId = livePacks[bound(packSeed, 0, livePacks.length - 1)];
+
+        address owner = PACKS.ownerOf(tokenId);
+        address to = _actor(actorSeed);
+        if (to == owner) return;
+
+        vm.prank(owner);
+        PACKS.transferFrom(owner, to, tokenId);
+    }
+
+    function redeemPack(uint256 packSeed) external {
+        if (livePacks.length == 0) return;
+        uint256 tokenId = livePacks[bound(packSeed, 0, livePacks.length - 1)];
+        if (!PACKS.isListed(tokenId)) return;
+
+        vm.prank(PACKS.creatorOf(tokenId));
+        PACKS.delistAndRedeem(tokenId);
+
+        _recordRelease(tokenId);
+    }
+
+    function unwrapPack(uint256 packSeed) external {
+        if (livePacks.length == 0) return;
+        uint256 tokenId = livePacks[bound(packSeed, 0, livePacks.length - 1)];
+        if (PACKS.isListed(tokenId)) return;
+
+        vm.prank(PACKS.ownerOf(tokenId));
+        PACKS.unwrap(tokenId);
+
+        _recordRelease(tokenId);
+    }
+
+    /// @dev Churns the whitelist under the lifecycle. At least two assets always stay
+    ///      depositable so minting keeps making progress.
+    function churnWhitelist(uint256 assetSeed) external {
+        address asset = assets[bound(assetSeed, 0, assets.length - 1)];
+
+        if (PACKS.isWhitelisted(asset)) {
+            if (PACKS.whitelistedAssets().length <= 2) return;
+            vm.prank(WHITELIST_ADMIN);
+            PACKS.removeAsset(asset);
+        } else {
+            vm.prank(WHITELIST_ADMIN);
+            PACKS.addAsset(asset);
+        }
+    }
+
+    /// @dev Observation step: the invariant layer uses this to prove unlisting is one way.
+    function observeListing() external {
+        for (uint256 i; i < livePacks.length; ++i) {
+            if (!PACKS.isListed(livePacks[i])) ghostSeenUnlisted[livePacks[i]] = true;
+        }
+    }
+
+    // ========== Views for the invariant layer ==========
+
+    function livePackCount() external view returns (uint256) {
+        return livePacks.length;
+    }
+
+    function terminatedPackCount() external view returns (uint256) {
+        return terminatedPacks.length;
+    }
+
+    function assetCount() external view returns (uint256) {
+        return assets.length;
+    }
+
+    function ghostPackAssets(uint256 tokenId) external view returns (address[] memory) {
+        return _ghostPackAssets[tokenId];
+    }
+
+    // ========== Internals ==========
+
+    function _actor(uint256 seed) internal view returns (address) {
+        return actors[bound(seed, 0, actors.length - 1)];
+    }
+
+    /// @dev Picks a non-empty, duplicate-free subset of the currently depositable assets.
+    function _pickDepositable(uint256 maskSeed, uint256 amountSeed)
+        internal
+        view
+        returns (address[] memory picked, uint256[] memory amounts)
+    {
+        address[] memory depositable = PACKS.whitelistedAssets();
+        if (depositable.length == 0) return (new address[](0), new uint256[](0));
+
+        uint256 mask = bound(maskSeed, 1, (1 << depositable.length) - 1);
+
+        uint256 count;
+        for (uint256 i; i < depositable.length; ++i) {
+            if (mask & (1 << i) != 0) ++count;
+        }
+
+        picked = new address[](count);
+        amounts = new uint256[](count);
+
+        uint256 cursor;
+        for (uint256 i; i < depositable.length; ++i) {
+            if (mask & (1 << i) == 0) continue;
+
+            uint256 unit = 10 ** MockStockToken(depositable[i]).decimals();
+            picked[cursor] = depositable[i];
+            amounts[cursor] = bound(uint256(keccak256(abi.encode(amountSeed, i))), 1, 1000 * unit);
+            ++cursor;
+        }
+    }
+
+    function _recordDeposits(uint256 tokenId, address[] memory picked, uint256[] memory amounts) internal {
+        for (uint256 i; i < picked.length; ++i) {
+            if (ghostBasket[tokenId][picked[i]] == 0) {
+                _ghostPackAssets[tokenId].push(picked[i]);
+            }
+            ghostBasket[tokenId][picked[i]] += amounts[i];
+            ghostDeposited[picked[i]] += amounts[i];
+        }
+    }
+
+    function _recordRelease(uint256 tokenId) internal {
+        address[] memory held = _ghostPackAssets[tokenId];
+        for (uint256 i; i < held.length; ++i) {
+            ghostReleased[held[i]] += ghostBasket[tokenId][held[i]];
+            delete ghostBasket[tokenId][held[i]];
+        }
+        delete _ghostPackAssets[tokenId];
+
+        _untrackLive(tokenId);
+        terminatedPacks.push(tokenId);
+    }
+
+    function _trackLive(uint256 tokenId) internal {
+        _livePackIndex[tokenId] = livePacks.length;
+        _isLive[tokenId] = true;
+        livePacks.push(tokenId);
+    }
+
+    function _untrackLive(uint256 tokenId) internal {
+        uint256 index = _livePackIndex[tokenId];
+        uint256 last = livePacks.length - 1;
+
+        if (index != last) {
+            uint256 moved = livePacks[last];
+            livePacks[index] = moved;
+            _livePackIndex[moved] = index;
+        }
+
+        livePacks.pop();
+        delete _livePackIndex[tokenId];
+        _isLive[tokenId] = false;
+    }
+}
+
+/// @notice The PRD's custody invariants, encoded directly.
+contract PackCustodyInvariantTest is StdInvariant, Test {
+    PackCustody internal packs;
+    PackCustodyHandler internal handler;
+
+    address internal admin = makeAddr("admin");
+    address internal whitelistAdmin = makeAddr("whitelistAdmin");
+
+    address[] internal assets;
+
+    function setUp() public {
+        assets.push(address(new MockStockToken("Amazon Test Stock", "tAMZN", 18)));
+        assets.push(address(new MockStockToken("AMD Test Stock", "tAMD", 18)));
+        assets.push(address(new MockStockToken("Netflix Test Stock", "tNFLX", 8)));
+        assets.push(address(new MockStockToken("Palantir Test Stock", "tPLTR", 6)));
+        assets.push(address(new MockStockToken("Tesla Test Stock", "tTSLA", 18)));
+
+        packs = new PackCustody(admin, assets);
+
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, whitelistAdmin);
+
+        handler = new PackCustodyHandler(packs, assets, whitelistAdmin);
+
+        bytes4[] memory selectors = new bytes4[](7);
+        selectors[0] = PackCustodyHandler.mintPack.selector;
+        selectors[1] = PackCustodyHandler.topUpPack.selector;
+        selectors[2] = PackCustodyHandler.transferPack.selector;
+        selectors[3] = PackCustodyHandler.redeemPack.selector;
+        selectors[4] = PackCustodyHandler.unwrapPack.selector;
+        selectors[5] = PackCustodyHandler.churnWhitelist.selector;
+        selectors[6] = PackCustodyHandler.observeListing.selector;
+
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+        targetContract(address(handler));
+    }
+
+    /// @notice Every asset custody holds is backed by a live Pack's recorded basket, and every
+    ///         recorded unit is actually held. Packs are fully backed and never over-credited.
+    function invariant_custodyMatchesTheSumOfRecordedBaskets() public view {
+        uint256 packCount = handler.livePackCount();
+
+        for (uint256 a; a < assets.length; ++a) {
+            uint256 recorded;
+            for (uint256 p; p < packCount; ++p) {
+                recorded += packs.basketAmountOf(handler.livePacks(p), assets[a]);
+            }
+
+            assertEq(MockStockToken(assets[a]).balanceOf(address(packs)), recorded);
+        }
+    }
+
+    /// @notice Nothing is skimmed: what came in, minus what went out, is exactly what is held.
+    ///         A protocol fee on any path would break this.
+    function invariant_depositsMinusReleasesEqualCustody() public view {
+        for (uint256 a; a < assets.length; ++a) {
+            uint256 deposited = handler.ghostDeposited(assets[a]);
+            uint256 released = handler.ghostReleased(assets[a]);
+
+            assertEq(MockStockToken(assets[a]).balanceOf(address(packs)), deposited - released);
+        }
+    }
+
+    /// @notice Recorded baskets equal an independently maintained additions-only mirror, so no
+    ///         path ever reduces a live Pack's holdings.
+    function invariant_basketsAreAdditionsOnly() public view {
+        uint256 packCount = handler.livePackCount();
+
+        for (uint256 p; p < packCount; ++p) {
+            uint256 tokenId = handler.livePacks(p);
+            address[] memory held = handler.ghostPackAssets(tokenId);
+
+            assertEq(packs.basketOf(tokenId).length, held.length);
+
+            for (uint256 i; i < held.length; ++i) {
+                assertEq(packs.basketAmountOf(tokenId, held[i]), handler.ghostBasket(tokenId, held[i]));
+            }
+        }
+    }
+
+    /// @notice A redeemed or unwrapped Pack keeps nothing behind.
+    function invariant_terminatedPacksAreFullyCleared() public view {
+        uint256 count = handler.terminatedPackCount();
+
+        for (uint256 i; i < count; ++i) {
+            uint256 tokenId = handler.terminatedPacks(i);
+
+            assertEq(packs.basketOf(tokenId).length, 0);
+            assertEq(packs.creatorOf(tokenId), address(0));
+            assertFalse(packs.isListed(tokenId));
+        }
+    }
+
+    /// @notice A listed Pack is always still held by its creator, which is what makes
+    ///         creator-only top-up and delist safe to gate on listing alone.
+    function invariant_listedPacksAreHeldByTheirCreator() public view {
+        uint256 packCount = handler.livePackCount();
+
+        for (uint256 p; p < packCount; ++p) {
+            uint256 tokenId = handler.livePacks(p);
+            if (!packs.isListed(tokenId)) continue;
+
+            assertEq(packs.ownerOf(tokenId), packs.creatorOf(tokenId));
+        }
+    }
+
+    /// @notice Leaving the pool is one way — no Pack ever reports itself listed again.
+    function invariant_unlistingNeverReverses() public view {
+        uint256 packCount = handler.livePackCount();
+
+        for (uint256 p; p < packCount; ++p) {
+            uint256 tokenId = handler.livePacks(p);
+            if (handler.ghostSeenUnlisted(tokenId)) {
+                assertFalse(packs.isListed(tokenId));
+            }
+        }
+    }
+
+    /// @notice Custody never holds an asset that was not depositable when it arrived, whatever
+    ///         the whitelist says now.
+    function invariant_onlyDepositedAssetsAreRecorded() public view {
+        uint256 packCount = handler.livePackCount();
+
+        for (uint256 p; p < packCount; ++p) {
+            address[] memory recorded = packs.basketAssetsOf(handler.livePacks(p));
+
+            for (uint256 i; i < recorded.length; ++i) {
+                bool known;
+                for (uint256 a; a < assets.length; ++a) {
+                    if (recorded[i] == assets[a]) known = true;
+                }
+                assertTrue(known);
+            }
+        }
+    }
+}

--- a/contracts/test/PackCustody.lifecycle.t.sol
+++ b/contracts/test/PackCustody.lifecycle.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice The two journeys a Pack can take, driven end to end through the external ABI and
+///         asserted only on what an explorer or a `cast` user could see.
+contract PackCustodyLifecycleTest is PackCustodyFixture {
+    // ========== mint -> top-up -> redeem ==========
+
+    function test_lifecycleMintTopUpRedeem() public {
+        uint256 amznStart = amzn.balanceOf(creator);
+        uint256 nflxStart = nflx.balanceOf(creator);
+        uint256 pltrStart = pltr.balanceOf(creator);
+        uint256 tslaStart = tsla.balanceOf(creator);
+
+        // Mint a fully funded Pack.
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        assertEq(packs.ownerOf(tokenId), creator);
+        assertTrue(packs.isListed(tokenId));
+        assertEq(packs.basketOf(tokenId).length, 3);
+        assertEq(amzn.balanceOf(creator), amznStart - 2e18);
+
+        // Top up: one existing asset, one new one.
+        (address[] memory addAssets, uint256[] memory addAmounts) = _pair(address(amzn), 4e18, address(tsla), 9e18);
+        vm.prank(creator);
+        packs.topUp(tokenId, addAssets, addAmounts);
+
+        assertEq(packs.basketOf(tokenId).length, 4);
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 6e18);
+        assertEq(packs.basketAmountOf(tokenId, address(tsla)), 9e18);
+        assertTrue(packs.isListed(tokenId));
+
+        // Delist and redeem: everything comes back, nothing is skimmed.
+        vm.prank(creator);
+        packs.delistAndRedeem(tokenId);
+
+        assertEq(amzn.balanceOf(creator), amznStart);
+        assertEq(nflx.balanceOf(creator), nflxStart);
+        assertEq(pltr.balanceOf(creator), pltrStart);
+        assertEq(tsla.balanceOf(creator), tslaStart);
+
+        assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(tsla.balanceOf(address(packs)), 0);
+
+        assertFalse(packs.isListed(tokenId));
+        assertEq(packs.basketOf(tokenId).length, 0);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, tokenId));
+        packs.ownerOf(tokenId);
+    }
+
+    // ========== mint -> transfer -> unwrap ==========
+
+    function test_lifecycleMintTransferUnwrap() public {
+        uint256 creatorAmznStart = amzn.balanceOf(creator);
+        uint256 buyerAmznStart = amzn.balanceOf(buyer);
+        uint256 buyerNflxStart = nflx.balanceOf(buyer);
+        uint256 buyerPltrStart = pltr.balanceOf(buyer);
+
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        // Settlement moves the Pack to its new holder; the basket follows the token.
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, tokenId);
+
+        assertEq(packs.ownerOf(tokenId), buyer);
+        assertFalse(packs.isListed(tokenId));
+        assertEq(packs.basketOf(tokenId).length, 3);
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 2e18);
+
+        // The creator keeps the assets they spent; they do not come back.
+        assertEq(amzn.balanceOf(creator), creatorAmznStart - 2e18);
+
+        // The holder unwraps the full recorded basket, at zero fee.
+        vm.prank(buyer);
+        packs.unwrap(tokenId);
+
+        assertEq(amzn.balanceOf(buyer), buyerAmznStart + 2e18);
+        assertEq(nflx.balanceOf(buyer), buyerNflxStart + 5e8);
+        assertEq(pltr.balanceOf(buyer), buyerPltrStart + 7e6);
+
+        assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(packs.basketOf(tokenId).length, 0);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, tokenId));
+        packs.ownerOf(tokenId);
+    }
+
+    // ========== Concurrent Packs ==========
+
+    function test_manyPacksMoveThroughBothPathsWithoutInterference() public {
+        uint256 keptPack = _mintDefaultPack(creator);
+        uint256 redeemedPack = _mintDefaultPack(creator);
+        uint256 soldPack = _mintDefaultPack(otherCreator);
+
+        assertEq(amzn.balanceOf(address(packs)), 6e18);
+
+        vm.prank(creator);
+        packs.delistAndRedeem(redeemedPack);
+
+        vm.prank(otherCreator);
+        packs.transferFrom(otherCreator, buyer, soldPack);
+
+        vm.prank(buyer);
+        packs.unwrap(soldPack);
+
+        // Only the untouched Pack's assets remain in custody.
+        assertEq(amzn.balanceOf(address(packs)), 2e18);
+        assertEq(nflx.balanceOf(address(packs)), 5e8);
+        assertEq(pltr.balanceOf(address(packs)), 7e6);
+
+        assertTrue(packs.isListed(keptPack));
+        assertEq(packs.basketAmountOf(keptPack, address(amzn)), 2e18);
+        assertEq(packs.balanceOf(creator), 1);
+    }
+}

--- a/contracts/test/PackCustody.mint.t.sol
+++ b/contracts/test/PackCustody.mint.t.sol
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {MockStockToken} from "./mocks/MockStockToken.sol";
+import {MockFeeOnTransferToken} from "./mocks/MockFeeOnTransferToken.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+contract PackCustodyMintTest is PackCustodyFixture {
+    event PackMinted(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+
+    // ========== Construction ==========
+
+    function test_constructorRecordsWhitelist() public view {
+        address[] memory listed = packs.whitelistedAssets();
+
+        assertEq(listed.length, 5);
+        assertEq(listed[0], address(amzn));
+        assertEq(listed[4], address(tsla));
+
+        assertTrue(packs.isWhitelisted(address(amzn)));
+        assertTrue(packs.isWhitelisted(address(tsla)));
+        assertFalse(packs.isWhitelisted(address(offList)));
+    }
+
+    function test_constructorGrantsAdminRoleOnly() public view {
+        assertTrue(packs.hasRole(packs.DEFAULT_ADMIN_ROLE(), admin));
+        assertFalse(packs.hasRole(packs.WHITELIST_ADMIN_ROLE(), admin));
+    }
+
+    function test_constructorRejectsZeroAdmin() public {
+        vm.expectRevert(PackCustody.ZeroAddress.selector);
+        new PackCustody(address(0), whitelist);
+    }
+
+    function test_constructorRejectsEmptyWhitelist() public {
+        vm.expectRevert(PackCustody.EmptyWhitelist.selector);
+        new PackCustody(admin, new address[](0));
+    }
+
+    function test_constructorRejectsZeroAsset() public {
+        address[] memory bad = new address[](1);
+        vm.expectRevert(PackCustody.ZeroAddress.selector);
+        new PackCustody(admin, bad);
+    }
+
+    function test_constructorRejectsDuplicateAsset() public {
+        address[] memory bad = new address[](2);
+        bad[0] = address(amzn);
+        bad[1] = address(amzn);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AlreadyWhitelisted.selector, address(amzn)));
+        new PackCustody(admin, bad);
+    }
+
+    function test_supportsErc721AndAccessControlInterfaces() public view {
+        assertTrue(packs.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(packs.supportsInterface(type(IERC721).interfaceId));
+        assertTrue(packs.supportsInterface(type(IAccessControl).interfaceId));
+    }
+
+    // ========== Minting ==========
+
+    function test_mintRecordsFullBasket() public {
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
+        assertEq(basket.length, 3);
+        assertEq(basket[0].asset, address(amzn));
+        assertEq(basket[0].amount, 2e18);
+        assertEq(basket[1].asset, address(nflx));
+        assertEq(basket[1].amount, 5e8);
+        assertEq(basket[2].asset, address(pltr));
+        assertEq(basket[2].amount, 7e6);
+    }
+
+    function test_mintTransfersBasketIntoCustody() public {
+        uint256 creatorBefore = amzn.balanceOf(creator);
+
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+
+        assertEq(amzn.balanceOf(address(packs)), 2e18);
+        assertEq(nflx.balanceOf(address(packs)), 5e8);
+        assertEq(pltr.balanceOf(address(packs)), 7e6);
+        assertEq(amzn.balanceOf(creator), creatorBefore - 2e18);
+    }
+
+    function test_mintAssignsOwnershipAndCreator() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        assertEq(packs.ownerOf(tokenId), creator);
+        assertEq(packs.creatorOf(tokenId), creator);
+        assertEq(packs.balanceOf(creator), 1);
+    }
+
+    function test_mintAssignsSequentialTokenIdsFromOne() public {
+        uint256 first = _mintDefaultPack(creator);
+        uint256 second = _mintDefaultPack(otherCreator);
+
+        assertEq(first, 1);
+        assertEq(second, 2);
+        assertEq(packs.totalMinted(), 2);
+    }
+
+    function test_mintEmitsPackMintedWithReceivedAmounts() public {
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+
+        vm.expectEmit(true, true, false, true, address(packs));
+        emit PackMinted(1, creator, assets, amounts);
+
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintAcceptsSingleAssetBasket() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(tsla), 3e18);
+
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
+        assertEq(basket.length, 1);
+        assertEq(basket[0].asset, address(tsla));
+        assertEq(basket[0].amount, 3e18);
+    }
+
+    function test_mintAcceptsFullWhitelistBasket() public {
+        address[] memory assets = new address[](5);
+        uint256[] memory amounts = new uint256[](5);
+        for (uint256 i; i < whitelist.length; ++i) {
+            assets[i] = whitelist[i];
+            amounts[i] = 10 ** MockStockToken(whitelist[i]).decimals();
+        }
+
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        assertEq(packs.basketOf(tokenId).length, 5);
+    }
+
+    function test_separatePacksAccountSeparately() public {
+        uint256 first = _mintDefaultPack(creator);
+        uint256 second = _mintDefaultPack(otherCreator);
+
+        assertEq(packs.basketAmountOf(first, address(amzn)), 2e18);
+        assertEq(packs.basketAmountOf(second, address(amzn)), 2e18);
+        assertEq(amzn.balanceOf(address(packs)), 4e18);
+    }
+
+    // ========== Minting: rejections ==========
+
+    function test_mintRevertsOnEmptyBasket() public {
+        vm.expectRevert(PackCustody.EmptyBasket.selector);
+        vm.prank(creator);
+        packs.mint(new address[](0), new uint256[](0));
+    }
+
+    function test_mintRevertsOnLengthMismatch() public {
+        address[] memory assets = new address[](2);
+        assets[0] = address(amzn);
+        assets[1] = address(nflx);
+
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1e18;
+
+        vm.expectRevert(PackCustody.LengthMismatch.selector);
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintRevertsOnNonWhitelistedAsset() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(offList), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(offList)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintRevertsWhenAnyAssetIsNotWhitelisted() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(offList), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(offList)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintRevertsOnZeroAmount() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(nflx), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.ZeroAmount.selector, address(nflx)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintRevertsOnDuplicateAsset() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(amzn), 2e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.DuplicateAsset.selector, address(amzn)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintRevertsWithoutApproval() public {
+        address unapproved = makeAddr("unapproved");
+        amzn.mint(unapproved, 5e18);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(packs), 0, 1e18)
+        );
+        vm.prank(unapproved);
+        packs.mint(assets, amounts);
+    }
+
+    function test_mintRevertsOnInsufficientBalance() public {
+        address broke = makeAddr("broke");
+        vm.prank(broke);
+        amzn.approve(address(packs), type(uint256).max);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(IERC20Errors.ERC20InsufficientBalance.selector, broke, 0, 1e18));
+        vm.prank(broke);
+        packs.mint(assets, amounts);
+    }
+
+    function test_failedMintLeavesNoCustodyOrToken() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(offList), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(offList)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+
+        assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(packs.totalMinted(), 0);
+        assertEq(packs.balanceOf(creator), 0);
+    }
+
+    // ========== Balance-delta accounting ==========
+
+    function test_mintRecordsAmountActuallyReceivedForFeeOnTransferAsset() public {
+        MockFeeOnTransferToken skimmed =
+            new MockFeeOnTransferToken("Skimmed Test Stock", "tSKIM", 100, makeAddr("feeSink"));
+
+        address[] memory list = new address[](1);
+        list[0] = address(skimmed);
+        PackCustody skimPacks = new PackCustody(admin, list);
+
+        skimmed.mint(creator, 1000e18);
+        vm.prank(creator);
+        skimmed.approve(address(skimPacks), type(uint256).max);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(skimmed), 100e18);
+        vm.prank(creator);
+        uint256 tokenId = skimPacks.mint(assets, amounts);
+
+        // 1% skim: custody received 99, and the recorded basket says 99 rather than 100.
+        assertEq(skimmed.balanceOf(address(skimPacks)), 99e18);
+        assertEq(skimPacks.basketAmountOf(tokenId, address(skimmed)), 99e18);
+    }
+
+    function test_mintRevertsWhenNothingIsReceived() public {
+        MockFeeOnTransferToken confiscatory =
+            new MockFeeOnTransferToken("Confiscatory", "tGONE", 10_000, makeAddr("feeSink"));
+
+        address[] memory list = new address[](1);
+        list[0] = address(confiscatory);
+        PackCustody gonePacks = new PackCustody(admin, list);
+
+        confiscatory.mint(creator, 1000e18);
+        vm.prank(creator);
+        confiscatory.approve(address(gonePacks), type(uint256).max);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(confiscatory), 100e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NoAssetsReceived.selector, address(confiscatory)));
+        vm.prank(creator);
+        gonePacks.mint(assets, amounts);
+    }
+
+    function test_donatedAssetsAreNotRecordedInAnyBasket() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        vm.prank(stranger);
+        amzn.transfer(address(packs), 500e18);
+
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 2e18);
+        assertGt(amzn.balanceOf(address(packs)), packs.basketAmountOf(tokenId, address(amzn)));
+    }
+
+    // ========== Views ==========
+
+    function test_basketOfUnknownPackIsEmpty() public view {
+        assertEq(packs.basketOf(999).length, 0);
+        assertEq(packs.basketAssetsOf(999).length, 0);
+        assertEq(packs.basketAmountOf(999, address(amzn)), 0);
+    }
+
+    function test_basketAssetsOfListsDistinctAssetsInDepositOrder() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        address[] memory assets = packs.basketAssetsOf(tokenId);
+        assertEq(assets.length, 3);
+        assertEq(assets[0], address(amzn));
+        assertEq(assets[1], address(nflx));
+        assertEq(assets[2], address(pltr));
+    }
+}

--- a/contracts/test/PackCustody.redeem.t.sol
+++ b/contracts/test/PackCustody.redeem.t.sol
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {MockReentrantToken} from "./mocks/MockReentrantToken.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice Delist-and-redeem is the creator's exit. It returns everything and charges nothing.
+contract PackCustodyRedeemTest is PackCustodyFixture {
+    event PackRedeemed(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+
+    uint256 internal packId;
+
+    function setUp() public override {
+        super.setUp();
+        packId = _mintDefaultPack(creator);
+    }
+
+    // ========== Redemption ==========
+
+    function test_redeemReturnsTheEntireBasketWithNoDeduction() public {
+        uint256 amznBefore = amzn.balanceOf(creator);
+        uint256 nflxBefore = nflx.balanceOf(creator);
+        uint256 pltrBefore = pltr.balanceOf(creator);
+
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(amzn.balanceOf(creator), amznBefore + 2e18);
+        assertEq(nflx.balanceOf(creator), nflxBefore + 5e8);
+        assertEq(pltr.balanceOf(creator), pltrBefore + 7e6);
+    }
+
+    function test_redeemRestoresTheCreatorsPreMintBalancesExactly() public {
+        uint256 amznBefore = amzn.balanceOf(otherCreator);
+        uint256 nflxBefore = nflx.balanceOf(otherCreator);
+
+        uint256 tokenId = _mintDefaultPack(otherCreator);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 11e18);
+        vm.startPrank(otherCreator);
+        packs.topUp(tokenId, assets, amounts);
+        packs.delistAndRedeem(tokenId);
+        vm.stopPrank();
+
+        assertEq(amzn.balanceOf(otherCreator), amznBefore);
+        assertEq(nflx.balanceOf(otherCreator), nflxBefore);
+    }
+
+    function test_redeemDrainsCustodyForThatPack() public {
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(nflx.balanceOf(address(packs)), 0);
+        assertEq(pltr.balanceOf(address(packs)), 0);
+    }
+
+    function test_redeemBurnsThePack() public {
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, packId));
+        packs.ownerOf(packId);
+
+        assertEq(packs.balanceOf(creator), 0);
+        assertFalse(packs.isListed(packId));
+    }
+
+    function test_redeemClearsTheRecordedBasket() public {
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(packs.basketOf(packId).length, 0);
+        assertEq(packs.basketAssetsOf(packId).length, 0);
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 0);
+        assertEq(packs.creatorOf(packId), address(0));
+    }
+
+    function test_redeemIncludesToppedUpAssets() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(tsla), 4e18);
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        uint256 amznBefore = amzn.balanceOf(creator);
+        uint256 tslaBefore = tsla.balanceOf(creator);
+
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(amzn.balanceOf(creator), amznBefore + 3e18);
+        assertEq(tsla.balanceOf(creator), tslaBefore + 4e18);
+    }
+
+    function test_redeemEmitsPackRedeemedWithTheFullBasket() public {
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+
+        vm.expectEmit(true, true, false, true, address(packs));
+        emit PackRedeemed(packId, creator, assets, amounts);
+
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+    }
+
+    function test_redeemLeavesOtherPacksUntouched() public {
+        uint256 otherPack = _mintDefaultPack(otherCreator);
+
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(packs.basketAmountOf(otherPack, address(amzn)), 2e18);
+        assertEq(amzn.balanceOf(address(packs)), 2e18);
+        assertTrue(packs.isListed(otherPack));
+    }
+
+    function test_redeemedTokenIdIsNeverReused() public {
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        uint256 next = _mintDefaultPack(creator);
+        assertGt(next, packId);
+    }
+
+    // ========== Authorization ==========
+
+    function test_nonCreatorCannotRedeem() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackCreator.selector, packId, stranger));
+        vm.prank(stranger);
+        packs.delistAndRedeem(packId);
+    }
+
+    function test_approvedOperatorCannotRedeem() public {
+        vm.prank(creator);
+        packs.approve(stranger, packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackCreator.selector, packId, stranger));
+        vm.prank(stranger);
+        packs.delistAndRedeem(packId);
+    }
+
+    function test_creatorCannotRedeemAfterTransfer() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+    }
+
+    function test_newHolderCannotRedeem() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(buyer);
+        packs.delistAndRedeem(packId);
+    }
+
+    function test_redeemRevertsOnUnknownPack() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, 999));
+        vm.prank(creator);
+        packs.delistAndRedeem(999);
+    }
+
+    function test_redeemCannotRunTwice() public {
+        vm.startPrank(creator);
+        packs.delistAndRedeem(packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        packs.delistAndRedeem(packId);
+        vm.stopPrank();
+    }
+
+    function test_toppingUpAfterRedeemReverts() public {
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    // ========== Whitelist independence ==========
+
+    function test_deWhitelistedAssetIsStillRedeemedInFull() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+        vm.startPrank(admin);
+        packs.grantRole(role, admin);
+        packs.removeAsset(address(nflx));
+        vm.stopPrank();
+
+        assertFalse(packs.isWhitelisted(address(nflx)));
+
+        uint256 nflxBefore = nflx.balanceOf(creator);
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(nflx.balanceOf(creator), nflxBefore + 5e8);
+    }
+
+    function test_redeemWorksWithAnEmptiedWhitelist() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+        vm.startPrank(admin);
+        packs.grantRole(role, admin);
+        for (uint256 i; i < whitelist.length; ++i) {
+            packs.removeAsset(whitelist[i]);
+        }
+        vm.stopPrank();
+
+        uint256 amznBefore = amzn.balanceOf(creator);
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        assertEq(amzn.balanceOf(creator), amznBefore + 2e18);
+        assertEq(amzn.balanceOf(address(packs)), 0);
+    }
+
+    // ========== Reentrancy ==========
+
+    function test_redeemRejectsReentrancyFromAHostileAsset() public {
+        MockReentrantToken hostile = new MockReentrantToken("Hostile", "tEVIL");
+
+        address[] memory list = new address[](1);
+        list[0] = address(hostile);
+        PackCustody hostilePacks = new PackCustody(admin, list);
+
+        hostile.mint(creator, 100e18);
+        vm.prank(creator);
+        hostile.approve(address(hostilePacks), type(uint256).max);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(hostile), 10e18);
+        vm.prank(creator);
+        uint256 tokenId = hostilePacks.mint(assets, amounts);
+
+        hostile.arm(address(hostilePacks), abi.encodeCall(PackCustody.delistAndRedeem, (tokenId)));
+
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        vm.prank(creator);
+        hostilePacks.delistAndRedeem(tokenId);
+
+        // The whole attempt reverted, so the Pack and its basket are exactly as they were.
+        assertEq(hostilePacks.ownerOf(tokenId), creator);
+        assertEq(hostilePacks.basketAmountOf(tokenId, address(hostile)), 10e18);
+        assertEq(hostile.balanceOf(address(hostilePacks)), 10e18);
+    }
+}

--- a/contracts/test/PackCustody.topUp.t.sol
+++ b/contracts/test/PackCustody.topUp.t.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {PackCustody} from "../src/PackCustody.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice Top-ups are the only way assets enter a Pack after mint, and they only ever add.
+contract PackCustodyTopUpTest is PackCustodyFixture {
+    event PackToppedUp(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
+    event PackUnlisted(uint256 indexed tokenId);
+
+    uint256 internal packId;
+
+    function setUp() public override {
+        super.setUp();
+        packId = _mintDefaultPack(creator);
+    }
+
+    // ========== Additions ==========
+
+    function test_topUpIncrementsAnExistingAsset() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 3e18);
+
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 5e18);
+        assertEq(packs.basketOf(packId).length, 3);
+    }
+
+    function test_topUpAddsANewAsset() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(tsla), 8e18);
+
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(packs.basketAmountOf(packId, address(tsla)), 8e18);
+        assertEq(packs.basketOf(packId).length, 4);
+        assertEq(packs.basketAssetsOf(packId)[3], address(tsla));
+    }
+
+    function test_topUpMovesAssetsIntoCustody() public {
+        uint256 custodyBefore = amzn.balanceOf(address(packs));
+        uint256 creatorBefore = amzn.balanceOf(creator);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 3e18);
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(amzn.balanceOf(address(packs)), custodyBefore + 3e18);
+        assertEq(amzn.balanceOf(creator), creatorBefore - 3e18);
+    }
+
+    function test_topUpHandlesMixedNewAndExistingAssets() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(pltr), 1e6, address(tsla), 2e18);
+
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(packs.basketAmountOf(packId, address(pltr)), 8e6);
+        assertEq(packs.basketAmountOf(packId, address(tsla)), 2e18);
+        assertEq(packs.basketOf(packId).length, 4);
+    }
+
+    function test_repeatedTopUpsAccumulate() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.startPrank(creator);
+        packs.topUp(packId, assets, amounts);
+        packs.topUp(packId, assets, amounts);
+        packs.topUp(packId, assets, amounts);
+        vm.stopPrank();
+
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 5e18);
+    }
+
+    function test_topUpEmitsPackToppedUpWithReceivedAmounts() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 3e18);
+
+        vm.expectEmit(true, true, false, true, address(packs));
+        emit PackToppedUp(packId, creator, assets, amounts);
+
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_topUpDoesNotAffectOtherPacks() public {
+        uint256 otherPack = _mintDefaultPack(otherCreator);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 3e18);
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(packs.basketAmountOf(otherPack, address(amzn)), 2e18);
+    }
+
+    // ========== Authorization ==========
+
+    function test_nonCreatorCannotTopUp() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackCreator.selector, packId, stranger));
+        vm.prank(stranger);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_otherCreatorCannotTopUpSomeoneElsesPack() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackCreator.selector, packId, otherCreator));
+        vm.prank(otherCreator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_approvedOperatorCannotTopUp() public {
+        vm.prank(creator);
+        packs.approve(stranger, packId);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackCreator.selector, packId, stranger));
+        vm.prank(stranger);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    // ========== Listing ==========
+
+    function test_mintedPackIsListed() public view {
+        assertTrue(packs.isListed(packId));
+    }
+
+    function test_unknownPackIsNotListed() public view {
+        assertFalse(packs.isListed(999));
+    }
+
+    function test_transferUnlistsThePack() public {
+        vm.expectEmit(true, false, false, false, address(packs));
+        emit PackUnlisted(packId);
+
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        assertFalse(packs.isListed(packId));
+    }
+
+    function test_creatorCannotTopUpAfterTransfer() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_newHolderCannotTopUp() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(buyer);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_unlistingIsOneWayEvenIfTheCreatorBuysItBack() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        vm.prank(buyer);
+        packs.transferFrom(buyer, creator, packId);
+
+        assertEq(packs.ownerOf(packId), creator);
+        assertFalse(packs.isListed(packId));
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_selfTransferDoesNotUnlist() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, creator, packId);
+
+        assertTrue(packs.isListed(packId));
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 3e18);
+    }
+
+    function test_topUpRevertsForUnknownPack() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, 999));
+        vm.prank(creator);
+        packs.topUp(999, assets, amounts);
+    }
+
+    // ========== Deposit rules ==========
+
+    function test_topUpRevertsOnNonWhitelistedAsset() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(offList), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(offList)));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_topUpRevertsOnDeWhitelistedAsset() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, admin);
+        vm.prank(admin);
+        packs.removeAsset(address(amzn));
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(amzn)));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_topUpRevertsOnZeroAmount() public {
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.ZeroAmount.selector, address(amzn)));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_topUpRevertsOnEmptyBasket() public {
+        vm.expectRevert(PackCustody.EmptyBasket.selector);
+        vm.prank(creator);
+        packs.topUp(packId, new address[](0), new uint256[](0));
+    }
+
+    function test_topUpRevertsOnLengthMismatch() public {
+        address[] memory assets = new address[](2);
+        assets[0] = address(amzn);
+        assets[1] = address(tsla);
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1e18;
+
+        vm.expectRevert(PackCustody.LengthMismatch.selector);
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_topUpRevertsOnDuplicateAsset() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(amzn), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.DuplicateAsset.selector, address(amzn)));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+
+    function test_failedTopUpLeavesTheBasketUnchanged() public {
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(offList), 1e18);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(offList)));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 2e18);
+        assertEq(amzn.balanceOf(address(packs)), 2e18);
+        assertEq(packs.basketOf(packId).length, 3);
+    }
+
+    // ========== Additions only ==========
+
+    function test_noExternalFunctionRemovesAssetsFromAListedPack() public {
+        // The full external surface for a listed Pack is mint, top-up, and whitelist
+        // administration; none of them can reduce a recorded amount.
+        uint256 before = packs.basketAmountOf(packId, address(amzn));
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+
+        assertGt(packs.basketAmountOf(packId, address(amzn)), before);
+    }
+}

--- a/contracts/test/PackCustody.unwrap.t.sol
+++ b/contracts/test/PackCustody.unwrap.t.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {MockReentrantToken} from "./mocks/MockReentrantToken.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice Unwrap is the holder's exit once a Pack has left its creator — the disclosed right
+///         that makes a ripped or purchased Pack worth holding.
+contract PackCustodyUnwrapTest is PackCustodyFixture {
+    event PackUnwrapped(uint256 indexed tokenId, address indexed holder, address[] assets, uint256[] amounts);
+
+    uint256 internal packId;
+
+    function setUp() public override {
+        super.setUp();
+        packId = _mintDefaultPack(creator);
+
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+    }
+
+    // ========== Unwrapping ==========
+
+    function test_holderReceivesTheEntireBasketWithNoDeduction() public {
+        uint256 amznBefore = amzn.balanceOf(buyer);
+        uint256 nflxBefore = nflx.balanceOf(buyer);
+        uint256 pltrBefore = pltr.balanceOf(buyer);
+
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        assertEq(amzn.balanceOf(buyer), amznBefore + 2e18);
+        assertEq(nflx.balanceOf(buyer), nflxBefore + 5e8);
+        assertEq(pltr.balanceOf(buyer), pltrBefore + 7e6);
+    }
+
+    function test_unwrapDrainsCustodyForThatPack() public {
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(nflx.balanceOf(address(packs)), 0);
+        assertEq(pltr.balanceOf(address(packs)), 0);
+    }
+
+    function test_unwrapBurnsThePackAndClearsTheBasket() public {
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, packId));
+        packs.ownerOf(packId);
+
+        assertEq(packs.basketOf(packId).length, 0);
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 0);
+        assertEq(packs.creatorOf(packId), address(0));
+    }
+
+    function test_unwrapEmitsPackUnwrappedWithTheFullBasket() public {
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+
+        vm.expectEmit(true, true, false, true, address(packs));
+        emit PackUnwrapped(packId, buyer, assets, amounts);
+
+        vm.prank(buyer);
+        packs.unwrap(packId);
+    }
+
+    function test_unwrapIncludesAssetsToppedUpBeforeTransfer() public {
+        uint256 freshPack = _mintDefaultPack(creator);
+
+        (address[] memory assets, uint256[] memory amounts) = _pair(address(amzn), 1e18, address(tsla), 6e18);
+        vm.startPrank(creator);
+        packs.topUp(freshPack, assets, amounts);
+        packs.transferFrom(creator, buyer, freshPack);
+        vm.stopPrank();
+
+        uint256 amznBefore = amzn.balanceOf(buyer);
+        uint256 tslaBefore = tsla.balanceOf(buyer);
+
+        vm.prank(buyer);
+        packs.unwrap(freshPack);
+
+        assertEq(amzn.balanceOf(buyer), amznBefore + 3e18);
+        assertEq(tsla.balanceOf(buyer), tslaBefore + 6e18);
+    }
+
+    function test_onlyTheCurrentHolderUnwrapsAfterAChainOfTransfers() public {
+        vm.prank(buyer);
+        packs.transferFrom(buyer, stranger, packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackHolder.selector, packId, buyer));
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        uint256 amznBefore = amzn.balanceOf(stranger);
+        vm.prank(stranger);
+        packs.unwrap(packId);
+
+        assertEq(amzn.balanceOf(stranger), amznBefore + 2e18);
+    }
+
+    function test_theBasketFollowsThePackNotTheCreator() public {
+        uint256 creatorAmznBefore = amzn.balanceOf(creator);
+
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        assertEq(amzn.balanceOf(creator), creatorAmznBefore);
+    }
+
+    // ========== Authorization ==========
+
+    function test_creatorCannotUnwrapWhileListed() public {
+        uint256 listedPack = _mintDefaultPack(creator);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackStillListed.selector, listedPack));
+        vm.prank(creator);
+        packs.unwrap(listedPack);
+    }
+
+    function test_formerCreatorCannotUnwrapAfterTransfer() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackHolder.selector, packId, creator));
+        vm.prank(creator);
+        packs.unwrap(packId);
+    }
+
+    function test_nonHolderCannotUnwrap() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackHolder.selector, packId, stranger));
+        vm.prank(stranger);
+        packs.unwrap(packId);
+    }
+
+    function test_approvedOperatorCannotUnwrap() public {
+        vm.prank(buyer);
+        packs.approve(stranger, packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackHolder.selector, packId, stranger));
+        vm.prank(stranger);
+        packs.unwrap(packId);
+    }
+
+    function test_unwrapRevertsOnUnknownPack() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackHolder.selector, 999, buyer));
+        vm.prank(buyer);
+        packs.unwrap(999);
+    }
+
+    function test_unwrapCannotRunTwice() public {
+        vm.startPrank(buyer);
+        packs.unwrap(packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.NotPackHolder.selector, packId, buyer));
+        packs.unwrap(packId);
+        vm.stopPrank();
+    }
+
+    // ========== The two exits converge ==========
+
+    function test_creatorWhoReacquiresAPackUnwrapsRatherThanRedeems() public {
+        vm.prank(buyer);
+        packs.transferFrom(buyer, creator, packId);
+
+        // Unlisting is one way, so the creator's exit is now unwrap, not delist-and-redeem.
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        uint256 amznBefore = amzn.balanceOf(creator);
+        vm.prank(creator);
+        packs.unwrap(packId);
+
+        assertEq(amzn.balanceOf(creator), amznBefore + 2e18);
+    }
+
+    function test_bothExitsReleaseIdenticalValue() public {
+        uint256 redeemedPack = _mintDefaultPack(otherCreator);
+
+        uint256 unwrapBefore = amzn.balanceOf(buyer);
+        vm.prank(buyer);
+        packs.unwrap(packId);
+        uint256 unwrapped = amzn.balanceOf(buyer) - unwrapBefore;
+
+        uint256 redeemBefore = amzn.balanceOf(otherCreator);
+        vm.prank(otherCreator);
+        packs.delistAndRedeem(redeemedPack);
+        uint256 redeemed = amzn.balanceOf(otherCreator) - redeemBefore;
+
+        assertEq(unwrapped, redeemed);
+    }
+
+    // ========== Whitelist independence ==========
+
+    function test_deWhitelistedAssetIsStillUnwrappedInFull() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+        vm.startPrank(admin);
+        packs.grantRole(role, admin);
+        packs.removeAsset(address(pltr));
+        vm.stopPrank();
+
+        uint256 pltrBefore = pltr.balanceOf(buyer);
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        assertEq(pltr.balanceOf(buyer), pltrBefore + 7e6);
+    }
+
+    // ========== Reentrancy ==========
+
+    function test_unwrapRejectsReentrancyFromAHostileAsset() public {
+        MockReentrantToken hostile = new MockReentrantToken("Hostile", "tEVIL");
+
+        address[] memory list = new address[](1);
+        list[0] = address(hostile);
+        PackCustody hostilePacks = new PackCustody(admin, list);
+
+        hostile.mint(creator, 100e18);
+        vm.prank(creator);
+        hostile.approve(address(hostilePacks), type(uint256).max);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(hostile), 10e18);
+        vm.startPrank(creator);
+        uint256 tokenId = hostilePacks.mint(assets, amounts);
+        hostilePacks.transferFrom(creator, buyer, tokenId);
+        vm.stopPrank();
+
+        hostile.arm(address(hostilePacks), abi.encodeCall(PackCustody.unwrap, (tokenId)));
+
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        vm.prank(buyer);
+        hostilePacks.unwrap(tokenId);
+
+        assertEq(hostilePacks.ownerOf(tokenId), buyer);
+        assertEq(hostilePacks.basketAmountOf(tokenId, address(hostile)), 10e18);
+        assertEq(hostile.balanceOf(address(hostilePacks)), 10e18);
+    }
+}

--- a/contracts/test/PackCustody.whitelist.t.sol
+++ b/contracts/test/PackCustody.whitelist.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {MockStockToken} from "./mocks/MockStockToken.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice The whitelist governs deposits only. These tests pin that boundary: an admin can
+///         change what may enter custody, and can never change what is already in it.
+contract PackCustodyWhitelistTest is PackCustodyFixture {
+    event AssetWhitelisted(address indexed asset);
+    event AssetRemovedFromWhitelist(address indexed asset);
+
+    address internal whitelistAdmin = makeAddr("whitelistAdmin");
+
+    function setUp() public override {
+        super.setUp();
+
+        // Read the role before pranking: a view call would otherwise consume the prank.
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, whitelistAdmin);
+    }
+
+    // ========== Administration ==========
+
+    function test_whitelistAdminCanAddAsset() public {
+        vm.expectEmit(true, false, false, false, address(packs));
+        emit AssetWhitelisted(address(offList));
+
+        vm.prank(whitelistAdmin);
+        packs.addAsset(address(offList));
+
+        assertTrue(packs.isWhitelisted(address(offList)));
+        assertEq(packs.whitelistedAssets().length, 6);
+    }
+
+    function test_whitelistAdminCanRemoveAsset() public {
+        vm.expectEmit(true, false, false, false, address(packs));
+        emit AssetRemovedFromWhitelist(address(nflx));
+
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+
+        assertFalse(packs.isWhitelisted(address(nflx)));
+        assertEq(packs.whitelistedAssets().length, 4);
+    }
+
+    function test_removedAssetIsAbsentFromWhitelistedAssets() public {
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+
+        address[] memory listed = packs.whitelistedAssets();
+        for (uint256 i; i < listed.length; ++i) {
+            assertTrue(listed[i] != address(nflx));
+        }
+    }
+
+    function test_assetCanBeReAddedAfterRemoval() public {
+        vm.startPrank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+        packs.addAsset(address(nflx));
+        vm.stopPrank();
+
+        assertTrue(packs.isWhitelisted(address(nflx)));
+        assertEq(packs.whitelistedAssets().length, 5);
+    }
+
+    function test_addRevertsOnAlreadyWhitelistedAsset() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AlreadyWhitelisted.selector, address(amzn)));
+        vm.prank(whitelistAdmin);
+        packs.addAsset(address(amzn));
+    }
+
+    function test_addRevertsOnZeroAddress() public {
+        vm.expectRevert(PackCustody.ZeroAddress.selector);
+        vm.prank(whitelistAdmin);
+        packs.addAsset(address(0));
+    }
+
+    function test_removeRevertsOnUnlistedAsset() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(offList)));
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(offList));
+    }
+
+    // ========== Access control ==========
+
+    function test_nonAdminCannotAddAsset() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, role)
+        );
+        vm.prank(stranger);
+        packs.addAsset(address(offList));
+    }
+
+    function test_nonAdminCannotRemoveAsset() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, role)
+        );
+        vm.prank(stranger);
+        packs.removeAsset(address(amzn));
+    }
+
+    function test_defaultAdminCannotAdministerWhitelistWithoutRole() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, role));
+        vm.prank(admin);
+        packs.addAsset(address(offList));
+    }
+
+    function test_revokedAdminCannotAdministerWhitelist() public {
+        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
+
+        vm.prank(admin);
+        packs.revokeRole(role, whitelistAdmin);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, whitelistAdmin, role)
+        );
+        vm.prank(whitelistAdmin);
+        packs.addAsset(address(offList));
+    }
+
+    // ========== Entry control only ==========
+
+    function test_addedAssetBecomesMintable() public {
+        vm.prank(whitelistAdmin);
+        packs.addAsset(address(offList));
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(offList), 4e18);
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        assertEq(packs.basketAmountOf(tokenId, address(offList)), 4e18);
+    }
+
+    function test_removedAssetCannotBeMinted() public {
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(nflx), 1e8);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(nflx)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+    }
+
+    function test_removalLeavesExistingBasketsIntact() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+
+        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
+        assertEq(basket.length, 3);
+        assertEq(packs.basketAmountOf(tokenId, address(nflx)), 5e8);
+        assertEq(nflx.balanceOf(address(packs)), 5e8);
+    }
+
+    function test_removalDoesNotAffectOtherAssetsInTheSameBasket() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 2e18);
+        assertEq(packs.basketAmountOf(tokenId, address(pltr)), 7e6);
+        assertTrue(packs.isWhitelisted(address(amzn)));
+        assertTrue(packs.isWhitelisted(address(pltr)));
+    }
+
+    function test_removalDoesNotAffectPackOwnership() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        vm.prank(whitelistAdmin);
+        packs.removeAsset(address(nflx));
+
+        assertEq(packs.ownerOf(tokenId), creator);
+        assertEq(packs.creatorOf(tokenId), creator);
+    }
+
+    function test_emptyingTheWhitelistBlocksMintingButKeepsCustodyRecorded() public {
+        uint256 tokenId = _mintDefaultPack(creator);
+
+        vm.startPrank(whitelistAdmin);
+        for (uint256 i; i < whitelist.length; ++i) {
+            packs.removeAsset(whitelist[i]);
+        }
+        vm.stopPrank();
+
+        assertEq(packs.whitelistedAssets().length, 0);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.AssetNotWhitelisted.selector, address(amzn)));
+        vm.prank(creator);
+        packs.mint(assets, amounts);
+
+        assertEq(packs.basketOf(tokenId).length, 3);
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 2e18);
+    }
+}

--- a/contracts/test/helpers/PackCustodyFixture.sol
+++ b/contracts/test/helpers/PackCustodyFixture.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {PackCustody} from "../../src/PackCustody.sol";
+import {MockStockToken} from "../mocks/MockStockToken.sol";
+
+/// @notice Shared deployment for PackCustody suites: five whitelisted Stock Token doubles
+///         with mixed decimals, one off-list token, and funded actors.
+abstract contract PackCustodyFixture is Test {
+    PackCustody internal packs;
+
+    MockStockToken internal amzn;
+    MockStockToken internal amd;
+    MockStockToken internal nflx;
+    MockStockToken internal pltr;
+    MockStockToken internal tsla;
+
+    /// @notice Deliberately not whitelisted.
+    MockStockToken internal offList;
+
+    address[] internal whitelist;
+
+    address internal admin = makeAddr("admin");
+    address internal creator = makeAddr("creator");
+    address internal otherCreator = makeAddr("otherCreator");
+    address internal buyer = makeAddr("buyer");
+    address internal stranger = makeAddr("stranger");
+
+    function setUp() public virtual {
+        // Mixed decimals mirror the real Stock Token spread rather than assuming 18 everywhere.
+        amzn = new MockStockToken("Amazon Test Stock", "tAMZN", 18);
+        amd = new MockStockToken("AMD Test Stock", "tAMD", 18);
+        nflx = new MockStockToken("Netflix Test Stock", "tNFLX", 8);
+        pltr = new MockStockToken("Palantir Test Stock", "tPLTR", 6);
+        tsla = new MockStockToken("Tesla Test Stock", "tTSLA", 18);
+        offList = new MockStockToken("Off List Token", "tOFF", 18);
+
+        whitelist.push(address(amzn));
+        whitelist.push(address(amd));
+        whitelist.push(address(nflx));
+        whitelist.push(address(pltr));
+        whitelist.push(address(tsla));
+
+        packs = new PackCustody(admin, whitelist);
+
+        _fundActor(creator);
+        _fundActor(otherCreator);
+        _fundActor(buyer);
+        _fundActor(stranger);
+    }
+
+    /// @dev Mints a generous balance of every token to `who` and approves custody for all of them.
+    function _fundActor(address who) internal {
+        MockStockToken[6] memory tokens = [amzn, amd, nflx, pltr, tsla, offList];
+
+        for (uint256 i; i < tokens.length; ++i) {
+            uint256 amount = 1_000_000 * (10 ** tokens[i].decimals());
+            tokens[i].mint(who, amount);
+
+            vm.prank(who);
+            tokens[i].approve(address(packs), type(uint256).max);
+        }
+    }
+
+    function _single(address asset, uint256 amount)
+        internal
+        pure
+        returns (address[] memory assets, uint256[] memory amounts)
+    {
+        assets = new address[](1);
+        amounts = new uint256[](1);
+        assets[0] = asset;
+        amounts[0] = amount;
+    }
+
+    function _pair(address assetA, uint256 amountA, address assetB, uint256 amountB)
+        internal
+        pure
+        returns (address[] memory assets, uint256[] memory amounts)
+    {
+        assets = new address[](2);
+        amounts = new uint256[](2);
+        assets[0] = assetA;
+        amounts[0] = amountA;
+        assets[1] = assetB;
+        amounts[1] = amountB;
+    }
+
+    /// @dev A representative three-asset basket across three decimal shapes.
+    function _defaultBasket() internal view returns (address[] memory assets, uint256[] memory amounts) {
+        assets = new address[](3);
+        amounts = new uint256[](3);
+        assets[0] = address(amzn);
+        amounts[0] = 2e18;
+        assets[1] = address(nflx);
+        amounts[1] = 5e8;
+        assets[2] = address(pltr);
+        amounts[2] = 7e6;
+    }
+
+    /// @dev Mints a Pack held by `who` containing the default basket.
+    function _mintDefaultPack(address who) internal returns (uint256 tokenId) {
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+        vm.prank(who);
+        tokenId = packs.mint(assets, amounts);
+    }
+}

--- a/contracts/test/mocks/MockFeeOnTransferToken.sol
+++ b/contracts/test/mocks/MockFeeOnTransferToken.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC-20 double that skims a fee on every transfer between accounts.
+/// @dev Exists to prove custody records what it actually received rather than what the caller
+///      declared. Mints and burns are not skimmed.
+contract MockFeeOnTransferToken is ERC20 {
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    address public immutable feeSink;
+    uint256 public immutable feeBps;
+
+    constructor(string memory name_, string memory symbol_, uint256 feeBps_, address feeSink_) ERC20(name_, symbol_) {
+        require(feeBps_ <= BPS_DENOMINATOR, "fee > 100%");
+        require(feeSink_ != address(0), "zero fee sink");
+        feeBps = feeBps_;
+        feeSink = feeSink_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 fee = (value * feeBps) / BPS_DENOMINATOR;
+        if (fee > 0) {
+            super._update(from, feeSink, fee);
+        }
+        super._update(from, to, value - fee);
+    }
+}

--- a/contracts/test/mocks/MockReentrantToken.sol
+++ b/contracts/test/mocks/MockReentrantToken.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC-20 double that calls back into custody while custody is paying out.
+/// @dev Arm it with the call to attempt; the re-entrant call fires whenever the armed target
+///      is the sender, which is exactly the moment custody releases a basket. Reverts are
+///      bubbled so the outer transaction fails with the guard's own error.
+contract MockReentrantToken is ERC20 {
+    address public reentryTarget;
+    bytes public reentryCalldata;
+
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function arm(address target, bytes calldata data) external {
+        reentryTarget = target;
+        reentryCalldata = data;
+    }
+
+    function disarm() external {
+        reentryTarget = address(0);
+        reentryCalldata = "";
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        super._update(from, to, value);
+
+        if (reentryTarget != address(0) && from == reentryTarget) {
+            (bool ok, bytes memory returndata) = reentryTarget.call(reentryCalldata);
+            if (!ok) {
+                assembly {
+                    revert(add(returndata, 0x20), mload(returndata))
+                }
+            }
+        }
+    }
+}

--- a/contracts/test/mocks/MockStockToken.sol
+++ b/contracts/test/mocks/MockStockToken.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice Openly mintable ERC-20 double standing in for a whitelisted Stock Token.
+/// @dev Decimals are configurable so suites can mix the 6/8/18 shapes real Stock Tokens use.
+contract MockStockToken is ERC20 {
+    uint8 private immutable _decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) ERC20(name_, symbol_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "install:forge-deps": "bash scripts/install-forge-deps.sh",
     "deploy:mockusd": "tsx scripts/deploy-mockusd.ts",
     "verify:mockusd": "tsx scripts/verify-mockusd.ts",
+    "deploy:packcustody": "tsx scripts/deploy-packcustody.ts",
+    "verify:packcustody": "tsx scripts/verify-packcustody.ts",
     "audit:prod": "pnpm audit --prod --audit-level=high",
     "audit:all": "pnpm audit --audit-level=high",
     "audit:all:gated": "node scripts/audit-all-gated.mjs",

--- a/scripts/deploy-packcustody.ts
+++ b/scripts/deploy-packcustody.ts
@@ -1,0 +1,87 @@
+/**
+ * Deploy PackCustody to Robinhood Chain testnet and record the address.
+ *
+ * Requires in .env.local (or shell):
+ *   DEPLOYER_PRIVATE_KEY (or OPERATOR_PRIVATE_KEY)
+ *   ROBINHOOD_TESTNET_RPC_URL
+ *
+ * Optional:
+ *   PACKCUSTODY_ADMIN           — defaults to deployer
+ *   PACKCUSTODY_WHITELIST_ADMIN — granted WHITELIST_ADMIN_ROLE when admin == deployer
+ *   PACKCUSTODY_WHITELIST       — comma-separated assets; defaults to the five approved
+ *                                 Stock Tokens in the PRD launch configuration
+ *
+ * Usage: pnpm deploy:packcustody
+ */
+import {
+  enrichDeploymentRecord,
+  loadEnvLocal,
+  patchEnvLocal,
+  readLatestBroadcastCreate,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+  ROBINHOOD_TESTNET_EXPLORER,
+  runForgeDeploy,
+} from "./deploy-utils";
+
+function main() {
+  const env = loadEnvLocal();
+  const rpcUrl =
+    env.ROBINHOOD_TESTNET_RPC_URL ?? env.NEXT_PUBLIC_ROBINHOOD_TESTNET_RPC_URL;
+  const deployerKey = env.DEPLOYER_PRIVATE_KEY ?? env.OPERATOR_PRIVATE_KEY;
+  if (!rpcUrl) {
+    throw new Error("ROBINHOOD_TESTNET_RPC_URL missing in .env.local");
+  }
+  if (!deployerKey) {
+    throw new Error(
+      "DEPLOYER_PRIVATE_KEY (or OPERATOR_PRIVATE_KEY) missing — set it, or export from a Foundry keystore with `cast wallet private-key --account <name>`"
+    );
+  }
+
+  console.log("Deploying PackCustody to Robinhood Chain testnet…");
+
+  const forgeEnv: Record<string, string> = {
+    DEPLOYER_PRIVATE_KEY: deployerKey,
+  };
+  if (env.PACKCUSTODY_ADMIN) forgeEnv.PACKCUSTODY_ADMIN = env.PACKCUSTODY_ADMIN;
+  if (env.PACKCUSTODY_WHITELIST_ADMIN) {
+    forgeEnv.PACKCUSTODY_WHITELIST_ADMIN = env.PACKCUSTODY_WHITELIST_ADMIN;
+  }
+  if (env.PACKCUSTODY_WHITELIST) {
+    forgeEnv.PACKCUSTODY_WHITELIST = env.PACKCUSTODY_WHITELIST;
+  }
+
+  const { address } = runForgeDeploy({
+    scriptTarget: "script/DeployPackCustody.s.sol:DeployPackCustody",
+    rpcUrl,
+    privateKey: deployerKey,
+    addressLabel: "PackCustody",
+    env: forgeEnv,
+  });
+
+  const broadcast = readLatestBroadcastCreate({
+    scriptFileName: "DeployPackCustody.s.sol",
+    chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+  });
+
+  const record = enrichDeploymentRecord("robinhood-testnet.packcustody.json", {
+    address,
+    txHash: broadcast?.txHash,
+    blockNumber: broadcast?.blockNumber,
+  });
+
+  patchEnvLocal("PACKCUSTODY_ADDRESS", address);
+  patchEnvLocal("NEXT_PUBLIC_PACKCUSTODY_ADDRESS", address);
+
+  console.log(`\nUpdated .env.local:`);
+  console.log(`  PACKCUSTODY_ADDRESS=${address}`);
+  console.log(`  NEXT_PUBLIC_PACKCUSTODY_ADDRESS=${address}`);
+  console.log(
+    `\nRecorded deployment in contracts/deployments/robinhood-testnet.packcustody.json`
+  );
+  console.log(`Explorer: ${ROBINHOOD_TESTNET_EXPLORER}/address/${address}`);
+  if (record.txHash) {
+    console.log(`Tx: ${ROBINHOOD_TESTNET_EXPLORER}/tx/${record.txHash}`);
+  }
+}
+
+main();

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -135,12 +135,22 @@ export function readLatestBroadcastCreate(opts: {
  * output. Uses execFileSync with an argv array so the private key is never
  * interpolated into a shell-parsed command string.
  */
+/**
+ * Robinhood Chain charges L1 calldata as extra gas, and for a contract deployment that
+ * component dominates the estimate and moves with the L1 base fee between estimation and
+ * execution. Forge's default 130% headroom is not enough: PackCustody's first attempt
+ * consumed its whole limit (4.1M of 4.4M gas was the L1 component) and reverted out of gas.
+ * Only gas actually used is billed, so a generous ceiling costs nothing.
+ */
+const GAS_ESTIMATE_MULTIPLIER = 400;
+
 export function runForgeDeploy(opts: {
   scriptTarget: string;
   rpcUrl: string;
   privateKey: string;
   addressLabel: string;
   env?: Record<string, string>;
+  gasEstimateMultiplier?: number;
 }): { address: string; output: string } {
   const output = execFileSync(
     "forge",
@@ -152,6 +162,8 @@ export function runForgeDeploy(opts: {
       "--private-key",
       opts.privateKey,
       "--broadcast",
+      "--gas-estimate-multiplier",
+      String(opts.gasEstimateMultiplier ?? GAS_ESTIMATE_MULTIPLIER),
       "-vv",
     ],
     {

--- a/scripts/deploy-utils.ts
+++ b/scripts/deploy-utils.ts
@@ -42,6 +42,11 @@ export function loadEnvLocal(): Record<string, string> {
     "MOCKUSD_MINTER",
     "MOCKUSD_ADDRESS",
     "NEXT_PUBLIC_MOCKUSD_ADDRESS",
+    "PACKCUSTODY_ADMIN",
+    "PACKCUSTODY_WHITELIST_ADMIN",
+    "PACKCUSTODY_WHITELIST",
+    "PACKCUSTODY_ADDRESS",
+    "NEXT_PUBLIC_PACKCUSTODY_ADDRESS",
     "ETHERSCAN_API_KEY",
   ]) {
     const value = process.env[key];

--- a/scripts/verify-packcustody.ts
+++ b/scripts/verify-packcustody.ts
@@ -1,0 +1,98 @@
+/**
+ * Source-verify PackCustody on Robinhood Chain testnet (Blockscout).
+ *
+ * Requires:
+ *   PACKCUSTODY_ADDRESS / NEXT_PUBLIC_PACKCUSTODY_ADDRESS (or --address=0x…)
+ *   The admin and whitelist used at deploy — read from the deployment record, or
+ *   overridden with PACKCUSTODY_ADMIN / PACKCUSTODY_WHITELIST.
+ *
+ * Usage: pnpm verify:packcustody
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  castAbiEncode,
+  CONTRACTS_DIR,
+  loadEnvLocal,
+  requireAddress,
+  ROBINHOOD_TESTNET_EXPLORER,
+  runForgeVerifyBlockscout,
+} from "./deploy-utils";
+
+type DeploymentRecord = {
+  address?: string;
+  admin?: string;
+  whitelist?: string[];
+};
+
+function readDeploymentRecord(): DeploymentRecord {
+  const path = join(
+    CONTRACTS_DIR,
+    "deployments",
+    "robinhood-testnet.packcustody.json"
+  );
+  if (!existsSync(path)) return {};
+  return JSON.parse(readFileSync(path, "utf8")) as DeploymentRecord;
+}
+
+function parseAddressFlag(argv: string[]): string | undefined {
+  const flag = argv.find((a) => a.startsWith("--address="));
+  return flag ? flag.slice("--address=".length) : undefined;
+}
+
+function resolveWhitelist(
+  env: Record<string, string>,
+  record: DeploymentRecord
+): `0x${string}`[] {
+  const raw = env.PACKCUSTODY_WHITELIST
+    ? env.PACKCUSTODY_WHITELIST.split(",")
+    : record.whitelist;
+
+  if (!raw?.length) {
+    throw new Error(
+      "PACKCUSTODY_WHITELIST missing — set it, or deploy first so the record carries the constructor whitelist"
+    );
+  }
+
+  return raw.map((asset, i) =>
+    requireAddress(asset.trim(), `PACKCUSTODY_WHITELIST[${i}]`)
+  );
+}
+
+function main() {
+  const env = loadEnvLocal();
+  const record = readDeploymentRecord();
+
+  const address = requireAddress(
+    parseAddressFlag(process.argv) ??
+      env.PACKCUSTODY_ADDRESS ??
+      env.NEXT_PUBLIC_PACKCUSTODY_ADDRESS ??
+      record.address,
+    "PACKCUSTODY_ADDRESS"
+  );
+  const admin = requireAddress(
+    env.PACKCUSTODY_ADMIN ?? record.admin,
+    "PACKCUSTODY_ADMIN (constructor arg — set in env or deployment record)"
+  );
+  const whitelist = resolveWhitelist(env, record);
+
+  const constructorArgsHex = castAbiEncode("constructor(address,address[])", [
+    admin,
+    `[${whitelist.join(",")}]`,
+  ]);
+
+  console.log(
+    `Verifying PackCustody at ${address} (admin=${admin}, ${whitelist.length} whitelisted assets)…`
+  );
+  const output = runForgeVerifyBlockscout({
+    address,
+    contractPath: "src/PackCustody.sol:PackCustody",
+    constructorArgsHex,
+  });
+  console.log(output);
+  console.log(
+    `Explorer: ${ROBINHOOD_TESTNET_EXPLORER}/address/${address}#code`
+  );
+}
+
+main();


### PR DESCRIPTION
Closes #275.

## Summary

`PackCustody` is an ERC-721 whose contract directly holds each Pack's recorded basket of whitelisted Stock Tokens, in raw token units. Minting pulls the whole basket atomically, so a Pack can never exist unfunded. Creators add to a listed Pack and never subtract; the only ways assets leave are the creator's full delist-and-redeem or the holder's post-transfer unwrap, both at zero protocol fee.

Per ADR-0004, Packs are plain custody-backed ERC-721s, not token-bound accounts. Oracle NAV, eligibility, and selection are deliberately absent — those belong to #276 and #279.

Deployed and verified on Robinhood Chain testnet at [`0x413e82F990DE796CC279c180F711d720A7Ee7728`](https://explorer.testnet.chain.robinhood.com/address/0x413e82F990DE796CC279c180F711d720A7Ee7728#code).

## Design decisions worth review

- **Listing is derived from a one-way latch.** A Pack leaves the pool the first time it moves to a new holder, and never rejoins. This gives RipEngine a clean seam — settlement is an ordinary `transferFrom` — with no stub dependency today. A creator who reacquires a ripped Pack unwraps rather than delists; both release identical value.
- **The whitelist governs deposits only.** It is administered under `WHITELIST_ADMIN_ROLE`, but removal only blocks new mints and top-ups. Redeem and unwrap ignore it entirely, so an admin action can never strand a creator's capital.
- **Balance-delta accounting.** Custody records what actually arrived, not what the caller declared, so basket conservation holds without trusting the token.

## Test plan

142 Foundry tests, all driving the external ABI only — no assertions on internal state.

- [x] Lifecycle: `mint → top-up → redeem` and `mint → transfer → unwrap`
- [x] Fuzz over every subset of the whitelist and its mixed 6/8/18 decimals — deposits round-trip to the exact starting balance, top-ups only accumulate, Packs never draw on each other's custody
- [x] Invariants: custody equals the sum of live recorded baskets, deposits minus releases equal custody, baskets match an independent additions-only mirror, terminated Packs keep nothing back, listed Packs are held by their creator, unlisting never reverses
- [x] Fail-closed paths: non-whitelisted asset, zero amount, duplicate entry, length mismatch, missing approval, insufficient balance, wrong caller on every gated function, double redeem/unwrap, reentrancy from a hostile ERC-20 on both exits
- [x] `FOUNDRY_PROFILE=ci forge test`, `forge fmt --check`, `pnpm typecheck`, `pnpm lint` (0 errors)

**Invariants were checked against mutants rather than trusted on a green run:** a one-unit skim on release breaks both conservation invariants, and making a deposit overwrite instead of accumulate breaks the additions-only mirror. Both mutations reverted.

## Note for reviewers

The first testnet deploy reverted out of gas — Robinhood Chain bills L1 calldata as extra gas, which was 4.1M of the 4.4M limit and drifts with the L1 base fee after estimation. `runForgeDeploy` now passes `--gas-estimate-multiplier 400`; only gas actually used is billed, so this also de-risks the larger contracts still to come.

Made with [Cursor](https://cursor.com)