### PR TITLE
Fix Multicall3 address checksum in shared chain constant

### DIFF
--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -12,7 +12,7 @@ export const PAYMENT_EXPLORER_URL =
 
 /** Canonical Multicall3 — verified present on Robinhood Chain testnet (#322). */
 export const MULTICALL3_ADDRESS =
-  "0xcA11bde05977b3631167028862be2a173976CA11" as const;
+  "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
 
 export const PAYMENT_CHAIN = defineChain({
   id: PAYMENT_CHAIN_ID,

--- a/packages/shared/src/shared.test.ts
+++ b/packages/shared/src/shared.test.ts
@@ -32,7 +32,7 @@ describe("@margin-call/shared single source of truth", () => {
 
   it("wires Multicall3 on the payment chain for batched reads", () => {
     expect(MULTICALL3_ADDRESS).toBe(
-      "0xcA11bde05977b3631167028862be2a173976CA11"
+      "0xcA11bde05977b3631167028862bE2a173976CA11"
     );
     expect(PAYMENT_CHAIN.contracts?.multicall3?.address).toBe(
       MULTICALL3_ADDRESS


### PR DESCRIPTION
## Summary
- `MULTICALL3_ADDRESS` in `packages/shared/src/chain.ts` had an invalid EIP-55 checksum (`...028862be2a...` → should be `...028862bE2a...`).
- viem validates the checksum and threw `Address "0xcA11…CA11" is invalid` **before** making any RPC call, so `poolIndexerActions:syncPoolFromChain` crashed in `readRestingPackMetas` (via `refreshRestingPacks`).
- The on-chain Multicall3 contract is unchanged — this was purely a string-casing bug. Regression from #322.

## Fix
- Correct the checksum casing in the constant and its assertion in `shared.test.ts`.

## Test plan
- [x] `pnpm test` — 75 passed
- [ ] Redeploy Convex (`npx convex dev --once`) and confirm `syncPoolFromChain` runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)