### PR TITLE
Fix indexer cursor advancing past failed Pack events (#321)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as lib_chain_abis from "../lib/chain/abis.js";
 import type * as lib_chain_addresses from "../lib/chain/addresses.js";
 import type * as lib_chain_clients from "../lib/chain/clients.js";
 import type * as lib_chain_walletAddress from "../lib/chain/walletAddress.js";
+import type * as lib_poolIndexerHandlers from "../lib/poolIndexerHandlers.js";
 import type * as lib_poolStats from "../lib/poolStats.js";
 import type * as lib_starterGrantConfig from "../lib/starterGrantConfig.js";
 import type * as lib_stockTokens from "../lib/stockTokens.js";
@@ -38,6 +39,7 @@ declare const fullApi: ApiFromModules<{
   "lib/chain/addresses": typeof lib_chain_addresses;
   "lib/chain/clients": typeof lib_chain_clients;
   "lib/chain/walletAddress": typeof lib_chain_walletAddress;
+  "lib/poolIndexerHandlers": typeof lib_poolIndexerHandlers;
   "lib/poolStats": typeof lib_poolStats;
   "lib/starterGrantConfig": typeof lib_starterGrantConfig;
   "lib/stockTokens": typeof lib_stockTokens;

--- a/convex/lib/poolIndexerHandlers.ts
+++ b/convex/lib/poolIndexerHandlers.ts
@@ -1,0 +1,275 @@
+/**
+ * Pool indexer scan + log-apply helpers.
+ *
+ * Kept outside the `"use node"` action file so Vitest can unit-test cursor
+ * advancement and error boundaries without Convex action bootstrap.
+ */
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  decodeEventLog,
+  type AbiEvent,
+  type Log,
+  type PublicClient,
+} from "viem";
+
+import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
+import { packCustodyAbi, ripEngineAbi } from "./chain/abis";
+import { stockSymbolForAddress } from "./stockTokens";
+
+export const MAX_BLOCK_SPAN = 2_000n;
+
+type BasketEntry = {
+  asset: string;
+  amount: string;
+  symbol: string | null;
+};
+
+/**
+ * True when viem reports a contract revert (as opposed to RPC/transport failure).
+ * Contract reverts for `navOfPack` mean "no usable NAV" (empty basket / quote fail).
+ */
+export function isContractCallRevert(err: unknown): boolean {
+  if (!(err instanceof BaseError)) return false;
+  return (
+    err.walk((e) => e instanceof ContractFunctionRevertedError) instanceof
+    ContractFunctionRevertedError
+  );
+}
+
+/** Decode a log against `abi`; return null when topics/data don't match. */
+export function tryDecodeEventLog(
+  abi: typeof ripEngineAbi | typeof packCustodyAbi,
+  log: Log
+) {
+  try {
+    return decodeEventLog({
+      abi,
+      data: log.data,
+      topics: log.topics,
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function readBasket(
+  client: PublicClient,
+  packCustody: `0x${string}`,
+  tokenId: bigint
+): Promise<BasketEntry[]> {
+  const basket = await client.readContract({
+    address: packCustody,
+    abi: packCustodyAbi,
+    functionName: "basketOf",
+    args: [tokenId],
+  });
+  return basket.map((entry) => ({
+    asset: entry.asset.toLowerCase(),
+    amount: entry.amount.toString(),
+    symbol: stockSymbolForAddress(entry.asset),
+  }));
+}
+
+/**
+ * Read pack NAV. Contract revert → null (genuinely unusable NAV).
+ * RPC / transport / unexpected errors propagate so the scan can retry.
+ */
+export async function readNavOfPack(
+  client: PublicClient,
+  ripEngine: `0x${string}`,
+  tokenId: bigint
+): Promise<string | null> {
+  try {
+    const nav = await client.readContract({
+      address: ripEngine,
+      abi: ripEngineAbi,
+      functionName: "navOfPack",
+      args: [tokenId],
+    });
+    return nav.toString();
+  } catch (err) {
+    if (isContractCallRevert(err)) return null;
+    throw err;
+  }
+}
+
+export async function upsertRestingPack(
+  ctx: ActionCtx,
+  client: PublicClient,
+  packCustody: `0x${string}`,
+  ripEngine: `0x${string}`,
+  tokenId: bigint,
+  maker: string,
+  eligible: boolean,
+  now: number,
+  knownNavWad?: string
+): Promise<void> {
+  const basket = await readBasket(client, packCustody, tokenId);
+  const navUsdWad =
+    knownNavWad !== undefined
+      ? knownNavWad
+      : await readNavOfPack(client, ripEngine, tokenId);
+  await ctx.runMutation(internal.poolIndexer.upsertPack, {
+    tokenId: Number(tokenId),
+    maker: maker.toLowerCase(),
+    basket,
+    navUsdWad,
+    status: "resting",
+    eligible,
+    updatedAt: now,
+  });
+}
+
+/**
+ * Read a pack's basket and upsert it in a terminal (non-resting) state.
+ * Shared by the PackExited / PackRipped / PackUnlisted handlers, which differ
+ * only in `status`, `navUsdWad`, and where the maker comes from.
+ */
+async function upsertTerminalPack(
+  ctx: ActionCtx,
+  client: PublicClient,
+  packCustody: `0x${string}`,
+  tokenId: bigint,
+  maker: string,
+  status: "ripped" | "unlisted",
+  navUsdWad: string | null,
+  now: number
+): Promise<void> {
+  const basket = await readBasket(client, packCustody, tokenId);
+  await ctx.runMutation(internal.poolIndexer.upsertPack, {
+    tokenId: Number(tokenId),
+    maker: maker.toLowerCase(),
+    basket,
+    navUsdWad,
+    status,
+    eligible: false,
+    updatedAt: now,
+  });
+}
+
+/**
+ * Scan a contract's logs from its persisted cursor (or `fallbackBlock`) up to
+ * `latest`, in `MAX_BLOCK_SPAN` chunks, applying each log and advancing the
+ * cursor only after a chunk fully succeeds.
+ */
+export async function scanLogs(
+  ctx: ActionCtx,
+  client: PublicClient,
+  opts: {
+    key: string;
+    address: `0x${string}`;
+    events: AbiEvent[];
+    fallbackBlock: bigint;
+    latest: bigint;
+    apply: (log: Log) => Promise<void>;
+  }
+): Promise<void> {
+  const cursor =
+    (await ctx.runQuery(internal.poolIndexer.getCursor, { key: opts.key })) ??
+    Number(opts.fallbackBlock);
+  let from = BigInt(cursor);
+  while (from <= opts.latest) {
+    const to =
+      from + MAX_BLOCK_SPAN > opts.latest ? opts.latest : from + MAX_BLOCK_SPAN;
+    const logs = await client.getLogs({
+      address: opts.address,
+      events: opts.events,
+      fromBlock: from,
+      toBlock: to,
+    });
+    for (const log of logs) {
+      await opts.apply(log);
+    }
+    // Advance only after every log in this chunk was applied successfully.
+    // A thrown apply/RPC error leaves the cursor unmoved so the next sync retries.
+    await ctx.runMutation(internal.poolIndexer.setCursor, {
+      key: opts.key,
+      blockNumber: Number(to),
+    });
+    from = to + 1n;
+  }
+}
+
+export async function applyRipEngineLog(
+  ctx: ActionCtx,
+  client: PublicClient,
+  addresses: {
+    packCustody: `0x${string}`;
+    ripEngine: `0x${string}`;
+  },
+  log: Log,
+  now: number
+): Promise<void> {
+  const decoded = tryDecodeEventLog(ripEngineAbi, log);
+  if (!decoded) return;
+
+  if (decoded.eventName === "PackEntered") {
+    await upsertRestingPack(
+      ctx,
+      client,
+      addresses.packCustody,
+      addresses.ripEngine,
+      decoded.args.tokenId,
+      decoded.args.maker,
+      true,
+      now
+    );
+    return;
+  }
+  if (decoded.eventName === "PackExited") {
+    await upsertTerminalPack(
+      ctx,
+      client,
+      addresses.packCustody,
+      decoded.args.tokenId,
+      decoded.args.maker,
+      "unlisted",
+      null,
+      now
+    );
+    return;
+  }
+  if (decoded.eventName === "PackRipped") {
+    await upsertTerminalPack(
+      ctx,
+      client,
+      addresses.packCustody,
+      decoded.args.tokenId,
+      decoded.args.maker,
+      "ripped",
+      decoded.args.nav.toString(),
+      now
+    );
+  }
+}
+
+export async function applyPackUnlisted(
+  ctx: ActionCtx,
+  client: PublicClient,
+  packCustody: `0x${string}`,
+  log: Log,
+  now: number
+): Promise<void> {
+  const decoded = tryDecodeEventLog(packCustodyAbi, log);
+  if (!decoded || decoded.eventName !== "PackUnlisted") return;
+
+  const tokenId = decoded.args.tokenId;
+  const maker = await client.readContract({
+    address: packCustody,
+    abi: packCustodyAbi,
+    functionName: "creatorOf",
+    args: [tokenId],
+  });
+  await upsertTerminalPack(
+    ctx,
+    client,
+    packCustody,
+    tokenId,
+    maker,
+    "unlisted",
+    null,
+    now
+  );
+}

--- a/convex/poolIndexerActions.ts
+++ b/convex/poolIndexerActions.ts
@@ -5,10 +5,10 @@ import {
   RIPENGINE_DEPLOY_BLOCK_BIGINT as RIPENGINE_DEPLOY_BLOCK,
 } from "@margin-call/shared";
 import { v } from "convex/values";
-import { decodeEventLog, parseAbiItem, type AbiEvent, type Log } from "viem";
+import { parseAbiItem } from "viem";
 
 import { internal } from "./_generated/api";
-import { type ActionCtx, internalAction } from "./_generated/server";
+import { internalAction } from "./_generated/server";
 import {
   assetRegistryAbi,
   packCustodyAbi,
@@ -17,13 +17,16 @@ import {
 import { requireIndexerAddresses } from "./lib/chain/addresses";
 import { createChainPublicClient } from "./lib/chain/clients";
 import {
+  applyPackUnlisted,
+  applyRipEngineLog,
+  scanLogs,
+  upsertRestingPack,
+} from "./lib/poolIndexerHandlers";
+import {
   buildNavDistribution,
   harmonicMeanWad,
   unitPriceFromHm,
 } from "./lib/poolStats";
-import { stockSymbolForAddress } from "./lib/stockTokens";
-
-const MAX_BLOCK_SPAN = 2_000n;
 
 const packUnlistedEvent = parseAbiItem(
   "event PackUnlisted(uint256 indexed tokenId)"
@@ -37,112 +40,6 @@ const packExitedEvent = parseAbiItem(
 const packRippedEvent = parseAbiItem(
   "event PackRipped(uint256 indexed tokenId, address indexed taker, address indexed maker, uint256 nav, uint256 unitPrice, uint256 protocolCut, uint256 crownCut, uint256 toMakers)"
 );
-
-type BasketEntry = {
-  asset: string;
-  amount: string;
-  symbol: string | null;
-};
-
-type PublicClient = ReturnType<typeof createChainPublicClient>;
-
-async function readBasket(
-  client: PublicClient,
-  packCustody: `0x${string}`,
-  tokenId: bigint
-): Promise<BasketEntry[]> {
-  const basket = await client.readContract({
-    address: packCustody,
-    abi: packCustodyAbi,
-    functionName: "basketOf",
-    args: [tokenId],
-  });
-  return basket.map((entry) => ({
-    asset: entry.asset.toLowerCase(),
-    amount: entry.amount.toString(),
-    symbol: stockSymbolForAddress(entry.asset),
-  }));
-}
-
-async function upsertRestingPack(
-  ctx: ActionCtx,
-  client: PublicClient,
-  packCustody: `0x${string}`,
-  ripEngine: `0x${string}`,
-  tokenId: bigint,
-  maker: string,
-  eligible: boolean,
-  now: number,
-  knownNavWad?: string
-): Promise<void> {
-  const basket = await readBasket(client, packCustody, tokenId);
-  let navUsdWad: string | null = knownNavWad ?? null;
-  // Only hit the chain when the caller didn't already have this pack's NAV
-  // (e.g. from eligibleSnapshot).
-  if (navUsdWad === null) {
-    try {
-      const nav = await client.readContract({
-        address: ripEngine,
-        abi: ripEngineAbi,
-        functionName: "navOfPack",
-        args: [tokenId],
-      });
-      navUsdWad = nav.toString();
-    } catch {
-      navUsdWad = null;
-    }
-  }
-  await ctx.runMutation(internal.poolIndexer.upsertPack, {
-    tokenId: Number(tokenId),
-    maker: maker.toLowerCase(),
-    basket,
-    navUsdWad,
-    status: "resting",
-    eligible,
-    updatedAt: now,
-  });
-}
-
-/**
- * Scan a contract's logs from its persisted cursor (or `fallbackBlock`) up to
- * `latest`, in `MAX_BLOCK_SPAN` chunks, applying each log and advancing the
- * cursor per chunk.
- */
-async function scanLogs(
-  ctx: ActionCtx,
-  client: PublicClient,
-  opts: {
-    key: string;
-    address: `0x${string}`;
-    events: AbiEvent[];
-    fallbackBlock: bigint;
-    latest: bigint;
-    apply: (log: Log) => Promise<void>;
-  }
-): Promise<void> {
-  const cursor =
-    (await ctx.runQuery(internal.poolIndexer.getCursor, { key: opts.key })) ??
-    Number(opts.fallbackBlock);
-  let from = BigInt(cursor);
-  while (from <= opts.latest) {
-    const to =
-      from + MAX_BLOCK_SPAN > opts.latest ? opts.latest : from + MAX_BLOCK_SPAN;
-    const logs = await client.getLogs({
-      address: opts.address,
-      events: opts.events,
-      fromBlock: from,
-      toBlock: to,
-    });
-    for (const log of logs) {
-      await opts.apply(log);
-    }
-    await ctx.runMutation(internal.poolIndexer.setCursor, {
-      key: opts.key,
-      blockNumber: Number(to),
-    });
-    from = to + 1n;
-  }
-}
 
 /**
  * Sync Pack membership + Pool Statistics from live RipEngine / PackCustody.
@@ -287,100 +184,3 @@ export const syncPoolFromChain = internalAction({
     };
   },
 });
-
-async function applyRipEngineLog(
-  ctx: ActionCtx,
-  client: PublicClient,
-  addresses: {
-    packCustody: `0x${string}`;
-    ripEngine: `0x${string}`;
-  },
-  log: Log,
-  now: number
-): Promise<void> {
-  try {
-    const decoded = decodeEventLog({
-      abi: ripEngineAbi,
-      data: log.data,
-      topics: log.topics,
-    });
-    if (decoded.eventName === "PackEntered") {
-      await upsertRestingPack(
-        ctx,
-        client,
-        addresses.packCustody,
-        addresses.ripEngine,
-        decoded.args.tokenId as bigint,
-        decoded.args.maker as string,
-        true,
-        now
-      );
-      return;
-    }
-    if (decoded.eventName === "PackExited") {
-      const tokenId = decoded.args.tokenId as bigint;
-      const basket = await readBasket(client, addresses.packCustody, tokenId);
-      await ctx.runMutation(internal.poolIndexer.upsertPack, {
-        tokenId: Number(tokenId),
-        maker: (decoded.args.maker as string).toLowerCase(),
-        basket,
-        navUsdWad: null,
-        status: "unlisted",
-        eligible: false,
-        updatedAt: now,
-      });
-      return;
-    }
-    if (decoded.eventName === "PackRipped") {
-      const tokenId = decoded.args.tokenId as bigint;
-      const basket = await readBasket(client, addresses.packCustody, tokenId);
-      await ctx.runMutation(internal.poolIndexer.upsertPack, {
-        tokenId: Number(tokenId),
-        maker: (decoded.args.maker as string).toLowerCase(),
-        basket,
-        navUsdWad: (decoded.args.nav as bigint).toString(),
-        status: "ripped",
-        eligible: false,
-        updatedAt: now,
-      });
-    }
-  } catch {
-    // Skip undecodable logs.
-  }
-}
-
-async function applyPackUnlisted(
-  ctx: ActionCtx,
-  client: PublicClient,
-  packCustody: `0x${string}`,
-  log: Log,
-  now: number
-): Promise<void> {
-  try {
-    const decoded = decodeEventLog({
-      abi: packCustodyAbi,
-      data: log.data,
-      topics: log.topics,
-    });
-    if (decoded.eventName !== "PackUnlisted") return;
-    const tokenId = decoded.args.tokenId as bigint;
-    const basket = await readBasket(client, packCustody, tokenId);
-    const maker = await client.readContract({
-      address: packCustody,
-      abi: packCustodyAbi,
-      functionName: "creatorOf",
-      args: [tokenId],
-    });
-    await ctx.runMutation(internal.poolIndexer.upsertPack, {
-      tokenId: Number(tokenId),
-      maker: maker.toLowerCase(),
-      basket,
-      navUsdWad: null,
-      status: "unlisted",
-      eligible: false,
-      updatedAt: now,
-    });
-  } catch {
-    // Skip undecodable logs.
-  }
-}

--- a/tests/convex/pool-indexer-scan.test.ts
+++ b/tests/convex/pool-indexer-scan.test.ts
@@ -1,0 +1,282 @@
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  encodeEventTopics,
+  HttpRequestError,
+  type Log,
+  type PublicClient,
+} from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ActionCtx } from "../../convex/_generated/server";
+import { ripEngineAbi } from "../../convex/lib/chain/abis";
+import {
+  applyRipEngineLog,
+  isContractCallRevert,
+  MAX_BLOCK_SPAN,
+  readNavOfPack,
+  scanLogs,
+  tryDecodeEventLog,
+} from "../../convex/lib/poolIndexerHandlers";
+
+const ZERO_ADDR = "0x0000000000000000000000000000000000000001" as const;
+const RIP = "0x00000000000000000000000000000000000000aa" as const;
+const PACK = "0x00000000000000000000000000000000000000bb" as const;
+
+function makeCtx(overrides?: {
+  cursor?: number | null;
+  onSetCursor?: (blockNumber: number) => void;
+  onUpsertPack?: () => Promise<void>;
+}): ActionCtx {
+  const setCursor = vi.fn(
+    async (_ref: unknown, args: { key: string; blockNumber: number }) => {
+      overrides?.onSetCursor?.(args.blockNumber);
+      return null;
+    }
+  );
+  const upsertPack = vi.fn(async () => {
+    if (overrides?.onUpsertPack) await overrides.onUpsertPack();
+    return null;
+  });
+
+  return {
+    runQuery: vi.fn(async () => overrides?.cursor ?? null),
+    runMutation: vi.fn(async (_ref: unknown, args: unknown) => {
+      // Dispatch by args shape — FunctionReferences aren't stringifiable in vitest.
+      if (
+        args &&
+        typeof args === "object" &&
+        "blockNumber" in args &&
+        "key" in args
+      ) {
+        return setCursor(_ref, args as { key: string; blockNumber: number });
+      }
+      if (
+        args &&
+        typeof args === "object" &&
+        "tokenId" in args &&
+        "status" in args
+      ) {
+        return upsertPack();
+      }
+      return null;
+    }),
+  } as unknown as ActionCtx;
+}
+
+function makeClient(overrides?: {
+  logs?: Log[];
+  getLogs?: () => Promise<Log[]>;
+  readContract?: (args: { functionName: string }) => Promise<unknown>;
+}): PublicClient {
+  return {
+    getLogs: overrides?.getLogs ?? (async () => overrides?.logs ?? []),
+    readContract:
+      overrides?.readContract ??
+      (async () => {
+        throw new Error("unexpected readContract");
+      }),
+  } as unknown as PublicClient;
+}
+
+function packEnteredLog(tokenId: bigint, maker: `0x${string}`): Log {
+  const topics = encodeEventTopics({
+    abi: ripEngineAbi,
+    eventName: "PackEntered",
+    args: { tokenId, maker },
+  });
+  return {
+    address: RIP,
+    blockHash: "0x" + "11".repeat(32),
+    blockNumber: 100n,
+    data: "0x",
+    logIndex: 0,
+    transactionHash: "0x" + "22".repeat(32),
+    transactionIndex: 0,
+    removed: false,
+    topics: topics as [`0x${string}`, ...`0x${string}`[]],
+  };
+}
+
+describe("isContractCallRevert", () => {
+  it("detects nested ContractFunctionRevertedError", () => {
+    const reverted = new ContractFunctionRevertedError({
+      abi: ripEngineAbi,
+      functionName: "navOfPack",
+      args: [1n],
+      data: "0x",
+    } as ConstructorParameters<typeof ContractFunctionRevertedError>[0]);
+    const wrapped = new BaseError("execution reverted", { cause: reverted });
+    expect(isContractCallRevert(wrapped)).toBe(true);
+  });
+
+  it("does not treat transport errors as reverts", () => {
+    const http = new HttpRequestError({
+      url: "https://example.invalid",
+      body: {},
+      details: "timeout",
+    });
+    expect(isContractCallRevert(http)).toBe(false);
+    expect(isContractCallRevert(new Error("RPC down"))).toBe(false);
+  });
+});
+
+describe("readNavOfPack", () => {
+  it("returns null on contract revert", async () => {
+    const reverted = new ContractFunctionRevertedError({
+      abi: ripEngineAbi,
+      functionName: "navOfPack",
+      args: [1n],
+      data: "0x",
+    } as ConstructorParameters<typeof ContractFunctionRevertedError>[0]);
+    const client = makeClient({
+      readContract: async () => {
+        throw new BaseError("reverted", { cause: reverted });
+      },
+    });
+    await expect(readNavOfPack(client, RIP, 1n)).resolves.toBeNull();
+  });
+
+  it("propagates RPC / transport failures", async () => {
+    const client = makeClient({
+      readContract: async () => {
+        throw new HttpRequestError({
+          url: "https://example.invalid",
+          body: {},
+          details: "ECONNRESET",
+        });
+      },
+    });
+    await expect(readNavOfPack(client, RIP, 1n)).rejects.toBeInstanceOf(
+      HttpRequestError
+    );
+  });
+
+  it("returns NAV string on success", async () => {
+    const client = makeClient({
+      readContract: async () => 42n * 10n ** 18n,
+    });
+    await expect(readNavOfPack(client, RIP, 1n)).resolves.toBe(
+      (42n * 10n ** 18n).toString()
+    );
+  });
+});
+
+describe("scanLogs cursor advancement", () => {
+  it("does not advance the cursor when apply fails mid-chunk", async () => {
+    const setCursorBlocks: number[] = [];
+    const ctx = makeCtx({
+      cursor: 10,
+      onSetCursor: (n) => setCursorBlocks.push(n),
+    });
+    const logs = [packEnteredLog(1n, ZERO_ADDR), packEnteredLog(2n, ZERO_ADDR)];
+    const client = makeClient({ logs });
+
+    let calls = 0;
+    await expect(
+      scanLogs(ctx, client, {
+        key: "ripEngine",
+        address: RIP,
+        events: [],
+        fallbackBlock: 1n,
+        latest: 10n + MAX_BLOCK_SPAN - 1n,
+        apply: async () => {
+          calls += 1;
+          if (calls === 2) throw new Error("mutation failed");
+        },
+      })
+    ).rejects.toThrow("mutation failed");
+
+    expect(calls).toBe(2);
+    expect(setCursorBlocks).toEqual([]);
+  });
+
+  it("advances the cursor only after a chunk fully succeeds", async () => {
+    const setCursorBlocks: number[] = [];
+    const ctx = makeCtx({
+      cursor: 100,
+      onSetCursor: (n) => setCursorBlocks.push(n),
+    });
+    const client = makeClient({
+      logs: [packEnteredLog(1n, ZERO_ADDR)],
+    });
+
+    await scanLogs(ctx, client, {
+      key: "ripEngine",
+      address: RIP,
+      events: [],
+      fallbackBlock: 1n,
+      latest: 150n,
+      apply: async () => undefined,
+    });
+
+    expect(setCursorBlocks).toEqual([150]);
+  });
+});
+
+describe("applyRipEngineLog error boundary", () => {
+  it("skips undecodable logs without throwing", async () => {
+    const ctx = makeCtx();
+    const client = makeClient();
+    const junk: Log = {
+      address: RIP,
+      blockHash: "0x" + "11".repeat(32),
+      blockNumber: 1n,
+      data: "0xdeadbeef",
+      logIndex: 0,
+      transactionHash: "0x" + "22".repeat(32),
+      transactionIndex: 0,
+      removed: false,
+      topics: ["0x" + "33".repeat(32)],
+    };
+    await expect(
+      applyRipEngineLog(
+        ctx,
+        client,
+        { packCustody: PACK, ripEngine: RIP },
+        junk,
+        Date.now()
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("propagates mutation failures after a successful decode", async () => {
+    const ctx = makeCtx({
+      onUpsertPack: async () => {
+        throw new Error("db write failed");
+      },
+    });
+    const client = makeClient({
+      readContract: async ({ functionName }) => {
+        if (functionName === "basketOf") {
+          return [{ asset: ZERO_ADDR, amount: 1n }];
+        }
+        if (functionName === "navOfPack") {
+          return 100n * 10n ** 18n;
+        }
+        throw new Error(`unexpected ${functionName}`);
+      },
+    });
+
+    await expect(
+      applyRipEngineLog(
+        ctx,
+        client,
+        { packCustody: PACK, ripEngine: RIP },
+        packEnteredLog(7n, ZERO_ADDR),
+        Date.now()
+      )
+    ).rejects.toThrow("db write failed");
+  });
+});
+
+describe("tryDecodeEventLog", () => {
+  it("decodes PackEntered", () => {
+    const log = packEnteredLog(9n, ZERO_ADDR);
+    const decoded = tryDecodeEventLog(ripEngineAbi, log);
+    expect(decoded?.eventName).toBe("PackEntered");
+    if (decoded?.eventName === "PackEntered") {
+      expect(decoded.args.tokenId).toBe(9n);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Scope log-handler `catch` to `decodeEventLog` only so RPC/DB failures propagate instead of being treated as undecodable logs
- Advance the chain cursor only after a chunk fully succeeds; failed chunks are retried on the next sync
- Treat `navOfPack` contract reverts as null NAV, but rethrow transport/RPC errors; add regression tests for mid-chunk mutation failure

Closes #321

## Test plan
- [x] `pnpm test tests/convex/pool-indexer-scan.test.ts`
- [x] `pnpm test` (full suite)
- [x] `pnpm check:ci` (pre-push)
- [ ] Optional: run pool sync against testnet and confirm a forced mutation/RPC failure leaves `chainCursors` unchanged


Made with [Cursor](https://cursor.com)