### PR TITLE
V1 · PackCustody settlement primitive (releaseToRecipient) (#299)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -61,14 +61,16 @@ This is a **valueless test asset**. It has no USD backing and nothing about it c
 
 ## PackCustody
 
-ERC-721 Packs backed by a recorded basket of whitelisted Stock Tokens held directly by the contract (issue [#275](https://github.com/hurley87/margin-call/issues/275)):
+ERC-721 Packs backed by a recorded basket of whitelisted Stock Tokens held directly by the contract (issues [#275](https://github.com/hurley87/margin-call/issues/275), [#299](https://github.com/hurley87/margin-call/issues/299)):
 
 - Name / symbol: `Margin Call Pack (Test Asset)` / `PACK`
 - `mint` deposits the whole basket in one transaction; a Pack can never exist unfunded
 - Custody accounting is raw token units, recorded from the balance actually received
 - `topUp` is creator-only and additions-only, while the Pack is still listed
 - `delistAndRedeem` (creator, while listed) and `unwrap` (holder, once transferred) both release the full basket at **zero protocol fee**
+- `releaseToRecipient` is `RIP_ENGINE_ROLE`-gated: moves a listed Pack to a recipient in one call without ERC-721 approval; basket ERC-20s stay in custody and the one-way unlisted latch fires on transfer (Rip settlement primitive — a Pack settles at most once)
 - `WHITELIST_ADMIN_ROLE` governs deposits only — de-whitelisting an asset never blocks redemption
+- Neither `WHITELIST_ADMIN_ROLE` nor `RIP_ENGINE_ROLE` is granted at construction; `DEFAULT_ADMIN_ROLE` grants them after deploy (RipEngine will receive `RIP_ENGINE_ROLE` when that contract lands)
 
 Oracle NAV, eligibility, and Rip selection live in later contracts; custody knows nothing about them.
 
@@ -182,7 +184,7 @@ Then take either exit. While the Pack is still yours, delist and redeem:
 cast send $PACKS "delistAndRedeem(uint256)" $ID --private-key $KEY --rpc-url $RPC
 ```
 
-Or transfer it — standing in for Rip settlement — and let the new holder unwrap:
+Or transfer it for a secondary sale / manual handoff, then let the new holder unwrap:
 
 ```bash
 cast send $PACKS "transferFrom(address,address,uint256)" $ME $BUYER $ID --private-key $KEY --rpc-url $RPC
@@ -190,7 +192,17 @@ cast call $PACKS "isListed(uint256)(bool)" $ID --rpc-url $RPC        # false
 cast send $PACKS "unwrap(uint256)" $ID --private-key $BUYER_KEY --rpc-url $RPC
 ```
 
-Both paths return the entire recorded basket and burn the Pack. Compare the token balances
+Rip settlement will use the role-gated primitive instead of a plain transfer (requires an
+account with `RIP_ENGINE_ROLE`):
+
+```bash
+# After admin has granted RIP_ENGINE_ROLE to $ENGINE:
+cast send $PACKS "releaseToRecipient(uint256,address)" $ID $BUYER --private-key $ENGINE_KEY --rpc-url $RPC
+cast call $PACKS "isListed(uint256)(bool)" $ID --rpc-url $RPC        # false
+cast send $PACKS "unwrap(uint256)" $ID --private-key $BUYER_KEY --rpc-url $RPC
+```
+
+Both exit paths return the entire recorded basket and burn the Pack. Compare the token balances
 before and after: nothing is deducted on either path.
 
 ## Layout

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -59,11 +59,6 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @notice Emitted the first time a Pack leaves its creator, retiring it from the pool.
     event PackUnlisted(uint256 indexed tokenId);
 
-    /// @notice Emitted when RipEngine settles a listed Pack to a recipient.
-    /// @dev Basket ERC-20s stay in custody; only ownership moves. The transfer also emits
-    ///      `PackUnlisted` via `_update`.
-    event PackReleased(uint256 indexed tokenId, address indexed from, address indexed to);
-
     /// @notice Emitted when a creator delists a Pack and takes its full basket back.
     event PackRedeemed(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
 
@@ -90,6 +85,7 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     error NotPackHolder(uint256 tokenId, address caller);
     error PackNotListed(uint256 tokenId);
     error PackStillListed(uint256 tokenId);
+    error SelfRelease(uint256 tokenId);
 
     /// @param admin Address granted DEFAULT_ADMIN_ROLE (can grant/revoke WHITELIST_ADMIN_ROLE
     ///        and RIP_ENGINE_ROLE).
@@ -185,16 +181,17 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @dev Privileged transfer: no ERC-721 approval required. Basket accounting and ERC-20
     ///      balances stay in custody; the one-way unlisted latch fires via `_update`. A Pack
     ///      settles at most once because an already-unlisted Pack reverts `PackNotListed`.
+    ///      Self-release is rejected so the latch cannot be skipped.
     /// @param tokenId The listed Pack to hand to the Taker.
     /// @param recipient The account that receives the Pack (typically the Taker).
-    function releaseToRecipient(uint256 tokenId, address recipient) external onlyRole(RIP_ENGINE_ROLE) nonReentrant {
+    function releaseToRecipient(uint256 tokenId, address recipient) external onlyRole(RIP_ENGINE_ROLE) {
         if (recipient == address(0)) revert ZeroAddress();
         if (!isListed(tokenId)) revert PackNotListed(tokenId);
 
         address from = ownerOf(tokenId);
-        _safeTransfer(from, recipient, tokenId, "");
+        if (recipient == from) revert SelfRelease(tokenId);
 
-        emit PackReleased(tokenId, from, recipient);
+        _transfer(from, recipient, tokenId);
     }
 
     /// @notice Whether a Pack is still held by its creator and can be topped up or delisted.

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -187,11 +187,7 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     ///      settles at most once because an already-unlisted Pack reverts `PackNotListed`.
     /// @param tokenId The listed Pack to hand to the Taker.
     /// @param recipient The account that receives the Pack (typically the Taker).
-    function releaseToRecipient(uint256 tokenId, address recipient)
-        external
-        onlyRole(RIP_ENGINE_ROLE)
-        nonReentrant
-    {
+    function releaseToRecipient(uint256 tokenId, address recipient) external onlyRole(RIP_ENGINE_ROLE) nonReentrant {
         if (recipient == address(0)) revert ZeroAddress();
         if (!isListed(tokenId)) revert PackNotListed(tokenId);
 

--- a/contracts/src/PackCustody.sol
+++ b/contracts/src/PackCustody.sol
@@ -25,6 +25,9 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @notice Role permitted to change which assets may be deposited.
     bytes32 public constant WHITELIST_ADMIN_ROLE = keccak256("WHITELIST_ADMIN_ROLE");
 
+    /// @notice Role permitted to settle a listed Pack to a recipient (RipEngine).
+    bytes32 public constant RIP_ENGINE_ROLE = keccak256("RIP_ENGINE_ROLE");
+
     /// @notice Whether an asset may be deposited into a Pack.
     /// @dev Entry control only. Assets already recorded in a basket stay redeemable whatever
     ///      this says later, so de-whitelisting can never strand a creator's capital.
@@ -56,6 +59,11 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     /// @notice Emitted the first time a Pack leaves its creator, retiring it from the pool.
     event PackUnlisted(uint256 indexed tokenId);
 
+    /// @notice Emitted when RipEngine settles a listed Pack to a recipient.
+    /// @dev Basket ERC-20s stay in custody; only ownership moves. The transfer also emits
+    ///      `PackUnlisted` via `_update`.
+    event PackReleased(uint256 indexed tokenId, address indexed from, address indexed to);
+
     /// @notice Emitted when a creator delists a Pack and takes its full basket back.
     event PackRedeemed(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts);
 
@@ -83,7 +91,8 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
     error PackNotListed(uint256 tokenId);
     error PackStillListed(uint256 tokenId);
 
-    /// @param admin Address granted DEFAULT_ADMIN_ROLE (can grant/revoke WHITELIST_ADMIN_ROLE).
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE (can grant/revoke WHITELIST_ADMIN_ROLE
+    ///        and RIP_ENGINE_ROLE).
     /// @param initialWhitelist Assets depositable at launch — the five approved Stock Tokens.
     constructor(address admin, address[] memory initialWhitelist) ERC721("Margin Call Pack (Test Asset)", "PACK") {
         if (admin == address(0)) revert ZeroAddress();
@@ -170,6 +179,26 @@ contract PackCustody is ERC721, AccessControl, ReentrancyGuard {
         (address[] memory assets, uint256[] memory amounts) = _release(tokenId, msg.sender);
 
         emit PackUnwrapped(tokenId, msg.sender, assets, amounts);
+    }
+
+    /// @notice Settle a listed Pack to `recipient` in one call (RipEngine settlement primitive).
+    /// @dev Privileged transfer: no ERC-721 approval required. Basket accounting and ERC-20
+    ///      balances stay in custody; the one-way unlisted latch fires via `_update`. A Pack
+    ///      settles at most once because an already-unlisted Pack reverts `PackNotListed`.
+    /// @param tokenId The listed Pack to hand to the Taker.
+    /// @param recipient The account that receives the Pack (typically the Taker).
+    function releaseToRecipient(uint256 tokenId, address recipient)
+        external
+        onlyRole(RIP_ENGINE_ROLE)
+        nonReentrant
+    {
+        if (recipient == address(0)) revert ZeroAddress();
+        if (!isListed(tokenId)) revert PackNotListed(tokenId);
+
+        address from = ownerOf(tokenId);
+        _safeTransfer(from, recipient, tokenId, "");
+
+        emit PackReleased(tokenId, from, recipient);
     }
 
     /// @notice Whether a Pack is still held by its creator and can be topped up or delisted.

--- a/contracts/test/PackCustody.fuzz.t.sol
+++ b/contracts/test/PackCustody.fuzz.t.sol
@@ -112,41 +112,6 @@ contract PackCustodyFuzzTest is PackCustodyFixture {
         }
     }
 
-    function testFuzz_mintReleaseUnwrapMovesTheWholeBasketToTheRecipient(uint8 maskSeed, uint256 amountSeed) public {
-        address ripEngine = makeAddr("ripEngine");
-        bytes32 role = packs.RIP_ENGINE_ROLE();
-        vm.prank(admin);
-        packs.grantRole(role, ripEngine);
-
-        uint256[5] memory creatorStart = _balances(creator);
-        uint256[5] memory buyerStart = _balances(buyer);
-
-        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
-
-        vm.prank(creator);
-        uint256 tokenId = packs.mint(assets, amounts);
-
-        vm.prank(ripEngine);
-        packs.releaseToRecipient(tokenId, buyer);
-
-        assertFalse(packs.isListed(tokenId));
-        for (uint256 i; i < assets.length; ++i) {
-            assertEq(packs.basketAmountOf(tokenId, assets[i]), amounts[i]);
-        }
-
-        vm.prank(buyer);
-        packs.unwrap(tokenId);
-
-        for (uint256 i; i < 5; ++i) {
-            address asset = whitelist[i];
-            uint256 spent = creatorStart[i] - MockStockToken(asset).balanceOf(creator);
-            uint256 gained = MockStockToken(asset).balanceOf(buyer) - buyerStart[i];
-
-            assertEq(gained, spent);
-            assertEq(MockStockToken(asset).balanceOf(address(packs)), 0);
-        }
-    }
-
     function testFuzz_topUpsAccumulateAndRedeemReturnsTheTotal(
         uint8 mintMask,
         uint256 mintSeed,
@@ -238,10 +203,7 @@ contract PackCustodyFuzzTest is PackCustodyFixture {
     }
 
     function testFuzz_releasingOnePackNeverDrawsOnAnothersBasket(uint8 maskSeed, uint256 amountSeed) public {
-        address ripEngine = makeAddr("ripEngine");
-        bytes32 role = packs.RIP_ENGINE_ROLE();
-        vm.prank(admin);
-        packs.grantRole(role, ripEngine);
+        _grantRipEngine();
 
         (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
 

--- a/contracts/test/PackCustody.fuzz.t.sol
+++ b/contracts/test/PackCustody.fuzz.t.sol
@@ -112,9 +112,7 @@ contract PackCustodyFuzzTest is PackCustodyFixture {
         }
     }
 
-    function testFuzz_mintReleaseUnwrapMovesTheWholeBasketToTheRecipient(uint8 maskSeed, uint256 amountSeed)
-        public
-    {
+    function testFuzz_mintReleaseUnwrapMovesTheWholeBasketToTheRecipient(uint8 maskSeed, uint256 amountSeed) public {
         address ripEngine = makeAddr("ripEngine");
         bytes32 role = packs.RIP_ENGINE_ROLE();
         vm.prank(admin);

--- a/contracts/test/PackCustody.fuzz.t.sol
+++ b/contracts/test/PackCustody.fuzz.t.sol
@@ -112,6 +112,43 @@ contract PackCustodyFuzzTest is PackCustodyFixture {
         }
     }
 
+    function testFuzz_mintReleaseUnwrapMovesTheWholeBasketToTheRecipient(uint8 maskSeed, uint256 amountSeed)
+        public
+    {
+        address ripEngine = makeAddr("ripEngine");
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, ripEngine);
+
+        uint256[5] memory creatorStart = _balances(creator);
+        uint256[5] memory buyerStart = _balances(buyer);
+
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(tokenId, buyer);
+
+        assertFalse(packs.isListed(tokenId));
+        for (uint256 i; i < assets.length; ++i) {
+            assertEq(packs.basketAmountOf(tokenId, assets[i]), amounts[i]);
+        }
+
+        vm.prank(buyer);
+        packs.unwrap(tokenId);
+
+        for (uint256 i; i < 5; ++i) {
+            address asset = whitelist[i];
+            uint256 spent = creatorStart[i] - MockStockToken(asset).balanceOf(creator);
+            uint256 gained = MockStockToken(asset).balanceOf(buyer) - buyerStart[i];
+
+            assertEq(gained, spent);
+            assertEq(MockStockToken(asset).balanceOf(address(packs)), 0);
+        }
+    }
+
     function testFuzz_topUpsAccumulateAndRedeemReturnsTheTotal(
         uint8 mintMask,
         uint256 mintSeed,
@@ -199,6 +236,38 @@ contract PackCustodyFuzzTest is PackCustodyFixture {
         }
         for (uint256 i; i < 5; ++i) {
             assertGe(MockStockToken(whitelist[i]).balanceOf(otherCreator), otherStart[i]);
+        }
+    }
+
+    function testFuzz_releasingOnePackNeverDrawsOnAnothersBasket(uint8 maskSeed, uint256 amountSeed) public {
+        address ripEngine = makeAddr("ripEngine");
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, ripEngine);
+
+        (address[] memory assets, uint256[] memory amounts) = _maskedBasket(maskSeed, amountSeed);
+
+        vm.prank(creator);
+        uint256 first = packs.mint(assets, amounts);
+
+        vm.prank(otherCreator);
+        uint256 second = packs.mint(assets, amounts);
+
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(first, buyer);
+
+        for (uint256 i; i < assets.length; ++i) {
+            assertEq(packs.basketAmountOf(first, assets[i]), amounts[i]);
+            assertEq(packs.basketAmountOf(second, assets[i]), amounts[i]);
+            assertEq(MockStockToken(assets[i]).balanceOf(address(packs)), amounts[i] * 2);
+        }
+
+        vm.prank(buyer);
+        packs.unwrap(first);
+
+        for (uint256 i; i < assets.length; ++i) {
+            assertEq(packs.basketAmountOf(second, assets[i]), amounts[i]);
+            assertEq(MockStockToken(assets[i]).balanceOf(address(packs)), amounts[i]);
         }
     }
 }

--- a/contracts/test/PackCustody.invariant.t.sol
+++ b/contracts/test/PackCustody.invariant.t.sol
@@ -11,6 +11,7 @@ import {MockStockToken} from "./mocks/MockStockToken.sol";
 contract PackCustodyHandler is Test {
     PackCustody public immutable PACKS;
     address public immutable WHITELIST_ADMIN;
+    address public immutable RIP_ENGINE;
 
     address[] public assets;
     address[] public actors;
@@ -32,9 +33,10 @@ contract PackCustodyHandler is Test {
 
     uint256[] public terminatedPacks;
 
-    constructor(PackCustody packs_, address[] memory assets_, address whitelistAdmin_) {
+    constructor(PackCustody packs_, address[] memory assets_, address whitelistAdmin_, address ripEngine_) {
         PACKS = packs_;
         WHITELIST_ADMIN = whitelistAdmin_;
+        RIP_ENGINE = ripEngine_;
         assets = assets_;
 
         actors.push(makeAddr("handlerActor0"));
@@ -91,6 +93,21 @@ contract PackCustodyHandler is Test {
 
         vm.prank(owner);
         PACKS.transferFrom(owner, to, tokenId);
+    }
+
+    /// @dev RipEngine settlement path: moves a listed Pack without touching basket ERC-20s.
+    function releasePack(uint256 packSeed, uint256 recipientSeed) external {
+        if (livePacks.length == 0) return;
+        uint256 tokenId = livePacks[bound(packSeed, 0, livePacks.length - 1)];
+        if (!PACKS.isListed(tokenId)) return;
+
+        address recipient = _actor(recipientSeed);
+        if (recipient == PACKS.ownerOf(tokenId)) return;
+
+        vm.prank(RIP_ENGINE);
+        PACKS.releaseToRecipient(tokenId, recipient);
+
+        ghostSeenUnlisted[tokenId] = true;
     }
 
     function redeemPack(uint256 packSeed) external {
@@ -242,6 +259,7 @@ contract PackCustodyInvariantTest is StdInvariant, Test {
 
     address internal admin = makeAddr("admin");
     address internal whitelistAdmin = makeAddr("whitelistAdmin");
+    address internal ripEngine = makeAddr("ripEngine");
 
     address[] internal assets;
 
@@ -254,20 +272,22 @@ contract PackCustodyInvariantTest is StdInvariant, Test {
 
         packs = new PackCustody(admin, assets);
 
-        bytes32 role = packs.WHITELIST_ADMIN_ROLE();
-        vm.prank(admin);
-        packs.grantRole(role, whitelistAdmin);
+        vm.startPrank(admin);
+        packs.grantRole(packs.WHITELIST_ADMIN_ROLE(), whitelistAdmin);
+        packs.grantRole(packs.RIP_ENGINE_ROLE(), ripEngine);
+        vm.stopPrank();
 
-        handler = new PackCustodyHandler(packs, assets, whitelistAdmin);
+        handler = new PackCustodyHandler(packs, assets, whitelistAdmin, ripEngine);
 
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](8);
         selectors[0] = PackCustodyHandler.mintPack.selector;
         selectors[1] = PackCustodyHandler.topUpPack.selector;
         selectors[2] = PackCustodyHandler.transferPack.selector;
-        selectors[3] = PackCustodyHandler.redeemPack.selector;
-        selectors[4] = PackCustodyHandler.unwrapPack.selector;
-        selectors[5] = PackCustodyHandler.churnWhitelist.selector;
-        selectors[6] = PackCustodyHandler.observeListing.selector;
+        selectors[3] = PackCustodyHandler.releasePack.selector;
+        selectors[4] = PackCustodyHandler.redeemPack.selector;
+        selectors[5] = PackCustodyHandler.unwrapPack.selector;
+        selectors[6] = PackCustodyHandler.churnWhitelist.selector;
+        selectors[7] = PackCustodyHandler.observeListing.selector;
 
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));

--- a/contracts/test/PackCustody.lifecycle.t.sol
+++ b/contracts/test/PackCustody.lifecycle.t.sol
@@ -95,10 +95,7 @@ contract PackCustodyLifecycleTest is PackCustodyFixture {
     // ========== mint -> top-up -> role-gated release -> unwrap ==========
 
     function test_lifecycleMintTopUpReleaseUnwrap() public {
-        address ripEngine = makeAddr("ripEngine");
-        bytes32 role = packs.RIP_ENGINE_ROLE();
-        vm.prank(admin);
-        packs.grantRole(role, ripEngine);
+        _grantRipEngine();
 
         uint256 creatorAmznStart = amzn.balanceOf(creator);
         uint256 buyerAmznStart = amzn.balanceOf(buyer);

--- a/contracts/test/PackCustody.lifecycle.t.sol
+++ b/contracts/test/PackCustody.lifecycle.t.sol
@@ -66,7 +66,7 @@ contract PackCustodyLifecycleTest is PackCustodyFixture {
         vm.prank(creator);
         uint256 tokenId = packs.mint(assets, amounts);
 
-        // Settlement moves the Pack to its new holder; the basket follows the token.
+        // Manual transfer still stands in for secondary sales; the basket follows the token.
         vm.prank(creator);
         packs.transferFrom(creator, buyer, tokenId);
 
@@ -87,6 +87,52 @@ contract PackCustodyLifecycleTest is PackCustodyFixture {
         assertEq(pltr.balanceOf(buyer), buyerPltrStart + 7e6);
 
         assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(packs.basketOf(tokenId).length, 0);
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, tokenId));
+        packs.ownerOf(tokenId);
+    }
+
+    // ========== mint -> top-up -> role-gated release -> unwrap ==========
+
+    function test_lifecycleMintTopUpReleaseUnwrap() public {
+        address ripEngine = makeAddr("ripEngine");
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, ripEngine);
+
+        uint256 creatorAmznStart = amzn.balanceOf(creator);
+        uint256 buyerAmznStart = amzn.balanceOf(buyer);
+        uint256 buyerTslaStart = tsla.balanceOf(buyer);
+
+        (address[] memory assets, uint256[] memory amounts) = _defaultBasket();
+        vm.prank(creator);
+        uint256 tokenId = packs.mint(assets, amounts);
+
+        (address[] memory addAssets, uint256[] memory addAmounts) = _pair(address(amzn), 4e18, address(tsla), 9e18);
+        vm.prank(creator);
+        packs.topUp(tokenId, addAssets, addAmounts);
+
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 6e18);
+        assertEq(packs.basketAmountOf(tokenId, address(tsla)), 9e18);
+        assertTrue(packs.isListed(tokenId));
+
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(tokenId, buyer);
+
+        assertEq(packs.ownerOf(tokenId), buyer);
+        assertFalse(packs.isListed(tokenId));
+        assertEq(packs.basketAmountOf(tokenId, address(amzn)), 6e18);
+        assertEq(packs.basketAmountOf(tokenId, address(tsla)), 9e18);
+        assertEq(amzn.balanceOf(creator), creatorAmznStart - 6e18);
+        assertEq(amzn.balanceOf(buyer), buyerAmznStart);
+
+        vm.prank(buyer);
+        packs.unwrap(tokenId);
+
+        assertEq(amzn.balanceOf(buyer), buyerAmznStart + 6e18);
+        assertEq(tsla.balanceOf(buyer), buyerTslaStart + 9e18);
+        assertEq(amzn.balanceOf(address(packs)), 0);
+        assertEq(tsla.balanceOf(address(packs)), 0);
         assertEq(packs.basketOf(tokenId).length, 0);
         vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, tokenId));
         packs.ownerOf(tokenId);

--- a/contracts/test/PackCustody.settle.t.sol
+++ b/contracts/test/PackCustody.settle.t.sol
@@ -30,7 +30,9 @@ contract PackCustodySettleTest is PackCustodyFixture {
     function test_unauthorizedCallerReverts() public {
         bytes32 role = packs.RIP_ENGINE_ROLE();
 
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, role));
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, role)
+        );
         vm.prank(stranger);
         packs.releaseToRecipient(packId, buyer);
     }

--- a/contracts/test/PackCustody.settle.t.sol
+++ b/contracts/test/PackCustody.settle.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {IERC721Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
+
+/// @notice Role-gated settlement: RipEngine hands a listed Pack to a recipient without moving
+///         basket ERC-20s — ownership + the one-way unlisted latch only.
+contract PackCustodySettleTest is PackCustodyFixture {
+    event PackUnlisted(uint256 indexed tokenId);
+    event PackReleased(uint256 indexed tokenId, address indexed from, address indexed to);
+
+    address internal ripEngine = makeAddr("ripEngine");
+
+    uint256 internal packId;
+
+    function setUp() public override {
+        super.setUp();
+        packId = _mintDefaultPack(creator);
+
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, ripEngine);
+    }
+
+    // ========== Authorization ==========
+
+    function test_unauthorizedCallerReverts() public {
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, role));
+        vm.prank(stranger);
+        packs.releaseToRecipient(packId, buyer);
+    }
+
+    function test_adminIsNotImplicitlyAuthorized() public {
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, role));
+        vm.prank(admin);
+        packs.releaseToRecipient(packId, buyer);
+    }
+
+    function test_roleIsGrantableAndRevocableByAdmin() public {
+        address nextEngine = makeAddr("nextEngine");
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+
+        vm.prank(admin);
+        packs.grantRole(role, nextEngine);
+
+        vm.prank(nextEngine);
+        packs.releaseToRecipient(packId, buyer);
+        assertEq(packs.ownerOf(packId), buyer);
+
+        uint256 listedPack = _mintDefaultPack(creator);
+
+        vm.prank(admin);
+        packs.revokeRole(role, nextEngine);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, nextEngine, role)
+        );
+        vm.prank(nextEngine);
+        packs.releaseToRecipient(listedPack, buyer);
+    }
+
+    function test_ripEngineRoleIsNotGrantedAtConstruction() public view {
+        assertFalse(packs.hasRole(packs.RIP_ENGINE_ROLE(), admin));
+    }
+
+    // ========== Happy path ==========
+
+    function test_releaseMovesPackToRecipientAndUnlistsWithoutMovingTokens() public {
+        uint256 custodyAmzn = amzn.balanceOf(address(packs));
+        uint256 custodyNflx = nflx.balanceOf(address(packs));
+        uint256 custodyPltr = pltr.balanceOf(address(packs));
+        uint256 buyerAmzn = amzn.balanceOf(buyer);
+
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, buyer);
+
+        assertEq(packs.ownerOf(packId), buyer);
+        assertFalse(packs.isListed(packId));
+        assertEq(packs.basketAmountOf(packId, address(amzn)), 2e18);
+        assertEq(packs.basketAmountOf(packId, address(nflx)), 5e8);
+        assertEq(packs.basketAmountOf(packId, address(pltr)), 7e6);
+        assertEq(packs.basketOf(packId).length, 3);
+
+        assertEq(amzn.balanceOf(address(packs)), custodyAmzn);
+        assertEq(nflx.balanceOf(address(packs)), custodyNflx);
+        assertEq(pltr.balanceOf(address(packs)), custodyPltr);
+        assertEq(amzn.balanceOf(buyer), buyerAmzn);
+    }
+
+    function test_releaseEmitsPackUnlistedAndPackReleased() public {
+        vm.expectEmit(true, false, false, true, address(packs));
+        emit PackUnlisted(packId);
+        vm.expectEmit(true, true, true, true, address(packs));
+        emit PackReleased(packId, creator, buyer);
+
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, buyer);
+    }
+
+    // ========== Settle-once ==========
+
+    function test_secondReleaseRevertsPackNotListed() public {
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, buyer);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, stranger);
+    }
+
+    function test_alreadyTransferredPackCannotBeSettled() public {
+        vm.prank(creator);
+        packs.transferFrom(creator, buyer, packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, stranger);
+    }
+
+    // ========== Edge cases ==========
+
+    function test_zeroAddressRecipientReverts() public {
+        vm.expectRevert(PackCustody.ZeroAddress.selector);
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, address(0));
+    }
+
+    function test_unknownTokenIdReverts() public {
+        uint256 missing = 999;
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, missing));
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(missing, buyer);
+    }
+
+    function test_burnedPackCannotBeSettled() public {
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, buyer);
+    }
+
+    // ========== Post-settle exits ==========
+
+    function test_recipientCanUnwrapAfterRelease() public {
+        uint256 buyerAmzn = amzn.balanceOf(buyer);
+        uint256 buyerNflx = nflx.balanceOf(buyer);
+        uint256 buyerPltr = pltr.balanceOf(buyer);
+
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, buyer);
+
+        vm.prank(buyer);
+        packs.unwrap(packId);
+
+        assertEq(amzn.balanceOf(buyer), buyerAmzn + 2e18);
+        assertEq(nflx.balanceOf(buyer), buyerNflx + 5e8);
+        assertEq(pltr.balanceOf(buyer), buyerPltr + 7e6);
+        assertEq(amzn.balanceOf(address(packs)), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, packId));
+        packs.ownerOf(packId);
+    }
+
+    function test_creatorCannotRedeemOrTopUpAfterRelease() public {
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, buyer);
+
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.delistAndRedeem(packId);
+
+        (address[] memory assets, uint256[] memory amounts) = _single(address(amzn), 1e18);
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.PackNotListed.selector, packId));
+        vm.prank(creator);
+        packs.topUp(packId, assets, amounts);
+    }
+}

--- a/contracts/test/PackCustody.settle.t.sol
+++ b/contracts/test/PackCustody.settle.t.sol
@@ -9,20 +9,15 @@ import {PackCustodyFixture} from "./helpers/PackCustodyFixture.sol";
 /// @notice Role-gated settlement: RipEngine hands a listed Pack to a recipient without moving
 ///         basket ERC-20s — ownership + the one-way unlisted latch only.
 contract PackCustodySettleTest is PackCustodyFixture {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
     event PackUnlisted(uint256 indexed tokenId);
-    event PackReleased(uint256 indexed tokenId, address indexed from, address indexed to);
-
-    address internal ripEngine = makeAddr("ripEngine");
 
     uint256 internal packId;
 
     function setUp() public override {
         super.setUp();
+        _grantRipEngine();
         packId = _mintDefaultPack(creator);
-
-        bytes32 role = packs.RIP_ENGINE_ROLE();
-        vm.prank(admin);
-        packs.grantRole(role, ripEngine);
     }
 
     // ========== Authorization ==========
@@ -68,8 +63,9 @@ contract PackCustodySettleTest is PackCustodyFixture {
         packs.releaseToRecipient(listedPack, buyer);
     }
 
-    function test_ripEngineRoleIsNotGrantedAtConstruction() public view {
-        assertFalse(packs.hasRole(packs.RIP_ENGINE_ROLE(), admin));
+    function test_ripEngineRoleIsNotGrantedAtConstruction() public {
+        PackCustody fresh = new PackCustody(admin, whitelist);
+        assertFalse(fresh.hasRole(fresh.RIP_ENGINE_ROLE(), admin));
     }
 
     // ========== Happy path ==========
@@ -96,11 +92,11 @@ contract PackCustodySettleTest is PackCustodyFixture {
         assertEq(amzn.balanceOf(buyer), buyerAmzn);
     }
 
-    function test_releaseEmitsPackUnlistedAndPackReleased() public {
+    function test_releaseEmitsTransferAndPackUnlisted() public {
+        vm.expectEmit(true, true, true, true, address(packs));
+        emit Transfer(creator, buyer, packId);
         vm.expectEmit(true, false, false, true, address(packs));
         emit PackUnlisted(packId);
-        vm.expectEmit(true, true, true, true, address(packs));
-        emit PackReleased(packId, creator, buyer);
 
         vm.prank(ripEngine);
         packs.releaseToRecipient(packId, buyer);
@@ -132,6 +128,12 @@ contract PackCustodySettleTest is PackCustodyFixture {
         vm.expectRevert(PackCustody.ZeroAddress.selector);
         vm.prank(ripEngine);
         packs.releaseToRecipient(packId, address(0));
+    }
+
+    function test_selfReleaseReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(PackCustody.SelfRelease.selector, packId));
+        vm.prank(ripEngine);
+        packs.releaseToRecipient(packId, creator);
     }
 
     function test_unknownTokenIdReverts() public {

--- a/contracts/test/helpers/PackCustodyFixture.sol
+++ b/contracts/test/helpers/PackCustodyFixture.sol
@@ -26,6 +26,7 @@ abstract contract PackCustodyFixture is Test {
     address internal otherCreator = makeAddr("otherCreator");
     address internal buyer = makeAddr("buyer");
     address internal stranger = makeAddr("stranger");
+    address internal ripEngine = makeAddr("ripEngine");
 
     function setUp() public virtual {
         // Mixed decimals mirror the real Stock Token spread rather than assuming 18 everywhere.
@@ -48,6 +49,13 @@ abstract contract PackCustodyFixture is Test {
         _fundActor(otherCreator);
         _fundActor(buyer);
         _fundActor(stranger);
+    }
+
+    /// @dev Grants `RIP_ENGINE_ROLE` to `ripEngine`. Role is not granted at construction.
+    function _grantRipEngine() internal {
+        bytes32 role = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(role, ripEngine);
     }
 
     /// @dev Mints a generous balance of every token to `who` and approves custody for all of them.


### PR DESCRIPTION
## Summary
- Adds `RIP_ENGINE_ROLE`-gated `releaseToRecipient` so a future RipEngine can hand a listed Pack to a Taker in one call without ERC-721 approval; basket ERC-20s stay in custody and the one-way unlisted latch fires via `_update` (settle-once).
- Extends unit, fuzz, invariant, and lifecycle suites so full backing / no over-draw / one-way unlisting hold under the new path.
- Documents the primitive and cast demo path in `contracts/README.md`. No testnet redeploy in this PR.

Closes #299

## Test plan
- [ ] `pnpm test:contracts --match-path 'test/PackCustody*'`
- [ ] `FOUNDRY_PROFILE=ci pnpm test:contracts:ci --match-path 'test/PackCustody*'`
- [ ] `cd contracts && forge fmt --check`
- [ ] Spot-check: unauthorized caller reverts; admin can grant/revoke `RIP_ENGINE_ROLE`; second `releaseToRecipient` reverts `PackNotListed`; recipient can unwrap after release


Made with [Cursor](https://cursor.com)