### PR TITLE
Set metadataBase to silence OG image warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,9 @@ const plexSans = IBM_Plex_Sans_Condensed({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"
+  ),
   title: "MARGIN CALL",
   description:
     "NAV-weighted Pack rips on Robinhood Chain testnet. Connect a wallet to play.",


### PR DESCRIPTION
## Summary
- Next.js warned in dev that social OG/Twitter image URLs fell back to `http://localhost:3000` because `metadataBase` was unset.
- Set `metadataBase` from `NEXT_PUBLIC_APP_URL` (with a localhost fallback for dev) so `openGraph` / `twitter` images resolve to absolute URLs.

Cosmetic/dev-only; no functional change. Unrelated to the wallet-login work (#328).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 75 passed
- [ ] Dev server no longer logs the `metadataBase property ... is not set` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)