### PR TITLE
Switch Privy to wallet-only login

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { usePrivy } from "@privy-io/react-auth";
 
 import { LandingScreen } from "@/components/landing/landing-screen";
 import { ConnectedShell } from "@/components/shell/connected-shell";
-import { getEmbeddedEvmWalletAddress } from "@/lib/privy/wallet";
+import { getEvmWalletAddress } from "@/lib/privy/wallet";
 
 export default function Home() {
   const { ready, authenticated, login, logout, user } = usePrivy();
@@ -23,7 +23,7 @@ export default function Home() {
     return <LandingScreen onLogin={login} />;
   }
 
-  const address = getEmbeddedEvmWalletAddress(user);
+  const address = getEvmWalletAddress(user);
 
   return <ConnectedShell address={address} onLogout={logout} />;
 }

--- a/src/lib/privy/__tests__/chain-id.test.ts
+++ b/src/lib/privy/__tests__/chain-id.test.ts
@@ -24,8 +24,8 @@ describe("payment chain id helpers", () => {
   });
 
   describe("Privy onboarding config", () => {
-    it("offers email + external wallet login with embedded EVM wallet creation", () => {
-      expect(privyConfig.loginMethods).toEqual(["email", "wallet"]);
+    it("offers external wallet login with embedded EVM wallet creation", () => {
+      expect(privyConfig.loginMethods).toEqual(["wallet"]);
       expect(privyConfig.appearance?.walletList).toEqual([
         "detected_wallets",
         "metamask",

--- a/src/lib/privy/__tests__/chain-id.test.ts
+++ b/src/lib/privy/__tests__/chain-id.test.ts
@@ -24,9 +24,14 @@ describe("payment chain id helpers", () => {
   });
 
   describe("Privy onboarding config", () => {
-    it("uses email-only hosted login with embedded EVM wallet creation", () => {
-      expect(privyConfig.loginMethods).toEqual(["email"]);
-      expect(privyConfig.appearance?.walletList).toBeUndefined();
+    it("offers email + external wallet login with embedded EVM wallet creation", () => {
+      expect(privyConfig.loginMethods).toEqual(["email", "wallet"]);
+      expect(privyConfig.appearance?.walletList).toEqual([
+        "detected_wallets",
+        "metamask",
+        "coinbase_wallet",
+        "wallet_connect",
+      ]);
       expect(privyConfig.embeddedWallets?.ethereum?.createOnLogin).toBe(
         "users-without-wallets"
       );

--- a/src/lib/privy/config.ts
+++ b/src/lib/privy/config.ts
@@ -33,10 +33,16 @@ export function isChainIdBase(chainId: string | number): boolean {
 }
 
 export const privyConfig: PrivyClientConfig = {
-  loginMethods: ["email"],
+  loginMethods: ["email", "wallet"],
   appearance: {
     theme: "dark",
     accentColor: "#d6a660",
+    walletList: [
+      "detected_wallets",
+      "metamask",
+      "coinbase_wallet",
+      "wallet_connect",
+    ],
   },
   embeddedWallets: {
     ethereum: {

--- a/src/lib/privy/config.ts
+++ b/src/lib/privy/config.ts
@@ -33,7 +33,7 @@ export function isChainIdBase(chainId: string | number): boolean {
 }
 
 export const privyConfig: PrivyClientConfig = {
-  loginMethods: ["email", "wallet"],
+  loginMethods: ["wallet"],
   appearance: {
     theme: "dark",
     accentColor: "#d6a660",

--- a/src/lib/privy/wallet.ts
+++ b/src/lib/privy/wallet.ts
@@ -10,29 +10,43 @@ export type PrivyWalletUser = {
   linkedAccounts?: PrivyWalletAccount[] | null;
 };
 
-function isEmbeddedEvmWallet(account: PrivyWalletAccount | null | undefined) {
+function isEvmWallet(account: PrivyWalletAccount | null | undefined) {
   return (
     typeof account?.address === "string" &&
     account.address.length > 0 &&
-    account.chainType === "ethereum" &&
-    (account.walletClientType === "privy" ||
-      account.walletClientType === "privy-v2")
+    account.chainType === "ethereum"
+  );
+}
+
+function isEmbeddedEvmWallet(account: PrivyWalletAccount | null | undefined) {
+  return (
+    isEvmWallet(account) &&
+    (account?.walletClientType === "privy" ||
+      account?.walletClientType === "privy-v2")
   );
 }
 
 /**
- * Returns the desk manager's canonical Privy embedded EVM wallet address.
- * External wallets are intentionally ignored for fresh-start email onboarding.
+ * Returns the user's active EVM wallet address.
+ *
+ * Prefers a Privy embedded wallet (the email-onboarding path) and falls back
+ * to any linked external EVM wallet (MetaMask, Coinbase Wallet, WalletConnect,
+ * …) so `wallet` login users are provisioned too.
  */
-export function getEmbeddedEvmWalletAddress(
+export function getEvmWalletAddress(
   user: PrivyWalletUser | null | undefined
 ): `0x${string}` | null {
   if (!user) return null;
-  const primaryWallet = user.wallet;
-  if (isEmbeddedEvmWallet(primaryWallet)) {
-    return (primaryWallet?.address as `0x${string}`) ?? null;
-  }
 
-  const linkedWallet = user.linkedAccounts?.find(isEmbeddedEvmWallet);
-  return (linkedWallet?.address as `0x${string}` | undefined) ?? null;
+  const accounts: (PrivyWalletAccount | null | undefined)[] = [
+    user.wallet,
+    ...(user.linkedAccounts ?? []),
+  ];
+
+  // Prefer an embedded Privy wallet, then any other connected EVM wallet.
+  const embedded = accounts.find(isEmbeddedEvmWallet);
+  if (embedded) return embedded.address as `0x${string}`;
+
+  const external = accounts.find(isEvmWallet);
+  return (external?.address as `0x${string}` | undefined) ?? null;
 }

--- a/src/lib/siwa/__tests__/verify-binding.test.ts
+++ b/src/lib/siwa/__tests__/verify-binding.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { siwaAuthMatchesTrader } from "@/lib/siwa/binding";
 import { siwaAuthMatchesConvexTrader } from "@/lib/siwa/binding";
-import { getEmbeddedEvmWalletAddress } from "@/lib/privy/wallet";
+import { getEvmWalletAddress } from "@/lib/privy/wallet";
 
 describe("siwaAuthMatchesTrader", () => {
   it("returns true when SIWA agent and wallet match trader identity", () => {
@@ -86,10 +86,10 @@ describe("siwaAuthMatchesConvexTrader", () => {
   });
 });
 
-describe("getEmbeddedEvmWalletAddress", () => {
+describe("getEvmWalletAddress", () => {
   it("prefers the primary embedded EVM wallet address when present", () => {
     expect(
-      getEmbeddedEvmWalletAddress({
+      getEvmWalletAddress({
         wallet: {
           type: "wallet",
           address: "0xabc",
@@ -110,7 +110,7 @@ describe("getEmbeddedEvmWalletAddress", () => {
 
   it("falls back to linked embedded EVM wallet address", () => {
     expect(
-      getEmbeddedEvmWalletAddress({
+      getEvmWalletAddress({
         wallet: null,
         linkedAccounts: [
           {
@@ -124,9 +124,30 @@ describe("getEmbeddedEvmWalletAddress", () => {
     ).toBe("0xdef");
   });
 
-  it("ignores external wallets", () => {
+  it("prefers an embedded wallet over a linked external wallet", () => {
     expect(
-      getEmbeddedEvmWalletAddress({
+      getEvmWalletAddress({
+        wallet: {
+          type: "wallet",
+          address: "0xext",
+          chainType: "ethereum",
+          walletClientType: "metamask",
+        },
+        linkedAccounts: [
+          {
+            type: "wallet",
+            address: "0xembedded",
+            chainType: "ethereum",
+            walletClientType: "privy",
+          },
+        ],
+      })
+    ).toBe("0xembedded");
+  });
+
+  it("falls back to an external EVM wallet when no embedded wallet exists", () => {
+    expect(
+      getEvmWalletAddress({
         wallet: null,
         linkedAccounts: [
           {
@@ -137,12 +158,12 @@ describe("getEmbeddedEvmWalletAddress", () => {
           },
         ],
       })
-    ).toBeNull();
+    ).toBe("0xdef");
   });
 
   it("returns null when no wallet is linked", () => {
     expect(
-      getEmbeddedEvmWalletAddress({
+      getEvmWalletAddress({
         wallet: null,
         linkedAccounts: [{ type: "email" }],
       })


### PR DESCRIPTION
## Summary
- **Wallet-only login:** `loginMethods: ["wallet"]` — email OTP is removed for now; the modal offers external wallet connection only.
- Add `appearance.walletList` (`detected_wallets`, `metamask`, `coinbase_wallet`, `wallet_connect`) so the modal surfaces browser-detected injected wallets plus MetaMask, Coinbase Wallet, and WalletConnect.
- Resolve the active EVM address for wallet-login users: `getEmbeddedEvmWalletAddress` only accepted Privy embedded wallets, so an external-wallet login resolved to `null` — the shell hung on "Wallet provisioning…" and the Starter Grant panel never mounted. Renamed to `getEvmWalletAddress`; still prefers the embedded wallet, now falls back to any linked external EVM wallet.
- Updated config + resolver tests.

## Notes
- **Privy dashboard:** the "Wallet" connector (and WalletConnect) may need to be enabled for the app in the dashboard to appear in production.
- **Network:** external wallets connect on whatever chain they're set to; existing `NetworkGuard` + `supportedChains: [PAYMENT_CHAIN]` prompt a switch to Robinhood testnet (46630).
- `embeddedWallets` config is retained (harmless — no embedded wallet is created for wallet-login users); re-adding email later is a one-line change.

## Test plan
- [x] `pnpm test` — 76 passed
- [x] `pnpm typecheck` — clean
- [ ] Manual: login modal shows wallet options only (no email); connecting a wallet authenticates, shell shows `Wallet 0x…`, Starter Grant panel mounts, and NetworkGuard prompts the testnet switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)