### PR TITLE
V1 · RipEngine core: selection + live pricing + Model-A settlement + Acquisition Fee (#301)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,13 @@ ASSETREGISTRY_SEED_FEEDS=        # true/false; default true
 ASSETREGISTRY_ADDRESS=             # Filled by `pnpm deploy:asset-registry`
 NEXT_PUBLIC_ASSETREGISTRY_ADDRESS= # Same address for the client
 
+# RipEngine (issue #301)
+RIPENGINE_ADMIN=
+RIPENGINE_SEED=                    # MockRandomness base seed; default 0xC0FFEE
+RIPENGINE_GRANT_ROLE=              # true/false; default true
+RIPENGINE_ADDRESS=                 # Filled by `pnpm deploy:rip-engine`
+NEXT_PUBLIC_RIPENGINE_ADDRESS=     # Same address for the client
+
 # Legacy deal-game addresses (optional — rebuild pending)
 # See docs/base-sepolia-configuration.md. Removed at #262.
 NEXT_PUBLIC_ESCROW_ADDRESS=  # MarginCallEscrow (legacy address record)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 Margin Call is a Next.js 16 (App Router) web app — a NAV-weighted Pack-rip game on Robinhood Chain. The agent-game UI/backend was torn down (#298); the app is currently a Privy connect shell plus SIWA/Convex auth scaffolding. See `CLAUDE.md` for tech stack and architecture. Design: `docs/prd-margin-call.md`; glossary: `CONTEXT.md`. Full V1 build: GitHub issue #297.
 
-The Foundry workspace lives under `contracts/` (LazerForge-based). MockUSD and PackCustody are on Robinhood Chain testnet; AssetRegistry + MockPriceFeed are built (issue #300) with a deploy script — testnet wire-up is #310. RipEngine / GameToken / Distributor follow in later slices. Stock Token map: `contracts/deployments/robinhood-testnet.stock-tokens.json`. See `contracts/README.md`.
+The Foundry workspace lives under `contracts/` (LazerForge-based). MockUSD and PackCustody are on Robinhood Chain testnet; AssetRegistry + MockPriceFeed (#300) and RipEngine (#301) are built with deploy scripts — testnet wire-up is #310. GameToken / Distributor follow in later slices. Stock Token map: `contracts/deployments/robinhood-testnet.stock-tokens.json`. See `contracts/README.md`.
 
 ### Commands
 
@@ -21,6 +21,7 @@ Standard commands are in `package.json` scripts and documented in `CLAUDE.md`:
 - `pnpm deploy:mockusd` / `pnpm verify:mockusd` — Robinhood testnet deploy + verify
 - `pnpm deploy:packcustody` / `pnpm verify:packcustody` — PackCustody deploy + verify
 - `pnpm deploy:asset-registry` — AssetRegistry + MockPriceFeed seed
+- `pnpm deploy:rip-engine` — RipEngine + MockRandomness
 
 ### Contracts caveats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Margin Call is a **NAV-weighted Pack-rip game** on Robinhood Chain. One global pool; a single kind of participant — a **user** — who creates Packs of tokenized stocks (as a **Maker**) and/or rips them (as a **Taker**). Selection is inversely weighted by a Pack's USD NAV and each Rip is priced at the live expected value plus a maker–taker surcharge, so cheap Packs come up often and rich ones rarely (the jackpot). Makers are made whole by a socialized, equal-rate **Acquisition Fee** (stablecoin); a game token (**Maker Emissions** + a **Buyer-Rebate** participation pot) is a steering layer streamed from an owner-funded **Distributor**. Authoritative design: **`docs/prd-margin-call.md`** (v2.0); domain glossary: **`CONTEXT.md`** (use its vocabulary — Maker, Taker, Rip, Pack, Acquisition Fee, Surcharge, Crown, Distributor, House). Full V1 build spec: GitHub issue #297.
 
-**Current implementation state — read before editing `src/` or `convex/`.** The legacy Wall Street agent-game (desk managers, AI traders, deals, Wire) was removed in #298. The app is an **auth shell**: Privy email OTP + embedded wallet on a minimal landing page, SIWA scaffolding, and Convex with only `siwaNonces` (+ `me` identity query). Pack-rip UI and game Convex modules land next per #297. On the contracts side, `contracts/` (LazerForge Foundry) has **MockUSD**, **PackCustody**, **AssetRegistry**, and **MockPriceFeed** built and tested; **RipEngine, GameToken, and the Distributor** land next per issue #297. Stock Token map: `contracts/deployments/robinhood-testnet.stock-tokens.json`. See `contracts/README.md`.
+**Current implementation state — read before editing `src/` or `convex/`.** The legacy Wall Street agent-game (desk managers, AI traders, deals, Wire) was removed in #298. The app is an **auth shell**: Privy email OTP + embedded wallet on a minimal landing page, SIWA scaffolding, and Convex with only `siwaNonces` (+ `me` identity query). Pack-rip UI and game Convex modules land next per #297. On the contracts side, `contracts/` (LazerForge Foundry) has **MockUSD**, **PackCustody**, **AssetRegistry**, **MockPriceFeed**, and **RipEngine** (selection + live pricing + Model-A settlement + Acquisition Fees) built and tested; **GameToken and the Distributor** land next per issue #297. Stock Token map: `contracts/deployments/robinhood-testnet.stock-tokens.json`. See `contracts/README.md`.
 
 ## Commands
 
@@ -19,6 +19,7 @@ Margin Call is a **NAV-weighted Pack-rip game** on Robinhood Chain. One global p
 - `pnpm deploy:mockusd` / `pnpm verify:mockusd` — Robinhood testnet deploy + Blockscout verify
 - `pnpm deploy:packcustody` / `pnpm verify:packcustody` — PackCustody deploy + verify
 - `pnpm deploy:asset-registry` — AssetRegistry + MockPriceFeed seed (testnet verify in #310)
+- `pnpm deploy:rip-engine` — RipEngine + MockRandomness (requires PackCustody / AssetRegistry / MockUSD addresses)
 
 ## Tech Stack
 
@@ -36,7 +37,7 @@ Convex holds auth scaffolding; the rip rebuild will add on-chain reads and game 
 
 - **`src/app/`** — App Router pages + SIWA nonce route under `src/app/api/siwa/`. Home is a minimal Privy connect shell.
 - **`convex/`** — `auth.config.ts`, `me.ts`, `siwaNonces.ts`, empty `http.ts`, schema (`siwaNonces` only), crons (SIWA nonce purge only).
-- **`contracts/`** — Foundry workspace (MockUSD + PackCustody + AssetRegistry / MockPriceFeed today; RipEngine + GameToken + Distributor next). See `contracts/README.md` and `contracts/REPRODUCIBILITY.md`.
+- **`contracts/`** — Foundry workspace (MockUSD + PackCustody + AssetRegistry / MockPriceFeed + RipEngine today; GameToken + Distributor next). See `contracts/README.md` and `contracts/REPRODUCIBILITY.md`.
 - **`src/lib/`** — Privy, SIWA, Convex server client, rate-limit, utils.
 - **`src/components/`** — Providers (Privy/Wagmi/Convex), landing shell, UI primitives.
 - **`src/hooks/`** — Network guard helpers (`use-base-network`).

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -70,22 +70,36 @@ ERC-721 Packs backed by a recorded basket of whitelisted Stock Tokens held direc
 - `delistAndRedeem` (creator, while listed) and `unwrap` (holder, once transferred) both release the full basket at **zero protocol fee**
 - `releaseToRecipient` is `RIP_ENGINE_ROLE`-gated: moves a listed Pack to a recipient in one call without ERC-721 approval; basket ERC-20s stay in custody and the one-way unlisted latch fires on transfer (Rip settlement primitive — a Pack settles at most once)
 - `WHITELIST_ADMIN_ROLE` governs deposits only — de-whitelisting an asset never blocks redemption
-- Neither `WHITELIST_ADMIN_ROLE` nor `RIP_ENGINE_ROLE` is granted at construction; `DEFAULT_ADMIN_ROLE` grants them after deploy (RipEngine will receive `RIP_ENGINE_ROLE` when that contract lands)
+- Neither `WHITELIST_ADMIN_ROLE` nor `RIP_ENGINE_ROLE` is granted at construction; `DEFAULT_ADMIN_ROLE` grants them after deploy (RipEngine receives `RIP_ENGINE_ROLE` via `pnpm deploy:rip-engine`)
 
-Oracle NAV, eligibility, and Rip selection live in AssetRegistry (and later RipEngine); custody knows nothing about them.
+Oracle NAV, eligibility, and Rip selection live in AssetRegistry and RipEngine; custody knows nothing about them.
 
 ## AssetRegistry + MockPriceFeed
 
 Owner-curated Stock Token whitelist, pool levers, and fail-closed Pack NAV (issue [#300](https://github.com/hurley87/margin-call/issues/300)):
 
 - Per asset: token address, `IPriceFeed`, `staleAfter`, status (`Active` / `Frozen` / `Delisting`), live inventory
-- `addAsset` / `setStatus` / `removeAsset` (zero inventory only); inventory adjusted via `INVENTORY_ROLE` (for RipEngine later)
+- `addAsset` / `setStatus` / `removeAsset` (zero inventory only); inventory adjusted via `INVENTORY_ROLE`
 - Owner setters for `minPackNav`, `poolMax`, `alpha`, `surcharge`, `protocolShareOfSurcharge`, `maxBatchSize`, and crown params — evented and prospective
 - `navOf` / `quote` return WAD USD (`$1 = 1e18`); every consumed feed read requires fresh, valid, non-paused data or reverts
 - Frozen assets are excluded from deposits and the price basket; Delisting blocks deposits but keeps resting Packs in the basket so inventory can drain
 - `MockPriceFeed` (`src/mocks/`) is the testnet / Foundry substitution point until real Robinhood feeds are wired (#310)
 
 Canonical Stock Token map: [`deployments/robinhood-testnet.stock-tokens.json`](./deployments/robinhood-testnet.stock-tokens.json).
+
+## RipEngine
+
+NAV-weighted Pack selection, live Rip pricing, Model-A settlement, and Acquisition Fees (issue [#301](https://github.com/hurley87/margin-call/issues/301)):
+
+- Explicit pool membership via `enterPool` / `exitPool` (PackCustody has no enumeration)
+- `eligibleSnapshot` fail-closed: not listed, frozen/stale/invalid NAV, or out of band → excluded
+- `quoteRip(count)` / `rip(count, maxTotalPayment)` price off one snapshot: `clamp(HM × (1+surcharge), [min, max]×(1+surcharge))` with `HM = n / Σ(1/N)`
+- Distinct draws without replacement, weights `∝ 1/NAV^alpha` (whole-number alpha only); entropy via injectable `IRandomnessSource` (`MockRandomness` in V1)
+- Protocol cut from the surcharge only; remainder socialized equally per resting Pack via a fee-per-Pack index (make-whole at `alpha = 1`)
+- Requires `eligibleCount > count` so socialization has a non-empty destination set
+- Maker `claimFees` / `claim`; admin `withdrawProtocolFees`
+- Crown carve-out is a documented seam for [#302](https://github.com/hurley87/margin-call/issues/302) — unused in V1 while `crownEnabled = false`
+- Equal-rate fee accrual follows enrollment (not per-rip eligibility); a Pack with a temporarily stale feed keeps accruing while undrawable
 
 ## Deploy (Robinhood Chain testnet)
 
@@ -144,6 +158,21 @@ pnpm deploy:asset-registry
 ```
 
 Writes `contracts/deployments/robinhood-testnet.asset-registry.json` and patches `ASSETREGISTRY_ADDRESS` / `NEXT_PUBLIC_ASSETREGISTRY_ADDRESS`. Testnet deploy + Blockscout verify of the full V1 set is tracked in [#310](https://github.com/hurley87/margin-call/issues/310).
+
+### RipEngine
+
+Requires PackCustody, AssetRegistry, and MockUSD addresses already in `.env.local`:
+
+```bash
+# Optional overrides:
+#   RIPENGINE_ADMIN=0x…              # defaults to deployer
+#   RIPENGINE_SEED=0xC0FFEE          # MockRandomness base seed
+#   RIPENGINE_GRANT_ROLE=true        # grant RIP_ENGINE_ROLE on PackCustody
+
+pnpm deploy:rip-engine
+```
+
+Writes `contracts/deployments/robinhood-testnet.rip-engine.json` and patches `RIPENGINE_ADDRESS` / `NEXT_PUBLIC_RIPENGINE_ADDRESS`.
 
 ### Explorer
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -97,9 +97,10 @@ NAV-weighted Pack selection, live Rip pricing, Model-A settlement, and Acquisiti
 - Distinct draws without replacement, weights `∝ 1/NAV^alpha` (whole-number alpha only); entropy via injectable `IRandomnessSource` (`MockRandomness` in V1)
 - Protocol cut from the surcharge only; remainder socialized equally per resting Pack via a fee-per-Pack index (make-whole at `alpha = 1`)
 - Requires `eligibleCount > count` so socialization has a non-empty destination set
-- Maker `claimFees` / `claim`; admin `withdrawProtocolFees`
+- Maker `claim(tokenIds)` (empty = crystallized only); admin `withdrawProtocolFees`
+- Unlisted Packs are purged at the start of every `rip` so ghosts cannot dilute fee socialization
 - Crown carve-out is a documented seam for [#302](https://github.com/hurley87/margin-call/issues/302) — unused in V1 while `crownEnabled = false`
-- Equal-rate fee accrual follows enrollment (not per-rip eligibility); a Pack with a temporarily stale feed keeps accruing while undrawable
+- Equal-rate fee accrual follows enrollment for listed Packs (not per-rip eligibility); a Pack with a temporarily stale feed keeps accruing while undrawable
 
 ## Deploy (Robinhood Chain testnet)
 

--- a/contracts/script/DeployRipEngine.s.sol
+++ b/contracts/script/DeployRipEngine.s.sol
@@ -45,7 +45,10 @@ contract DeployRipEngine is Utils {
         RipEngine engine = new RipEngine(admin, packs, registry, stablecoin, address(randomness));
 
         if (grantRole) {
-            require(admin == deployer, "DeployRipEngine: deployer must be admin to grant RIP_ENGINE_ROLE");
+            require(
+                PackCustody(packs).hasRole(bytes32(0), deployer),
+                "DeployRipEngine: deployer must hold PackCustody DEFAULT_ADMIN_ROLE to grant RIP_ENGINE_ROLE"
+            );
             PackCustody(packs).grantRole(keccak256("RIP_ENGINE_ROLE"), address(engine));
         }
         vm.stopBroadcast();

--- a/contracts/script/DeployRipEngine.s.sol
+++ b/contracts/script/DeployRipEngine.s.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {console2} from "forge-std/console2.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {RipEngine} from "../src/RipEngine.sol";
+import {MockRandomness} from "../src/mocks/MockRandomness.sol";
+import {Utils} from "./utils/Utils.sol";
+
+/// @notice Deploy RipEngine + MockRandomness, grant PackCustody `RIP_ENGINE_ROLE`.
+/// @dev Signing: set DEPLOYER_PRIVATE_KEY. Env:
+///        PACKCUSTODY_ADDRESS / RIPENGINE_PACKS     — required PackCustody
+///        ASSETREGISTRY_ADDRESS / RIPENGINE_REGISTRY — required AssetRegistry
+///        MOCKUSD_ADDRESS / RIPENGINE_STABLECOIN     — required stablecoin
+///        RIPENGINE_ADMIN                            — optional; defaults to deployer
+///        RIPENGINE_SEED                             — optional MockRandomness base seed
+///        RIPENGINE_GRANT_ROLE                       — optional; "true" (default) grants
+///                                                     RIP_ENGINE_ROLE when deployer is packs admin
+contract DeployRipEngine is Utils {
+    uint256 internal constant ROBINHOOD_TESTNET_CHAIN_ID = 46_630;
+
+    function run() external {
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        address admin = vm.envOr("RIPENGINE_ADMIN", deployer);
+
+        address packs = vm.envOr("RIPENGINE_PACKS", address(0));
+        if (packs == address(0)) {
+            packs = vm.envAddress("PACKCUSTODY_ADDRESS");
+        }
+        address registry = vm.envOr("RIPENGINE_REGISTRY", address(0));
+        if (registry == address(0)) {
+            registry = vm.envAddress("ASSETREGISTRY_ADDRESS");
+        }
+        address stablecoin = vm.envOr("RIPENGINE_STABLECOIN", address(0));
+        if (stablecoin == address(0)) {
+            stablecoin = vm.envAddress("MOCKUSD_ADDRESS");
+        }
+
+        uint256 seed = vm.envOr("RIPENGINE_SEED", uint256(0xC0FFEE));
+        bool grantRole = vm.envOr("RIPENGINE_GRANT_ROLE", true);
+
+        vm.startBroadcast(deployerKey);
+        MockRandomness randomness = new MockRandomness(admin, seed);
+        RipEngine engine = new RipEngine(admin, packs, registry, stablecoin, address(randomness));
+
+        if (grantRole) {
+            require(admin == deployer, "DeployRipEngine: deployer must be admin to grant RIP_ENGINE_ROLE");
+            PackCustody(packs).grantRole(keccak256("RIP_ENGINE_ROLE"), address(engine));
+        }
+        vm.stopBroadcast();
+
+        console2.log("RipEngine deployed at:", address(engine));
+        console2.log("MockRandomness:", address(randomness));
+        console2.log("PackCustody:", packs);
+        console2.log("AssetRegistry:", registry);
+        console2.log("Stablecoin:", stablecoin);
+        console2.log("Admin:", admin);
+
+        _writeRecord(address(engine), address(randomness), packs, registry, stablecoin, deployer, admin, grantRole);
+    }
+
+    function _writeRecord(
+        address engine,
+        address randomness,
+        address packs,
+        address registry,
+        address stablecoin,
+        address deployer,
+        address admin,
+        bool grantedRole
+    ) internal {
+        string memory obj = "ripengine";
+        vm.serializeUint(obj, "version", 1);
+        vm.serializeUint(obj, "chainId", block.chainid);
+        vm.serializeAddress(obj, "address", engine);
+        vm.serializeAddress(obj, "randomness", randomness);
+        vm.serializeAddress(obj, "packs", packs);
+        vm.serializeAddress(obj, "registry", registry);
+        vm.serializeAddress(obj, "stablecoin", stablecoin);
+        vm.serializeAddress(obj, "deployer", deployer);
+        vm.serializeAddress(obj, "admin", admin);
+        vm.serializeBool(obj, "grantedRipEngineRole", grantedRole);
+        vm.serializeUint(obj, "blockNumber", block.number);
+        vm.serializeUint(obj, "timestamp", block.timestamp);
+        vm.serializeString(obj, "solc", "0.8.28");
+        vm.serializeString(obj, "evmVersion", "cancun");
+        vm.serializeUint(obj, "optimizerRuns", 1_000_000);
+        vm.serializeString(obj, "bytecodeHash", "none");
+        string memory finalJson = vm.serializeBool(obj, "cborMetadata", false);
+
+        string memory fileName = block.chainid == ROBINHOOD_TESTNET_CHAIN_ID
+            ? "robinhood-testnet.rip-engine"
+            : string.concat("chain-", vm.toString(block.chainid), ".rip-engine");
+
+        writeOutput(finalJson, fileName);
+        console2.log("Wrote deployment record:", getOutputPath(fileName));
+    }
+}

--- a/contracts/src/RipEngine.sol
+++ b/contracts/src/RipEngine.sol
@@ -15,6 +15,7 @@ import {RipMath} from "./libraries/RipMath.sol";
 /// @title RipEngine
 /// @notice NAV-weighted Pack selection, live Rip pricing, Model-A settlement, Acquisition Fees.
 /// @dev Pool membership is explicit (`enterPool` / `exitPool`) — PackCustody has no enumeration.
+///      Unlisted Packs are purged before fee socialization so ghosts cannot dilute the rate.
 ///      Crown carve-out is a documented seam for #302; V1 leaves `crownShareOfSurcharge` unused.
 contract RipEngine is AccessControl, ReentrancyGuard {
     using SafeERC20 for IERC20;
@@ -31,10 +32,7 @@ contract RipEngine is AccessControl, ReentrancyGuard {
     /// @notice Maker recorded at enrollment (custody clears `creatorOf` on burn).
     mapping(uint256 tokenId => address maker) public makerOf;
 
-    /// @notice True while the Pack is in the resting set.
-    mapping(uint256 tokenId => bool resting) public isResting;
-
-    /// @dev Dense resting set for O(1) swap-and-pop removal.
+    /// @dev Dense resting set for O(1) swap-and-pop removal. Membership ↔ `_restingIndex[id] != 0`.
     uint256[] private _resting;
     mapping(uint256 tokenId => uint256 indexPlusOne) private _restingIndex;
 
@@ -81,13 +79,31 @@ contract RipEngine is AccessControl, ReentrancyGuard {
     error PackNotListed(uint256 tokenId);
     error PackAlreadyResting(uint256 tokenId);
     error PackNotResting(uint256 tokenId);
-    error PackStillListed(uint256 tokenId);
     error EmptyEligibleSet();
     error DegenerateEligibleSet(uint256 eligible, uint256 count);
     error CountOutOfRange(uint256 count, uint256 maxBatchSize);
     error SlippageExceeded(uint256 totalPaid, uint256 maxTotalPayment);
     error NothingToClaim();
     error ZeroAmount();
+
+    /// @dev Eligible snapshot + priced batch totals.
+    struct Eligible {
+        uint256[] tokenIds;
+        uint256[] navs;
+        uint256 count;
+    }
+
+    /// @dev Per-unit and batch totals in stablecoin units (plus WAD unit price for events).
+    struct RipQuote {
+        uint256 unitPriceWad;
+        uint256 hm;
+        uint256 unitStable;
+        uint256 totalPaid;
+        uint256 protocolCutUnit;
+        uint256 toMakersUnit;
+        uint256 protocolCutTotal;
+        uint256 toMakersTotal;
+    }
 
     /// @param admin DEFAULT_ADMIN_ROLE holder.
     /// @param packs_ PackCustody (must later grant this contract `RIP_ENGINE_ROLE`).
@@ -114,14 +130,20 @@ contract RipEngine is AccessControl, ReentrancyGuard {
     // Pool enrollment
     // ─────────────────────────────────────────────────────────────────────────
 
+    /// @notice True while the Pack is in the resting set.
+    function isResting(uint256 tokenId) public view returns (bool) {
+        return _restingIndex[tokenId] != 0;
+    }
+
     /// @notice Enroll a listed Pack into the resting set. Maker-only.
-    /// @dev Snapshots `makerOf` and the fee checkpoint. Does not require NAV eligibility —
-    ///      undrawable Packs still accrue the equal-rate Acquisition Fee while enrolled.
+    /// @dev Snapshots `makerOf` and the fee checkpoint. Listed Packs accrue the equal-rate
+    ///      Acquisition Fee while enrolled (including temporarily undrawable / out-of-band).
+    ///      Unlisted Packs are purged before socialization and never accrue.
     function enterPool(uint256 tokenId) external nonReentrant {
         if (!packs.isListed(tokenId)) revert PackNotListed(tokenId);
         address creator = packs.creatorOf(tokenId);
         if (msg.sender != creator) revert NotPackCreator(tokenId, msg.sender);
-        if (isResting[tokenId]) revert PackAlreadyResting(tokenId);
+        if (isResting(tokenId)) revert PackAlreadyResting(tokenId);
 
         makerOf[tokenId] = creator;
         feeCheckpoint[tokenId] = accFeePerPack;
@@ -131,28 +153,17 @@ contract RipEngine is AccessControl, ReentrancyGuard {
     }
 
     /// @notice Remove a Pack from the resting set.
-    /// @dev Maker may exit while listed. Anyone may exit once the Pack is no longer listed
-    ///      (ripped / transferred / redeemed) so the set cannot retain ghosts.
+    /// @dev Maker may exit while listed. Anyone may exit once unlisted (ripped / transferred /
+    ///      redeemed). Crystallizes pending fees into `claimableFees` then clears enrollment.
     function exitPool(uint256 tokenId) external nonReentrant {
-        if (!isResting[tokenId]) revert PackNotResting(tokenId);
+        if (!isResting(tokenId)) revert PackNotResting(tokenId);
 
         address maker = makerOf[tokenId];
-        bool listed = packs.isListed(tokenId);
-        if (listed) {
-            if (msg.sender != maker) revert NotPackCreator(tokenId, msg.sender);
+        if (packs.isListed(tokenId) && msg.sender != maker) {
+            revert NotPackCreator(tokenId, msg.sender);
         }
 
-        _crystallize(tokenId);
-        _removeResting(tokenId);
-        // Keep makerOf so a later claimFees on a still-listed exit path retains identity;
-        // cleared only when we want — leave for claim path. Actually after exit while listed,
-        // maker may re-enter. Clear makerOf only if not listed? If listed and maker exits,
-        // they can re-enter which overwrites makerOf. If unlisted, makerOf stays for claims.
-        if (listed) {
-            delete makerOf[tokenId];
-            delete feeCheckpoint[tokenId];
-        }
-
+        _leavePool(tokenId);
         emit PackExited(tokenId, maker);
     }
 
@@ -167,12 +178,117 @@ contract RipEngine is AccessControl, ReentrancyGuard {
     }
 
     /// @notice Eligible Packs and their NAVs at the current block (fail-closed per Pack).
-    /// @dev A Pack drops out when not listed, navOf reverts (frozen/stale/invalid), or out of band.
+    /// @dev Drops Packs that are not listed, fail nav (frozen/stale/invalid), or are out of band.
     function eligibleSnapshot()
         public
         view
         returns (uint256[] memory tokenIds, uint256[] memory navs, uint256 eligibleCount)
     {
+        Eligible memory e = _eligible();
+        return (e.tokenIds, e.navs, e.count);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Live pricing + Rip
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Quote a batch Rip off a single eligible snapshot.
+    function quoteRip(uint256 count)
+        public
+        view
+        returns (uint256 eligible, uint256 hm, uint256 unitPrice, uint256 totalPayment)
+    {
+        (Eligible memory e, RipQuote memory q) = _quote(count);
+        return (e.count, q.hm, q.unitPriceWad, q.totalPaid);
+    }
+
+    /// @notice Rip `count` distinct Packs. Priced off one snapshot; settles Model A.
+    /// @param count Packs to draw (1..maxBatchSize); requires eligibleCount > count.
+    /// @param maxTotalPayment Slippage bound in stablecoin units (live pricing).
+    /// @return tokenIds Drawn Pack ids, now held by the Taker.
+    function rip(uint256 count, uint256 maxTotalPayment) external nonReentrant returns (uint256[] memory tokenIds) {
+        // Drop unlisted ghosts before selection and fee socialization.
+        _purgeUnlisted();
+
+        (Eligible memory e, RipQuote memory q) = _quote(count);
+        if (q.totalPaid > maxTotalPayment) revert SlippageExceeded(q.totalPaid, maxTotalPayment);
+
+        stablecoin.safeTransferFrom(msg.sender, address(this), q.totalPaid);
+        protocolAccrued += q.protocolCutTotal;
+
+        tokenIds = _settleDraws(e, count, q);
+        _socialize(q.toMakersTotal);
+
+        emit RipSettled(msg.sender, count, q.unitPriceWad, q.totalPaid, q.protocolCutTotal, q.toMakersTotal);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Acquisition Fee claims + protocol withdrawal
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Pending Acquisition Fee for a resting Pack (stablecoin units), including uncrystallized.
+    function pendingOf(uint256 tokenId) public view returns (uint256) {
+        if (!isResting(tokenId)) return 0;
+        return accFeePerPack - feeCheckpoint[tokenId];
+    }
+
+    /// @notice Crystallize optional Pack ids owned by the caller, then withdraw all claimable fees.
+    /// @param tokenIds Resting Packs to crystallize first; empty withdraws already-crystallized only.
+    function claim(uint256[] calldata tokenIds) external nonReentrant returns (uint256 amount) {
+        for (uint256 i; i < tokenIds.length; ++i) {
+            uint256 tokenId = tokenIds[i];
+            if (!isResting(tokenId)) continue;
+            if (makerOf[tokenId] != msg.sender) continue;
+            _crystallize(tokenId);
+        }
+        amount = _withdrawClaimable(msg.sender);
+    }
+
+    /// @notice Admin withdraws accrued protocol cut.
+    function withdrawProtocolFees(address to) external onlyRole(DEFAULT_ADMIN_ROLE) returns (uint256 amount) {
+        if (to == address(0)) revert ZeroAddress();
+        amount = protocolAccrued;
+        if (amount == 0) revert ZeroAmount();
+        protocolAccrued = 0;
+        stablecoin.safeTransfer(to, amount);
+        emit ProtocolFeesWithdrawn(to, amount);
+    }
+
+    /// @notice Swap the randomness source (prospective).
+    function setRandomness(address randomness_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (randomness_ == address(0)) revert ZeroAddress();
+        randomness = IRandomnessSource(randomness_);
+        emit RandomnessUpdated(randomness_);
+    }
+
+    /// @notice Sum USD NAV of a Pack via registry quotes (no basket reshape). Fail-closed.
+    /// @dev External so `_tryNav` can wrap it in try/catch.
+    function navOfPack(uint256 tokenId) external view returns (uint256 nav) {
+        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
+        uint256 length = basket.length;
+        if (length == 0) revert AssetRegistry.EmptyBasket();
+        for (uint256 i; i < length; ++i) {
+            nav += registry.quote(basket[i].asset, basket[i].amount);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internals — quote / settle
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function _quote(uint256 count) internal view returns (Eligible memory e, RipQuote memory q) {
+        if (count == 0 || count > registry.maxBatchSize()) {
+            revert CountOutOfRange(count, registry.maxBatchSize());
+        }
+
+        e = _eligible();
+        if (e.count == 0) revert EmptyEligibleSet();
+        if (e.count <= count) revert DegenerateEligibleSet(e.count, count);
+
+        q = _priceRip(e.navs, count);
+    }
+
+    function _eligible() internal view returns (Eligible memory e) {
         uint256 n = _resting.length;
         uint256[] memory idsBuf = new uint256[](n);
         uint256[] memory navBuf = new uint256[](n);
@@ -193,95 +309,19 @@ contract RipEngine is AccessControl, ReentrancyGuard {
             }
         }
 
-        tokenIds = new uint256[](count);
-        navs = new uint256[](count);
+        e.tokenIds = new uint256[](count);
+        e.navs = new uint256[](count);
         for (uint256 i; i < count; ++i) {
-            tokenIds[i] = idsBuf[i];
-            navs[i] = navBuf[i];
+            e.tokenIds[i] = idsBuf[i];
+            e.navs[i] = navBuf[i];
         }
-        eligibleCount = count;
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Live pricing
-    // ─────────────────────────────────────────────────────────────────────────
-
-    /// @notice Quote a batch Rip off a single eligible snapshot.
-    /// @return eligible Number of Packs in the price/selection set.
-    /// @return hm Harmonic mean of eligible NAVs (WAD USD).
-    /// @return unitPrice Clamped per-Pack Rip price (WAD USD).
-    /// @return totalPayment Total stablecoin units the Taker would pay (`count * unitStable`).
-    function quoteRip(uint256 count)
-        public
-        view
-        returns (uint256 eligible, uint256 hm, uint256 unitPrice, uint256 totalPayment)
-    {
-        if (count == 0 || count > registry.maxBatchSize()) {
-            revert CountOutOfRange(count, registry.maxBatchSize());
-        }
-
-        (, uint256[] memory navs, uint256 eligibleCount) = eligibleSnapshot();
-        if (eligibleCount == 0) revert EmptyEligibleSet();
-        if (eligibleCount <= count) revert DegenerateEligibleSet(eligibleCount, count);
-
-        hm = RipMath.harmonicMean(navs);
-        unitPrice = RipMath.clampUnitPrice(hm, registry.surcharge(), registry.minPackNav(), registry.poolMax());
-        totalPayment = _wadToStable(unitPrice) * count;
-        eligible = eligibleCount;
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Rip — Model A settlement
-    // ─────────────────────────────────────────────────────────────────────────
-
-    /// @dev Per-unit and batch totals in stablecoin units (plus WAD unit price for events).
-    struct RipQuote {
-        uint256 unitPriceWad;
-        uint256 unitStable;
-        uint256 totalPaid;
-        uint256 protocolCutUnit;
-        uint256 toMakersUnit;
-        uint256 protocolCutTotal;
-        uint256 toMakersTotal;
-    }
-
-    /// @notice Rip `count` distinct Packs. Priced off one snapshot; settles Model A.
-    /// @param count Packs to draw (1..maxBatchSize); requires eligibleCount > count.
-    /// @param maxTotalPayment Slippage bound in stablecoin units (live pricing).
-    /// @return tokenIds Drawn Pack ids, now held by the Taker.
-    function rip(uint256 count, uint256 maxTotalPayment) external nonReentrant returns (uint256[] memory tokenIds) {
-        if (count == 0 || count > registry.maxBatchSize()) {
-            revert CountOutOfRange(count, registry.maxBatchSize());
-        }
-
-        (uint256[] memory eligibleIds, uint256[] memory navs, uint256 eligibleCount) = eligibleSnapshot();
-        if (eligibleCount == 0) revert EmptyEligibleSet();
-        if (eligibleCount <= count) revert DegenerateEligibleSet(eligibleCount, count);
-
-        RipQuote memory q = _priceRip(navs, count);
-        if (q.totalPaid > maxTotalPayment) revert SlippageExceeded(q.totalPaid, maxTotalPayment);
-
-        stablecoin.safeTransferFrom(msg.sender, address(this), q.totalPaid);
-        protocolAccrued += q.protocolCutTotal;
-
-        tokenIds = _settleDraws(eligibleIds, navs, count, q);
-
-        // Socialize to_makers equally across Packs still enrolled.
-        // Guaranteed remaining > 0 by eligibleCount > count (see DegenerateEligibleSet).
-        uint256 distributable = q.toMakersTotal + feeDust;
-        uint256 perPack = distributable / _resting.length;
-        feeDust = distributable % _resting.length;
-        if (perPack > 0) {
-            accFeePerPack += perPack;
-        }
-
-        emit RipSettled(msg.sender, count, q.unitPriceWad, q.totalPaid, q.protocolCutTotal, q.toMakersTotal);
+        e.count = count;
     }
 
     function _priceRip(uint256[] memory navs, uint256 count) internal view returns (RipQuote memory q) {
         uint256 surcharge = registry.surcharge();
-        q.unitPriceWad =
-            RipMath.clampUnitPrice(RipMath.harmonicMean(navs), surcharge, registry.minPackNav(), registry.poolMax());
+        q.hm = RipMath.harmonicMean(navs);
+        q.unitPriceWad = RipMath.clampUnitPrice(q.hm, surcharge, registry.minPackNav(), registry.poolMax());
         q.unitStable = _wadToStable(q.unitPriceWad);
         q.totalPaid = q.unitStable * count;
 
@@ -295,99 +335,80 @@ contract RipEngine is AccessControl, ReentrancyGuard {
         q.toMakersTotal = q.toMakersUnit * count;
     }
 
-    function _settleDraws(uint256[] memory eligibleIds, uint256[] memory navs, uint256 count, RipQuote memory q)
+    function _settleDraws(Eligible memory e, uint256 count, RipQuote memory q)
         internal
         returns (uint256[] memory tokenIds)
     {
-        uint256[] memory weights = new uint256[](eligibleIds.length);
+        uint256[] memory weights = new uint256[](e.count);
         {
             uint256 alpha = registry.alpha();
-            for (uint256 i; i < eligibleIds.length; ++i) {
-                weights[i] = RipMath.weightOf(navs[i], alpha);
+            for (uint256 i; i < e.count; ++i) {
+                weights[i] = RipMath.weightOf(e.navs[i], alpha);
             }
         }
 
         uint256[] memory drawnIdx;
         {
-            uint256 seed =
-                randomness.nextSeed(keccak256(abi.encode(count, eligibleIds.length, _resting.length, msg.sender)));
+            uint256 seed = randomness.nextSeed(keccak256(abi.encode(count, e.count, _resting.length, msg.sender)));
             drawnIdx = RipMath.drawDistinct(weights, seed, count);
         }
 
         tokenIds = new uint256[](count);
         for (uint256 k; k < count; ++k) {
             uint256 idx = drawnIdx[k];
-            tokenIds[k] = eligibleIds[idx];
-            _finalizeDrawnPack(eligibleIds[idx], msg.sender, navs[idx], q);
+            uint256 tokenId = e.tokenIds[idx];
+            tokenIds[k] = tokenId;
+            _finalizeDrawnPack(tokenId, msg.sender, e.navs[idx], q);
         }
     }
 
     function _finalizeDrawnPack(uint256 tokenId, address taker, uint256 nav, RipQuote memory q) internal {
         address maker = makerOf[tokenId];
-        _crystallize(tokenId);
-        _removeResting(tokenId);
-        delete feeCheckpoint[tokenId];
+        _leavePool(tokenId);
         packs.releaseToRecipient(tokenId, taker);
         emit PackRipped(tokenId, taker, maker, nav, q.unitPriceWad, q.protocolCutUnit, q.toMakersUnit);
     }
 
-    // ─────────────────────────────────────────────────────────────────────────
-    // Acquisition Fee claims + protocol withdrawal
-    // ─────────────────────────────────────────────────────────────────────────
-
-    /// @notice Pending Acquisition Fee for a resting Pack (stablecoin units), including uncrystallized.
-    function pendingOf(uint256 tokenId) public view returns (uint256) {
-        if (!isResting[tokenId]) return 0;
-        return accFeePerPack - feeCheckpoint[tokenId];
-    }
-
-    /// @notice Crystallize fees for the given resting Packs into `claimableFees[maker]` and withdraw all.
-    function claimFees(uint256[] calldata tokenIds) external nonReentrant returns (uint256 amount) {
-        for (uint256 i; i < tokenIds.length; ++i) {
-            uint256 tokenId = tokenIds[i];
-            if (!isResting[tokenId]) continue;
-            if (makerOf[tokenId] != msg.sender) continue;
-            _crystallize(tokenId);
+    function _socialize(uint256 toMakersTotal) internal {
+        // Guaranteed remaining > 0 by eligibleCount > count after purge + draws.
+        uint256 remaining = _resting.length;
+        uint256 distributable = toMakersTotal + feeDust;
+        uint256 perPack = distributable / remaining;
+        feeDust = distributable % remaining;
+        if (perPack > 0) {
+            accFeePerPack += perPack;
         }
-        amount = claimableFees[msg.sender];
-        if (amount == 0) revert NothingToClaim();
-        claimableFees[msg.sender] = 0;
-        stablecoin.safeTransfer(msg.sender, amount);
-        emit FeesClaimed(msg.sender, amount);
-    }
-
-    /// @notice Withdraw already-crystallized Acquisition Fees (no Pack ids needed).
-    function claim() external nonReentrant returns (uint256 amount) {
-        amount = claimableFees[msg.sender];
-        if (amount == 0) revert NothingToClaim();
-        claimableFees[msg.sender] = 0;
-        stablecoin.safeTransfer(msg.sender, amount);
-        emit FeesClaimed(msg.sender, amount);
-    }
-
-    /// @notice Admin withdraws accrued protocol cut.
-    function withdrawProtocolFees(address to) external onlyRole(DEFAULT_ADMIN_ROLE) returns (uint256 amount) {
-        if (to == address(0)) revert ZeroAddress();
-        amount = protocolAccrued;
-        if (amount == 0) revert ZeroAmount();
-        protocolAccrued = 0;
-        stablecoin.safeTransfer(to, amount);
-        emit ProtocolFeesWithdrawn(to, amount);
-    }
-
-    /// @notice Swap the randomness source (prospective).
-    function setRandomness(address randomness_) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (randomness_ == address(0)) revert ZeroAddress();
-        randomness = IRandomnessSource(randomness_);
-        emit RandomnessUpdated(randomness_);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Internals
+    // Internals — pool membership
     // ─────────────────────────────────────────────────────────────────────────
+
+    /// @dev Crystallize, remove from resting set, clear enrollment storage.
+    function _leavePool(uint256 tokenId) internal {
+        _crystallize(tokenId);
+        _removeResting(tokenId);
+        delete makerOf[tokenId];
+        delete feeCheckpoint[tokenId];
+    }
+
+    /// @dev Remove unlisted Packs from the resting set (descending so swap-pop is safe).
+    function _purgeUnlisted() internal {
+        uint256 i = _resting.length;
+        while (i > 0) {
+            unchecked {
+                --i;
+            }
+            uint256 tokenId = _resting[i];
+            if (!packs.isListed(tokenId)) {
+                address maker = makerOf[tokenId];
+                _leavePool(tokenId);
+                emit PackExited(tokenId, maker);
+            }
+        }
+    }
 
     function _addResting(uint256 tokenId) internal {
-        isResting[tokenId] = true;
         _resting.push(tokenId);
         _restingIndex[tokenId] = _resting.length; // 1-based
     }
@@ -405,10 +426,8 @@ contract RipEngine is AccessControl, ReentrancyGuard {
 
         _resting.pop();
         delete _restingIndex[tokenId];
-        isResting[tokenId] = false;
     }
 
-    /// @dev Credit uncrystallized fee to the Maker and bump the checkpoint.
     function _crystallize(uint256 tokenId) internal {
         uint256 pending = accFeePerPack - feeCheckpoint[tokenId];
         if (pending > 0) {
@@ -417,26 +436,22 @@ contract RipEngine is AccessControl, ReentrancyGuard {
         }
     }
 
+    function _withdrawClaimable(address maker) internal returns (uint256 amount) {
+        amount = claimableFees[maker];
+        if (amount == 0) revert NothingToClaim();
+        claimableFees[maker] = 0;
+        stablecoin.safeTransfer(maker, amount);
+        emit FeesClaimed(maker, amount);
+    }
+
     function _tryNav(uint256 tokenId) internal view returns (bool ok, uint256 nav) {
-        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
-        uint256 length = basket.length;
-        if (length == 0) return (false, 0);
-
-        address[] memory tokens = new address[](length);
-        uint256[] memory amounts = new uint256[](length);
-        for (uint256 i; i < length; ++i) {
-            tokens[i] = basket[i].asset;
-            amounts[i] = basket[i].amount;
-        }
-
-        try registry.navOf(tokens, amounts) returns (uint256 value) {
+        try this.navOfPack(tokenId) returns (uint256 value) {
             return (true, value);
         } catch {
             return (false, 0);
         }
     }
 
-    /// @dev Convert WAD USD to stablecoin units (peg trusted at par).
     function _wadToStable(uint256 wad) internal view returns (uint256) {
         return (wad * (10 ** uint256(stableDecimals))) / WAD;
     }

--- a/contracts/src/RipEngine.sol
+++ b/contracts/src/RipEngine.sol
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {AssetRegistry} from "./AssetRegistry.sol";
+import {PackCustody} from "./PackCustody.sol";
+import {IRandomnessSource} from "./interfaces/IRandomnessSource.sol";
+import {RipMath} from "./libraries/RipMath.sol";
+
+/// @title RipEngine
+/// @notice NAV-weighted Pack selection, live Rip pricing, Model-A settlement, Acquisition Fees.
+/// @dev Pool membership is explicit (`enterPool` / `exitPool`) — PackCustody has no enumeration.
+///      Crown carve-out is a documented seam for #302; V1 leaves `crownShareOfSurcharge` unused.
+contract RipEngine is AccessControl, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant WAD = 1e18;
+
+    PackCustody public immutable packs;
+    AssetRegistry public immutable registry;
+    IERC20 public immutable stablecoin;
+    uint8 public immutable stableDecimals;
+
+    IRandomnessSource public randomness;
+
+    /// @notice Maker recorded at enrollment (custody clears `creatorOf` on burn).
+    mapping(uint256 tokenId => address maker) public makerOf;
+
+    /// @notice True while the Pack is in the resting set.
+    mapping(uint256 tokenId => bool resting) public isResting;
+
+    /// @dev Dense resting set for O(1) swap-and-pop removal.
+    uint256[] private _resting;
+    mapping(uint256 tokenId => uint256 indexPlusOne) private _restingIndex;
+
+    /// @notice Cumulative Acquisition Fee per resting Pack (stablecoin units).
+    uint256 public accFeePerPack;
+
+    /// @notice Integer remainder of fee socialization not yet distributed.
+    uint256 public feeDust;
+
+    /// @notice Fee-index checkpoint at enrollment (or last crystallize).
+    mapping(uint256 tokenId => uint256 checkpoint) public feeCheckpoint;
+
+    /// @notice Crystallized Acquisition Fee balances (stablecoin units), keyed by Maker.
+    mapping(address maker => uint256 amount) public claimableFees;
+
+    /// @notice Protocol cut accrued (stablecoin units), withdrawable by admin.
+    uint256 public protocolAccrued;
+
+    event PackEntered(uint256 indexed tokenId, address indexed maker);
+    event PackExited(uint256 indexed tokenId, address indexed maker);
+    event PackRipped(
+        uint256 indexed tokenId,
+        address indexed taker,
+        address indexed maker,
+        uint256 nav,
+        uint256 unitPrice,
+        uint256 protocolCut,
+        uint256 toMakers
+    );
+    event RipSettled(
+        address indexed taker,
+        uint256 count,
+        uint256 unitPrice,
+        uint256 totalPaid,
+        uint256 protocolCut,
+        uint256 toMakers
+    );
+    event FeesClaimed(address indexed maker, uint256 amount);
+    event ProtocolFeesWithdrawn(address indexed to, uint256 amount);
+    event RandomnessUpdated(address indexed randomness);
+
+    error ZeroAddress();
+    error NotPackCreator(uint256 tokenId, address caller);
+    error PackNotListed(uint256 tokenId);
+    error PackAlreadyResting(uint256 tokenId);
+    error PackNotResting(uint256 tokenId);
+    error PackStillListed(uint256 tokenId);
+    error EmptyEligibleSet();
+    error DegenerateEligibleSet(uint256 eligible, uint256 count);
+    error CountOutOfRange(uint256 count, uint256 maxBatchSize);
+    error SlippageExceeded(uint256 totalPaid, uint256 maxTotalPayment);
+    error NothingToClaim();
+    error ZeroAmount();
+
+    /// @param admin DEFAULT_ADMIN_ROLE holder.
+    /// @param packs_ PackCustody (must later grant this contract `RIP_ENGINE_ROLE`).
+    /// @param registry_ AssetRegistry for NAV / levers.
+    /// @param stablecoin_ Payment token (MockUSD on testnet); peg trusted at par.
+    /// @param randomness_ Injectable entropy source.
+    constructor(address admin, address packs_, address registry_, address stablecoin_, address randomness_) {
+        if (
+            admin == address(0) || packs_ == address(0) || registry_ == address(0) || stablecoin_ == address(0)
+                || randomness_ == address(0)
+        ) {
+            revert ZeroAddress();
+        }
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        packs = PackCustody(packs_);
+        registry = AssetRegistry(registry_);
+        stablecoin = IERC20(stablecoin_);
+        stableDecimals = IERC20Metadata(stablecoin_).decimals();
+        randomness = IRandomnessSource(randomness_);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Pool enrollment
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Enroll a listed Pack into the resting set. Maker-only.
+    /// @dev Snapshots `makerOf` and the fee checkpoint. Does not require NAV eligibility —
+    ///      undrawable Packs still accrue the equal-rate Acquisition Fee while enrolled.
+    function enterPool(uint256 tokenId) external nonReentrant {
+        if (!packs.isListed(tokenId)) revert PackNotListed(tokenId);
+        address creator = packs.creatorOf(tokenId);
+        if (msg.sender != creator) revert NotPackCreator(tokenId, msg.sender);
+        if (isResting[tokenId]) revert PackAlreadyResting(tokenId);
+
+        makerOf[tokenId] = creator;
+        feeCheckpoint[tokenId] = accFeePerPack;
+        _addResting(tokenId);
+
+        emit PackEntered(tokenId, creator);
+    }
+
+    /// @notice Remove a Pack from the resting set.
+    /// @dev Maker may exit while listed. Anyone may exit once the Pack is no longer listed
+    ///      (ripped / transferred / redeemed) so the set cannot retain ghosts.
+    function exitPool(uint256 tokenId) external nonReentrant {
+        if (!isResting[tokenId]) revert PackNotResting(tokenId);
+
+        address maker = makerOf[tokenId];
+        bool listed = packs.isListed(tokenId);
+        if (listed) {
+            if (msg.sender != maker) revert NotPackCreator(tokenId, msg.sender);
+        }
+
+        _crystallize(tokenId);
+        _removeResting(tokenId);
+        // Keep makerOf so a later claimFees on a still-listed exit path retains identity;
+        // cleared only when we want — leave for claim path. Actually after exit while listed,
+        // maker may re-enter. Clear makerOf only if not listed? If listed and maker exits,
+        // they can re-enter which overwrites makerOf. If unlisted, makerOf stays for claims.
+        if (listed) {
+            delete makerOf[tokenId];
+            delete feeCheckpoint[tokenId];
+        }
+
+        emit PackExited(tokenId, maker);
+    }
+
+    /// @notice Resting Pack ids (enrollment order; gaps closed on removal).
+    function restingPackIds() external view returns (uint256[] memory) {
+        return _resting;
+    }
+
+    /// @notice Number of Packs currently enrolled.
+    function restingCount() external view returns (uint256) {
+        return _resting.length;
+    }
+
+    /// @notice Eligible Packs and their NAVs at the current block (fail-closed per Pack).
+    /// @dev A Pack drops out when not listed, navOf reverts (frozen/stale/invalid), or out of band.
+    function eligibleSnapshot()
+        public
+        view
+        returns (uint256[] memory tokenIds, uint256[] memory navs, uint256 eligibleCount)
+    {
+        uint256 n = _resting.length;
+        uint256[] memory idsBuf = new uint256[](n);
+        uint256[] memory navBuf = new uint256[](n);
+        uint256 count;
+
+        for (uint256 i; i < n; ++i) {
+            uint256 tokenId = _resting[i];
+            if (!packs.isListed(tokenId)) continue;
+
+            (bool ok, uint256 nav) = _tryNav(tokenId);
+            if (!ok) continue;
+            if (!registry.isNavInBand(nav)) continue;
+
+            idsBuf[count] = tokenId;
+            navBuf[count] = nav;
+            unchecked {
+                ++count;
+            }
+        }
+
+        tokenIds = new uint256[](count);
+        navs = new uint256[](count);
+        for (uint256 i; i < count; ++i) {
+            tokenIds[i] = idsBuf[i];
+            navs[i] = navBuf[i];
+        }
+        eligibleCount = count;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Live pricing
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Quote a batch Rip off a single eligible snapshot.
+    /// @return eligible Number of Packs in the price/selection set.
+    /// @return hm Harmonic mean of eligible NAVs (WAD USD).
+    /// @return unitPrice Clamped per-Pack Rip price (WAD USD).
+    /// @return totalPayment Total stablecoin units the Taker would pay (`count * unitStable`).
+    function quoteRip(uint256 count)
+        public
+        view
+        returns (uint256 eligible, uint256 hm, uint256 unitPrice, uint256 totalPayment)
+    {
+        if (count == 0 || count > registry.maxBatchSize()) {
+            revert CountOutOfRange(count, registry.maxBatchSize());
+        }
+
+        (, uint256[] memory navs, uint256 eligibleCount) = eligibleSnapshot();
+        if (eligibleCount == 0) revert EmptyEligibleSet();
+        if (eligibleCount <= count) revert DegenerateEligibleSet(eligibleCount, count);
+
+        hm = RipMath.harmonicMean(navs);
+        unitPrice = RipMath.clampUnitPrice(hm, registry.surcharge(), registry.minPackNav(), registry.poolMax());
+        totalPayment = _wadToStable(unitPrice) * count;
+        eligible = eligibleCount;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rip — Model A settlement
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @dev Per-unit and batch totals in stablecoin units (plus WAD unit price for events).
+    struct RipQuote {
+        uint256 unitPriceWad;
+        uint256 unitStable;
+        uint256 totalPaid;
+        uint256 protocolCutUnit;
+        uint256 toMakersUnit;
+        uint256 protocolCutTotal;
+        uint256 toMakersTotal;
+    }
+
+    /// @notice Rip `count` distinct Packs. Priced off one snapshot; settles Model A.
+    /// @param count Packs to draw (1..maxBatchSize); requires eligibleCount > count.
+    /// @param maxTotalPayment Slippage bound in stablecoin units (live pricing).
+    /// @return tokenIds Drawn Pack ids, now held by the Taker.
+    function rip(uint256 count, uint256 maxTotalPayment) external nonReentrant returns (uint256[] memory tokenIds) {
+        if (count == 0 || count > registry.maxBatchSize()) {
+            revert CountOutOfRange(count, registry.maxBatchSize());
+        }
+
+        (uint256[] memory eligibleIds, uint256[] memory navs, uint256 eligibleCount) = eligibleSnapshot();
+        if (eligibleCount == 0) revert EmptyEligibleSet();
+        if (eligibleCount <= count) revert DegenerateEligibleSet(eligibleCount, count);
+
+        RipQuote memory q = _priceRip(navs, count);
+        if (q.totalPaid > maxTotalPayment) revert SlippageExceeded(q.totalPaid, maxTotalPayment);
+
+        stablecoin.safeTransferFrom(msg.sender, address(this), q.totalPaid);
+        protocolAccrued += q.protocolCutTotal;
+
+        tokenIds = _settleDraws(eligibleIds, navs, count, q);
+
+        // Socialize to_makers equally across Packs still enrolled.
+        // Guaranteed remaining > 0 by eligibleCount > count (see DegenerateEligibleSet).
+        uint256 distributable = q.toMakersTotal + feeDust;
+        uint256 perPack = distributable / _resting.length;
+        feeDust = distributable % _resting.length;
+        if (perPack > 0) {
+            accFeePerPack += perPack;
+        }
+
+        emit RipSettled(msg.sender, count, q.unitPriceWad, q.totalPaid, q.protocolCutTotal, q.toMakersTotal);
+    }
+
+    function _priceRip(uint256[] memory navs, uint256 count) internal view returns (RipQuote memory q) {
+        uint256 surcharge = registry.surcharge();
+        q.unitPriceWad =
+            RipMath.clampUnitPrice(RipMath.harmonicMean(navs), surcharge, registry.minPackNav(), registry.poolMax());
+        q.unitStable = _wadToStable(q.unitPriceWad);
+        q.totalPaid = q.unitStable * count;
+
+        // Split from the paid unit so "base never cut" holds under band clamp.
+        uint256 baseStable = (q.unitStable * WAD) / (WAD + surcharge);
+        uint256 surStable = q.unitStable - baseStable;
+        q.protocolCutUnit = (surStable * registry.protocolShareOfSurcharge()) / WAD;
+        // Crown seam (#302): when enabled, carve crownShareOfSurcharge from surcharge here.
+        q.toMakersUnit = q.unitStable - q.protocolCutUnit;
+        q.protocolCutTotal = q.protocolCutUnit * count;
+        q.toMakersTotal = q.toMakersUnit * count;
+    }
+
+    function _settleDraws(uint256[] memory eligibleIds, uint256[] memory navs, uint256 count, RipQuote memory q)
+        internal
+        returns (uint256[] memory tokenIds)
+    {
+        uint256[] memory weights = new uint256[](eligibleIds.length);
+        {
+            uint256 alpha = registry.alpha();
+            for (uint256 i; i < eligibleIds.length; ++i) {
+                weights[i] = RipMath.weightOf(navs[i], alpha);
+            }
+        }
+
+        uint256[] memory drawnIdx;
+        {
+            uint256 seed =
+                randomness.nextSeed(keccak256(abi.encode(count, eligibleIds.length, _resting.length, msg.sender)));
+            drawnIdx = RipMath.drawDistinct(weights, seed, count);
+        }
+
+        tokenIds = new uint256[](count);
+        for (uint256 k; k < count; ++k) {
+            uint256 idx = drawnIdx[k];
+            tokenIds[k] = eligibleIds[idx];
+            _finalizeDrawnPack(eligibleIds[idx], msg.sender, navs[idx], q);
+        }
+    }
+
+    function _finalizeDrawnPack(uint256 tokenId, address taker, uint256 nav, RipQuote memory q) internal {
+        address maker = makerOf[tokenId];
+        _crystallize(tokenId);
+        _removeResting(tokenId);
+        delete feeCheckpoint[tokenId];
+        packs.releaseToRecipient(tokenId, taker);
+        emit PackRipped(tokenId, taker, maker, nav, q.unitPriceWad, q.protocolCutUnit, q.toMakersUnit);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Acquisition Fee claims + protocol withdrawal
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Pending Acquisition Fee for a resting Pack (stablecoin units), including uncrystallized.
+    function pendingOf(uint256 tokenId) public view returns (uint256) {
+        if (!isResting[tokenId]) return 0;
+        return accFeePerPack - feeCheckpoint[tokenId];
+    }
+
+    /// @notice Crystallize fees for the given resting Packs into `claimableFees[maker]` and withdraw all.
+    function claimFees(uint256[] calldata tokenIds) external nonReentrant returns (uint256 amount) {
+        for (uint256 i; i < tokenIds.length; ++i) {
+            uint256 tokenId = tokenIds[i];
+            if (!isResting[tokenId]) continue;
+            if (makerOf[tokenId] != msg.sender) continue;
+            _crystallize(tokenId);
+        }
+        amount = claimableFees[msg.sender];
+        if (amount == 0) revert NothingToClaim();
+        claimableFees[msg.sender] = 0;
+        stablecoin.safeTransfer(msg.sender, amount);
+        emit FeesClaimed(msg.sender, amount);
+    }
+
+    /// @notice Withdraw already-crystallized Acquisition Fees (no Pack ids needed).
+    function claim() external nonReentrant returns (uint256 amount) {
+        amount = claimableFees[msg.sender];
+        if (amount == 0) revert NothingToClaim();
+        claimableFees[msg.sender] = 0;
+        stablecoin.safeTransfer(msg.sender, amount);
+        emit FeesClaimed(msg.sender, amount);
+    }
+
+    /// @notice Admin withdraws accrued protocol cut.
+    function withdrawProtocolFees(address to) external onlyRole(DEFAULT_ADMIN_ROLE) returns (uint256 amount) {
+        if (to == address(0)) revert ZeroAddress();
+        amount = protocolAccrued;
+        if (amount == 0) revert ZeroAmount();
+        protocolAccrued = 0;
+        stablecoin.safeTransfer(to, amount);
+        emit ProtocolFeesWithdrawn(to, amount);
+    }
+
+    /// @notice Swap the randomness source (prospective).
+    function setRandomness(address randomness_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (randomness_ == address(0)) revert ZeroAddress();
+        randomness = IRandomnessSource(randomness_);
+        emit RandomnessUpdated(randomness_);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internals
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function _addResting(uint256 tokenId) internal {
+        isResting[tokenId] = true;
+        _resting.push(tokenId);
+        _restingIndex[tokenId] = _resting.length; // 1-based
+    }
+
+    function _removeResting(uint256 tokenId) internal {
+        uint256 indexPlusOne = _restingIndex[tokenId];
+        uint256 index = indexPlusOne - 1;
+        uint256 lastIndex = _resting.length - 1;
+
+        if (index != lastIndex) {
+            uint256 moved = _resting[lastIndex];
+            _resting[index] = moved;
+            _restingIndex[moved] = indexPlusOne;
+        }
+
+        _resting.pop();
+        delete _restingIndex[tokenId];
+        isResting[tokenId] = false;
+    }
+
+    /// @dev Credit uncrystallized fee to the Maker and bump the checkpoint.
+    function _crystallize(uint256 tokenId) internal {
+        uint256 pending = accFeePerPack - feeCheckpoint[tokenId];
+        if (pending > 0) {
+            claimableFees[makerOf[tokenId]] += pending;
+            feeCheckpoint[tokenId] = accFeePerPack;
+        }
+    }
+
+    function _tryNav(uint256 tokenId) internal view returns (bool ok, uint256 nav) {
+        PackCustody.BasketEntry[] memory basket = packs.basketOf(tokenId);
+        uint256 length = basket.length;
+        if (length == 0) return (false, 0);
+
+        address[] memory tokens = new address[](length);
+        uint256[] memory amounts = new uint256[](length);
+        for (uint256 i; i < length; ++i) {
+            tokens[i] = basket[i].asset;
+            amounts[i] = basket[i].amount;
+        }
+
+        try registry.navOf(tokens, amounts) returns (uint256 value) {
+            return (true, value);
+        } catch {
+            return (false, 0);
+        }
+    }
+
+    /// @dev Convert WAD USD to stablecoin units (peg trusted at par).
+    function _wadToStable(uint256 wad) internal view returns (uint256) {
+        return (wad * (10 ** uint256(stableDecimals))) / WAD;
+    }
+}

--- a/contracts/src/interfaces/IRandomnessSource.sol
+++ b/contracts/src/interfaces/IRandomnessSource.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title IRandomnessSource
+/// @notice Injectable entropy for RipEngine Pack selection.
+/// @dev V1 ships a disclosed House-seeded mock. Non-view so a real source can bump a nonce
+///      or consume a beacon round. Replaced by verifiable randomness on any mainnet deploy.
+interface IRandomnessSource {
+    /// @notice Produce the next seed for a draw.
+    /// @param salt Caller-chosen domain separator (e.g. rip count + resting length).
+    /// @return seed Uniform-ish entropy for weighted selection.
+    function nextSeed(bytes32 salt) external returns (uint256 seed);
+}

--- a/contracts/src/libraries/RipMath.sol
+++ b/contracts/src/libraries/RipMath.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title RipMath
+/// @notice Pure selection / pricing helpers for RipEngine.
+/// @dev Weights are `SCALE * WAD / N^alpha` with whole-number alpha only (multiples of WAD).
+///      Harmonic mean uses the correct `n / Σ(1/N_i)` form. Draw is without replacement.
+library RipMath {
+    /// @notice WAD scale for ratios and USD NAV ($1 = 1e18).
+    uint256 internal constant WAD = 1e18;
+
+    /// @notice Fixed large constant so inverse-NAV weights stay above 1 for NAV ≤ poolMax.
+    /// @dev PRD suggests ~1e36; with WAD-NAV the product `SCALE * WAD` is 1e54 before / N^α.
+    uint256 internal constant SCALE = 1e36;
+
+    /// @notice Max whole-number exponent for `N^alpha` (guards gas / overflow).
+    uint256 internal constant MAX_ALPHA_EXPONENT = 8;
+
+    error EmptySet();
+    error ZeroNav();
+    error FractionalAlphaUnsupported(uint256 alpha);
+    error AlphaExponentTooHigh(uint256 exponent);
+    error CountOutOfRange(uint256 count, uint256 setSize);
+    error ZeroTotalWeight();
+
+    /// @notice Selection weight `SCALE * WAD / N^alpha` (WAD-scaled).
+    /// @dev `alpha` must be a whole multiple of WAD (0, 1e18, 2e18, …). Alpha 0 → uniform.
+    function weightOf(uint256 nav, uint256 alpha) internal pure returns (uint256) {
+        if (nav == 0) revert ZeroNav();
+        if (alpha % WAD != 0) revert FractionalAlphaUnsupported(alpha);
+
+        uint256 exponent = alpha / WAD;
+        if (exponent > MAX_ALPHA_EXPONENT) revert AlphaExponentTooHigh(exponent);
+
+        if (exponent == 0) {
+            return SCALE; // uniform — independent of NAV
+        }
+
+        uint256 powered = nav;
+        for (uint256 i = 1; i < exponent; ++i) {
+            powered = (powered * nav) / WAD;
+        }
+
+        return (SCALE * WAD) / powered;
+    }
+
+    /// @notice Harmonic mean of WAD-NAV values: `n / Σ(1/N_i)`.
+    function harmonicMean(uint256[] memory navs) internal pure returns (uint256) {
+        uint256 n = navs.length;
+        if (n == 0) revert EmptySet();
+
+        uint256 invSum;
+        for (uint256 i; i < n; ++i) {
+            uint256 nav = navs[i];
+            if (nav == 0) revert ZeroNav();
+            invSum += (WAD * WAD) / nav; // 1/N in WAD² so hm stays in WAD
+        }
+
+        // hm = n / Σ(1/N) = n * WAD² / invSum, but invSum already has WAD²/N so:
+        // hm_WAD = n * WAD / Σ(WAD/N) where Σ(WAD/N) = invSum / WAD
+        // => hm = n * WAD * WAD / invSum
+        return (n * WAD * WAD) / invSum;
+    }
+
+    /// @notice `clamp(hm * (1 + surcharge), [minPackNav, poolMax] * (1 + surcharge))`.
+    function clampUnitPrice(uint256 harmonicMean_, uint256 surcharge, uint256 minPackNav, uint256 poolMax)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 factor = WAD + surcharge;
+        uint256 raw = (harmonicMean_ * factor) / WAD;
+        uint256 lo = (minPackNav * factor) / WAD;
+        uint256 hi = (poolMax * factor) / WAD;
+
+        if (raw < lo) return lo;
+        if (raw > hi) return hi;
+        return raw;
+    }
+
+    /// @notice Draw `count` distinct indices with probability ∝ `weights`, without replacement.
+    /// @dev Mutates a working copy of weights via swap-and-pop. Seed expanded per draw.
+    /// @return indices Drawn positions into the original `weights` array (pre-mutation order).
+    function drawDistinct(uint256[] memory weights, uint256 seed, uint256 count)
+        internal
+        pure
+        returns (uint256[] memory indices)
+    {
+        uint256 n = weights.length;
+        if (count == 0 || count > n) revert CountOutOfRange(count, n);
+
+        // Working arrays: weight + original index (so we return pre-mutation positions).
+        uint256[] memory w = new uint256[](n);
+        uint256[] memory orig = new uint256[](n);
+        uint256 total;
+        for (uint256 i; i < n; ++i) {
+            w[i] = weights[i];
+            orig[i] = i;
+            total += weights[i];
+        }
+        if (total == 0) revert ZeroTotalWeight();
+
+        indices = new uint256[](count);
+        uint256 remaining = n;
+
+        for (uint256 k; k < count; ++k) {
+            uint256 drawSeed = uint256(keccak256(abi.encodePacked(seed, k)));
+            uint256 pick = drawSeed % total;
+            uint256 cumulative;
+            uint256 chosen = remaining - 1; // fallback
+
+            for (uint256 i; i < remaining; ++i) {
+                cumulative += w[i];
+                if (pick < cumulative) {
+                    chosen = i;
+                    break;
+                }
+            }
+
+            indices[k] = orig[chosen];
+            total -= w[chosen];
+
+            // Swap-and-pop chosen out of the working set.
+            uint256 last = remaining - 1;
+            if (chosen != last) {
+                w[chosen] = w[last];
+                orig[chosen] = orig[last];
+            }
+            remaining = last;
+        }
+    }
+}

--- a/contracts/src/mocks/MockRandomness.sol
+++ b/contracts/src/mocks/MockRandomness.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IRandomnessSource} from "../interfaces/IRandomnessSource.sol";
+
+/// @title MockRandomness
+/// @notice Deterministic randomness double for RipEngine tests and V1 House seeding.
+/// @dev Visibly a test double — not a verifiable beacon. Admin sets the base seed; each
+///      `nextSeed` mixes base + monotonic nonce + salt. The disclosed House keeper (#309)
+///      can rotate the seed between rips.
+contract MockRandomness is IRandomnessSource, AccessControl {
+    bytes32 public constant SEED_ADMIN_ROLE = keccak256("SEED_ADMIN_ROLE");
+
+    /// @notice Always true — on-chain disclosure that this is a test source.
+    bool public constant IS_TEST_SOURCE = true;
+
+    uint256 private _baseSeed;
+    uint256 private _nonce;
+
+    event SeedUpdated(uint256 baseSeed);
+    event SeedConsumed(uint256 indexed nonce, bytes32 salt, uint256 seed);
+
+    error ZeroAddress();
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE and SEED_ADMIN_ROLE.
+    /// @param initialSeed Starting base seed (any non-zero value is fine; zero is allowed).
+    constructor(address admin, uint256 initialSeed) {
+        if (admin == address(0)) revert ZeroAddress();
+        _baseSeed = initialSeed;
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(SEED_ADMIN_ROLE, admin);
+    }
+
+    /// @inheritdoc IRandomnessSource
+    function nextSeed(bytes32 salt) external returns (uint256 seed) {
+        uint256 nonce = ++_nonce;
+        seed = uint256(keccak256(abi.encodePacked(_baseSeed, nonce, salt, block.timestamp, block.prevrandao)));
+        emit SeedConsumed(nonce, salt, seed);
+    }
+
+    /// @notice Rotate the base seed (House operator / test harness).
+    function setSeed(uint256 baseSeed) external onlyRole(SEED_ADMIN_ROLE) {
+        _baseSeed = baseSeed;
+        emit SeedUpdated(baseSeed);
+    }
+
+    /// @notice Current base seed (for tests / disclosure).
+    function baseSeed() external view returns (uint256) {
+        return _baseSeed;
+    }
+
+    /// @notice How many seeds have been consumed.
+    function nonce() external view returns (uint256) {
+        return _nonce;
+    }
+}

--- a/contracts/src/mocks/MockRandomness.sol
+++ b/contracts/src/mocks/MockRandomness.sol
@@ -34,15 +34,15 @@ contract MockRandomness is IRandomnessSource, AccessControl {
 
     /// @inheritdoc IRandomnessSource
     function nextSeed(bytes32 salt) external returns (uint256 seed) {
-        uint256 nonce = ++_nonce;
-        seed = uint256(keccak256(abi.encodePacked(_baseSeed, nonce, salt, block.timestamp, block.prevrandao)));
-        emit SeedConsumed(nonce, salt, seed);
+        uint256 n = ++_nonce;
+        seed = uint256(keccak256(abi.encodePacked(_baseSeed, n, salt, block.timestamp, block.prevrandao)));
+        emit SeedConsumed(n, salt, seed);
     }
 
     /// @notice Rotate the base seed (House operator / test harness).
-    function setSeed(uint256 baseSeed) external onlyRole(SEED_ADMIN_ROLE) {
-        _baseSeed = baseSeed;
-        emit SeedUpdated(baseSeed);
+    function setSeed(uint256 newBaseSeed) external onlyRole(SEED_ADMIN_ROLE) {
+        _baseSeed = newBaseSeed;
+        emit SeedUpdated(newBaseSeed);
     }
 
     /// @notice Current base seed (for tests / disclosure).

--- a/contracts/test/RipEngine.fees.t.sol
+++ b/contracts/test/RipEngine.fees.t.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {RipEngine} from "../src/RipEngine.sol";
+import {MockRandomness} from "../src/mocks/MockRandomness.sol";
+import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
+
+contract RipEngineFeesTest is RipEngineFixture {
+    function test_claimFees_withdrawsAccruedAcquisitionFee() public {
+        _enrollPack(maker, 30 * WAD);
+        _enrollPack(maker2, 40 * WAD);
+        _enrollPack(maker, 50 * WAD);
+
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+        vm.prank(taker);
+        engine.rip(1, totalPayment);
+
+        // Two packs remain; both makers may have pending depending on who was drawn.
+        uint256[] memory makerPacks = engine.restingPackIds();
+        uint256 pendingSum;
+        for (uint256 i; i < makerPacks.length; ++i) {
+            pendingSum += engine.pendingOf(makerPacks[i]);
+        }
+        assertGt(pendingSum, 0);
+
+        // Claim for maker's resting packs.
+        uint256[] memory claimIds = new uint256[](makerPacks.length);
+        for (uint256 i; i < makerPacks.length; ++i) {
+            claimIds[i] = makerPacks[i];
+        }
+
+        uint256 makerBalBefore = usd.balanceOf(maker);
+        uint256 maker2BalBefore = usd.balanceOf(maker2);
+
+        // Only packs owned by msg.sender as maker crystallize.
+        vm.prank(maker);
+        try engine.claimFees(claimIds) returns (uint256 amt) {
+            assertGt(amt, 0);
+            assertEq(usd.balanceOf(maker), makerBalBefore + amt);
+        } catch {
+            // Maker's packs may all have been drawn — that's ok; try maker2.
+        }
+
+        vm.prank(maker2);
+        try engine.claimFees(claimIds) returns (uint256 amt2) {
+            if (amt2 > 0) {
+                assertEq(usd.balanceOf(maker2), maker2BalBefore + amt2);
+            }
+        } catch {}
+    }
+
+    function test_claimFees_makerReceivesEqualRateShare() public {
+        // Three packs, all same maker — rip 1, remaining 2 split fees equally.
+        uint256 a = _enrollPack(maker, 40 * WAD);
+        uint256 b = _enrollPack(maker, 50 * WAD);
+        uint256 c = _enrollPack(maker, 60 * WAD);
+
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+        uint256 surcharge = registry.surcharge();
+        uint256 baseStable = (totalPayment * WAD) / (WAD + surcharge);
+        uint256 surStable = totalPayment - baseStable;
+        uint256 protocolCut = (surStable * registry.protocolShareOfSurcharge()) / WAD;
+        uint256 toMakers = totalPayment - protocolCut;
+
+        vm.prank(taker);
+        engine.rip(1, totalPayment);
+
+        uint256 perPack = toMakers / 2;
+        assertEq(engine.accFeePerPack(), perPack);
+
+        uint256 pendingA = engine.pendingOf(a);
+        uint256 pendingB = engine.pendingOf(b);
+        uint256 pendingC = engine.pendingOf(c);
+        // Drawn pack has 0 pending; the other two each have perPack.
+        assertEq(pendingA + pendingB + pendingC, perPack * 2);
+
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = a;
+        ids[1] = b;
+        ids[2] = c;
+
+        uint256 before = usd.balanceOf(maker);
+        vm.prank(maker);
+        uint256 claimed = engine.claimFees(ids);
+        assertEq(claimed, perPack * 2);
+        assertEq(usd.balanceOf(maker), before + claimed);
+        assertGe(claimed, baseStable); // make-whole for the socialized base across remaining
+    }
+
+    function test_claim_crystallizedBalance() public {
+        _enrollPack(maker, 40 * WAD);
+        _enrollPack(maker, 50 * WAD);
+        _enrollPack(maker2, 60 * WAD);
+
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+        vm.prank(taker);
+        engine.rip(1, totalPayment);
+
+        // Exit remaining maker packs to crystallize without claiming yet.
+        uint256[] memory resting = engine.restingPackIds();
+        for (uint256 i; i < resting.length; ++i) {
+            if (engine.makerOf(resting[i]) == maker && packs.isListed(resting[i])) {
+                vm.prank(maker);
+                engine.exitPool(resting[i]);
+            }
+        }
+
+        uint256 claimable = engine.claimableFees(maker);
+        if (claimable > 0) {
+            uint256 before = usd.balanceOf(maker);
+            vm.prank(maker);
+            uint256 amt = engine.claim();
+            assertEq(amt, claimable);
+            assertEq(usd.balanceOf(maker), before + amt);
+            assertEq(engine.claimableFees(maker), 0);
+        }
+    }
+
+    function test_claim_nothingReverts() public {
+        vm.expectRevert(RipEngine.NothingToClaim.selector);
+        vm.prank(maker);
+        engine.claim();
+    }
+
+    function test_withdrawProtocolFees() public {
+        _enrollMany(maker, 3, 50 * WAD);
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+        vm.prank(taker);
+        engine.rip(1, totalPayment);
+
+        uint256 accrued = engine.protocolAccrued();
+        assertGt(accrued, 0);
+
+        address treasury = makeAddr("treasury");
+        vm.prank(admin);
+        uint256 withdrawn = engine.withdrawProtocolFees(treasury);
+        assertEq(withdrawn, accrued);
+        assertEq(usd.balanceOf(treasury), accrued);
+        assertEq(engine.protocolAccrued(), 0);
+    }
+
+    function test_withdrawProtocolFees_unauthorized() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, engine.DEFAULT_ADMIN_ROLE()
+            )
+        );
+        vm.prank(stranger);
+        engine.withdrawProtocolFees(stranger);
+    }
+
+    function test_setRandomness() public {
+        MockRandomness next = new MockRandomness(admin, 99);
+        vm.prank(admin);
+        engine.setRandomness(address(next));
+        assertEq(address(engine.randomness()), address(next));
+    }
+}

--- a/contracts/test/RipEngine.fees.t.sol
+++ b/contracts/test/RipEngine.fees.t.sol
@@ -2,56 +2,53 @@
 pragma solidity ^0.8.20;
 
 import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {Test} from "forge-std/Test.sol";
 import {RipEngine} from "../src/RipEngine.sol";
 import {MockRandomness} from "../src/mocks/MockRandomness.sol";
 import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
 
-contract RipEngineFeesTest is RipEngineFixture {
-    function test_claimFees_withdrawsAccruedAcquisitionFee() public {
-        _enrollPack(maker, 30 * WAD);
-        _enrollPack(maker2, 40 * WAD);
-        _enrollPack(maker, 50 * WAD);
+contract RipEngineFeesTest is Test, RipEngineFixture {
+    function test_claim_withdrawsAccruedAcquisitionFee() public {
+        uint256 a = _enrollPack(maker, 30 * WAD);
+        uint256 b = _enrollPack(maker2, 40 * WAD);
+        uint256 c = _enrollPack(maker, 50 * WAD);
 
         (,,, uint256 totalPayment) = engine.quoteRip(1);
         vm.prank(taker);
-        engine.rip(1, totalPayment);
+        uint256[] memory drawn = engine.rip(1, totalPayment);
 
-        // Two packs remain; both makers may have pending depending on who was drawn.
-        uint256[] memory makerPacks = engine.restingPackIds();
-        uint256 pendingSum;
-        for (uint256 i; i < makerPacks.length; ++i) {
-            pendingSum += engine.pendingOf(makerPacks[i]);
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = a;
+        ids[1] = b;
+        ids[2] = c;
+
+        uint256 makerPending;
+        uint256 maker2Pending;
+        for (uint256 i; i < 3; ++i) {
+            if (drawn[0] == ids[i]) continue;
+            if (engine.makerOf(ids[i]) == maker) makerPending += engine.pendingOf(ids[i]);
+            if (engine.makerOf(ids[i]) == maker2) maker2Pending += engine.pendingOf(ids[i]);
         }
-        assertGt(pendingSum, 0);
+        assertGt(makerPending + maker2Pending, 0);
 
-        // Claim for maker's resting packs.
-        uint256[] memory claimIds = new uint256[](makerPacks.length);
-        for (uint256 i; i < makerPacks.length; ++i) {
-            claimIds[i] = makerPacks[i];
-        }
-
-        uint256 makerBalBefore = usd.balanceOf(maker);
-        uint256 maker2BalBefore = usd.balanceOf(maker2);
-
-        // Only packs owned by msg.sender as maker crystallize.
-        vm.prank(maker);
-        try engine.claimFees(claimIds) returns (uint256 amt) {
-            assertGt(amt, 0);
-            assertEq(usd.balanceOf(maker), makerBalBefore + amt);
-        } catch {
-            // Maker's packs may all have been drawn — that's ok; try maker2.
+        if (makerPending > 0) {
+            uint256 before = usd.balanceOf(maker);
+            vm.prank(maker);
+            uint256 claimed = engine.claim(ids);
+            assertEq(claimed, makerPending);
+            assertEq(usd.balanceOf(maker), before + claimed);
         }
 
-        vm.prank(maker2);
-        try engine.claimFees(claimIds) returns (uint256 amt2) {
-            if (amt2 > 0) {
-                assertEq(usd.balanceOf(maker2), maker2BalBefore + amt2);
-            }
-        } catch {}
+        if (maker2Pending > 0) {
+            uint256 before2 = usd.balanceOf(maker2);
+            vm.prank(maker2);
+            uint256 claimed2 = engine.claim(ids);
+            assertEq(claimed2, maker2Pending);
+            assertEq(usd.balanceOf(maker2), before2 + claimed2);
+        }
     }
 
-    function test_claimFees_makerReceivesEqualRateShare() public {
-        // Three packs, all same maker — rip 1, remaining 2 split fees equally.
+    function test_claim_makerReceivesEqualRateShare() public {
         uint256 a = _enrollPack(maker, 40 * WAD);
         uint256 b = _enrollPack(maker, 50 * WAD);
         uint256 c = _enrollPack(maker, 60 * WAD);
@@ -72,7 +69,6 @@ contract RipEngineFeesTest is RipEngineFixture {
         uint256 pendingA = engine.pendingOf(a);
         uint256 pendingB = engine.pendingOf(b);
         uint256 pendingC = engine.pendingOf(c);
-        // Drawn pack has 0 pending; the other two each have perPack.
         assertEq(pendingA + pendingB + pendingC, perPack * 2);
 
         uint256[] memory ids = new uint256[](3);
@@ -82,13 +78,13 @@ contract RipEngineFeesTest is RipEngineFixture {
 
         uint256 before = usd.balanceOf(maker);
         vm.prank(maker);
-        uint256 claimed = engine.claimFees(ids);
+        uint256 claimed = engine.claim(ids);
         assertEq(claimed, perPack * 2);
         assertEq(usd.balanceOf(maker), before + claimed);
-        assertGe(claimed, baseStable); // make-whole for the socialized base across remaining
+        assertGe(claimed, baseStable);
     }
 
-    function test_claim_crystallizedBalance() public {
+    function test_claim_emptyTokenIdsWithdrawsCrystallizedOnly() public {
         _enrollPack(maker, 40 * WAD);
         _enrollPack(maker, 50 * WAD);
         _enrollPack(maker2, 60 * WAD);
@@ -97,7 +93,6 @@ contract RipEngineFeesTest is RipEngineFixture {
         vm.prank(taker);
         engine.rip(1, totalPayment);
 
-        // Exit remaining maker packs to crystallize without claiming yet.
         uint256[] memory resting = engine.restingPackIds();
         for (uint256 i; i < resting.length; ++i) {
             if (engine.makerOf(resting[i]) == maker && packs.isListed(resting[i])) {
@@ -107,20 +102,48 @@ contract RipEngineFeesTest is RipEngineFixture {
         }
 
         uint256 claimable = engine.claimableFees(maker);
-        if (claimable > 0) {
-            uint256 before = usd.balanceOf(maker);
-            vm.prank(maker);
-            uint256 amt = engine.claim();
-            assertEq(amt, claimable);
-            assertEq(usd.balanceOf(maker), before + amt);
-            assertEq(engine.claimableFees(maker), 0);
-        }
+        assertGt(claimable, 0);
+
+        uint256[] memory none = new uint256[](0);
+        uint256 before = usd.balanceOf(maker);
+        vm.prank(maker);
+        uint256 amt = engine.claim(none);
+        assertEq(amt, claimable);
+        assertEq(usd.balanceOf(maker), before + amt);
+        assertEq(engine.claimableFees(maker), 0);
     }
 
     function test_claim_nothingReverts() public {
+        uint256[] memory none = new uint256[](0);
         vm.expectRevert(RipEngine.NothingToClaim.selector);
         vm.prank(maker);
-        engine.claim();
+        engine.claim(none);
+    }
+
+    function test_ghostPackDoesNotDiluteFees() public {
+        _enrollPack(maker, 40 * WAD);
+        uint256 ghost = _enrollPack(maker, 50 * WAD);
+        _enrollPack(maker2, 60 * WAD);
+
+        vm.prank(maker);
+        packs.delistAndRedeem(ghost);
+        assertFalse(packs.isListed(ghost));
+        assertTrue(engine.isResting(ghost));
+
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+        uint256 surcharge = registry.surcharge();
+        uint256 surStable = totalPayment - (totalPayment * WAD) / (WAD + surcharge);
+        uint256 protocolCut = (surStable * registry.protocolShareOfSurcharge()) / WAD;
+        uint256 toMakers = totalPayment - protocolCut;
+
+        vm.prank(taker);
+        engine.rip(1, totalPayment);
+
+        // Ghost purged; one drawn; one remains → divisor is 1, not diluted by the ghost.
+        assertFalse(engine.isResting(ghost));
+        assertEq(engine.restingCount(), 1);
+        assertEq(engine.accFeePerPack(), toMakers);
+        assertEq(engine.feeDust(), 0);
     }
 
     function test_withdrawProtocolFees() public {
@@ -141,10 +164,9 @@ contract RipEngineFeesTest is RipEngineFixture {
     }
 
     function test_withdrawProtocolFees_unauthorized() public {
+        bytes32 role = engine.DEFAULT_ADMIN_ROLE();
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, engine.DEFAULT_ADMIN_ROLE()
-            )
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, stranger, role)
         );
         vm.prank(stranger);
         engine.withdrawProtocolFees(stranger);

--- a/contracts/test/RipEngine.invariant.t.sol
+++ b/contracts/test/RipEngine.invariant.t.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {AssetRegistry} from "../src/AssetRegistry.sol";
+import {MockUSD} from "../src/MockUSD.sol";
+import {PackCustody} from "../src/PackCustody.sol";
+import {RipEngine} from "../src/RipEngine.sol";
+import {MockPriceFeed} from "../src/mocks/MockPriceFeed.sol";
+import {MockRandomness} from "../src/mocks/MockRandomness.sol";
+import {MockStockToken} from "./mocks/MockStockToken.sol";
+
+/// @notice Drives enroll / rip / claim through the public ABI and tracks fee ghosts.
+contract RipEngineHandler is Test {
+    uint256 internal constant WAD = 1e18;
+
+    RipEngine public immutable ENGINE;
+    PackCustody public immutable PACKS;
+    MockUSD public immutable USD;
+    address public immutable ADMIN;
+
+    address[] public makers;
+    address public taker;
+
+    uint256 public ghostPaidIn;
+    uint256 public ghostClaimedOut;
+    uint256 public ghostProtocolOut;
+    mapping(uint256 tokenId => bool everResting) public ghostEverResting;
+    mapping(uint256 tokenId => bool everSettled) public ghostEverSettled;
+
+    constructor(RipEngine engine_, PackCustody packs_, MockUSD usd_, address admin_, address taker_) {
+        ENGINE = engine_;
+        PACKS = packs_;
+        USD = usd_;
+        ADMIN = admin_;
+        taker = taker_;
+
+        makers.push(makeAddr("invMaker0"));
+        makers.push(makeAddr("invMaker1"));
+        makers.push(makeAddr("invMaker2"));
+    }
+
+    function enroll(uint256 makerSeed, uint256 navSeed) external {
+        address maker = makers[bound(makerSeed, 0, makers.length - 1)];
+        uint256 nav = bound(navSeed, 20 * WAD, 300 * WAD);
+        nav = (nav / WAD) * WAD;
+        if (nav < 20 * WAD) nav = 20 * WAD;
+        if (nav > 300 * WAD) nav = 300 * WAD;
+
+        uint256 amount = nav / 100;
+        if (amount == 0) return;
+
+        MockStockToken amzn = MockStockToken(PACKS.whitelistedAssets()[0]);
+        if (amzn.balanceOf(maker) < amount) {
+            amzn.mint(maker, amount * 10);
+            vm.prank(maker);
+            amzn.approve(address(PACKS), type(uint256).max);
+        }
+
+        address[] memory assets = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        assets[0] = address(amzn);
+        amounts[0] = amount;
+
+        vm.prank(maker);
+        uint256 tokenId = PACKS.mint(assets, amounts);
+        vm.prank(maker);
+        ENGINE.enterPool(tokenId);
+
+        ghostEverResting[tokenId] = true;
+    }
+
+    function rip(uint256 countSeed, uint256) external {
+        uint256 resting = ENGINE.restingCount();
+        if (resting < 2) return;
+
+        (,, uint256 eligible) = ENGINE.eligibleSnapshot();
+        if (eligible < 2) return;
+
+        uint256 maxCount = eligible - 1;
+        if (maxCount > 5) maxCount = 5;
+        uint256 count = bound(countSeed, 1, maxCount);
+
+        try ENGINE.quoteRip(count) returns (uint256, uint256, uint256, uint256 totalPayment) {
+            if (USD.balanceOf(taker) < totalPayment) {
+                vm.prank(ADMIN);
+                USD.mint(taker, totalPayment * 10);
+            }
+            vm.prank(taker);
+            USD.approve(address(ENGINE), type(uint256).max);
+
+            vm.prank(taker);
+            uint256[] memory drawn = ENGINE.rip(count, totalPayment);
+            ghostPaidIn += totalPayment;
+            for (uint256 i; i < drawn.length; ++i) {
+                assertFalse(ghostEverSettled[drawn[i]]);
+                ghostEverSettled[drawn[i]] = true;
+                assertFalse(ENGINE.isResting(drawn[i]));
+            }
+        } catch {}
+    }
+
+    function claim(uint256 makerSeed) external {
+        address maker = makers[bound(makerSeed, 0, makers.length - 1)];
+        uint256[] memory resting = ENGINE.restingPackIds();
+        if (resting.length == 0 && ENGINE.claimableFees(maker) == 0) return;
+
+        uint256 before = USD.balanceOf(maker);
+        vm.prank(maker);
+        try ENGINE.claimFees(resting) {
+            ghostClaimedOut += USD.balanceOf(maker) - before;
+        } catch {
+            vm.prank(maker);
+            try ENGINE.claim() returns (uint256 amt) {
+                ghostClaimedOut += amt;
+            } catch {}
+        }
+    }
+
+    function withdrawProtocol() external {
+        uint256 accrued = ENGINE.protocolAccrued();
+        if (accrued == 0) return;
+        address treasury = makeAddr("invTreasury");
+        uint256 before = USD.balanceOf(treasury);
+        vm.prank(ADMIN);
+        try ENGINE.withdrawProtocolFees(treasury) {
+            ghostProtocolOut += USD.balanceOf(treasury) - before;
+        } catch {}
+    }
+}
+
+contract RipEngineInvariantTest is StdInvariant, Test {
+    uint8 internal constant FEED_DECIMALS = 8;
+    uint64 internal constant STALE_AFTER = 1 hours;
+
+    RipEngineHandler internal handler;
+    RipEngine internal engine;
+    PackCustody internal packs;
+    MockUSD internal usd;
+
+    address internal admin = makeAddr("admin");
+    address internal taker = makeAddr("taker");
+    address internal maker0 = makeAddr("invMaker0");
+    address internal maker1 = makeAddr("invMaker1");
+    address internal maker2 = makeAddr("invMaker2");
+
+    function setUp() public {
+        MockStockToken amzn = new MockStockToken("Amazon", "tAMZN", 18);
+        MockStockToken amd = new MockStockToken("AMD", "tAMD", 18);
+        MockStockToken nflx = new MockStockToken("NFLX", "tNFLX", 8);
+        MockStockToken pltr = new MockStockToken("PLTR", "tPLTR", 6);
+        MockStockToken tsla = new MockStockToken("TSLA", "tTSLA", 18);
+
+        address[] memory whitelist = new address[](5);
+        whitelist[0] = address(amzn);
+        whitelist[1] = address(amd);
+        whitelist[2] = address(nflx);
+        whitelist[3] = address(pltr);
+        whitelist[4] = address(tsla);
+
+        packs = new PackCustody(admin, whitelist);
+        AssetRegistry registry = new AssetRegistry(admin);
+        usd = new MockUSD(admin);
+        MockRandomness randomness = new MockRandomness(admin, 1);
+
+        MockPriceFeed amznFeed = new MockPriceFeed(admin, FEED_DECIMALS, 100e8);
+        MockPriceFeed amdFeed = new MockPriceFeed(admin, FEED_DECIMALS, 50e8);
+        MockPriceFeed nflxFeed = new MockPriceFeed(admin, FEED_DECIMALS, 200e8);
+        MockPriceFeed pltrFeed = new MockPriceFeed(admin, FEED_DECIMALS, 25e8);
+        MockPriceFeed tslaFeed = new MockPriceFeed(admin, FEED_DECIMALS, 300e8);
+
+        vm.startPrank(admin);
+        registry.addAsset(address(amzn), address(amznFeed), STALE_AFTER);
+        registry.addAsset(address(amd), address(amdFeed), STALE_AFTER);
+        registry.addAsset(address(nflx), address(nflxFeed), STALE_AFTER);
+        registry.addAsset(address(pltr), address(pltrFeed), STALE_AFTER);
+        registry.addAsset(address(tsla), address(tslaFeed), STALE_AFTER);
+        usd.grantRole(usd.MINTER_ROLE(), admin);
+        vm.stopPrank();
+
+        engine = new RipEngine(admin, address(packs), address(registry), address(usd), address(randomness));
+        bytes32 ripRole = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(ripRole, address(engine));
+
+        address[3] memory makerAddrs = [maker0, maker1, maker2];
+        for (uint256 i; i < makerAddrs.length; ++i) {
+            amzn.mint(makerAddrs[i], 1_000_000e18);
+            vm.prank(makerAddrs[i]);
+            amzn.approve(address(packs), type(uint256).max);
+        }
+        vm.prank(admin);
+        usd.mint(taker, 10_000_000e6);
+        vm.prank(taker);
+        usd.approve(address(engine), type(uint256).max);
+
+        handler = new RipEngineHandler(engine, packs, usd, admin, taker);
+        targetContract(address(handler));
+    }
+
+    /// @notice Engine stablecoin balance covers unclaimed maker fees + protocol.
+    function invariant_solvency() public view {
+        uint256 balance = usd.balanceOf(address(engine));
+        uint256 claimable = engine.claimableFees(maker0) + engine.claimableFees(maker1) + engine.claimableFees(maker2);
+
+        uint256[] memory resting = engine.restingPackIds();
+        uint256 pending;
+        for (uint256 i; i < resting.length; ++i) {
+            pending += engine.pendingOf(resting[i]);
+        }
+
+        assertGe(balance, claimable + pending + engine.protocolAccrued());
+    }
+
+    /// @notice Payments in equal remaining balance + claims + protocol withdrawals.
+    function invariant_conservation() public view {
+        uint256 balance = usd.balanceOf(address(engine));
+        assertEq(handler.ghostPaidIn(), balance + handler.ghostClaimedOut() + handler.ghostProtocolOut());
+    }
+
+    /// @notice No Pack is enrolled twice.
+    function invariant_noDoubleEnrollment() public view {
+        uint256[] memory ids = engine.restingPackIds();
+        assertEq(ids.length, engine.restingCount());
+        for (uint256 i; i < ids.length; ++i) {
+            assertTrue(engine.isResting(ids[i]));
+            for (uint256 j; j < i; ++j) {
+                assertTrue(ids[i] != ids[j]);
+            }
+        }
+    }
+
+    /// @notice A settled Pack never returns to the resting set.
+    function invariant_settleOnce() public view {
+        uint256[] memory ids = engine.restingPackIds();
+        for (uint256 i; i < ids.length; ++i) {
+            assertFalse(handler.ghostEverSettled(ids[i]));
+        }
+    }
+}

--- a/contracts/test/RipEngine.invariant.t.sol
+++ b/contracts/test/RipEngine.invariant.t.sol
@@ -2,47 +2,48 @@
 pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
-import {StdInvariant} from "forge-std/StdInvariant.sol";
-import {AssetRegistry} from "../src/AssetRegistry.sol";
-import {MockUSD} from "../src/MockUSD.sol";
+import {MockStockToken} from "./mocks/MockStockToken.sol";
 import {PackCustody} from "../src/PackCustody.sol";
 import {RipEngine} from "../src/RipEngine.sol";
-import {MockPriceFeed} from "../src/mocks/MockPriceFeed.sol";
-import {MockRandomness} from "../src/mocks/MockRandomness.sol";
-import {MockStockToken} from "./mocks/MockStockToken.sol";
+import {MockUSD} from "../src/MockUSD.sol";
+import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
 
-/// @notice Drives enroll / rip / claim through the public ABI and tracks fee ghosts.
+/// @notice Drives enroll / rip / claim / withdraw against the shared fixture stack.
 contract RipEngineHandler is Test {
     uint256 internal constant WAD = 1e18;
 
-    RipEngine public immutable ENGINE;
-    PackCustody public immutable PACKS;
-    MockUSD public immutable USD;
-    address public immutable ADMIN;
-
-    address[] public makers;
+    RipEngine public engine;
+    PackCustody public packs;
+    MockUSD public usd;
+    address public admin;
     address public taker;
+    address[] public makers;
 
     uint256 public ghostPaidIn;
     uint256 public ghostClaimedOut;
     uint256 public ghostProtocolOut;
-    mapping(uint256 tokenId => bool everResting) public ghostEverResting;
     mapping(uint256 tokenId => bool everSettled) public ghostEverSettled;
 
-    constructor(RipEngine engine_, PackCustody packs_, MockUSD usd_, address admin_, address taker_) {
-        ENGINE = engine_;
-        PACKS = packs_;
-        USD = usd_;
-        ADMIN = admin_;
+    function configure(
+        RipEngine engine_,
+        PackCustody packs_,
+        MockUSD usd_,
+        address admin_,
+        address taker_,
+        address[] memory makers_
+    ) external {
+        engine = engine_;
+        packs = packs_;
+        usd = usd_;
+        admin = admin_;
         taker = taker_;
-
-        makers.push(makeAddr("invMaker0"));
-        makers.push(makeAddr("invMaker1"));
-        makers.push(makeAddr("invMaker2"));
+        for (uint256 i; i < makers_.length; ++i) {
+            makers.push(makers_[i]);
+        }
     }
 
     function enroll(uint256 makerSeed, uint256 navSeed) external {
-        address maker = makers[bound(makerSeed, 0, makers.length - 1)];
+        address who = makers[bound(makerSeed, 0, makers.length - 1)];
         uint256 nav = bound(navSeed, 20 * WAD, 300 * WAD);
         nav = (nav / WAD) * WAD;
         if (nav < 20 * WAD) nav = 20 * WAD;
@@ -51,158 +52,112 @@ contract RipEngineHandler is Test {
         uint256 amount = nav / 100;
         if (amount == 0) return;
 
-        MockStockToken amzn = MockStockToken(PACKS.whitelistedAssets()[0]);
-        if (amzn.balanceOf(maker) < amount) {
-            amzn.mint(maker, amount * 10);
-            vm.prank(maker);
-            amzn.approve(address(PACKS), type(uint256).max);
+        MockStockToken token = MockStockToken(packs.whitelistedAssets()[0]);
+        if (token.balanceOf(who) < amount) {
+            token.mint(who, amount * 10);
+            vm.prank(who);
+            token.approve(address(packs), type(uint256).max);
         }
 
         address[] memory assets = new address[](1);
         uint256[] memory amounts = new uint256[](1);
-        assets[0] = address(amzn);
+        assets[0] = address(token);
         amounts[0] = amount;
 
-        vm.prank(maker);
-        uint256 tokenId = PACKS.mint(assets, amounts);
-        vm.prank(maker);
-        ENGINE.enterPool(tokenId);
-
-        ghostEverResting[tokenId] = true;
+        vm.prank(who);
+        uint256 tokenId = packs.mint(assets, amounts);
+        vm.prank(who);
+        engine.enterPool(tokenId);
     }
 
     function rip(uint256 countSeed, uint256) external {
-        uint256 resting = ENGINE.restingCount();
-        if (resting < 2) return;
-
-        (,, uint256 eligible) = ENGINE.eligibleSnapshot();
+        if (engine.restingCount() < 2) return;
+        (,, uint256 eligible) = engine.eligibleSnapshot();
         if (eligible < 2) return;
 
         uint256 maxCount = eligible - 1;
         if (maxCount > 5) maxCount = 5;
         uint256 count = bound(countSeed, 1, maxCount);
 
-        try ENGINE.quoteRip(count) returns (uint256, uint256, uint256, uint256 totalPayment) {
-            if (USD.balanceOf(taker) < totalPayment) {
-                vm.prank(ADMIN);
-                USD.mint(taker, totalPayment * 10);
+        try engine.quoteRip(count) returns (uint256, uint256, uint256, uint256 totalPayment) {
+            if (usd.balanceOf(taker) < totalPayment) {
+                vm.prank(admin);
+                usd.mint(taker, totalPayment * 10);
             }
             vm.prank(taker);
-            USD.approve(address(ENGINE), type(uint256).max);
+            usd.approve(address(engine), type(uint256).max);
 
             vm.prank(taker);
-            uint256[] memory drawn = ENGINE.rip(count, totalPayment);
+            uint256[] memory drawn = engine.rip(count, totalPayment);
             ghostPaidIn += totalPayment;
             for (uint256 i; i < drawn.length; ++i) {
                 assertFalse(ghostEverSettled[drawn[i]]);
                 ghostEverSettled[drawn[i]] = true;
-                assertFalse(ENGINE.isResting(drawn[i]));
+                assertFalse(engine.isResting(drawn[i]));
             }
         } catch {}
     }
 
     function claim(uint256 makerSeed) external {
-        address maker = makers[bound(makerSeed, 0, makers.length - 1)];
-        uint256[] memory resting = ENGINE.restingPackIds();
-        if (resting.length == 0 && ENGINE.claimableFees(maker) == 0) return;
+        address who = makers[bound(makerSeed, 0, makers.length - 1)];
+        uint256[] memory resting = engine.restingPackIds();
+        if (resting.length == 0 && engine.claimableFees(who) == 0) return;
 
-        uint256 before = USD.balanceOf(maker);
-        vm.prank(maker);
-        try ENGINE.claimFees(resting) {
-            ghostClaimedOut += USD.balanceOf(maker) - before;
+        uint256 before = usd.balanceOf(who);
+        vm.prank(who);
+        try engine.claim(resting) {
+            ghostClaimedOut += usd.balanceOf(who) - before;
         } catch {
-            vm.prank(maker);
-            try ENGINE.claim() returns (uint256 amt) {
+            uint256[] memory none = new uint256[](0);
+            vm.prank(who);
+            try engine.claim(none) returns (uint256 amt) {
                 ghostClaimedOut += amt;
             } catch {}
         }
     }
 
     function withdrawProtocol() external {
-        uint256 accrued = ENGINE.protocolAccrued();
+        uint256 accrued = engine.protocolAccrued();
         if (accrued == 0) return;
         address treasury = makeAddr("invTreasury");
-        uint256 before = USD.balanceOf(treasury);
-        vm.prank(ADMIN);
-        try ENGINE.withdrawProtocolFees(treasury) {
-            ghostProtocolOut += USD.balanceOf(treasury) - before;
+        uint256 before = usd.balanceOf(treasury);
+        vm.prank(admin);
+        try engine.withdrawProtocolFees(treasury) {
+            ghostProtocolOut += usd.balanceOf(treasury) - before;
         } catch {}
     }
 }
 
-contract RipEngineInvariantTest is StdInvariant, Test {
-    uint8 internal constant FEED_DECIMALS = 8;
-    uint64 internal constant STALE_AFTER = 1 hours;
-
+/// @notice Invariants compose `RipEngineFixture` instead of redeploying the stack.
+contract RipEngineInvariantTest is Test, RipEngineFixture {
     RipEngineHandler internal handler;
-    RipEngine internal engine;
-    PackCustody internal packs;
-    MockUSD internal usd;
+    address internal maker3;
 
-    address internal admin = makeAddr("admin");
-    address internal taker = makeAddr("taker");
-    address internal maker0 = makeAddr("invMaker0");
-    address internal maker1 = makeAddr("invMaker1");
-    address internal maker2 = makeAddr("invMaker2");
+    function setUp() public override {
+        super.setUp();
+        maker3 = makeAddr("invMaker2");
+        _fundMaker(maker3);
 
-    function setUp() public {
-        MockStockToken amzn = new MockStockToken("Amazon", "tAMZN", 18);
-        MockStockToken amd = new MockStockToken("AMD", "tAMD", 18);
-        MockStockToken nflx = new MockStockToken("NFLX", "tNFLX", 8);
-        MockStockToken pltr = new MockStockToken("PLTR", "tPLTR", 6);
-        MockStockToken tsla = new MockStockToken("TSLA", "tTSLA", 18);
+        address[] memory makers_ = new address[](3);
+        makers_[0] = maker;
+        makers_[1] = maker2;
+        makers_[2] = maker3;
 
-        address[] memory whitelist = new address[](5);
-        whitelist[0] = address(amzn);
-        whitelist[1] = address(amd);
-        whitelist[2] = address(nflx);
-        whitelist[3] = address(pltr);
-        whitelist[4] = address(tsla);
+        handler = new RipEngineHandler();
+        handler.configure(engine, packs, usd, admin, taker, makers_);
 
-        packs = new PackCustody(admin, whitelist);
-        AssetRegistry registry = new AssetRegistry(admin);
-        usd = new MockUSD(admin);
-        MockRandomness randomness = new MockRandomness(admin, 1);
-
-        MockPriceFeed amznFeed = new MockPriceFeed(admin, FEED_DECIMALS, 100e8);
-        MockPriceFeed amdFeed = new MockPriceFeed(admin, FEED_DECIMALS, 50e8);
-        MockPriceFeed nflxFeed = new MockPriceFeed(admin, FEED_DECIMALS, 200e8);
-        MockPriceFeed pltrFeed = new MockPriceFeed(admin, FEED_DECIMALS, 25e8);
-        MockPriceFeed tslaFeed = new MockPriceFeed(admin, FEED_DECIMALS, 300e8);
-
-        vm.startPrank(admin);
-        registry.addAsset(address(amzn), address(amznFeed), STALE_AFTER);
-        registry.addAsset(address(amd), address(amdFeed), STALE_AFTER);
-        registry.addAsset(address(nflx), address(nflxFeed), STALE_AFTER);
-        registry.addAsset(address(pltr), address(pltrFeed), STALE_AFTER);
-        registry.addAsset(address(tsla), address(tslaFeed), STALE_AFTER);
-        usd.grantRole(usd.MINTER_ROLE(), admin);
-        vm.stopPrank();
-
-        engine = new RipEngine(admin, address(packs), address(registry), address(usd), address(randomness));
-        bytes32 ripRole = packs.RIP_ENGINE_ROLE();
-        vm.prank(admin);
-        packs.grantRole(ripRole, address(engine));
-
-        address[3] memory makerAddrs = [maker0, maker1, maker2];
-        for (uint256 i; i < makerAddrs.length; ++i) {
-            amzn.mint(makerAddrs[i], 1_000_000e18);
-            vm.prank(makerAddrs[i]);
-            amzn.approve(address(packs), type(uint256).max);
-        }
-        vm.prank(admin);
-        usd.mint(taker, 10_000_000e6);
-        vm.prank(taker);
-        usd.approve(address(engine), type(uint256).max);
-
-        handler = new RipEngineHandler(engine, packs, usd, admin, taker);
+        bytes4[] memory selectors = new bytes4[](4);
+        selectors[0] = RipEngineHandler.enroll.selector;
+        selectors[1] = RipEngineHandler.rip.selector;
+        selectors[2] = RipEngineHandler.claim.selector;
+        selectors[3] = RipEngineHandler.withdrawProtocol.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
         targetContract(address(handler));
     }
 
-    /// @notice Engine stablecoin balance covers unclaimed maker fees + protocol.
     function invariant_solvency() public view {
         uint256 balance = usd.balanceOf(address(engine));
-        uint256 claimable = engine.claimableFees(maker0) + engine.claimableFees(maker1) + engine.claimableFees(maker2);
+        uint256 claimable = engine.claimableFees(maker) + engine.claimableFees(maker2) + engine.claimableFees(maker3);
 
         uint256[] memory resting = engine.restingPackIds();
         uint256 pending;
@@ -213,13 +168,11 @@ contract RipEngineInvariantTest is StdInvariant, Test {
         assertGe(balance, claimable + pending + engine.protocolAccrued());
     }
 
-    /// @notice Payments in equal remaining balance + claims + protocol withdrawals.
     function invariant_conservation() public view {
         uint256 balance = usd.balanceOf(address(engine));
         assertEq(handler.ghostPaidIn(), balance + handler.ghostClaimedOut() + handler.ghostProtocolOut());
     }
 
-    /// @notice No Pack is enrolled twice.
     function invariant_noDoubleEnrollment() public view {
         uint256[] memory ids = engine.restingPackIds();
         assertEq(ids.length, engine.restingCount());
@@ -231,7 +184,6 @@ contract RipEngineInvariantTest is StdInvariant, Test {
         }
     }
 
-    /// @notice A settled Pack never returns to the resting set.
     function invariant_settleOnce() public view {
         uint256[] memory ids = engine.restingPackIds();
         for (uint256 i; i < ids.length; ++i) {

--- a/contracts/test/RipEngine.pool.t.sol
+++ b/contracts/test/RipEngine.pool.t.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {Test} from "forge-std/Test.sol";
 import {AssetRegistry} from "../src/AssetRegistry.sol";
 import {RipEngine} from "../src/RipEngine.sol";
 import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
 
-contract RipEnginePoolTest is RipEngineFixture {
+contract RipEnginePoolTest is Test, RipEngineFixture {
     function test_enterPool_enrollsListedPack() public {
         uint256 id = _mintPackAtNav(maker, 25 * WAD);
         vm.prank(maker);

--- a/contracts/test/RipEngine.pool.t.sol
+++ b/contracts/test/RipEngine.pool.t.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AssetRegistry} from "../src/AssetRegistry.sol";
+import {RipEngine} from "../src/RipEngine.sol";
+import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
+
+contract RipEnginePoolTest is RipEngineFixture {
+    function test_enterPool_enrollsListedPack() public {
+        uint256 id = _mintPackAtNav(maker, 25 * WAD);
+        vm.prank(maker);
+        engine.enterPool(id);
+
+        assertTrue(engine.isResting(id));
+        assertEq(engine.makerOf(id), maker);
+        assertEq(engine.restingCount(), 1);
+        assertEq(engine.restingPackIds()[0], id);
+    }
+
+    function test_enterPool_nonCreatorReverts() public {
+        uint256 id = _mintPackAtNav(maker, 25 * WAD);
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.NotPackCreator.selector, id, stranger));
+        vm.prank(stranger);
+        engine.enterPool(id);
+    }
+
+    function test_enterPool_unlistedReverts() public {
+        uint256 id = _mintPackAtNav(maker, 25 * WAD);
+        vm.prank(maker);
+        packs.delistAndRedeem(id);
+
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.PackNotListed.selector, id));
+        vm.prank(maker);
+        engine.enterPool(id);
+    }
+
+    function test_enterPool_twiceReverts() public {
+        uint256 id = _enrollPack(maker, 25 * WAD);
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.PackAlreadyResting.selector, id));
+        vm.prank(maker);
+        engine.enterPool(id);
+    }
+
+    function test_exitPool_makerWhileListed() public {
+        uint256 id = _enrollPack(maker, 25 * WAD);
+        vm.prank(maker);
+        engine.exitPool(id);
+        assertFalse(engine.isResting(id));
+        assertEq(engine.restingCount(), 0);
+        assertTrue(packs.isListed(id));
+    }
+
+    function test_exitPool_permissionlessWhenUnlisted() public {
+        uint256 id = _enrollPack(maker, 25 * WAD);
+        vm.prank(maker);
+        packs.transferFrom(maker, stranger, id);
+        assertFalse(packs.isListed(id));
+
+        vm.prank(stranger);
+        engine.exitPool(id);
+        assertFalse(engine.isResting(id));
+    }
+
+    function test_exitPool_strangerWhileListedReverts() public {
+        uint256 id = _enrollPack(maker, 25 * WAD);
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.NotPackCreator.selector, id, stranger));
+        vm.prank(stranger);
+        engine.exitPool(id);
+    }
+
+    function test_eligibleSnapshot_excludesFrozenAsset() public {
+        uint256 id = _enrollPack(maker, 25 * WAD);
+        _enrollPack(maker2, 30 * WAD);
+
+        vm.prank(admin);
+        registry.setStatus(address(amzn), AssetRegistry.Status.Frozen);
+
+        (uint256[] memory ids,, uint256 eligible) = engine.eligibleSnapshot();
+        assertEq(eligible, 0);
+        assertEq(ids.length, 0);
+        assertEq(engine.restingCount(), 2);
+        assertTrue(engine.isResting(id));
+    }
+
+    function test_eligibleSnapshot_excludesStaleFeed() public {
+        _enrollPack(maker, 25 * WAD);
+        _enrollPack(maker2, 30 * WAD);
+
+        vm.prank(admin);
+        amznFeed.setUpdatedAt(block.timestamp - STALE_AFTER - 1);
+
+        (,, uint256 eligible) = engine.eligibleSnapshot();
+        assertEq(eligible, 0);
+    }
+
+    function test_eligibleSnapshot_excludesOutOfBand() public {
+        uint256 dusty = _enrollPack(maker, 15 * WAD);
+        uint256 ok = _enrollPack(maker2, 25 * WAD);
+
+        (uint256[] memory ids, uint256[] memory navs, uint256 eligible) = engine.eligibleSnapshot();
+        assertEq(eligible, 1);
+        assertEq(ids[0], ok);
+        assertEq(navs[0], 25 * WAD);
+        assertTrue(engine.isResting(dusty));
+    }
+}

--- a/contracts/test/RipEngine.pricing.t.sol
+++ b/contracts/test/RipEngine.pricing.t.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {Test} from "forge-std/Test.sol";
 import {RipEngine} from "../src/RipEngine.sol";
 import {RipMath} from "../src/libraries/RipMath.sol";
 import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
 
-contract RipEnginePricingTest is RipEngineFixture {
+contract RipEnginePricingTest is Test, RipEngineFixture {
     function test_quoteRip_pricesOffSingleSnapshot() public {
         _enrollPack(maker, 22 * WAD);
         _enrollPack(maker, 100 * WAD);

--- a/contracts/test/RipEngine.pricing.t.sol
+++ b/contracts/test/RipEngine.pricing.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {RipEngine} from "../src/RipEngine.sol";
+import {RipMath} from "../src/libraries/RipMath.sol";
+import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
+
+contract RipEnginePricingTest is RipEngineFixture {
+    function test_quoteRip_pricesOffSingleSnapshot() public {
+        _enrollPack(maker, 22 * WAD);
+        _enrollPack(maker, 100 * WAD);
+        _enrollPack(maker2, 200 * WAD);
+
+        (uint256 eligible, uint256 hm, uint256 unitPrice, uint256 totalPayment) = engine.quoteRip(1);
+        assertEq(eligible, 3);
+
+        uint256[] memory navs = new uint256[](3);
+        navs[0] = 22 * WAD;
+        navs[1] = 100 * WAD;
+        navs[2] = 200 * WAD;
+        uint256 expectedHm = RipMath.harmonicMean(navs);
+        assertEq(hm, expectedHm);
+
+        uint256 expectedUnit =
+            RipMath.clampUnitPrice(expectedHm, registry.surcharge(), registry.minPackNav(), registry.poolMax());
+        assertEq(unitPrice, expectedUnit);
+        assertEq(totalPayment, (expectedUnit * 1e6) / WAD); // MockUSD 6 decimals
+    }
+
+    function test_quoteRip_batchUsesSameUnitPrice() public {
+        _enrollMany(maker, 4, 50 * WAD);
+
+        (,, uint256 unit1, uint256 total1) = engine.quoteRip(1);
+        (,, uint256 unit2, uint256 total2) = engine.quoteRip(2);
+        assertEq(unit1, unit2);
+        assertEq(total2, total1 * 2);
+    }
+
+    function test_quoteRip_emptyEligibleReverts() public {
+        vm.expectRevert(RipEngine.EmptyEligibleSet.selector);
+        engine.quoteRip(1);
+    }
+
+    function test_quoteRip_degenerateReverts() public {
+        // One eligible — cannot rip 1 (needs eligible > count).
+        _enrollPack(maker, 50 * WAD);
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.DegenerateEligibleSet.selector, uint256(1), uint256(1)));
+        engine.quoteRip(1);
+    }
+
+    function test_quoteRip_countOutOfRange() public {
+        _enrollMany(maker, 3, 50 * WAD);
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.CountOutOfRange.selector, uint256(0), uint256(5)));
+        engine.quoteRip(0);
+
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.CountOutOfRange.selector, uint256(6), uint256(5)));
+        engine.quoteRip(6);
+    }
+
+    function test_quoteRip_bandClampFloor() public {
+        // Force hm near min by enrolling only min-NAV packs; price = min*(1+s).
+        _enrollMany(maker, 3, 20 * WAD);
+        (,, uint256 unitPrice,) = engine.quoteRip(1);
+        uint256 floor = (20 * WAD * 11) / 10; // 10% surcharge
+        assertEq(unitPrice, floor);
+    }
+}

--- a/contracts/test/RipEngine.settlement.t.sol
+++ b/contracts/test/RipEngine.settlement.t.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {Test} from "forge-std/Test.sol";
 import {RipEngine} from "../src/RipEngine.sol";
 import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
 
-contract RipEngineSettlementTest is RipEngineFixture {
+contract RipEngineSettlementTest is Test, RipEngineFixture {
     event PackRipped(
         uint256 indexed tokenId,
         address indexed taker,

--- a/contracts/test/RipEngine.settlement.t.sol
+++ b/contracts/test/RipEngine.settlement.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {RipEngine} from "../src/RipEngine.sol";
+import {RipEngineFixture} from "./helpers/RipEngineFixture.sol";
+
+contract RipEngineSettlementTest is RipEngineFixture {
+    event PackRipped(
+        uint256 indexed tokenId,
+        address indexed taker,
+        address indexed maker,
+        uint256 nav,
+        uint256 unitPrice,
+        uint256 protocolCut,
+        uint256 toMakers
+    );
+    event RipSettled(
+        address indexed taker,
+        uint256 count,
+        uint256 unitPrice,
+        uint256 totalPaid,
+        uint256 protocolCut,
+        uint256 toMakers
+    );
+
+    function test_rip_transfersPackToTaker() public {
+        uint256 a = _enrollPack(maker, 30 * WAD);
+        uint256 b = _enrollPack(maker2, 40 * WAD);
+        assertTrue(engine.isResting(a));
+        assertTrue(engine.isResting(b));
+
+        uint256 balBefore = usd.balanceOf(taker);
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+
+        vm.prank(taker);
+        uint256[] memory drawn = engine.rip(1, totalPayment);
+
+        assertEq(drawn.length, 1);
+        assertEq(packs.ownerOf(drawn[0]), taker);
+        assertFalse(packs.isListed(drawn[0]));
+        assertFalse(engine.isResting(drawn[0]));
+        assertEq(engine.restingCount(), 1);
+        assertEq(usd.balanceOf(taker), balBefore - totalPayment);
+    }
+
+    function test_rip_batchDistinctWithoutReplacement() public {
+        _enrollMany(maker, 5, 50 * WAD);
+
+        (,,, uint256 totalPayment) = engine.quoteRip(3);
+        vm.prank(taker);
+        uint256[] memory drawn = engine.rip(3, totalPayment);
+
+        assertEq(drawn.length, 3);
+        for (uint256 i; i < 3; ++i) {
+            assertEq(packs.ownerOf(drawn[i]), taker);
+            for (uint256 j; j < i; ++j) {
+                assertTrue(drawn[i] != drawn[j]);
+            }
+        }
+        assertEq(engine.restingCount(), 2);
+    }
+
+    function test_rip_slippageReverts() public {
+        _enrollMany(maker, 3, 50 * WAD);
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.SlippageExceeded.selector, totalPayment, totalPayment - 1));
+        vm.prank(taker);
+        engine.rip(1, totalPayment - 1);
+    }
+
+    function test_rip_protocolCutFromSurchargeOnly() public {
+        _enrollMany(maker, 3, 50 * WAD);
+
+        (,, uint256 unitPriceWad, uint256 totalPayment) = engine.quoteRip(1);
+        uint256 unitStable = totalPayment; // count=1
+        uint256 surcharge = registry.surcharge();
+        uint256 baseStable = (unitStable * WAD) / (WAD + surcharge);
+        uint256 surStable = unitStable - baseStable;
+        uint256 expectedProtocol = (surStable * registry.protocolShareOfSurcharge()) / WAD;
+        uint256 expectedToMakers = unitStable - expectedProtocol;
+
+        // Make-whole: toMakers >= base
+        assertGe(expectedToMakers, baseStable);
+
+        vm.prank(taker);
+        engine.rip(1, totalPayment);
+
+        assertEq(engine.protocolAccrued(), expectedProtocol);
+        // Two packs remain; fee index bumps by toMakers/2 (+dust).
+        uint256 remaining = 2;
+        uint256 perPack = expectedToMakers / remaining;
+        assertEq(engine.accFeePerPack(), perPack);
+        assertEq(engine.feeDust(), expectedToMakers % remaining);
+        // Silence unused
+        unitPriceWad;
+    }
+
+    function test_rip_drawnPackStopsAccruing() public {
+        uint256 a = _enrollPack(maker, 30 * WAD);
+        uint256 b = _enrollPack(maker2, 40 * WAD);
+        uint256 c = _enrollPack(maker, 50 * WAD);
+
+        (,,, uint256 pay1) = engine.quoteRip(1);
+        vm.prank(taker);
+        uint256[] memory drawn = engine.rip(1, pay1);
+        uint256 ripped = drawn[0];
+        uint256 accAfterFirst = engine.accFeePerPack();
+
+        // Second rip — ripped pack must not be resting / accruing.
+        assertFalse(engine.isResting(ripped));
+        (,,, uint256 pay2) = engine.quoteRip(1);
+        vm.prank(taker);
+        engine.rip(1, pay2);
+
+        assertEq(engine.pendingOf(ripped), 0);
+        assertGt(engine.accFeePerPack(), accAfterFirst);
+        // One of a/b/c still resting
+        uint256 restingLeft = 0;
+        if (engine.isResting(a)) restingLeft++;
+        if (engine.isResting(b)) restingLeft++;
+        if (engine.isResting(c)) restingLeft++;
+        assertEq(restingLeft, 1);
+    }
+
+    function test_rip_settlesAtMostOnce() public {
+        _enrollMany(maker, 3, 50 * WAD);
+        (,,, uint256 totalPayment) = engine.quoteRip(1);
+        vm.prank(taker);
+        uint256[] memory drawn = engine.rip(1, totalPayment);
+
+        // Already unlisted — releaseToRecipient would revert PackNotListed if called again.
+        // Engine no longer has it resting, so it cannot be drawn again.
+        (uint256[] memory eligible,, uint256 count) = engine.eligibleSnapshot();
+        for (uint256 i; i < count; ++i) {
+            assertTrue(eligible[i] != drawn[0]);
+        }
+    }
+
+    function test_rip_emptyReverts() public {
+        vm.expectRevert(RipEngine.EmptyEligibleSet.selector);
+        vm.prank(taker);
+        engine.rip(1, type(uint256).max);
+    }
+
+    function test_rip_degenerateReverts() public {
+        _enrollPack(maker, 50 * WAD);
+        vm.expectRevert(abi.encodeWithSelector(RipEngine.DegenerateEligibleSet.selector, uint256(1), uint256(1)));
+        vm.prank(taker);
+        engine.rip(1, type(uint256).max);
+    }
+}

--- a/contracts/test/RipMath.t.sol
+++ b/contracts/test/RipMath.t.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {RipMath} from "../src/libraries/RipMath.sol";
+
+/// @notice Pure math coverage: weights, harmonic mean, clamp, seeded draw distribution.
+contract RipMathTest is Test {
+    uint256 internal constant WAD = 1e18;
+
+    // PRD worked example (illustrative live prices).
+    uint256 internal constant GME = 22_16 * 1e16; // $22.16
+    uint256 internal constant NVDA = 196_74 * 1e16; // $196.74
+    uint256 internal constant TSLA = 307_35 * 1e16; // $307.35
+
+    // ========== weightOf ==========
+
+    function test_weightOf_alphaZero_isUniform() public pure {
+        uint256 wCheap = RipMath.weightOf(20 * WAD, 0);
+        uint256 wRich = RipMath.weightOf(300 * WAD, 0);
+        assertEq(wCheap, wRich);
+        assertEq(wCheap, RipMath.SCALE);
+    }
+
+    function test_weightOf_alphaOne_isInverseNav() public pure {
+        uint256 wGme = RipMath.weightOf(GME, WAD);
+        uint256 wNvda = RipMath.weightOf(NVDA, WAD);
+        uint256 wTsla = RipMath.weightOf(TSLA, WAD);
+
+        // Relative shares ≈ 84% / 10% / 6%.
+        uint256 total = wGme + wNvda + wTsla;
+        assertApproxEqRel((wGme * WAD) / total, 84e16, 0.02e18); // ±2%
+        assertApproxEqRel((wNvda * WAD) / total, 10e16, 0.05e18);
+        assertApproxEqRel((wTsla * WAD) / total, 6e16, 0.05e18);
+    }
+
+    function test_weightOf_alphaTwo_favorsCheapHarder() public pure {
+        uint256 wCheap1 = RipMath.weightOf(20 * WAD, WAD);
+        uint256 wRich1 = RipMath.weightOf(200 * WAD, WAD);
+        uint256 ratio1 = (wCheap1 * WAD) / wRich1; // ~10×
+
+        uint256 wCheap2 = RipMath.weightOf(20 * WAD, 2 * WAD);
+        uint256 wRich2 = RipMath.weightOf(200 * WAD, 2 * WAD);
+        uint256 ratio2 = (wCheap2 * WAD) / wRich2; // ~100×
+
+        assertGt(ratio2, ratio1);
+        assertApproxEqRel(ratio2, 100 * WAD, 0.01e18);
+    }
+
+    function test_weightOf_zeroNavReverts() public {
+        vm.expectRevert(RipMath.ZeroNav.selector);
+        this.weightOfExternal(0, WAD);
+    }
+
+    function test_weightOf_fractionalAlphaReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(RipMath.FractionalAlphaUnsupported.selector, WAD / 2));
+        this.weightOfExternal(20 * WAD, WAD / 2);
+    }
+
+    function test_weightOf_exponentTooHighReverts() public {
+        uint256 alpha = 9 * WAD;
+        vm.expectRevert(abi.encodeWithSelector(RipMath.AlphaExponentTooHigh.selector, uint256(9)));
+        this.weightOfExternal(20 * WAD, alpha);
+    }
+
+    function weightOfExternal(uint256 nav, uint256 alpha) external pure returns (uint256) {
+        return RipMath.weightOf(nav, alpha);
+    }
+
+    // ========== harmonicMean ==========
+
+    function test_harmonicMean_prdWorkedExample() public pure {
+        uint256[] memory navs = new uint256[](3);
+        navs[0] = GME;
+        navs[1] = NVDA;
+        navs[2] = TSLA;
+
+        uint256 hm = RipMath.harmonicMean(navs);
+        // PRD: ≈ $56
+        assertApproxEqRel(hm, 56 * WAD, 0.02e18);
+    }
+
+    function test_harmonicMean_equalNavs() public pure {
+        uint256[] memory navs = new uint256[](3);
+        navs[0] = 100 * WAD;
+        navs[1] = 100 * WAD;
+        navs[2] = 100 * WAD;
+        assertEq(RipMath.harmonicMean(navs), 100 * WAD);
+    }
+
+    function test_harmonicMean_emptyReverts() public {
+        uint256[] memory navs = new uint256[](0);
+        vm.expectRevert(RipMath.EmptySet.selector);
+        this.harmonicMeanExternal(navs);
+    }
+
+    function test_harmonicMean_zeroNavReverts() public {
+        uint256[] memory navs = new uint256[](2);
+        navs[0] = 100 * WAD;
+        navs[1] = 0;
+        vm.expectRevert(RipMath.ZeroNav.selector);
+        this.harmonicMeanExternal(navs);
+    }
+
+    function harmonicMeanExternal(uint256[] memory navs) external pure returns (uint256) {
+        return RipMath.harmonicMean(navs);
+    }
+
+    // ========== clampUnitPrice ==========
+
+    function test_clampUnitPrice_interior() public pure {
+        // hm=$56, surcharge=10% → $61.6; band [$20,$300]×1.1 = [$22,$330]
+        uint256 price = RipMath.clampUnitPrice(56 * WAD, WAD / 10, 20 * WAD, 300 * WAD);
+        assertEq(price, (56 * WAD * 11) / 10);
+    }
+
+    function test_clampUnitPrice_floor() public pure {
+        // hm below min → clamps to min*(1+s)
+        uint256 price = RipMath.clampUnitPrice(10 * WAD, WAD / 10, 20 * WAD, 300 * WAD);
+        assertEq(price, (20 * WAD * 11) / 10);
+    }
+
+    function test_clampUnitPrice_ceiling() public pure {
+        uint256 price = RipMath.clampUnitPrice(400 * WAD, WAD / 10, 20 * WAD, 300 * WAD);
+        assertEq(price, (300 * WAD * 11) / 10);
+    }
+
+    // ========== drawDistinct ==========
+
+    function test_drawDistinct_noReplacement() public pure {
+        uint256[] memory weights = new uint256[](5);
+        for (uint256 i; i < 5; ++i) {
+            weights[i] = 100;
+        }
+
+        uint256[] memory drawn = RipMath.drawDistinct(weights, 42, 3);
+        assertEq(drawn.length, 3);
+
+        // All distinct.
+        for (uint256 i; i < drawn.length; ++i) {
+            assertLt(drawn[i], 5);
+            for (uint256 j; j < i; ++j) {
+                assertTrue(drawn[i] != drawn[j]);
+            }
+        }
+    }
+
+    function test_drawDistinct_countOutOfRange() public {
+        uint256[] memory weights = new uint256[](2);
+        weights[0] = 1;
+        weights[1] = 1;
+
+        vm.expectRevert(abi.encodeWithSelector(RipMath.CountOutOfRange.selector, uint256(0), uint256(2)));
+        this.drawDistinctExternal(weights, 1, 0);
+
+        vm.expectRevert(abi.encodeWithSelector(RipMath.CountOutOfRange.selector, uint256(3), uint256(2)));
+        this.drawDistinctExternal(weights, 1, 3);
+    }
+
+    function test_drawDistinct_zeroTotalWeightReverts() public {
+        uint256[] memory weights = new uint256[](2);
+        vm.expectRevert(RipMath.ZeroTotalWeight.selector);
+        this.drawDistinctExternal(weights, 1, 1);
+    }
+
+    function drawDistinctExternal(uint256[] memory weights, uint256 seed, uint256 count)
+        external
+        pure
+        returns (uint256[] memory)
+    {
+        return RipMath.drawDistinct(weights, seed, count);
+    }
+
+    // ========== Statistical odds over seeded draws ==========
+
+    function test_drawDistinct_prdOddsDistribution() public pure {
+        uint256[] memory weights = new uint256[](3);
+        weights[0] = RipMath.weightOf(GME, WAD);
+        weights[1] = RipMath.weightOf(NVDA, WAD);
+        weights[2] = RipMath.weightOf(TSLA, WAD);
+
+        uint256[3] memory counts;
+        uint256 samples = 10_000;
+
+        for (uint256 s; s < samples; ++s) {
+            uint256[] memory drawn = RipMath.drawDistinct(weights, s + 1, 1);
+            counts[drawn[0]]++;
+        }
+
+        // Expected ≈ 84% / 10% / 6%. Allow ±2pp absolute for 10k samples.
+        assertApproxEqAbs((counts[0] * 100) / samples, 84, 2);
+        assertApproxEqAbs((counts[1] * 100) / samples, 10, 2);
+        assertApproxEqAbs((counts[2] * 100) / samples, 6, 2);
+    }
+
+    function test_drawDistinct_uniformWhenEqualWeights() public pure {
+        uint256[] memory weights = new uint256[](4);
+        for (uint256 i; i < 4; ++i) {
+            weights[i] = 1e18;
+        }
+
+        uint256[4] memory counts;
+        uint256 samples = 8_000;
+
+        for (uint256 s; s < samples; ++s) {
+            uint256[] memory drawn = RipMath.drawDistinct(weights, s + 7, 1);
+            counts[drawn[0]]++;
+        }
+
+        for (uint256 i; i < 4; ++i) {
+            assertApproxEqAbs((counts[i] * 100) / samples, 25, 2);
+        }
+    }
+}

--- a/contracts/test/helpers/RipEngineFixture.sol
+++ b/contracts/test/helpers/RipEngineFixture.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {AssetRegistry} from "../../src/AssetRegistry.sol";
+import {MockUSD} from "../../src/MockUSD.sol";
+import {PackCustody} from "../../src/PackCustody.sol";
+import {RipEngine} from "../../src/RipEngine.sol";
+import {MockPriceFeed} from "../../src/mocks/MockPriceFeed.sol";
+import {MockRandomness} from "../../src/mocks/MockRandomness.sol";
+import {MockStockToken} from "../mocks/MockStockToken.sol";
+
+/// @notice Wired PackCustody + AssetRegistry + MockUSD + RipEngine for game-loop tests.
+abstract contract RipEngineFixture is Test {
+    uint256 internal constant WAD = 1e18;
+    uint8 internal constant FEED_DECIMALS = 8;
+    uint64 internal constant STALE_AFTER = 1 hours;
+
+    PackCustody internal packs;
+    AssetRegistry internal registry;
+    MockUSD internal usd;
+    MockRandomness internal randomness;
+    RipEngine internal engine;
+
+    MockStockToken internal amzn;
+    MockStockToken internal amd;
+    MockStockToken internal nflx;
+    MockStockToken internal pltr;
+    MockStockToken internal tsla;
+
+    MockPriceFeed internal amznFeed;
+    MockPriceFeed internal amdFeed;
+    MockPriceFeed internal nflxFeed;
+    MockPriceFeed internal pltrFeed;
+    MockPriceFeed internal tslaFeed;
+
+    address internal admin = makeAddr("admin");
+    address internal maker = makeAddr("maker");
+    address internal maker2 = makeAddr("maker2");
+    address internal taker = makeAddr("taker");
+    address internal stranger = makeAddr("stranger");
+
+    function setUp() public virtual {
+        amzn = new MockStockToken("Amazon Test Stock", "tAMZN", 18);
+        amd = new MockStockToken("AMD Test Stock", "tAMD", 18);
+        nflx = new MockStockToken("Netflix Test Stock", "tNFLX", 8);
+        pltr = new MockStockToken("Palantir Test Stock", "tPLTR", 6);
+        tsla = new MockStockToken("Tesla Test Stock", "tTSLA", 18);
+
+        address[] memory whitelist = new address[](5);
+        whitelist[0] = address(amzn);
+        whitelist[1] = address(amd);
+        whitelist[2] = address(nflx);
+        whitelist[3] = address(pltr);
+        whitelist[4] = address(tsla);
+
+        packs = new PackCustody(admin, whitelist);
+        registry = new AssetRegistry(admin);
+        usd = new MockUSD(admin);
+        randomness = new MockRandomness(admin, 0xC0FFEE);
+
+        amznFeed = new MockPriceFeed(admin, FEED_DECIMALS, 100e8); // $100
+        amdFeed = new MockPriceFeed(admin, FEED_DECIMALS, 50e8); // $50
+        nflxFeed = new MockPriceFeed(admin, FEED_DECIMALS, 200e8); // $200
+        pltrFeed = new MockPriceFeed(admin, FEED_DECIMALS, 25e8); // $25
+        tslaFeed = new MockPriceFeed(admin, FEED_DECIMALS, 300e8); // $300
+
+        vm.startPrank(admin);
+        registry.addAsset(address(amzn), address(amznFeed), STALE_AFTER);
+        registry.addAsset(address(amd), address(amdFeed), STALE_AFTER);
+        registry.addAsset(address(nflx), address(nflxFeed), STALE_AFTER);
+        registry.addAsset(address(pltr), address(pltrFeed), STALE_AFTER);
+        registry.addAsset(address(tsla), address(tslaFeed), STALE_AFTER);
+        usd.grantRole(usd.MINTER_ROLE(), admin);
+        vm.stopPrank();
+
+        engine = new RipEngine(admin, address(packs), address(registry), address(usd), address(randomness));
+
+        bytes32 ripRole = packs.RIP_ENGINE_ROLE();
+        vm.prank(admin);
+        packs.grantRole(ripRole, address(engine));
+
+        _fundMaker(maker);
+        _fundMaker(maker2);
+        _fundTaker(taker);
+    }
+
+    function _fundMaker(address who) internal {
+        MockStockToken[5] memory tokens = [amzn, amd, nflx, pltr, tsla];
+        for (uint256 i; i < tokens.length; ++i) {
+            tokens[i].mint(who, 1_000_000 * (10 ** tokens[i].decimals()));
+            vm.prank(who);
+            tokens[i].approve(address(packs), type(uint256).max);
+        }
+    }
+
+    function _fundTaker(address who) internal {
+        vm.prank(admin);
+        usd.mint(who, 1_000_000e6);
+        vm.prank(who);
+        usd.approve(address(engine), type(uint256).max);
+    }
+
+    /// @dev Single-asset Pack with target WAD NAV. Uses AMZN ($100): amount = nav/100.
+    function _mintPackAtNav(address who, uint256 navWad) internal returns (uint256 tokenId) {
+        // nav = amount * 100e8 * 1e18 / 1e26 = amount * 100 → amount = nav/100
+        uint256 amount = navWad / 100;
+        address[] memory assets = new address[](1);
+        uint256[] memory amounts = new uint256[](1);
+        assets[0] = address(amzn);
+        amounts[0] = amount;
+        vm.prank(who);
+        tokenId = packs.mint(assets, amounts);
+    }
+
+    /// @dev Mint + enterPool.
+    function _enrollPack(address who, uint256 navWad) internal returns (uint256 tokenId) {
+        tokenId = _mintPackAtNav(who, navWad);
+        vm.prank(who);
+        engine.enterPool(tokenId);
+    }
+
+    /// @dev Enroll `n` packs at the same NAV for the maker.
+    function _enrollMany(address who, uint256 n, uint256 navWad) internal returns (uint256[] memory ids) {
+        ids = new uint256[](n);
+        for (uint256 i; i < n; ++i) {
+            ids[i] = _enrollPack(who, navWad);
+        }
+    }
+}

--- a/contracts/test/helpers/RipEngineFixture.sol
+++ b/contracts/test/helpers/RipEngineFixture.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {AssetRegistry} from "../../src/AssetRegistry.sol";
 import {MockUSD} from "../../src/MockUSD.sol";
 import {PackCustody} from "../../src/PackCustody.sol";
@@ -11,7 +11,10 @@ import {MockRandomness} from "../../src/mocks/MockRandomness.sol";
 import {MockStockToken} from "../mocks/MockStockToken.sol";
 
 /// @notice Wired PackCustody + AssetRegistry + MockUSD + RipEngine for game-loop tests.
-abstract contract RipEngineFixture is Test {
+/// @dev Does not inherit `Test` so invariant suites can mix this with `StdInvariant`.
+abstract contract RipEngineFixture {
+    Vm private constant _vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
     uint256 internal constant WAD = 1e18;
     uint8 internal constant FEED_DECIMALS = 8;
     uint64 internal constant STALE_AFTER = 1 hours;
@@ -34,13 +37,20 @@ abstract contract RipEngineFixture is Test {
     MockPriceFeed internal pltrFeed;
     MockPriceFeed internal tslaFeed;
 
-    address internal admin = makeAddr("admin");
-    address internal maker = makeAddr("maker");
-    address internal maker2 = makeAddr("maker2");
-    address internal taker = makeAddr("taker");
-    address internal stranger = makeAddr("stranger");
+    // Deterministic labels matching forge-std `makeAddr`.
+    address internal admin = address(uint160(uint256(keccak256(abi.encodePacked("admin")))));
+    address internal maker = address(uint160(uint256(keccak256(abi.encodePacked("maker")))));
+    address internal maker2 = address(uint160(uint256(keccak256(abi.encodePacked("maker2")))));
+    address internal taker = address(uint160(uint256(keccak256(abi.encodePacked("taker")))));
+    address internal stranger = address(uint160(uint256(keccak256(abi.encodePacked("stranger")))));
 
     function setUp() public virtual {
+        _vm.label(admin, "admin");
+        _vm.label(maker, "maker");
+        _vm.label(maker2, "maker2");
+        _vm.label(taker, "taker");
+        _vm.label(stranger, "stranger");
+
         amzn = new MockStockToken("Amazon Test Stock", "tAMZN", 18);
         amd = new MockStockToken("AMD Test Stock", "tAMD", 18);
         nflx = new MockStockToken("Netflix Test Stock", "tNFLX", 8);
@@ -59,25 +69,25 @@ abstract contract RipEngineFixture is Test {
         usd = new MockUSD(admin);
         randomness = new MockRandomness(admin, 0xC0FFEE);
 
-        amznFeed = new MockPriceFeed(admin, FEED_DECIMALS, 100e8); // $100
-        amdFeed = new MockPriceFeed(admin, FEED_DECIMALS, 50e8); // $50
-        nflxFeed = new MockPriceFeed(admin, FEED_DECIMALS, 200e8); // $200
-        pltrFeed = new MockPriceFeed(admin, FEED_DECIMALS, 25e8); // $25
-        tslaFeed = new MockPriceFeed(admin, FEED_DECIMALS, 300e8); // $300
+        amznFeed = new MockPriceFeed(admin, FEED_DECIMALS, 100e8);
+        amdFeed = new MockPriceFeed(admin, FEED_DECIMALS, 50e8);
+        nflxFeed = new MockPriceFeed(admin, FEED_DECIMALS, 200e8);
+        pltrFeed = new MockPriceFeed(admin, FEED_DECIMALS, 25e8);
+        tslaFeed = new MockPriceFeed(admin, FEED_DECIMALS, 300e8);
 
-        vm.startPrank(admin);
+        _vm.startPrank(admin);
         registry.addAsset(address(amzn), address(amznFeed), STALE_AFTER);
         registry.addAsset(address(amd), address(amdFeed), STALE_AFTER);
         registry.addAsset(address(nflx), address(nflxFeed), STALE_AFTER);
         registry.addAsset(address(pltr), address(pltrFeed), STALE_AFTER);
         registry.addAsset(address(tsla), address(tslaFeed), STALE_AFTER);
         usd.grantRole(usd.MINTER_ROLE(), admin);
-        vm.stopPrank();
+        _vm.stopPrank();
 
         engine = new RipEngine(admin, address(packs), address(registry), address(usd), address(randomness));
 
         bytes32 ripRole = packs.RIP_ENGINE_ROLE();
-        vm.prank(admin);
+        _vm.prank(admin);
         packs.grantRole(ripRole, address(engine));
 
         _fundMaker(maker);
@@ -88,39 +98,36 @@ abstract contract RipEngineFixture is Test {
     function _fundMaker(address who) internal {
         MockStockToken[5] memory tokens = [amzn, amd, nflx, pltr, tsla];
         for (uint256 i; i < tokens.length; ++i) {
-            tokens[i].mint(who, 1_000_000 * (10 ** tokens[i].decimals()));
-            vm.prank(who);
+            uint256 amount = 1_000_000 * (10 ** tokens[i].decimals());
+            tokens[i].mint(who, amount);
+            _vm.prank(who);
             tokens[i].approve(address(packs), type(uint256).max);
         }
     }
 
     function _fundTaker(address who) internal {
-        vm.prank(admin);
+        _vm.prank(admin);
         usd.mint(who, 1_000_000e6);
-        vm.prank(who);
+        _vm.prank(who);
         usd.approve(address(engine), type(uint256).max);
     }
 
-    /// @dev Single-asset Pack with target WAD NAV. Uses AMZN ($100): amount = nav/100.
     function _mintPackAtNav(address who, uint256 navWad) internal returns (uint256 tokenId) {
-        // nav = amount * 100e8 * 1e18 / 1e26 = amount * 100 → amount = nav/100
         uint256 amount = navWad / 100;
         address[] memory assets = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         assets[0] = address(amzn);
         amounts[0] = amount;
-        vm.prank(who);
+        _vm.prank(who);
         tokenId = packs.mint(assets, amounts);
     }
 
-    /// @dev Mint + enterPool.
     function _enrollPack(address who, uint256 navWad) internal returns (uint256 tokenId) {
         tokenId = _mintPackAtNav(who, navWad);
-        vm.prank(who);
+        _vm.prank(who);
         engine.enterPool(tokenId);
     }
 
-    /// @dev Enroll `n` packs at the same NAV for the maker.
     function _enrollMany(address who, uint256 n, uint256 navWad) internal returns (uint256[] memory ids) {
         ids = new uint256[](n);
         for (uint256 i; i < n; ++i) {

--- a/docs/prd-margin-call.md
+++ b/docs/prd-margin-call.md
@@ -52,7 +52,7 @@ odds_i   = weight_i / Σ_j weight_j
 **Rip price (dynamic, live)**
 
 ```
-harmonic_mean = (Σ_i N_i) / (Σ_i 1/N_i)      // over eligible Packs
+harmonic_mean = n / (Σ_i 1/N_i)              // over eligible Packs
 rip_price     = harmonic_mean × (1 + surcharge)
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "deploy:packcustody": "tsx scripts/deploy-packcustody.ts",
     "verify:packcustody": "tsx scripts/verify-packcustody.ts",
     "deploy:asset-registry": "tsx scripts/deploy-asset-registry.ts",
+    "deploy:rip-engine": "tsx scripts/deploy-rip-engine.ts",
     "audit:prod": "pnpm audit --prod --audit-level=high",
     "audit:all": "pnpm audit --audit-level=high",
     "audit:all:gated": "node scripts/audit-all-gated.mjs",

--- a/scripts/deploy-rip-engine.ts
+++ b/scripts/deploy-rip-engine.ts
@@ -1,0 +1,106 @@
+/**
+ * Deploy RipEngine + MockRandomness to Robinhood Chain testnet and grant
+ * PackCustody RIP_ENGINE_ROLE.
+ *
+ * Requires in .env.local (or shell):
+ *   DEPLOYER_PRIVATE_KEY (or OPERATOR_PRIVATE_KEY)
+ *   ROBINHOOD_TESTNET_RPC_URL
+ *   PACKCUSTODY_ADDRESS
+ *   ASSETREGISTRY_ADDRESS
+ *   MOCKUSD_ADDRESS
+ *
+ * Optional:
+ *   RIPENGINE_ADMIN       — defaults to deployer
+ *   RIPENGINE_SEED        — MockRandomness base seed
+ *   RIPENGINE_GRANT_ROLE  — "true"/"false"; default true
+ *
+ * Usage: pnpm deploy:rip-engine
+ *
+ * Testnet wire-up and Blockscout verify are tracked in #310.
+ */
+import {
+  enrichDeploymentRecord,
+  loadEnvLocal,
+  patchEnvLocal,
+  readLatestBroadcastCreate,
+  ROBINHOOD_TESTNET_CHAIN_ID,
+  ROBINHOOD_TESTNET_EXPLORER,
+  runForgeDeploy,
+} from "./deploy-utils";
+
+function main() {
+  const env = loadEnvLocal();
+  const rpcUrl =
+    env.ROBINHOOD_TESTNET_RPC_URL ?? env.NEXT_PUBLIC_ROBINHOOD_TESTNET_RPC_URL;
+  const deployerKey = env.DEPLOYER_PRIVATE_KEY ?? env.OPERATOR_PRIVATE_KEY;
+  if (!rpcUrl) {
+    throw new Error("ROBINHOOD_TESTNET_RPC_URL missing in .env.local");
+  }
+  if (!deployerKey) {
+    throw new Error(
+      "DEPLOYER_PRIVATE_KEY (or OPERATOR_PRIVATE_KEY) missing — set it, or export from a Foundry keystore with `cast wallet private-key --account <name>`"
+    );
+  }
+  if (!env.PACKCUSTODY_ADDRESS) {
+    throw new Error("PACKCUSTODY_ADDRESS missing in .env.local");
+  }
+  if (!env.ASSETREGISTRY_ADDRESS) {
+    throw new Error("ASSETREGISTRY_ADDRESS missing in .env.local");
+  }
+  if (!env.MOCKUSD_ADDRESS) {
+    throw new Error("MOCKUSD_ADDRESS missing in .env.local");
+  }
+
+  console.log("Deploying RipEngine to Robinhood Chain testnet…");
+
+  const forgeEnv: Record<string, string> = {
+    DEPLOYER_PRIVATE_KEY: deployerKey,
+    PACKCUSTODY_ADDRESS: env.PACKCUSTODY_ADDRESS,
+    ASSETREGISTRY_ADDRESS: env.ASSETREGISTRY_ADDRESS,
+    MOCKUSD_ADDRESS: env.MOCKUSD_ADDRESS,
+  };
+  if (env.RIPENGINE_ADMIN) {
+    forgeEnv.RIPENGINE_ADMIN = env.RIPENGINE_ADMIN;
+  }
+  if (env.RIPENGINE_SEED) {
+    forgeEnv.RIPENGINE_SEED = env.RIPENGINE_SEED;
+  }
+  if (env.RIPENGINE_GRANT_ROLE) {
+    forgeEnv.RIPENGINE_GRANT_ROLE = env.RIPENGINE_GRANT_ROLE;
+  }
+
+  const { address } = runForgeDeploy({
+    scriptTarget: "script/DeployRipEngine.s.sol:DeployRipEngine",
+    rpcUrl,
+    privateKey: deployerKey,
+    addressLabel: "RipEngine",
+    env: forgeEnv,
+  });
+
+  const broadcast = readLatestBroadcastCreate({
+    scriptFileName: "DeployRipEngine.s.sol",
+    chainId: ROBINHOOD_TESTNET_CHAIN_ID,
+  });
+
+  const record = enrichDeploymentRecord("robinhood-testnet.rip-engine.json", {
+    address,
+    txHash: broadcast?.txHash,
+    blockNumber: broadcast?.blockNumber,
+  });
+
+  patchEnvLocal("RIPENGINE_ADDRESS", address);
+  patchEnvLocal("NEXT_PUBLIC_RIPENGINE_ADDRESS", address);
+
+  console.log(`\nUpdated .env.local:`);
+  console.log(`  RIPENGINE_ADDRESS=${address}`);
+  console.log(`  NEXT_PUBLIC_RIPENGINE_ADDRESS=${address}`);
+  console.log(
+    `\nRecorded deployment in contracts/deployments/robinhood-testnet.rip-engine.json`
+  );
+  console.log(`Explorer: ${ROBINHOOD_TESTNET_EXPLORER}/address/${address}`);
+  if (record.txHash) {
+    console.log(`Tx: ${ROBINHOOD_TESTNET_EXPLORER}/tx/${record.txHash}`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements [#301](https://github.com/hurley87/margin-call/issues/301): the Taker rip path — NAV-weighted selection, live pricing, Model-A settlement, and Maker Acquisition Fees.

- `IRandomnessSource` + `MockRandomness` (deterministic / House-seeded V1)
- `RipMath` pure library: inverse-NAV weights (whole-number alpha), correct harmonic mean `n/Σ(1/N)`, band clamp, without-replacement draw
- `RipEngine`: explicit `enterPool`/`exitPool`, `quoteRip`/`rip`, fee-per-Pack index, Maker claims, protocol withdrawal
- Foundry unit + invariant suites; `DeployRipEngine` + `pnpm deploy:rip-engine`
- Docs: contracts README, CLAUDE/AGENTS, PRD harmonic-mean formula fix

**Design notes (for review):**
- Pool membership is explicit enrollment (PackCustody has no enumeration)
- `eligibleCount > count` required so socialization has a non-empty destination
- Fee accrual follows enrollment (stale-feed Packs keep accruing while undrawable)
- Crown carve-out left as a seam for #302
- AssetRegistry inventory mirroring deferred to #310

## Acceptance criteria

- [x] `rip(count)` with count ≤ maxBatchSize; distinct draws (without replacement); empty/degenerate set reverts; batch priced off one snapshot
- [x] Odds `∝ 1/NAV^alpha` (verified statistically over seeded draws); price = `clamp(HM×(1+surcharge), [minPackNav, poolMax]×(1+surcharge))`
- [x] Protocol cut from the surcharge only; base fully socialized equally per resting Pack via the fee-per-Pack index; make-whole invariant holds
- [x] Maker fee-claim withdraws accrued Acquisition Fee; drawn Pack settles via the primitive and stops accruing
- [x] Randomness behind an injectable interface (deterministic in tests; disclosed House seed in V1)

## Test plan

- [x] `forge fmt --check`
- [x] `FOUNDRY_PROFILE=ci forge test` (255 passed)
- [ ] Review RipEngine settlement math vs PRD Model A
- [ ] Optional: `pnpm deploy:rip-engine` on Robinhood testnet after #310 wire-up


Made with [Cursor](https://cursor.com)