### PR TITLE
V1 · Maker flow: create / top-up / delist / redeem Packs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ NEXT_PUBLIC_PACKCUSTODY_ADDRESS= # Same address for the client
 # contracts/deployments/robinhood-testnet.stock-tokens.json)
 ASSETREGISTRY_ADMIN=
 ASSETREGISTRY_INVENTORY=         # Granted INVENTORY_ROLE when admin == deployer
-ASSETREGISTRY_STALE_AFTER=       # Seconds; default 3600
+ASSETREGISTRY_STALE_AFTER=       # Seconds; seeded test feeds default to uint64 max (static fixtures)
 ASSETREGISTRY_SEED_FEEDS=        # true/false; default true
 ASSETREGISTRY_ADDRESS=             # Filled by `pnpm deploy:asset-registry`
 NEXT_PUBLIC_ASSETREGISTRY_ADDRESS= # Same address for the client
@@ -158,4 +158,3 @@ NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_AUTH_TOKEN=           # For source map uploads
 SENTRY_ORG=
 SENTRY_PROJECT=
-

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -98,6 +98,17 @@ NAV-weighted Pack selection, live Rip pricing, Model-A settlement, and Acquisiti
 - Protocol and crown cuts from the surcharge only; remainder socialized equally per resting Pack via a fee-per-Pack index (make-whole at `alpha = 1`)
 - Requires `eligibleCount > count` so socialization has a non-empty destination set
 - Maker `claim(tokenIds)` (empty = crystallized only); admin `withdrawProtocolFees`
+
+Deployed fee-read limitation: Robinhood testnet RipEngine exposes only
+`restingCount()` plus the full-array `restingPackIds()` view. It has no indexed,
+offset, or cursor-based resting-Pack accessor, while `claim(tokenIds)` accepts an
+arbitrary caller-supplied array. The web client therefore checks `restingCount()`
+at one block and reads the array only at or below its explicit 500-Pack cap; above
+that cap it reports pending fees as unknown and can claim only already-crystallized
+fees with `claim([])`. Within the cap, claim writes are split into 25-Pack batches.
+Complete scalable visibility requires a new paginated contract API and redeployment;
+the client must not advertise an undeployed ABI.
+
 - Unlisted Packs are purged at the start of every `rip` so ghosts cannot dilute fee socialization
 - Equal-rate fee accrual follows enrollment for listed Packs (not per-rip eligibility); a Pack with a temporarily stale feed keeps accruing while undrawable
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -204,13 +204,23 @@ Writes `contracts/deployments/robinhood-testnet.packcustody.json` (address, admi
 # Optional overrides in .env.local:
 #   ASSETREGISTRY_ADMIN=0x…          # defaults to deployer
 #   ASSETREGISTRY_INVENTORY=0x…      # granted INVENTORY_ROLE when admin == deployer
-#   ASSETREGISTRY_STALE_AFTER=3600   # seconds; default 3600
+#   ASSETREGISTRY_STALE_AFTER=…      # seeded mocks default to uint64 max (static fixtures)
 #   ASSETREGISTRY_SEED_FEEDS=true    # deploy MockPriceFeeds + addAsset for the launch five
 
 pnpm deploy:asset-registry
 ```
 
 Writes `contracts/deployments/robinhood-testnet.asset-registry.json` and patches `ASSETREGISTRY_ADDRESS` / `NEXT_PUBLIC_ASSETREGISTRY_ADDRESS`.
+
+Seeded `MockPriceFeed` values are disclosed, static test fixtures rather than live market prices. They default to a non-expiring staleness bound while still failing closed when paused, invalid, or zero. Existing deployments can be inspected and configured idempotently; the command is a dry run unless `--execute` is supplied:
+
+```bash
+pnpm configure:asset-registry-mock-feeds
+# After reviewing the exact plan and explicitly approving the on-chain writes:
+pnpm configure:asset-registry-mock-feeds -- --execute
+```
+
+Execution requires the current AssetRegistry admin key through the ignored `.env.local` file or process environment. The script never prints the key, verifies chain id `46630`, committed token/feed mappings, mock-feed disclosure and health, simulates each write, waits for successful receipts, and verifies a post-write quote. It skips completed assets, so rerunning after a partial failure is safe. Do not use this static policy for a live oracle; configure real feeds with their published finite heartbeat.
 
 ```bash
 pnpm verify:asset-registry   # AssetRegistry + seeded MockPriceFeeds

--- a/contracts/script/DeployAssetRegistry.s.sol
+++ b/contracts/script/DeployAssetRegistry.s.sol
@@ -25,10 +25,7 @@ contract DeployAssetRegistry is Utils {
         address admin = vm.envOr("ASSETREGISTRY_ADMIN", deployer);
         address inventory = vm.envOr("ASSETREGISTRY_INVENTORY", address(0));
         bool seedFeeds = vm.envOr("ASSETREGISTRY_SEED_FEEDS", true);
-        uint256 configuredStaleAfter =
-            vm.envOr("ASSETREGISTRY_STALE_AFTER", seedFeeds ? uint256(type(uint64).max) : uint256(3_600));
-        require(configuredStaleAfter <= type(uint64).max, "DeployAssetRegistry: staleAfter exceeds uint64");
-        uint64 staleAfter = uint64(configuredStaleAfter);
+        uint64 staleAfter = _configuredStaleAfter(seedFeeds);
 
         address[] memory tokens = LaunchTokens.tokens();
         string[] memory symbols = LaunchTokens.symbols();
@@ -67,6 +64,13 @@ contract DeployAssetRegistry is Utils {
         }
 
         _writeRecord(address(registry), deployer, admin, inventory, tokens, feeds, symbols, staleAfter, seedFeeds);
+    }
+
+    function _configuredStaleAfter(bool seedFeeds) internal view returns (uint64) {
+        uint256 configured =
+            vm.envOr("ASSETREGISTRY_STALE_AFTER", seedFeeds ? uint256(type(uint64).max) : uint256(3_600));
+        require(configured <= type(uint64).max, "DeployAssetRegistry: staleAfter exceeds uint64");
+        return uint64(configured);
     }
 
     function _writeRecord(

--- a/contracts/script/DeployAssetRegistry.s.sol
+++ b/contracts/script/DeployAssetRegistry.s.sol
@@ -11,7 +11,7 @@ import {Utils} from "./utils/Utils.sol";
 /// @dev Signing: set DEPLOYER_PRIVATE_KEY. Env:
 ///        ASSETREGISTRY_ADMIN         — optional; defaults to deployer
 ///        ASSETREGISTRY_INVENTORY     — optional; granted INVENTORY_ROLE when admin == deployer
-///        ASSETREGISTRY_STALE_AFTER   — optional; seconds, default 3600
+///        ASSETREGISTRY_STALE_AFTER   — optional; seconds, defaults to uint64 max for seeded mocks
 ///        ASSETREGISTRY_SEED_FEEDS    — optional; "true" (default) deploys MockPriceFeeds + addAsset
 ///      Stock token addresses come from `LaunchTokens` (JSON mirror:
 ///      `deployments/robinhood-testnet.stock-tokens.json`).
@@ -24,8 +24,11 @@ contract DeployAssetRegistry is Utils {
         address deployer = vm.addr(deployerKey);
         address admin = vm.envOr("ASSETREGISTRY_ADMIN", deployer);
         address inventory = vm.envOr("ASSETREGISTRY_INVENTORY", address(0));
-        uint64 staleAfter = uint64(vm.envOr("ASSETREGISTRY_STALE_AFTER", uint256(3_600)));
         bool seedFeeds = vm.envOr("ASSETREGISTRY_SEED_FEEDS", true);
+        uint256 configuredStaleAfter =
+            vm.envOr("ASSETREGISTRY_STALE_AFTER", seedFeeds ? uint256(type(uint64).max) : uint256(3_600));
+        require(configuredStaleAfter <= type(uint64).max, "DeployAssetRegistry: staleAfter exceeds uint64");
+        uint64 staleAfter = uint64(configuredStaleAfter);
 
         address[] memory tokens = LaunchTokens.tokens();
         string[] memory symbols = LaunchTokens.symbols();

--- a/contracts/test/AssetRegistry.staleness.t.sol
+++ b/contracts/test/AssetRegistry.staleness.t.sol
@@ -29,6 +29,28 @@ contract AssetRegistryStalenessTest is AssetRegistryFixture {
         assertEq(registry.quote(address(amzn), 1e18), 100e18);
     }
 
+    function test_setAssetFeed_maxStaleAfterMakesStaticMockNonExpiring() public {
+        vm.prank(admin);
+        amznFeed.setUpdatedAt(block.timestamp - STALE_AFTER - 1);
+
+        vm.expectRevert();
+        registry.quote(address(amzn), 1e18);
+
+        vm.prank(admin);
+        registry.setAssetFeed(address(amzn), address(amznFeed), type(uint64).max);
+
+        AssetRegistry.Asset memory asset = registry.getAsset(address(amzn));
+        assertEq(asset.feed, address(amznFeed));
+        assertEq(asset.staleAfter, type(uint64).max);
+        assertEq(registry.quote(address(amzn), 1e18), 100e18);
+    }
+
+    function test_setAssetFeed_nonAdminCannotDisableStaleness() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        registry.setAssetFeed(address(amzn), address(amznFeed), type(uint64).max);
+    }
+
     function test_quote_pausedFeedReverts() public {
         vm.prank(admin);
         amznFeed.setPaused(true);

--- a/convex/lib/chain/abis.ts
+++ b/convex/lib/chain/abis.ts
@@ -2,8 +2,10 @@
  * Contract ABIs — source of truth: `@margin-call/shared`.
  */
 export {
+  erc20Abi,
   mockUsdAbi,
   packCustodyAbi,
   ripEngineAbi,
   assetRegistryAbi,
+  getPackMintedTokenId,
 } from "@margin-call/shared";

--- a/convex/lib/poolIndexerHandlers.ts
+++ b/convex/lib/poolIndexerHandlers.ts
@@ -362,6 +362,19 @@ export async function applyRipEngineLog(
     return;
   }
   if (decoded.eventName === "PackExited") {
+    const isListed = await client.readContract({
+      address: addresses.packCustody,
+      abi: packCustodyAbi,
+      functionName: "isListed",
+      args: [decoded.args.tokenId],
+      blockNumber: log.blockNumber ?? undefined,
+    });
+    // RipEngine also emits PackExited when it purges a Pack that PackCustody
+    // already unlisted. In that case PackCustody's event is authoritative; do
+    // not regress an unlisted/redeemed record when the two cursors advance in
+    // separate sync runs.
+    if (!isListed) return;
+
     const navUsdWad = await readNavOfPack(
       client,
       addresses.ripEngine,

--- a/convex/lib/poolIndexerHandlers.ts
+++ b/convex/lib/poolIndexerHandlers.ts
@@ -267,7 +267,7 @@ export async function refreshRestingPacks(
 
 /**
  * Read a pack's basket and upsert it in a terminal (non-resting) state.
- * Shared by the PackExited / PackRipped / PackUnlisted handlers, which differ
+ * Shared by terminal/non-resting handlers, which differ
  * only in `status`, `navUsdWad`, and where the maker comes from.
  */
 async function upsertTerminalPack(
@@ -276,7 +276,7 @@ async function upsertTerminalPack(
   packCustody: `0x${string}`,
   tokenId: bigint,
   maker: string,
-  status: "ripped" | "unlisted",
+  status: "exited" | "ripped" | "unlisted",
   navUsdWad: string | null,
   now: number
 ): Promise<void> {
@@ -362,14 +362,19 @@ export async function applyRipEngineLog(
     return;
   }
   if (decoded.eventName === "PackExited") {
+    const navUsdWad = await readNavOfPack(
+      client,
+      addresses.ripEngine,
+      decoded.args.tokenId
+    );
     await upsertTerminalPack(
       ctx,
       client,
       addresses.packCustody,
       decoded.args.tokenId,
       decoded.args.maker,
-      "unlisted",
-      null,
+      "exited",
+      navUsdWad,
       now
     );
     return;
@@ -388,7 +393,7 @@ export async function applyRipEngineLog(
   }
 }
 
-export async function applyPackUnlisted(
+export async function applyPackCustodyLog(
   ctx: ActionCtx,
   client: PublicClient,
   packCustody: `0x${string}`,
@@ -396,7 +401,27 @@ export async function applyPackUnlisted(
   now: number
 ): Promise<void> {
   const decoded = tryDecodeEventLog(packCustodyAbi, log);
-  if (!decoded || decoded.eventName !== "PackUnlisted") return;
+  if (!decoded) return;
+
+  if (decoded.eventName === "PackRedeemed") {
+    const basket = decoded.args.assets.map((asset, index) => ({
+      asset: asset.toLowerCase(),
+      amount: decoded.args.amounts[index]!.toString(),
+      symbol: stockSymbolForAddress(asset),
+    }));
+    await ctx.runMutation(internal.poolIndexer.upsertPack, {
+      tokenId: Number(decoded.args.tokenId),
+      maker: decoded.args.creator.toLowerCase(),
+      basket,
+      navUsdWad: null,
+      status: "unlisted",
+      eligible: false,
+      updatedAt: now,
+    });
+    return;
+  }
+
+  if (decoded.eventName !== "PackUnlisted") return;
 
   const tokenId = decoded.args.tokenId;
   const maker = await client.readContract({
@@ -416,3 +441,6 @@ export async function applyPackUnlisted(
     now
   );
 }
+
+/** Backward-compatible narrow helper retained for focused tests/importers. */
+export const applyPackUnlisted = applyPackCustodyLog;

--- a/convex/pool.ts
+++ b/convex/pool.ts
@@ -1,7 +1,11 @@
-import { paginationOptsValidator } from "convex/server";
+import {
+  paginationOptsValidator,
+  paginationResultValidator,
+} from "convex/server";
 import { v } from "convex/values";
 
 import { query } from "./_generated/server";
+import { normalizeWalletAddress } from "./lib/chain/walletAddress";
 
 const navBucketValidator = v.object({
   minUsd: v.number(),
@@ -13,6 +17,22 @@ const basketEntryValidator = v.object({
   asset: v.string(),
   amount: v.string(),
   symbol: v.union(v.string(), v.null()),
+});
+
+const packStatusValidator = v.union(
+  v.literal("resting"),
+  v.literal("ripped"),
+  v.literal("unlisted")
+);
+
+const indexedPackValidator = v.object({
+  tokenId: v.number(),
+  maker: v.string(),
+  basket: v.array(basketEntryValidator),
+  navUsdWad: v.union(v.string(), v.null()),
+  status: packStatusValidator,
+  eligible: v.boolean(),
+  updatedAt: v.number(),
 });
 
 const emptySnapshot = {
@@ -106,6 +126,44 @@ export const listPacks = query({
       })),
       isDone: result.isDone,
       continueCursor: result.continueCursor,
+    };
+  },
+});
+
+/** Public, paginated Pack history for a normalized Maker wallet. */
+export const listPacksByMaker = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    maker: v.string(),
+    status: v.optional(packStatusValidator),
+  },
+  returns: paginationResultValidator(indexedPackValidator),
+  handler: async (ctx, args) => {
+    // Pack ownership here is public indexed chain data. The wallet argument is
+    // a lookup key, not an authorization claim about the caller.
+    const maker = normalizeWalletAddress(args.maker);
+    const packs = args.status
+      ? ctx.db
+          .query("packs")
+          .withIndex("by_maker_and_status", (q) =>
+            q.eq("maker", maker).eq("status", args.status!)
+          )
+      : ctx.db
+          .query("packs")
+          .withIndex("by_maker_and_status", (q) => q.eq("maker", maker));
+
+    const result = await packs.order("desc").paginate(args.paginationOpts);
+    return {
+      ...result,
+      page: result.page.map((pack) => ({
+        tokenId: pack.tokenId,
+        maker: pack.maker,
+        basket: pack.basket,
+        navUsdWad: pack.navUsdWad,
+        status: pack.status,
+        eligible: pack.eligible,
+        updatedAt: pack.updatedAt,
+      })),
     };
   },
 });

--- a/convex/pool.ts
+++ b/convex/pool.ts
@@ -21,6 +21,7 @@ const basketEntryValidator = v.object({
 
 const packStatusValidator = v.union(
   v.literal("resting"),
+  v.literal("exited"),
   v.literal("ripped"),
   v.literal("unlisted")
 );
@@ -84,7 +85,12 @@ export const listPacks = query({
   args: {
     paginationOpts: paginationOptsValidator,
     status: v.optional(
-      v.union(v.literal("resting"), v.literal("ripped"), v.literal("unlisted"))
+      v.union(
+        v.literal("resting"),
+        v.literal("exited"),
+        v.literal("ripped"),
+        v.literal("unlisted")
+      )
     ),
   },
   returns: v.object({
@@ -96,6 +102,7 @@ export const listPacks = query({
         navUsdWad: v.union(v.string(), v.null()),
         status: v.union(
           v.literal("resting"),
+          v.literal("exited"),
           v.literal("ripped"),
           v.literal("unlisted")
         ),
@@ -178,6 +185,7 @@ export const getPack = query({
       navUsdWad: v.union(v.string(), v.null()),
       status: v.union(
         v.literal("resting"),
+        v.literal("exited"),
         v.literal("ripped"),
         v.literal("unlisted")
       ),

--- a/convex/poolIndexer.ts
+++ b/convex/poolIndexer.ts
@@ -54,6 +54,7 @@ export const upsertPack = internalMutation({
     navUsdWad: v.union(v.string(), v.null()),
     status: v.union(
       v.literal("resting"),
+      v.literal("exited"),
       v.literal("ripped"),
       v.literal("unlisted")
     ),
@@ -67,7 +68,18 @@ export const upsertPack = internalMutation({
       .withIndex("by_tokenId", (q) => q.eq("tokenId", args.tokenId))
       .unique();
     if (existing) {
-      await ctx.db.patch(existing._id, args);
+      // The contracts have independent cursors. Preserve irreversible custody
+      // states against a delayed PackExited/PackEntered event, but allow the
+      // more specific PackRipped event to upgrade an earlier PackUnlisted.
+      const staleAgainstTerminalState =
+        (existing.status === "ripped" && args.status !== "ripped") ||
+        (existing.status === "unlisted" &&
+          (args.status === "exited" || args.status === "resting"));
+      if (staleAgainstTerminalState) {
+        await ctx.db.patch(existing._id, { updatedAt: args.updatedAt });
+      } else {
+        await ctx.db.patch(existing._id, args);
+      }
     } else {
       await ctx.db.insert("packs", args);
     }

--- a/convex/poolIndexerActions.ts
+++ b/convex/poolIndexerActions.ts
@@ -13,7 +13,7 @@ import { assetRegistryAbi, ripEngineAbi } from "./lib/chain/abis";
 import { requireIndexerAddresses } from "./lib/chain/addresses";
 import { createChainPublicClient } from "./lib/chain/clients";
 import {
-  applyPackUnlisted,
+  applyPackCustodyLog,
   applyRipEngineLog,
   refreshRestingPacks,
   scanLogs,
@@ -26,6 +26,9 @@ import {
 
 const packUnlistedEvent = parseAbiItem(
   "event PackUnlisted(uint256 indexed tokenId)"
+);
+const packRedeemedEvent = parseAbiItem(
+  "event PackRedeemed(uint256 indexed tokenId, address indexed creator, address[] assets, uint256[] amounts)"
 );
 const packEnteredEvent = parseAbiItem(
   "event PackEntered(uint256 indexed tokenId, address indexed maker)"
@@ -80,11 +83,11 @@ export const syncPoolFromChain = internalAction({
     await scanLogs(ctx, client, {
       key: "packCustody",
       address: addresses.packCustody,
-      events: [packUnlistedEvent],
+      events: [packUnlistedEvent, packRedeemedEvent],
       fallbackBlock: PACKCUSTODY_DEPLOY_BLOCK,
       latest,
       apply: (log) =>
-        applyPackUnlisted(ctx, client, addresses.packCustody, log, now),
+        applyPackCustodyLog(ctx, client, addresses.packCustody, log, now),
     });
 
     // Live eligible snapshot + quote

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -53,7 +53,8 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_tokenId", ["tokenId"])
-    .index("by_status", ["status"]),
+    .index("by_status", ["status"])
+    .index("by_maker_and_status", ["maker", "status"]),
 
   poolSnapshots: defineTable({
     key: v.literal("latest"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -46,6 +46,7 @@ export default defineSchema({
     navUsdWad: v.union(v.string(), v.null()),
     status: v.union(
       v.literal("resting"),
+      v.literal("exited"),
       v.literal("ripped"),
       v.literal("unlisted")
     ),

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "deploy:packcustody": "tsx scripts/deploy-packcustody.ts",
     "verify:packcustody": "tsx scripts/verify-packcustody.ts",
     "deploy:asset-registry": "tsx scripts/deploy-asset-registry.ts",
+    "configure:asset-registry-mock-feeds": "tsx scripts/configure-asset-registry-mock-feeds.ts",
     "verify:asset-registry": "tsx scripts/verify-asset-registry.ts",
     "deploy:rip-engine": "tsx scripts/deploy-rip-engine.ts",
     "verify:rip-engine": "tsx scripts/verify-rip-engine.ts",

--- a/packages/shared/src/abis-source.test.ts
+++ b/packages/shared/src/abis-source.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { toEventSignature, toFunctionSignature } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { packCustodyAbi, ripEngineAbi } from "./abis";
+
+function sourceSignature(
+  source: string,
+  kind: "function" | "event",
+  name: string
+): string {
+  const match = new RegExp(`\\b${kind}\\s+${name}\\s*\\(([^)]*)\\)`, "m").exec(
+    source
+  );
+  if (!match && kind === "function") {
+    const mapping = new RegExp(
+      `mapping\\s*\\(\\s*([^\\s=]+)[^=]*=>[^)]*\\)\\s+public\\s+${name}\\s*;`,
+      "m"
+    ).exec(source);
+    if (mapping) return `${name}(${mapping[1]})`;
+  }
+  if (!match) throw new Error(`${kind} ${name} is missing from Foundry source`);
+  const types = match[1]!
+    .split(",")
+    .map((argument) => argument.trim())
+    .filter(Boolean)
+    .map((argument) => argument.split(/\s+/)[0]);
+  return `${name}(${types.join(",")})`;
+}
+
+function abiFunctions(abi: readonly unknown[]) {
+  return abi.filter(
+    (item): item is Extract<(typeof abi)[number], { type: "function" }> =>
+      typeof item === "object" &&
+      item !== null &&
+      "type" in item &&
+      item.type === "function"
+  );
+}
+
+function abiEvents(abi: readonly unknown[]) {
+  return abi.filter(
+    (item): item is Extract<(typeof abi)[number], { type: "event" }> =>
+      typeof item === "object" &&
+      item !== null &&
+      "type" in item &&
+      item.type === "event"
+  );
+}
+
+describe("shared ABI parity with Foundry source", () => {
+  it("matches every exported PackCustody lifecycle function and event", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "contracts/src/PackCustody.sol"),
+      "utf8"
+    );
+    for (const item of abiFunctions(packCustodyAbi)) {
+      expect(toFunctionSignature(item)).toBe(
+        sourceSignature(source, "function", item.name)
+      );
+    }
+    for (const item of abiEvents(packCustodyAbi)) {
+      expect(toEventSignature(item)).toBe(
+        sourceSignature(source, "event", item.name)
+      );
+    }
+  });
+
+  it("matches every exported RipEngine lifecycle function and event", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "contracts/src/RipEngine.sol"),
+      "utf8"
+    );
+    for (const item of abiFunctions(ripEngineAbi)) {
+      expect(toFunctionSignature(item)).toBe(
+        sourceSignature(source, "function", item.name)
+      );
+    }
+    for (const item of abiEvents(ripEngineAbi)) {
+      expect(toEventSignature(item)).toBe(
+        sourceSignature(source, "event", item.name)
+      );
+    }
+  });
+});

--- a/packages/shared/src/abis.test.ts
+++ b/packages/shared/src/abis.test.ts
@@ -1,0 +1,144 @@
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  toEventSignature,
+  toFunctionSignature,
+  type Address,
+  type TransactionReceipt,
+} from "viem";
+import { describe, expect, it } from "vitest";
+
+import {
+  assetRegistryAbi,
+  erc20Abi,
+  getPackMintedTokenId,
+  packCustodyAbi,
+  ripEngineAbi,
+} from "./abis";
+
+const functionSignatures = (abi: readonly unknown[]) =>
+  abi
+    .filter(
+      (item): item is Extract<(typeof abi)[number], { type: "function" }> =>
+        typeof item === "object" &&
+        item !== null &&
+        "type" in item &&
+        item.type === "function"
+    )
+    .map(toFunctionSignature);
+
+const eventSignatures = (abi: readonly unknown[]) =>
+  abi
+    .filter(
+      (item): item is Extract<(typeof abi)[number], { type: "event" }> =>
+        typeof item === "object" &&
+        item !== null &&
+        "type" in item &&
+        item.type === "event"
+    )
+    .map(toEventSignature);
+
+describe("Maker lifecycle ABIs", () => {
+  it("exposes ERC-20 funding calls", () => {
+    expect(functionSignatures(erc20Abi)).toEqual([
+      "balanceOf(address)",
+      "allowance(address,address)",
+      "approve(address,uint256)",
+    ]);
+  });
+
+  it("exposes PackCustody lifecycle calls and receipt events", () => {
+    expect(functionSignatures(packCustodyAbi)).toEqual(
+      expect.arrayContaining([
+        "mint(address[],uint256[])",
+        "topUp(uint256,address[],uint256[])",
+        "delistAndRedeem(uint256)",
+        "basketOf(uint256)",
+        "creatorOf(uint256)",
+        "isListed(uint256)",
+        "whitelistedAssets()",
+      ])
+    );
+    expect(eventSignatures(packCustodyAbi)).toEqual(
+      expect.arrayContaining([
+        "PackMinted(uint256,address,address[],uint256[])",
+        "PackToppedUp(uint256,address,address[],uint256[])",
+        "PackUnlisted(uint256)",
+        "PackRedeemed(uint256,address,address[],uint256[])",
+      ])
+    );
+  });
+
+  it("exposes RipEngine Maker lifecycle calls", () => {
+    expect(functionSignatures(ripEngineAbi)).toEqual(
+      expect.arrayContaining([
+        "enterPool(uint256)",
+        "exitPool(uint256)",
+        "isResting(uint256)",
+        "syncPackNav(uint256)",
+        "pendingOf(uint256)",
+        "claimableFees(address)",
+        "claim(uint256[])",
+      ])
+    );
+  });
+
+  it("exposes AssetRegistry quote and Pack band reads", () => {
+    expect(functionSignatures(assetRegistryAbi)).toEqual(
+      expect.arrayContaining([
+        "quote(address,uint256)",
+        "minPackNav()",
+        "poolMax()",
+      ])
+    );
+  });
+});
+
+describe("getPackMintedTokenId", () => {
+  const custody = "0x0000000000000000000000000000000000000001" as Address;
+  const creator = "0x0000000000000000000000000000000000000002" as Address;
+  const asset = "0x0000000000000000000000000000000000000003" as Address;
+
+  const packMintedLog = (address: Address, tokenId: bigint) => ({
+    address,
+    blockHash: null,
+    blockNumber: null,
+    data: encodeAbiParameters(
+      [{ type: "address[]" }, { type: "uint256[]" }],
+      [[asset], [10n]]
+    ),
+    logIndex: null,
+    removed: false,
+    topics: encodeEventTopics({
+      abi: packCustodyAbi,
+      eventName: "PackMinted",
+      args: { tokenId, creator },
+    }),
+    transactionHash: null,
+    transactionIndex: null,
+  });
+
+  it("decodes the token id from the expected custody contract", () => {
+    const receipt = {
+      logs: [
+        packMintedLog("0x0000000000000000000000000000000000000004", 99n),
+        packMintedLog(custody, 42n),
+      ],
+    } as Pick<TransactionReceipt, "logs">;
+
+    expect(getPackMintedTokenId(receipt, custody)).toBe(42n);
+  });
+
+  it("rejects missing or ambiguous PackMinted events", () => {
+    expect(() => getPackMintedTokenId({ logs: [] }, custody)).toThrow(
+      "Expected one PackMinted event, received 0"
+    );
+
+    const receipt = {
+      logs: [packMintedLog(custody, 1n), packMintedLog(custody, 2n)],
+    } as Pick<TransactionReceipt, "logs">;
+    expect(() => getPackMintedTokenId(receipt, custody)).toThrow(
+      "Expected one PackMinted event, received 2"
+    );
+  });
+});

--- a/packages/shared/src/abis.test.ts
+++ b/packages/shared/src/abis.test.ts
@@ -38,6 +38,17 @@ const eventSignatures = (abi: readonly unknown[]) =>
     )
     .map(toEventSignature);
 
+const errorNames = (abi: readonly unknown[]) =>
+  abi
+    .filter(
+      (item): item is Extract<(typeof abi)[number], { type: "error" }> =>
+        typeof item === "object" &&
+        item !== null &&
+        "type" in item &&
+        item.type === "error"
+    )
+    .map((item) => item.name);
+
 describe("Maker lifecycle ABIs", () => {
   it("exposes ERC-20 funding calls", () => {
     expect(functionSignatures(erc20Abi)).toEqual([
@@ -90,6 +101,16 @@ describe("Maker lifecycle ABIs", () => {
         "quote(address,uint256)",
         "minPackNav()",
         "poolMax()",
+      ])
+    );
+    expect(errorNames(assetRegistryAbi)).toEqual(
+      expect.arrayContaining([
+        "FeedStale",
+        "FeedPaused",
+        "FeedInvalid",
+        "FeedZeroPrice",
+        "AssetNotListed",
+        "AssetNotInPriceBasket",
       ])
     );
   });

--- a/packages/shared/src/abis.test.ts
+++ b/packages/shared/src/abis.test.ts
@@ -77,6 +77,7 @@ describe("Maker lifecycle ABIs", () => {
         "isResting(uint256)",
         "syncPackNav(uint256)",
         "pendingOf(uint256)",
+        "makerOf(uint256)",
         "claimableFees(address)",
         "claim(uint256[])",
       ])

--- a/packages/shared/src/abis.ts
+++ b/packages/shared/src/abis.ts
@@ -223,6 +223,13 @@ export const ripEngineAbi = [
   },
   {
     type: "function",
+    name: "makerOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
     name: "claimableFees",
     stateMutability: "view",
     inputs: [{ name: "maker", type: "address" }],

--- a/packages/shared/src/abis.ts
+++ b/packages/shared/src/abis.ts
@@ -1,9 +1,47 @@
+import {
+  isAddressEqual,
+  parseEventLogs,
+  type Address,
+  type TransactionReceipt,
+} from "viem";
+
 /**
- * Minimal ABIs for V1 Pack-rip contracts (reads + Starter Grant mint).
- * Keep in sync with contracts/src/{MockUSD,PackCustody,RipEngine}.sol.
+ * Canonical ABIs for V1 Pack-rip contracts.
+ * Keep in sync with contracts/src/{MockUSD,PackCustody,RipEngine,AssetRegistry}.sol.
  */
 
+export const erc20Abi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
 export const mockUsdAbi = [
+  ...erc20Abi,
   {
     type: "function",
     name: "mint",
@@ -16,13 +54,6 @@ export const mockUsdAbi = [
   },
   {
     type: "function",
-    name: "balanceOf",
-    stateMutability: "view",
-    inputs: [{ name: "account", type: "address" }],
-    outputs: [{ name: "", type: "uint256" }],
-  },
-  {
-    type: "function",
     name: "decimals",
     stateMutability: "view",
     inputs: [],
@@ -31,6 +62,34 @@ export const mockUsdAbi = [
 ] as const;
 
 export const packCustodyAbi = [
+  {
+    type: "function",
+    name: "mint",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "assets", type: "address[]" },
+      { name: "amounts", type: "uint256[]" },
+    ],
+    outputs: [{ name: "tokenId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "topUp",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "tokenId", type: "uint256" },
+      { name: "assets", type: "address[]" },
+      { name: "amounts", type: "uint256[]" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "delistAndRedeem",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [],
+  },
   {
     type: "function",
     name: "basketOf",
@@ -62,6 +121,13 @@ export const packCustodyAbi = [
     outputs: [{ name: "", type: "bool" }],
   },
   {
+    type: "function",
+    name: "whitelistedAssets",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address[]" }],
+  },
+  {
     type: "event",
     name: "PackMinted",
     inputs: [
@@ -86,9 +152,89 @@ export const packCustodyAbi = [
     name: "PackUnlisted",
     inputs: [{ name: "tokenId", type: "uint256", indexed: true }],
   },
+  {
+    type: "event",
+    name: "PackRedeemed",
+    inputs: [
+      { name: "tokenId", type: "uint256", indexed: true },
+      { name: "creator", type: "address", indexed: true },
+      { name: "assets", type: "address[]", indexed: false },
+      { name: "amounts", type: "uint256[]", indexed: false },
+    ],
+  },
 ] as const;
 
+/** Decode the one Pack minted by a successful `PackCustody.mint` receipt. */
+export function getPackMintedTokenId(
+  receipt: Pick<TransactionReceipt, "logs">,
+  packCustodyAddress: Address
+): bigint {
+  const logs = parseEventLogs({
+    abi: packCustodyAbi,
+    eventName: "PackMinted",
+    logs: receipt.logs.filter((log) =>
+      isAddressEqual(log.address, packCustodyAddress)
+    ),
+    strict: true,
+  });
+
+  if (logs.length !== 1) {
+    throw new Error(`Expected one PackMinted event, received ${logs.length}`);
+  }
+
+  return logs[0].args.tokenId;
+}
+
 export const ripEngineAbi = [
+  {
+    type: "function",
+    name: "enterPool",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "exitPool",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "isResting",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "syncPackNav",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "nav", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "pendingOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "claimableFees",
+    stateMutability: "view",
+    inputs: [{ name: "maker", type: "address" }],
+    outputs: [{ name: "amount", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "claim",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "tokenIds", type: "uint256[]" }],
+    outputs: [{ name: "amount", type: "uint256" }],
+  },
   {
     type: "function",
     name: "restingPackIds",
@@ -166,6 +312,16 @@ export const ripEngineAbi = [
 ] as const;
 
 export const assetRegistryAbi = [
+  {
+    type: "function",
+    name: "quote",
+    stateMutability: "view",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
   {
     type: "function",
     name: "surcharge",

--- a/packages/shared/src/abis.ts
+++ b/packages/shared/src/abis.ts
@@ -320,6 +320,44 @@ export const ripEngineAbi = [
 
 export const assetRegistryAbi = [
   {
+    type: "error",
+    name: "FeedStale",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "updatedAt", type: "uint256" },
+      { name: "staleAfter", type: "uint64" },
+      { name: "now_", type: "uint256" },
+    ],
+  },
+  {
+    type: "error",
+    name: "FeedPaused",
+    inputs: [{ name: "token", type: "address" }],
+  },
+  {
+    type: "error",
+    name: "FeedInvalid",
+    inputs: [{ name: "token", type: "address" }],
+  },
+  {
+    type: "error",
+    name: "FeedZeroPrice",
+    inputs: [{ name: "token", type: "address" }],
+  },
+  {
+    type: "error",
+    name: "AssetNotListed",
+    inputs: [{ name: "token", type: "address" }],
+  },
+  {
+    type: "error",
+    name: "AssetNotInPriceBasket",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "status", type: "uint8" },
+    ],
+  },
+  {
     type: "function",
     name: "quote",
     stateMutability: "view",

--- a/scripts/asset-registry-mock-feed-policy.test.ts
+++ b/scripts/asset-registry-mock-feed-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STATIC_TEST_FEED_STALE_AFTER,
+  planMockFeedPolicy,
+  type MockFeedPolicySnapshot,
+} from "./asset-registry-mock-feed-policy";
+
+const FEED = "0x0000000000000000000000000000000000000001" as const;
+
+function snapshot(
+  overrides: Partial<MockFeedPolicySnapshot> = {}
+): MockFeedPolicySnapshot {
+  return {
+    symbol: "AMZN",
+    expectedFeed: FEED,
+    configuredFeed: FEED,
+    staleAfter: 3_600n,
+    isTestFeed: true,
+    price: 18_500_000_000n,
+    paused: false,
+    valid: true,
+    ...overrides,
+  };
+}
+
+describe("static test-feed policy", () => {
+  it("updates finite test feeds and skips the desired state", () => {
+    expect(planMockFeedPolicy(snapshot())).toBe("update");
+    expect(
+      planMockFeedPolicy(snapshot({ staleAfter: STATIC_TEST_FEED_STALE_AFTER }))
+    ).toBe("skip");
+  });
+
+  it.each([
+    [
+      { configuredFeed: "0x0000000000000000000000000000000000000002" },
+      "does not match",
+    ],
+    [{ isTestFeed: false }, "not a disclosed test feed"],
+    [{ price: 0n }, "must be positive"],
+    [{ paused: true }, "feed is paused"],
+    [{ valid: false }, "feed is invalid"],
+  ] as const)("fails closed for an unsafe snapshot", (overrides, message) => {
+    expect(() => planMockFeedPolicy(snapshot(overrides))).toThrow(message);
+  });
+});

--- a/scripts/asset-registry-mock-feed-policy.ts
+++ b/scripts/asset-registry-mock-feed-policy.ts
@@ -1,0 +1,47 @@
+import { maxUint64, type Address } from "viem";
+
+export const STATIC_TEST_FEED_STALE_AFTER = maxUint64;
+
+export type MockFeedPolicySnapshot = {
+  symbol: string;
+  expectedFeed: Address;
+  configuredFeed: Address;
+  staleAfter: bigint;
+  isTestFeed: boolean;
+  price: bigint;
+  paused: boolean;
+  valid: boolean;
+};
+
+export function planMockFeedPolicy(
+  snapshot: MockFeedPolicySnapshot
+): "skip" | "update" {
+  if (
+    snapshot.configuredFeed.toLowerCase() !==
+    snapshot.expectedFeed.toLowerCase()
+  ) {
+    throw new Error(
+      `${snapshot.symbol}: configured feed does not match the committed deployment record`
+    );
+  }
+  if (!snapshot.isTestFeed) {
+    throw new Error(`${snapshot.symbol}: feed is not a disclosed test feed`);
+  }
+  if (snapshot.price <= 0n) {
+    throw new Error(`${snapshot.symbol}: feed price must be positive`);
+  }
+  if (snapshot.paused) {
+    throw new Error(
+      `${snapshot.symbol}: feed is paused; refusing to reconfigure`
+    );
+  }
+  if (!snapshot.valid) {
+    throw new Error(
+      `${snapshot.symbol}: feed is invalid; refusing to reconfigure`
+    );
+  }
+
+  return snapshot.staleAfter === STATIC_TEST_FEED_STALE_AFTER
+    ? "skip"
+    : "update";
+}

--- a/scripts/configure-asset-registry-mock-feeds.ts
+++ b/scripts/configure-asset-registry-mock-feeds.ts
@@ -1,0 +1,207 @@
+/**
+ * Configure the committed Robinhood testnet MockPriceFeeds as static,
+ * non-expiring test fixtures. Dry-run by default; pass --execute to write.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  PAYMENT_CHAIN_ID,
+  createRobinhoodPublicClient,
+  createRobinhoodWalletClient,
+  parsePrivateKey,
+} from "@margin-call/shared";
+import { getAddress, parseAbi, zeroHash, type Address } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+
+import {
+  STATIC_TEST_FEED_STALE_AFTER,
+  planMockFeedPolicy,
+} from "./asset-registry-mock-feed-policy";
+import { loadEnvLocal, ROOT } from "./deploy-utils";
+
+const registryAbi = parseAbi([
+  "function hasRole(bytes32 role, address account) view returns (bool)",
+  "function getAsset(address token) view returns (address feed, uint64 staleAfter, uint8 status, uint8 tokenDecimals, uint256 inventory)",
+  "function setAssetFeed(address token, address feed, uint64 staleAfter)",
+  "function quote(address token, uint256 amount) view returns (uint256)",
+]);
+
+const mockFeedAbi = parseAbi([
+  "function IS_TEST_FEED() view returns (bool)",
+  "function latestAnswer() view returns (uint256 price, uint256 updatedAt, bool paused, bool valid)",
+]);
+
+type DeploymentRecord = {
+  chainId: number;
+  address: Address;
+  symbols: string[];
+  tokens: Address[];
+  feeds: Address[];
+};
+
+type PendingUpdate = {
+  symbol: string;
+  token: Address;
+  feed: Address;
+  tokenDecimals: number;
+};
+
+function readDeployment(): DeploymentRecord {
+  const path = join(
+    ROOT,
+    "contracts/deployments/robinhood-testnet.asset-registry.json"
+  );
+  const record = JSON.parse(readFileSync(path, "utf8")) as DeploymentRecord;
+  if (record.chainId !== PAYMENT_CHAIN_ID) {
+    throw new Error(`Deployment record chainId must be ${PAYMENT_CHAIN_ID}`);
+  }
+  if (
+    record.symbols.length === 0 ||
+    record.symbols.length !== record.tokens.length ||
+    record.symbols.length !== record.feeds.length
+  ) {
+    throw new Error("Deployment record symbols, tokens, and feeds must align");
+  }
+  return record;
+}
+
+async function main() {
+  const execute = process.argv.includes("--execute");
+  const deployment = readDeployment();
+  const registry = getAddress(deployment.address);
+  const publicClient = createRobinhoodPublicClient();
+
+  const chainId = await publicClient.getChainId();
+  if (chainId !== PAYMENT_CHAIN_ID) {
+    throw new Error(`RPC chainId ${chainId} is not ${PAYMENT_CHAIN_ID}`);
+  }
+  if (!(await publicClient.getBytecode({ address: registry }))) {
+    throw new Error(`AssetRegistry has no bytecode at ${registry}`);
+  }
+
+  const updates: PendingUpdate[] = [];
+  for (let index = 0; index < deployment.symbols.length; index += 1) {
+    const symbol = deployment.symbols[index]!;
+    const token = getAddress(deployment.tokens[index]!);
+    const expectedFeed = getAddress(deployment.feeds[index]!);
+    const asset = await publicClient.readContract({
+      address: registry,
+      abi: registryAbi,
+      functionName: "getAsset",
+      args: [token],
+    });
+    const configuredFeed = getAddress(asset[0]);
+    if (!(await publicClient.getBytecode({ address: configuredFeed }))) {
+      throw new Error(`${symbol}: configured feed has no bytecode`);
+    }
+
+    const [isTestFeed, answer] = await Promise.all([
+      publicClient.readContract({
+        address: configuredFeed,
+        abi: mockFeedAbi,
+        functionName: "IS_TEST_FEED",
+      }),
+      publicClient.readContract({
+        address: configuredFeed,
+        abi: mockFeedAbi,
+        functionName: "latestAnswer",
+      }),
+    ]);
+    const decision = planMockFeedPolicy({
+      symbol,
+      expectedFeed,
+      configuredFeed,
+      staleAfter: asset[1],
+      isTestFeed,
+      price: answer[0],
+      paused: answer[2],
+      valid: answer[3],
+    });
+
+    console.log(
+      `${symbol}: ${decision === "skip" ? "already static" : "would set static policy"}`
+    );
+    if (decision === "update") {
+      updates.push({
+        symbol,
+        token,
+        feed: configuredFeed,
+        tokenDecimals: asset[3],
+      });
+    }
+  }
+
+  if (updates.length === 0) {
+    console.log("AssetRegistry mock-feed policy is already configured.");
+    return;
+  }
+  if (!execute) {
+    console.log(
+      `Dry run complete: ${updates.length} update(s). Re-run with --execute after explicit approval.`
+    );
+    return;
+  }
+
+  const processPrivateKey =
+    process.env.DEPLOYER_PRIVATE_KEY ?? process.env.OPERATOR_PRIVATE_KEY;
+  const env = processPrivateKey ? null : loadEnvLocal();
+  const rawPrivateKey =
+    processPrivateKey ?? env?.DEPLOYER_PRIVATE_KEY ?? env?.OPERATOR_PRIVATE_KEY;
+  if (!rawPrivateKey) {
+    throw new Error("DEPLOYER_PRIVATE_KEY (or OPERATOR_PRIVATE_KEY) missing");
+  }
+  const privateKey = parsePrivateKey(rawPrivateKey);
+  const account = privateKeyToAccount(privateKey);
+  const isAdmin = await publicClient.readContract({
+    address: registry,
+    abi: registryAbi,
+    functionName: "hasRole",
+    args: [zeroHash, account.address],
+  });
+  if (!isAdmin) {
+    throw new Error(
+      `${account.address} does not hold AssetRegistry admin role`
+    );
+  }
+  const walletClient = createRobinhoodWalletClient(privateKey);
+
+  for (const update of updates) {
+    const simulation = await publicClient.simulateContract({
+      account,
+      address: registry,
+      abi: registryAbi,
+      functionName: "setAssetFeed",
+      args: [update.token, update.feed, STATIC_TEST_FEED_STALE_AFTER],
+    });
+    const hash = await walletClient.writeContract(simulation.request);
+    const receipt = await publicClient.waitForTransactionReceipt({ hash });
+    if (receipt.status !== "success") {
+      throw new Error(`${update.symbol}: setAssetFeed transaction reverted`);
+    }
+
+    const configured = await publicClient.readContract({
+      address: registry,
+      abi: registryAbi,
+      functionName: "getAsset",
+      args: [update.token],
+    });
+    if (configured[1] !== STATIC_TEST_FEED_STALE_AFTER) {
+      throw new Error(`${update.symbol}: post-write staleAfter mismatch`);
+    }
+    await publicClient.readContract({
+      address: registry,
+      abi: registryAbi,
+      functionName: "quote",
+      args: [update.token, 10n ** BigInt(update.tokenDecimals)],
+    });
+    console.log(`${update.symbol}: configured in ${hash}`);
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(
+    error instanceof Error ? error.message : "Configuration failed"
+  );
+  process.exitCode = 1;
+});

--- a/scripts/deploy-asset-registry.ts
+++ b/scripts/deploy-asset-registry.ts
@@ -8,7 +8,7 @@
  * Optional:
  *   ASSETREGISTRY_ADMIN       — defaults to deployer
  *   ASSETREGISTRY_INVENTORY   — granted INVENTORY_ROLE when admin == deployer
- *   ASSETREGISTRY_STALE_AFTER — seconds; default 3600
+ *   ASSETREGISTRY_STALE_AFTER — seconds; seeded mocks default to uint64 max
  *   ASSETREGISTRY_SEED_FEEDS  — "true"/"false"; default true
  *
  * Usage: pnpm deploy:asset-registry

--- a/src/components/maker/acquisition-fees-panel.tsx
+++ b/src/components/maker/acquisition-fees-panel.tsx
@@ -1,22 +1,16 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useWallets } from "@privy-io/react-auth";
 import {
   PAYMENT_CHAIN,
   createRobinhoodPublicClient,
   ripEngineAbi,
   txExplorerUrl,
 } from "@margin-call/shared";
-import {
-  createWalletClient,
-  custom,
-  formatUnits,
-  type Address,
-  type Hash,
-} from "viem";
+import { formatUnits, type Address } from "viem";
 
 import { GameButton } from "@/components/ui/game-button";
+import { useMakerTransactionClient } from "@/hooks/use-maker-transaction-client";
 import { getContractAddresses } from "@/lib/contracts/addresses";
 import {
   claimAcquisitionFees,
@@ -25,6 +19,13 @@ import {
   type AcquisitionFeeSnapshot,
   type ClaimPhase,
 } from "@/lib/maker/acquisition-fees";
+import {
+  PendingTransactionError,
+  createBrowserJournalStorage,
+  ensureWorkflow,
+  listWorkflows,
+  requestFingerprint,
+} from "@/lib/maker/transaction-journal";
 
 type ViewProps = {
   snapshot: AcquisitionFeeSnapshot | null;
@@ -62,10 +63,21 @@ export function AcquisitionFeesView({
   onClaim,
   onRefresh,
 }: ViewProps) {
-  const hash = phase.kind === "pending" ? phase.hash : null;
+  const hash =
+    phase.kind === "pending"
+      ? phase.hash
+      : phase.kind === "error"
+        ? (phase.hash ?? null)
+        : null;
   const decimals = snapshot?.stablecoinDecimals ?? 0;
   const claimDisabled =
-    !configured || isBusy || isReading || !snapshot || snapshot.total === 0n;
+    !configured ||
+    isBusy ||
+    isReading ||
+    !snapshot ||
+    (snapshot.visibilityComplete
+      ? snapshot.total === 0n
+      : snapshot.crystallized === 0n);
 
   return (
     <div className="mt-5 border border-[var(--t-divider)]/60 bg-[var(--t-panel)]/40 p-4">
@@ -90,21 +102,39 @@ export function AcquisitionFeesView({
               {formatStablecoin(snapshot.crystallized, decimals)}
             </dd>
           </div>
-          <div>
-            <dt className="text-[var(--t-muted)]">
-              Pending across {snapshot.restingMakerTokenIds.length} resting Pack
-              {snapshot.restingMakerTokenIds.length === 1 ? "" : "s"}
-            </dt>
-            <dd className="mt-1 font-bold text-[var(--t-text)]">
-              {formatStablecoin(snapshot.pending, decimals)}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-[var(--t-muted)]">Total claimable</dt>
-            <dd className="mt-1 font-bold text-[var(--t-green)]">
-              {formatStablecoin(snapshot.total, decimals)}
-            </dd>
-          </div>
+          {snapshot.visibilityComplete ? (
+            <div>
+              <dt className="text-[var(--t-muted)]">
+                Pending across {snapshot.restingMakerTokenIds.length} resting
+                Pack
+                {snapshot.restingMakerTokenIds.length === 1 ? "" : "s"}
+              </dt>
+              <dd className="mt-1 font-bold text-[var(--t-text)]">
+                {formatStablecoin(snapshot.pending!, decimals)}
+              </dd>
+            </div>
+          ) : (
+            <div>
+              <dt className="text-[var(--t-muted)]">Pending visibility</dt>
+              <dd className="mt-1 font-bold text-[var(--t-amber)]">Unknown</dd>
+            </div>
+          )}
+          {snapshot.visibilityComplete ? (
+            <div>
+              <dt className="text-[var(--t-muted)]">Total claimable</dt>
+              <dd className="mt-1 font-bold text-[var(--t-green)]">
+                {formatStablecoin(snapshot.total!, decimals)}
+              </dd>
+            </div>
+          ) : (
+            <div>
+              <dt className="text-[var(--t-muted)]">Known claimable</dt>
+              <dd className="mt-1 font-bold text-[var(--t-amber)]">
+                {formatStablecoin(snapshot.crystallized, decimals)} plus unknown
+                pending
+              </dd>
+            </div>
+          )}
           <div>
             <dt className="text-[var(--t-muted)]">Current wallet balance</dt>
             <dd className="mt-1 font-bold text-[var(--t-text)]">
@@ -115,6 +145,20 @@ export function AcquisitionFeesView({
       ) : (
         <p className="mt-3 text-xs text-[var(--t-muted)]">
           Reading live fee and MockUSD balances…
+        </p>
+      )}
+
+      {snapshot && !snapshot.visibilityComplete && (
+        <p
+          role="alert"
+          className="mt-3 text-xs leading-5 text-[var(--t-amber)]"
+        >
+          Pending fees are not shown: the deployed RipEngine only exposes one
+          unpaged restingPackIds() array, and the live set has{" "}
+          {snapshot.restingCount.toString()} Packs, above this client&apos;s
+          explicit {snapshot.visibilityLimit}-Pack safety cap. Claiming is
+          limited to already crystallized fees; no partial pending total is
+          reported.
         </p>
       )}
 
@@ -131,7 +175,7 @@ export function AcquisitionFeesView({
           [REFRESH FEES]
         </GameButton>
       </div>
-      {snapshot?.total === 0n && !isReading && (
+      {snapshot?.visibilityComplete && snapshot.total === 0n && !isReading && (
         <p className="mt-2 text-xs text-[var(--t-muted)]">
           No Acquisition Fees are currently claimable.
         </p>
@@ -160,7 +204,7 @@ export function AcquisitionFeesView({
       )}
       {isReading && (
         <p className="mt-2 text-xs text-[var(--t-muted)]">
-          Refreshing the complete live resting set and MockUSD balance…
+          Refreshing bounded live fee visibility and MockUSD balance…
         </p>
       )}
       {readError && (
@@ -177,8 +221,10 @@ export function AcquisitionFeesPanel({
 }: {
   walletAddress: Address;
 }) {
-  const { wallets } = useWallets();
   const publicClient = useMemo(() => createRobinhoodPublicClient(), []);
+  const { walletReady, getWalletClient, waitForReceipt } =
+    useMakerTransactionClient(walletAddress, publicClient);
+  const journalStorage = useMemo(() => createBrowserJournalStorage(), []);
   const addresses = useMemo(() => {
     try {
       return getContractAddresses();
@@ -192,6 +238,7 @@ export function AcquisitionFeesPanel({
   const [isReading, setIsReading] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const readSequence = useRef(0);
+  const recoveryStarted = useRef(false);
 
   const refresh = useCallback(async () => {
     if (!addresses) return null;
@@ -220,51 +267,134 @@ export function AcquisitionFeesPanel({
     void refresh().catch(() => undefined);
   }, [refresh]);
 
+  async function claimWithWorkflow(tokenIds: bigint[], workflowKey: string) {
+    if (!addresses) throw new Error("Contract addresses are not configured");
+    const walletClient = await getWalletClient();
+    await claimAcquisitionFees(
+      tokenIds,
+      {
+        claim: (ids) =>
+          walletClient.writeContract({
+            account: walletAddress,
+            chain: PAYMENT_CHAIN,
+            address: addresses.ripEngine,
+            abi: ripEngineAbi,
+            functionName: "claim",
+            args: [ids],
+          }),
+        waitForReceipt,
+        hasClaimable: async (ids) => {
+          const blockNumber = await publicClient.getBlockNumber();
+          const [crystallized, pending] = await Promise.all([
+            publicClient.readContract({
+              address: addresses.ripEngine,
+              abi: ripEngineAbi,
+              functionName: "claimableFees",
+              args: [walletAddress],
+              blockNumber,
+            }),
+            ids.length === 0
+              ? Promise.resolve<bigint[]>([])
+              : publicClient.multicall({
+                  allowFailure: false,
+                  blockNumber,
+                  contracts: ids.map((tokenId) => ({
+                    address: addresses.ripEngine,
+                    abi: ripEngineAbi,
+                    functionName: "pendingOf" as const,
+                    args: [tokenId] as const,
+                  })),
+                }),
+          ]);
+          return crystallized > 0n || pending.some((amount) => amount > 0n);
+        },
+      },
+      setPhase,
+      async () => {
+        await refresh();
+      },
+      { storage: journalStorage, workflowKey }
+    );
+    journalStorage.remove(workflowKey);
+  }
+
+  useEffect(() => {
+    if (recoveryStarted.current || !addresses || !walletReady) return;
+    const workflow = listWorkflows(
+      journalStorage,
+      PAYMENT_CHAIN.id,
+      walletAddress,
+      "claim"
+    )[0];
+    if (!workflow) return;
+    recoveryStarted.current = true;
+    const raw = workflow.context.tokenIds;
+    if (typeof raw !== "string") return;
+    const tokenIds = (JSON.parse(raw) as string[]).map(BigInt);
+    setIsBusy(true);
+    void claimWithWorkflow(tokenIds, workflow.key)
+      .catch((error) => {
+        setPhase({
+          kind: "error",
+          message: errorMessage(
+            error,
+            "Acquisition Fee recovery needs attention"
+          ),
+          hash:
+            error instanceof PendingTransactionError ? error.hash : undefined,
+        });
+      })
+      .finally(() => setIsBusy(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addresses, journalStorage, walletAddress, walletReady]);
+
   async function onClaim() {
     if (!addresses || isBusy) return;
     setIsBusy(true);
     setPhase({ kind: "idle" });
     try {
+      const existing = listWorkflows(
+        journalStorage,
+        PAYMENT_CHAIN.id,
+        walletAddress,
+        "claim"
+      )[0];
+      if (existing) {
+        const raw = existing.context.tokenIds;
+        if (typeof raw !== "string") {
+          throw new Error("Saved Acquisition Fee claim is invalid");
+        }
+        await claimWithWorkflow(
+          (JSON.parse(raw) as string[]).map(BigInt),
+          existing.key
+        );
+        return;
+      }
       const freshSnapshot = await refresh();
-      if (!freshSnapshot || freshSnapshot.total === 0n) {
+      if (
+        !freshSnapshot ||
+        (freshSnapshot.visibilityComplete
+          ? freshSnapshot.total === 0n
+          : freshSnapshot.crystallized === 0n)
+      ) {
         throw new Error("No Acquisition Fees are currently claimable");
       }
-      const wallet = wallets.find(
-        (candidate) =>
-          candidate.address.toLowerCase() === walletAddress.toLowerCase()
-      );
-      if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
-      const provider = await wallet.getEthereumProvider();
-      const walletClient = createWalletClient({
-        account: walletAddress,
-        chain: PAYMENT_CHAIN,
-        transport: custom(provider),
+      const tokenIds = freshSnapshot.visibilityComplete
+        ? freshSnapshot.restingMakerTokenIds
+        : [];
+      const workflow = ensureWorkflow(journalStorage, {
+        chainId: PAYMENT_CHAIN.id,
+        wallet: walletAddress,
+        kind: "claim",
+        requestFingerprint: requestFingerprint(["acquisition-fees"]),
+        context: { tokenIds: JSON.stringify(tokenIds.map(String)) },
       });
-
-      await claimAcquisitionFees(
-        freshSnapshot.restingMakerTokenIds,
-        {
-          claim: (tokenIds) =>
-            walletClient.writeContract({
-              account: walletAddress,
-              chain: PAYMENT_CHAIN,
-              address: addresses.ripEngine,
-              abi: ripEngineAbi,
-              functionName: "claim",
-              args: [tokenIds],
-            }),
-          waitForReceipt: (hash: Hash) =>
-            publicClient.waitForTransactionReceipt({ hash }),
-        },
-        setPhase,
-        async () => {
-          await refresh();
-        }
-      );
+      await claimWithWorkflow(tokenIds, workflow.key);
     } catch (error) {
       setPhase({
         kind: "error",
         message: errorMessage(error, "Acquisition Fee claim failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);

--- a/src/components/maker/acquisition-fees-panel.tsx
+++ b/src/components/maker/acquisition-fees-panel.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useWallets } from "@privy-io/react-auth";
+import {
+  PAYMENT_CHAIN,
+  createRobinhoodPublicClient,
+  ripEngineAbi,
+  txExplorerUrl,
+} from "@margin-call/shared";
+import {
+  createWalletClient,
+  custom,
+  formatUnits,
+  type Address,
+  type Hash,
+} from "viem";
+
+import { GameButton } from "@/components/ui/game-button";
+import { getContractAddresses } from "@/lib/contracts/addresses";
+import {
+  claimAcquisitionFees,
+  claimPhaseMessage,
+  readAcquisitionFeeSnapshot,
+  type AcquisitionFeeSnapshot,
+  type ClaimPhase,
+} from "@/lib/maker/acquisition-fees";
+
+type ViewProps = {
+  snapshot: AcquisitionFeeSnapshot | null;
+  phase: ClaimPhase;
+  isReading: boolean;
+  isBusy: boolean;
+  configured: boolean;
+  readError?: string;
+  onClaim: () => void;
+  onRefresh: () => void;
+};
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) return fallback;
+  if (/reject|denied|declined/i.test(error.message)) {
+    return `Transaction rejected: ${error.message}`;
+  }
+  return error.message;
+}
+
+function formatStablecoin(value: bigint, decimals: number): string {
+  const formatted = formatUnits(value, decimals);
+  const [whole, fraction = ""] = formatted.split(".");
+  const compactFraction = fraction.slice(0, 6).replace(/0+$/, "");
+  return `${compactFraction ? `${whole}.${compactFraction}` : whole} MockUSD`;
+}
+
+export function AcquisitionFeesView({
+  snapshot,
+  phase,
+  isReading,
+  isBusy,
+  configured,
+  readError,
+  onClaim,
+  onRefresh,
+}: ViewProps) {
+  const hash = phase.kind === "pending" ? phase.hash : null;
+  const decimals = snapshot?.stablecoinDecimals ?? 0;
+  const claimDisabled =
+    !configured || isBusy || isReading || !snapshot || snapshot.total === 0n;
+
+  return (
+    <div className="mt-5 border border-[var(--t-divider)]/60 bg-[var(--t-panel)]/40 p-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+          Acquisition Fees
+        </h3>
+        <span className="text-[10px] uppercase tracking-[0.14em] text-[var(--t-muted)]">
+          Live RipEngine accounting
+        </span>
+      </div>
+
+      {!configured ? (
+        <p role="alert" className="mt-3 text-xs text-[var(--t-red)]">
+          Robinhood testnet contract addresses are not configured.
+        </p>
+      ) : snapshot ? (
+        <dl className="mt-3 grid gap-3 text-xs sm:grid-cols-2">
+          <div>
+            <dt className="text-[var(--t-muted)]">Already crystallized</dt>
+            <dd className="mt-1 font-bold text-[var(--t-text)]">
+              {formatStablecoin(snapshot.crystallized, decimals)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[var(--t-muted)]">
+              Pending across {snapshot.restingMakerTokenIds.length} resting Pack
+              {snapshot.restingMakerTokenIds.length === 1 ? "" : "s"}
+            </dt>
+            <dd className="mt-1 font-bold text-[var(--t-text)]">
+              {formatStablecoin(snapshot.pending, decimals)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[var(--t-muted)]">Total claimable</dt>
+            <dd className="mt-1 font-bold text-[var(--t-green)]">
+              {formatStablecoin(snapshot.total, decimals)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[var(--t-muted)]">Current wallet balance</dt>
+            <dd className="mt-1 font-bold text-[var(--t-text)]">
+              {formatStablecoin(snapshot.mockUsdBalance, decimals)}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="mt-3 text-xs text-[var(--t-muted)]">
+          Reading live fee and MockUSD balances…
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <GameButton onClick={onClaim} disabled={claimDisabled} size="sm">
+          {isBusy ? "[CLAIM IN PROGRESS]" : "[CLAIM ACQUISITION FEES]"}
+        </GameButton>
+        <GameButton
+          onClick={onRefresh}
+          disabled={!configured || isBusy || isReading}
+          variant="secondary"
+          size="sm"
+        >
+          [REFRESH FEES]
+        </GameButton>
+      </div>
+      {snapshot?.total === 0n && !isReading && (
+        <p className="mt-2 text-xs text-[var(--t-muted)]">
+          No Acquisition Fees are currently claimable.
+        </p>
+      )}
+      <p
+        role={phase.kind === "error" ? "alert" : "status"}
+        className={`mt-2 text-xs ${
+          phase.kind === "error" || phase.kind === "refresh-error"
+            ? "text-[var(--t-red)]"
+            : phase.kind === "complete"
+              ? "text-[var(--t-green)]"
+              : "text-[var(--t-muted)]"
+        }`}
+      >
+        {claimPhaseMessage(phase)}
+      </p>
+      {hash && (
+        <a
+          className="text-xs text-[var(--t-accent)] underline underline-offset-4"
+          href={txExplorerUrl(hash)}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View pending transaction
+        </a>
+      )}
+      {isReading && (
+        <p className="mt-2 text-xs text-[var(--t-muted)]">
+          Refreshing the complete live resting set and MockUSD balance…
+        </p>
+      )}
+      {readError && (
+        <p role="alert" className="mt-2 text-xs text-[var(--t-red)]">
+          Live fee reads unavailable: {readError}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function AcquisitionFeesPanel({
+  walletAddress,
+}: {
+  walletAddress: Address;
+}) {
+  const { wallets } = useWallets();
+  const publicClient = useMemo(() => createRobinhoodPublicClient(), []);
+  const addresses = useMemo(() => {
+    try {
+      return getContractAddresses();
+    } catch {
+      return null;
+    }
+  }, []);
+  const [snapshot, setSnapshot] = useState<AcquisitionFeeSnapshot | null>(null);
+  const [phase, setPhase] = useState<ClaimPhase>({ kind: "idle" });
+  const [readError, setReadError] = useState<string>();
+  const [isReading, setIsReading] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const readSequence = useRef(0);
+
+  const refresh = useCallback(async () => {
+    if (!addresses) return null;
+    const sequence = ++readSequence.current;
+    setIsReading(true);
+    setReadError(undefined);
+    try {
+      const next = await readAcquisitionFeeSnapshot(
+        publicClient,
+        addresses,
+        walletAddress
+      );
+      if (sequence === readSequence.current) setSnapshot(next);
+      return next;
+    } catch (error) {
+      if (sequence === readSequence.current) {
+        setReadError(errorMessage(error, "Chain reads unavailable"));
+      }
+      throw error;
+    } finally {
+      if (sequence === readSequence.current) setIsReading(false);
+    }
+  }, [addresses, publicClient, walletAddress]);
+
+  useEffect(() => {
+    void refresh().catch(() => undefined);
+  }, [refresh]);
+
+  async function onClaim() {
+    if (!addresses || isBusy) return;
+    setIsBusy(true);
+    setPhase({ kind: "idle" });
+    try {
+      const freshSnapshot = await refresh();
+      if (!freshSnapshot || freshSnapshot.total === 0n) {
+        throw new Error("No Acquisition Fees are currently claimable");
+      }
+      const wallet = wallets.find(
+        (candidate) =>
+          candidate.address.toLowerCase() === walletAddress.toLowerCase()
+      );
+      if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
+      const provider = await wallet.getEthereumProvider();
+      const walletClient = createWalletClient({
+        account: walletAddress,
+        chain: PAYMENT_CHAIN,
+        transport: custom(provider),
+      });
+
+      await claimAcquisitionFees(
+        freshSnapshot.restingMakerTokenIds,
+        {
+          claim: (tokenIds) =>
+            walletClient.writeContract({
+              account: walletAddress,
+              chain: PAYMENT_CHAIN,
+              address: addresses.ripEngine,
+              abi: ripEngineAbi,
+              functionName: "claim",
+              args: [tokenIds],
+            }),
+          waitForReceipt: (hash: Hash) =>
+            publicClient.waitForTransactionReceipt({ hash }),
+        },
+        setPhase,
+        async () => {
+          await refresh();
+        }
+      );
+    } catch (error) {
+      setPhase({
+        kind: "error",
+        message: errorMessage(error, "Acquisition Fee claim failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <AcquisitionFeesView
+      snapshot={snapshot}
+      phase={phase}
+      isReading={isReading}
+      isBusy={isBusy}
+      configured={Boolean(addresses)}
+      readError={readError}
+      onClaim={() => void onClaim()}
+      onRefresh={() => void refresh().catch(() => undefined)}
+    />
+  );
+}

--- a/src/components/maker/acquisition-fees-panel.tsx
+++ b/src/components/maker/acquisition-fees-panel.tsx
@@ -105,9 +105,9 @@ export function AcquisitionFeesView({
           {snapshot.visibilityComplete ? (
             <div>
               <dt className="text-[var(--t-muted)]">
-                Pending across {snapshot.restingMakerTokenIds.length} resting
-                Pack
+                Pending fees across {snapshot.restingMakerTokenIds.length} Pack
                 {snapshot.restingMakerTokenIds.length === 1 ? "" : "s"}
+                {" with nonzero accrual"}
               </dt>
               <dd className="mt-1 font-bold text-[var(--t-text)]">
                 {formatStablecoin(snapshot.pending!, decimals)}

--- a/src/components/maker/acquisition-fees-panel.ui.test.tsx
+++ b/src/components/maker/acquisition-fees-panel.ui.test.tsx
@@ -12,6 +12,9 @@ const SNAPSHOT: AcquisitionFeeSnapshot = {
   mockUsdBalance: 9_000_000n,
   stablecoinDecimals: 6,
   restingMakerTokenIds: [11n, 22n],
+  restingCount: 4n,
+  visibilityComplete: true,
+  visibilityLimit: 500,
 };
 
 function renderView(
@@ -64,11 +67,36 @@ describe("AcquisitionFeesView", () => {
 
   it("shows submitted claims as pending rather than successful", () => {
     const hash = `0x${"1".repeat(64)}` as const;
-    const html = renderView({ phase: { kind: "pending", hash }, isBusy: true });
+    const html = renderView({
+      phase: { kind: "pending", hash, batch: 1, totalBatches: 2 },
+      isBusy: true,
+    });
 
-    expect(html).toContain("Claim submitted — waiting for confirmation");
+    expect(html).toContain(
+      "Claim batch 1 of 2 submitted — waiting for confirmation"
+    );
     expect(html).toContain("View pending transaction");
     expect(html).not.toContain("Acquisition Fee claim confirmed");
+  });
+
+  it("discloses capped visibility without presenting a partial total", () => {
+    const html = renderView({
+      snapshot: {
+        ...SNAPSHOT,
+        pending: null,
+        total: null,
+        restingMakerTokenIds: [],
+        restingCount: 700n,
+        visibilityComplete: false,
+      },
+    });
+
+    expect(html).toContain("Pending visibility");
+    expect(html).toContain("Unknown");
+    expect(html).toContain(
+      "above this client&#x27;s explicit 500-Pack safety cap"
+    );
+    expect(html).not.toContain("Total claimable");
   });
 
   it("renders rejected and reverted claims as errors", () => {

--- a/src/components/maker/acquisition-fees-panel.ui.test.tsx
+++ b/src/components/maker/acquisition-fees-panel.ui.test.tsx
@@ -1,0 +1,92 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { AcquisitionFeeSnapshot } from "@/lib/maker/acquisition-fees";
+import { AcquisitionFeesView } from "./acquisition-fees-panel";
+
+const SNAPSHOT: AcquisitionFeeSnapshot = {
+  blockNumber: 123n,
+  crystallized: 1_250_000n,
+  pending: 2_500_000n,
+  total: 3_750_000n,
+  mockUsdBalance: 9_000_000n,
+  stablecoinDecimals: 6,
+  restingMakerTokenIds: [11n, 22n],
+};
+
+function renderView(
+  overrides: Partial<Parameters<typeof AcquisitionFeesView>[0]> = {}
+) {
+  return renderToStaticMarkup(
+    <AcquisitionFeesView
+      snapshot={SNAPSHOT}
+      phase={{ kind: "idle" }}
+      isReading={false}
+      isBusy={false}
+      configured
+      onClaim={() => undefined}
+      onRefresh={() => undefined}
+      {...overrides}
+    />
+  );
+}
+
+describe("AcquisitionFeesView", () => {
+  it("shows the live stablecoin breakdown using live decimals", () => {
+    const html = renderView();
+
+    expect(html).toContain("Already crystallized");
+    expect(html).toContain("1.25 MockUSD");
+    expect(html).toContain("Pending across 2 resting Packs");
+    expect(html).toContain("2.5 MockUSD");
+    expect(html).toContain("Total claimable");
+    expect(html).toContain("3.75 MockUSD");
+    expect(html).toContain("Current wallet balance");
+    expect(html).toContain("9 MockUSD");
+  });
+
+  it("disables claim when the refreshed live total is zero", () => {
+    const html = renderView({
+      snapshot: {
+        ...SNAPSHOT,
+        crystallized: 0n,
+        pending: 0n,
+        total: 0n,
+        restingMakerTokenIds: [],
+      },
+    });
+
+    expect(html).toContain("No Acquisition Fees are currently claimable");
+    expect(html).toMatch(
+      /<button[^>]*disabled[^>]*>\[CLAIM ACQUISITION FEES\]/
+    );
+  });
+
+  it("shows submitted claims as pending rather than successful", () => {
+    const hash = `0x${"1".repeat(64)}` as const;
+    const html = renderView({ phase: { kind: "pending", hash }, isBusy: true });
+
+    expect(html).toContain("Claim submitted — waiting for confirmation");
+    expect(html).toContain("View pending transaction");
+    expect(html).not.toContain("Acquisition Fee claim confirmed");
+  });
+
+  it("renders rejected and reverted claims as errors", () => {
+    expect(
+      renderView({
+        phase: {
+          kind: "error",
+          message: "Transaction rejected: User rejected request",
+        },
+      })
+    ).toContain("Transaction rejected: User rejected request");
+    expect(
+      renderView({
+        phase: {
+          kind: "error",
+          message: "Acquisition Fee claim transaction reverted",
+        },
+      })
+    ).toContain("Acquisition Fee claim transaction reverted");
+  });
+});

--- a/src/components/maker/acquisition-fees-panel.ui.test.tsx
+++ b/src/components/maker/acquisition-fees-panel.ui.test.tsx
@@ -40,7 +40,7 @@ describe("AcquisitionFeesView", () => {
 
     expect(html).toContain("Already crystallized");
     expect(html).toContain("1.25 MockUSD");
-    expect(html).toContain("Pending across 2 resting Packs");
+    expect(html).toContain("Pending fees across 2 Packs with nonzero accrual");
     expect(html).toContain("2.5 MockUSD");
     expect(html).toContain("Total claimable");
     expect(html).toContain("3.75 MockUSD");
@@ -59,6 +59,7 @@ describe("AcquisitionFeesView", () => {
       },
     });
 
+    expect(html).toContain("Pending fees across 0 Packs with nonzero accrual");
     expect(html).toContain("No Acquisition Fees are currently claimable");
     expect(html).toMatch(
       /<button[^>]*disabled[^>]*>\[CLAIM ACQUISITION FEES\]/

--- a/src/components/maker/my-packs-dashboard.tsx
+++ b/src/components/maker/my-packs-dashboard.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { usePaginatedQuery } from "convex/react";
+
+import { api } from "../../../convex/_generated/api";
+import { formatWadUsd } from "@/lib/pool/nav-distribution";
+import { formatShortAddress } from "@/lib/utils";
+
+type Props = {
+  walletAddress: string | null;
+};
+
+function basketLabel(
+  basket: Array<{ asset: string; symbol: string | null }>
+): string {
+  return (
+    basket
+      .map((entry) => entry.symbol ?? formatShortAddress(entry.asset))
+      .join(" · ") || "Empty basket"
+  );
+}
+
+function statusLabel(status: "resting" | "ripped" | "unlisted"): string {
+  switch (status) {
+    case "resting":
+      return "Resting";
+    case "ripped":
+      return "Ripped";
+    case "unlisted":
+      return "Unlisted";
+  }
+}
+
+export function MyPacksDashboard({ walletAddress }: Props) {
+  const { results, status, loadMore } = usePaginatedQuery(
+    api.pool.listPacksByMaker,
+    walletAddress ? { maker: walletAddress } : "skip",
+    { initialNumItems: 20 }
+  );
+
+  const loadingFirstPage = status === "LoadingFirstPage";
+
+  return (
+    <section className="mt-10" aria-labelledby="my-packs-heading">
+      <p className="text-[11px] font-bold uppercase tracking-[0.28em] text-[var(--t-green)]">
+        Maker
+      </p>
+      <h2
+        id="my-packs-heading"
+        className="mt-2 font-[family-name:var(--font-plex-sans)] text-2xl font-black uppercase text-[var(--t-accent)]"
+      >
+        My Packs
+      </h2>
+
+      {!walletAddress ? (
+        <p className="mt-3 text-sm text-[var(--t-muted)]">
+          Waiting for connected wallet…
+        </p>
+      ) : loadingFirstPage ? (
+        <p className="mt-3 text-sm text-[var(--t-muted)]">
+          Loading your Packs…<span className="cursor-blink">█</span>
+        </p>
+      ) : results.length === 0 ? (
+        <p className="mt-3 text-sm text-[var(--t-muted)]">
+          No Packs indexed for this wallet.
+        </p>
+      ) : (
+        <ul className="mt-3 divide-y divide-[var(--t-divider)]/40">
+          {results.map((pack) => (
+            <li key={pack.tokenId} className="py-3">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <span className="font-bold text-[var(--t-accent)]">
+                  Pack #{pack.tokenId}
+                </span>
+                <span className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-text)]">
+                  {statusLabel(pack.status)}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-[var(--t-text)]/90">
+                {basketLabel(pack.basket)}
+              </p>
+              <p className="mt-1 flex flex-wrap gap-x-3 text-xs text-[var(--t-muted)]">
+                <span>
+                  Indexed NAV{" "}
+                  {pack.navUsdWad ? formatWadUsd(pack.navUsdWad) : "—"}
+                </span>
+                <span
+                  className={
+                    pack.eligible
+                      ? "text-[var(--t-green)]"
+                      : "text-[var(--t-muted)]"
+                  }
+                >
+                  {pack.eligible ? "Eligible" : "Ineligible"}
+                </span>
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {status === "CanLoadMore" && (
+        <button
+          type="button"
+          onClick={() => loadMore(20)}
+          className="mt-4 font-mono text-xs font-bold uppercase tracking-[0.16em] text-[var(--t-accent)] hover:underline"
+        >
+          [LOAD MORE PACKS]
+        </button>
+      )}
+      {status === "LoadingMore" && (
+        <p className="mt-4 text-xs text-[var(--t-muted)]">Loading more…</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/maker/my-packs-dashboard.tsx
+++ b/src/components/maker/my-packs-dashboard.tsx
@@ -4,6 +4,7 @@ import { usePaginatedQuery } from "convex/react";
 import type { Address } from "viem";
 
 import { api } from "../../../convex/_generated/api";
+import { AcquisitionFeesPanel } from "@/components/maker/acquisition-fees-panel";
 import { PackLifecycleActions } from "@/components/maker/pack-lifecycle-actions";
 import { formatWadUsd } from "@/lib/pool/nav-distribution";
 import { formatShortAddress } from "@/lib/utils";
@@ -53,6 +54,10 @@ export function MyPacksDashboard({ walletAddress }: Props) {
       >
         My Packs
       </h2>
+
+      {walletAddress && (
+        <AcquisitionFeesPanel walletAddress={walletAddress as Address} />
+      )}
 
       {!walletAddress ? (
         <p className="mt-3 text-sm text-[var(--t-muted)]">

--- a/src/components/maker/my-packs-dashboard.tsx
+++ b/src/components/maker/my-packs-dashboard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { usePaginatedQuery } from "convex/react";
+import type { Address } from "viem";
 
 import { api } from "../../../convex/_generated/api";
+import { PackLifecycleActions } from "@/components/maker/pack-lifecycle-actions";
 import { formatWadUsd } from "@/lib/pool/nav-distribution";
 import { formatShortAddress } from "@/lib/utils";
 
@@ -94,6 +96,10 @@ export function MyPacksDashboard({ walletAddress }: Props) {
                   {pack.eligible ? "Eligible" : "Ineligible"}
                 </span>
               </p>
+              <PackLifecycleActions
+                tokenId={pack.tokenId}
+                walletAddress={walletAddress as Address}
+              />
             </li>
           ))}
         </ul>

--- a/src/components/maker/my-packs-dashboard.tsx
+++ b/src/components/maker/my-packs-dashboard.tsx
@@ -23,10 +23,14 @@ function basketLabel(
   );
 }
 
-function statusLabel(status: "resting" | "ripped" | "unlisted"): string {
+function statusLabel(
+  status: "resting" | "exited" | "ripped" | "unlisted"
+): string {
   switch (status) {
     case "resting":
       return "Resting";
+    case "exited":
+      return "Exited · Listed";
     case "ripped":
       return "Ripped";
     case "unlisted":

--- a/src/components/maker/my-packs-dashboard.ui.test.tsx
+++ b/src/components/maker/my-packs-dashboard.ui.test.tsx
@@ -1,0 +1,106 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { usePaginatedQueryMock } = vi.hoisted(() => ({
+  usePaginatedQueryMock: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  usePaginatedQuery: usePaginatedQueryMock,
+}));
+
+import { MyPacksDashboard } from "./my-packs-dashboard";
+
+const WALLET = "0x1234567890abcdef1234567890abcdef12345678";
+
+describe("MyPacksDashboard", () => {
+  beforeEach(() => {
+    usePaginatedQueryMock.mockReset();
+  });
+
+  it("skips the public query until a connected wallet is available", () => {
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: "LoadingFirstPage",
+      loadMore: vi.fn(),
+    });
+
+    const html = renderToStaticMarkup(
+      <MyPacksDashboard walletAddress={null} />
+    );
+
+    expect(usePaginatedQueryMock.mock.calls[0]?.[1]).toBe("skip");
+    expect(html).toContain("Waiting for connected wallet");
+  });
+
+  it("shows a first-page loading state instead of an empty state", () => {
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: "LoadingFirstPage",
+      loadMore: vi.fn(),
+    });
+
+    const html = renderToStaticMarkup(
+      <MyPacksDashboard walletAddress={WALLET} />
+    );
+
+    expect(usePaginatedQueryMock.mock.calls[0]?.[1]).toEqual({ maker: WALLET });
+    expect(html).toContain("Loading your Packs");
+    expect(html).not.toContain("No Packs indexed");
+  });
+
+  it("shows the wallet-scoped empty state after loading", () => {
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: "Exhausted",
+      loadMore: vi.fn(),
+    });
+
+    const html = renderToStaticMarkup(
+      <MyPacksDashboard walletAddress={WALLET} />
+    );
+
+    expect(html).toContain("No Packs indexed for this wallet.");
+  });
+
+  it("renders indexed Pack lifecycle fields and pagination state", () => {
+    usePaginatedQueryMock.mockReturnValue({
+      results: [
+        {
+          tokenId: 42,
+          maker: WALLET,
+          basket: [
+            {
+              asset: "0x0000000000000000000000000000000000000001",
+              amount: "1000000000000000000",
+              symbol: "AAPL",
+            },
+            {
+              asset: "0x0000000000000000000000000000000000000002",
+              amount: "2000000000000000000",
+              symbol: "MSFT",
+            },
+          ],
+          navUsdWad: "123450000000000000000",
+          status: "resting",
+          eligible: true,
+          updatedAt: 1,
+        },
+      ],
+      status: "CanLoadMore",
+      loadMore: vi.fn(),
+    });
+
+    const html = renderToStaticMarkup(
+      <MyPacksDashboard walletAddress={WALLET} />
+    );
+
+    expect(html).toContain("My Packs");
+    expect(html).toContain("Pack #42");
+    expect(html).toContain("AAPL · MSFT");
+    expect(html).toContain("Indexed NAV $123.45");
+    expect(html).toContain("Eligible");
+    expect(html).toContain("Resting");
+    expect(html).toContain("[LOAD MORE PACKS]");
+  });
+});

--- a/src/components/maker/my-packs-dashboard.ui.test.tsx
+++ b/src/components/maker/my-packs-dashboard.ui.test.tsx
@@ -15,6 +15,10 @@ vi.mock("./pack-lifecycle-actions", () => ({
   ),
 }));
 
+vi.mock("./acquisition-fees-panel", () => ({
+  AcquisitionFeesPanel: () => <div>[LIVE ACQUISITION FEES]</div>,
+}));
+
 import { MyPacksDashboard } from "./my-packs-dashboard";
 
 const WALLET = "0x1234567890abcdef1234567890abcdef12345678";
@@ -102,6 +106,7 @@ describe("MyPacksDashboard", () => {
     );
 
     expect(html).toContain("My Packs");
+    expect(html).toContain("[LIVE ACQUISITION FEES]");
     expect(html).toContain("Pack #42");
     expect(html).toContain("AAPL · MSFT");
     expect(html).toContain("Indexed NAV $123.45");

--- a/src/components/maker/my-packs-dashboard.ui.test.tsx
+++ b/src/components/maker/my-packs-dashboard.ui.test.tsx
@@ -9,6 +9,12 @@ vi.mock("convex/react", () => ({
   usePaginatedQuery: usePaginatedQueryMock,
 }));
 
+vi.mock("./pack-lifecycle-actions", () => ({
+  PackLifecycleActions: ({ tokenId }: { tokenId: number }) => (
+    <button>[MANAGE PACK #{tokenId}]</button>
+  ),
+}));
+
 import { MyPacksDashboard } from "./my-packs-dashboard";
 
 const WALLET = "0x1234567890abcdef1234567890abcdef12345678";
@@ -101,6 +107,7 @@ describe("MyPacksDashboard", () => {
     expect(html).toContain("Indexed NAV $123.45");
     expect(html).toContain("Eligible");
     expect(html).toContain("Resting");
+    expect(html).toContain("[MANAGE PACK #42]");
     expect(html).toContain("[LOAD MORE PACKS]");
   });
 });

--- a/src/components/maker/pack-composer.tsx
+++ b/src/components/maker/pack-composer.tsx
@@ -15,7 +15,6 @@ import {
   type StockToken,
 } from "@margin-call/shared";
 import {
-  formatUnits,
   type Address,
   type Hash,
   type PublicClient,
@@ -26,6 +25,10 @@ import { GameButton } from "@/components/ui/game-button";
 import { useMakerTransactionClient } from "@/hooks/use-maker-transaction-client";
 import { getContractAddresses } from "@/lib/contracts/addresses";
 import { formatWadUsd } from "@/lib/pool/nav-distribution";
+import {
+  formatAllowanceDisplay,
+  formatTokenAmountDisplay,
+} from "@/lib/token-display";
 import {
   buildPackPlan,
   createAndEnrollPack,
@@ -129,14 +132,6 @@ function workflowPlan(
     selected,
     approvals: selected.filter((_, index) => saved[index]!.needsApproval),
   };
-}
-
-function formatBalance(value: bigint | undefined, decimals: number): string {
-  if (value === undefined) return "Unavailable";
-  const formatted = formatUnits(value, decimals);
-  const [whole, fraction = ""] = formatted.split(".");
-  const compactFraction = fraction.slice(0, 6).replace(/0+$/, "");
-  return compactFraction ? `${whole}.${compactFraction}` : whole;
 }
 
 function inputRows(
@@ -325,6 +320,14 @@ export function PackComposerView({
           <div className="mt-5 space-y-3">
             {ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => {
               const tokenRead = reads.tokens[token.symbol] ?? {};
+              const balance = formatTokenAmountDisplay(
+                tokenRead.balance,
+                token.decimals
+              );
+              const allowance = formatAllowanceDisplay(
+                tokenRead.allowance,
+                token.decimals
+              );
               const parsed = parseTokenAmount(
                 values[token.symbol] ?? "",
                 token.decimals
@@ -336,11 +339,11 @@ export function PackComposerView({
               return (
                 <div
                   key={token.address}
-                  className="grid gap-2 border border-[var(--t-divider)]/50 bg-[var(--t-panel)]/40 p-3 sm:grid-cols-[5rem_1fr_auto] sm:items-center"
+                  className="grid min-w-0 gap-2 overflow-hidden border border-[var(--t-divider)]/50 bg-[var(--t-panel)]/40 p-3 sm:grid-cols-[5rem_minmax(0,1fr)_minmax(0,12rem)] sm:items-center"
                 >
                   <label
                     htmlFor={`pack-${token.symbol}`}
-                    className="font-bold text-[var(--t-accent)]"
+                    className="min-w-0 break-all font-bold text-[var(--t-accent)]"
                   >
                     {token.symbol}
                   </label>
@@ -355,18 +358,31 @@ export function PackComposerView({
                     }
                     disabled={isBusy}
                     aria-describedby={`pack-${token.symbol}-details`}
-                    className="min-h-11 border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 text-[var(--t-text)] outline-none focus:border-[var(--t-accent)] disabled:opacity-50"
+                    className="min-h-11 min-w-0 border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 text-[var(--t-text)] outline-none focus:border-[var(--t-accent)] disabled:opacity-50"
                   />
                   <div
                     id={`pack-${token.symbol}-details`}
-                    className="text-xs text-[var(--t-muted)] sm:text-right"
+                    className="min-w-0 max-w-full overflow-hidden text-xs text-[var(--t-muted)] sm:text-right"
                   >
-                    <p>
-                      Balance {formatBalance(tokenRead.balance, token.decimals)}
+                    <p className="flex min-w-0 gap-1 sm:justify-end">
+                      <span className="shrink-0">Balance</span>
+                      <span
+                        className="min-w-0 truncate tabular-nums"
+                        title={balance.exact}
+                        aria-label={balance.exact}
+                      >
+                        {balance.compact}
+                      </span>
                     </p>
-                    <p>
-                      Allowance{" "}
-                      {formatBalance(tokenRead.allowance, token.decimals)}
+                    <p className="flex min-w-0 gap-1 sm:justify-end">
+                      <span className="shrink-0">Allowance</span>
+                      <span
+                        className="min-w-0 truncate tabular-nums"
+                        title={allowance.exact}
+                        aria-label={allowance.exact}
+                      >
+                        {allowance.compact}
+                      </span>
                     </p>
                     {tokenRead.quote !== undefined && (
                       <p className="text-[var(--t-green)]">

--- a/src/components/maker/pack-composer.tsx
+++ b/src/components/maker/pack-composer.tsx
@@ -40,6 +40,7 @@ import {
   type TokenAmountInput,
   type TransactionPhase,
 } from "@/lib/maker/pack-composer";
+import { describeAssetRegistryQuoteError } from "@/lib/maker/quote-errors";
 import {
   PendingTransactionError,
   createBrowserJournalStorage,
@@ -205,9 +206,9 @@ async function readComposerChainState(
             functionName: "quote",
             args: [token.address, parsed.amount],
           });
-        } catch {
+        } catch (error) {
           tokenReads[token.symbol].quoteError =
-            "live quote unavailable or stale";
+            describeAssetRegistryQuoteError(error);
         }
       })
     );
@@ -394,7 +395,7 @@ export function PackComposerView({
                     )}
                     {tokenRead.quoteError && (
                       <p className="text-[var(--t-red)]">
-                        Quote unavailable or stale
+                        {tokenRead.quoteError}
                       </p>
                     )}
                   </div>
@@ -442,7 +443,7 @@ export function PackComposerView({
 
           {isReading && (
             <p className="mt-3 text-xs text-[var(--t-muted)]">
-              Refreshing live balances, allowances, quotes, and band…
+              Refreshing on-chain balances, allowances, quotes, and band…
             </p>
           )}
           {reads.error && (

--- a/src/components/maker/pack-composer.tsx
+++ b/src/components/maker/pack-composer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useWallets } from "@privy-io/react-auth";
 import {
   PAYMENT_CHAIN,
   PAYMENT_EXPLORER_URL,
@@ -16,8 +15,6 @@ import {
   type StockToken,
 } from "@margin-call/shared";
 import {
-  createWalletClient,
-  custom,
   formatUnits,
   type Address,
   type Hash,
@@ -26,6 +23,7 @@ import {
 } from "viem";
 
 import { GameButton } from "@/components/ui/game-button";
+import { useMakerTransactionClient } from "@/hooks/use-maker-transaction-client";
 import { getContractAddresses } from "@/lib/contracts/addresses";
 import { formatWadUsd } from "@/lib/pool/nav-distribution";
 import {
@@ -39,6 +37,14 @@ import {
   type TokenAmountInput,
   type TransactionPhase,
 } from "@/lib/maker/pack-composer";
+import {
+  PendingTransactionError,
+  createBrowserJournalStorage,
+  ensureWorkflow,
+  listWorkflows,
+  requestFingerprint,
+  type LifecycleWorkflow,
+} from "@/lib/maker/transaction-journal";
 
 const FAUCET_URL = "https://faucet.testnet.chain.robinhood.com";
 
@@ -92,9 +98,37 @@ function phaseHash(phase: TransactionPhase): Hash | null {
     case "mint-pending":
     case "enrollment-pending":
       return phase.hash;
+    case "error":
+      return phase.hash ?? null;
     default:
       return null;
   }
+}
+
+function workflowPlan(
+  workflow: LifecycleWorkflow
+): Pick<PackPlan, "selected" | "approvals"> {
+  const raw = workflow.context.plan;
+  if (typeof raw !== "string") throw new Error("Saved Pack plan is missing");
+  const saved = JSON.parse(raw) as Array<{
+    symbol: string;
+    address: Address;
+    amount: string;
+    allowance: string;
+    quote: string;
+    needsApproval: boolean;
+  }>;
+  const selected = saved.map((token) => ({
+    symbol: token.symbol,
+    address: token.address,
+    amount: BigInt(token.amount),
+    allowance: BigInt(token.allowance),
+    quote: BigInt(token.quote),
+  }));
+  return {
+    selected,
+    approvals: selected.filter((_, index) => saved[index]!.needsApproval),
+  };
 }
 
 function formatBalance(value: bigint | undefined, decimals: number): string {
@@ -198,7 +232,9 @@ async function readComposerChainState(
 
 function makeTransactionAdapter(
   publicClient: PublicClient,
-  walletClient: ReturnType<typeof createWalletClient>,
+  walletClient: Awaited<
+    ReturnType<ReturnType<typeof useMakerTransactionClient>["getWalletClient"]>
+  >,
   walletAddress: Address,
   addresses: ComposerAddresses
 ): PackTransactionAdapter {
@@ -494,8 +530,12 @@ export function PackComposerView({
 }
 
 export function PackComposer({ walletAddress }: { walletAddress: Address }) {
-  const { wallets } = useWallets();
   const publicClient = useMemo(() => createRobinhoodPublicClient(), []);
+  const { walletReady, getWalletClient } = useMakerTransactionClient(
+    walletAddress,
+    publicClient
+  );
+  const journalStorage = useMemo(() => createBrowserJournalStorage(), []);
   const addresses = useMemo(() => {
     try {
       return getContractAddresses();
@@ -514,6 +554,7 @@ export function PackComposer({ walletAddress }: { walletAddress: Address }) {
   const [isReading, setIsReading] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const readSequence = useRef(0);
+  const recoveryStarted = useRef(false);
   const valueSignature = ROBINHOOD_TESTNET_STOCK_TOKENS.map(
     (token) => values[token.symbol] ?? ""
   ).join("|");
@@ -547,17 +588,7 @@ export function PackComposer({ walletAddress }: { walletAddress: Address }) {
   );
 
   async function adapterForConnectedWallet() {
-    const wallet = wallets.find(
-      (candidate) =>
-        candidate.address.toLowerCase() === walletAddress.toLowerCase()
-    );
-    if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
-    const provider = await wallet.getEthereumProvider();
-    const walletClient = createWalletClient({
-      account: walletAddress,
-      chain: PAYMENT_CHAIN,
-      transport: custom(provider),
-    });
+    const walletClient = await getWalletClient();
     if (!addresses) throw new Error("Contract addresses are not configured");
     return makeTransactionAdapter(
       publicClient,
@@ -567,11 +598,61 @@ export function PackComposer({ walletAddress }: { walletAddress: Address }) {
     );
   }
 
+  async function resumeWorkflow(workflow: LifecycleWorkflow) {
+    const adapter = await adapterForConnectedWallet();
+    const tokenId = await createAndEnrollPack(
+      workflowPlan(workflow),
+      adapter,
+      setPhase,
+      setMintedTokenId,
+      { storage: journalStorage, workflowKey: workflow.key }
+    );
+    setMintedTokenId(tokenId);
+    journalStorage.remove(workflow.key);
+    await refresh();
+  }
+
+  useEffect(() => {
+    if (recoveryStarted.current || !addresses || !walletReady) return;
+    const workflow = listWorkflows(
+      journalStorage,
+      PAYMENT_CHAIN.id,
+      walletAddress,
+      "create"
+    )[0];
+    if (!workflow) return;
+    recoveryStarted.current = true;
+    setIsBusy(true);
+    void resumeWorkflow(workflow)
+      .catch((error) => {
+        setPhase({
+          kind: "error",
+          message: errorMessage(error, "Pack recovery needs attention"),
+          hash:
+            error instanceof PendingTransactionError ? error.hash : undefined,
+        });
+      })
+      .finally(() => setIsBusy(false));
+    // Recovery is intentionally a one-shot per mount; the explicit retry keeps
+    // wallet prompts user-driven after the first reconciliation pass.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addresses, journalStorage, walletAddress, walletReady]);
+
   async function onSubmit() {
     if (!addresses || isBusy || mintedTokenId !== null) return;
     setIsBusy(true);
     setPhase({ kind: "idle" });
     try {
+      const existing = listWorkflows(
+        journalStorage,
+        PAYMENT_CHAIN.id,
+        walletAddress,
+        "create"
+      )[0];
+      if (existing) {
+        await resumeWorkflow(existing);
+        return;
+      }
       const freshReads = await readComposerChainState(
         publicClient,
         addresses,
@@ -588,12 +669,40 @@ export function PackComposer({ walletAddress }: { walletAddress: Address }) {
         throw new Error(freshPlan.errors.join(". "));
       }
       const adapter = await adapterForConnectedWallet();
-      await createAndEnrollPack(freshPlan, adapter, setPhase, setMintedTokenId);
+      const fingerprint = requestFingerprint(
+        freshPlan.selected.flatMap((token) => [token.address, token.amount])
+      );
+      const workflow = ensureWorkflow(journalStorage, {
+        chainId: PAYMENT_CHAIN.id,
+        wallet: walletAddress,
+        kind: "create",
+        requestFingerprint: fingerprint,
+        context: {
+          plan: JSON.stringify(
+            freshPlan.selected.map((token) => ({
+              ...token,
+              amount: token.amount.toString(),
+              allowance: token.allowance.toString(),
+              quote: token.quote.toString(),
+              needsApproval: token.allowance < token.amount,
+            }))
+          ),
+        },
+      });
+      await createAndEnrollPack(
+        freshPlan,
+        adapter,
+        setPhase,
+        setMintedTokenId,
+        { storage: journalStorage, workflowKey: workflow.key }
+      );
+      journalStorage.remove(workflow.key);
       await refresh();
     } catch (error) {
       setPhase({
         kind: "error",
         message: errorMessage(error, "Pack creation failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);
@@ -605,12 +714,24 @@ export function PackComposer({ walletAddress }: { walletAddress: Address }) {
     setIsBusy(true);
     try {
       const adapter = await adapterForConnectedWallet();
-      await enrollMintedPack(mintedTokenId, adapter, setPhase);
+      const workflow = listWorkflows(
+        journalStorage,
+        PAYMENT_CHAIN.id,
+        walletAddress,
+        "create"
+      )[0];
+      if (!workflow) throw new Error("Saved Pack workflow is unavailable");
+      await enrollMintedPack(mintedTokenId, adapter, setPhase, {
+        storage: journalStorage,
+        workflowKey: workflow.key,
+      });
+      journalStorage.remove(workflow.key);
       await refresh();
     } catch (error) {
       setPhase({
         kind: "error",
         message: errorMessage(error, "Pool enrollment failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);

--- a/src/components/maker/pack-composer.tsx
+++ b/src/components/maker/pack-composer.tsx
@@ -1,0 +1,661 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useWallets } from "@privy-io/react-auth";
+import {
+  PAYMENT_CHAIN,
+  PAYMENT_EXPLORER_URL,
+  ROBINHOOD_TESTNET_STOCK_TOKENS,
+  assetRegistryAbi,
+  createRobinhoodPublicClient,
+  erc20Abi,
+  getPackMintedTokenId,
+  packCustodyAbi,
+  ripEngineAbi,
+  txExplorerUrl,
+  type StockToken,
+} from "@margin-call/shared";
+import {
+  createWalletClient,
+  custom,
+  formatUnits,
+  type Address,
+  type Hash,
+  type PublicClient,
+  type TransactionReceipt,
+} from "viem";
+
+import { GameButton } from "@/components/ui/game-button";
+import { getContractAddresses } from "@/lib/contracts/addresses";
+import { formatWadUsd } from "@/lib/pool/nav-distribution";
+import {
+  buildPackPlan,
+  createAndEnrollPack,
+  enrollMintedPack,
+  parseTokenAmount,
+  transactionPhaseMessage,
+  type PackPlan,
+  type PackTransactionAdapter,
+  type TokenAmountInput,
+  type TransactionPhase,
+} from "@/lib/maker/pack-composer";
+
+const FAUCET_URL = "https://faucet.testnet.chain.robinhood.com";
+
+type TokenRead = {
+  balance?: bigint;
+  allowance?: bigint;
+  quote?: bigint;
+  quoteError?: string;
+};
+
+type ChainReads = {
+  tokens: Record<string, TokenRead>;
+  minPackNav?: bigint;
+  poolMax?: bigint;
+  error?: string;
+};
+
+type ComposerAddresses = NonNullable<ReturnType<typeof getContractAddresses>>;
+
+type ViewProps = {
+  walletAddress: Address;
+  values: Record<string, string>;
+  reads: ChainReads;
+  plan: PackPlan;
+  phase: TransactionPhase;
+  mintedTokenId: bigint | null;
+  isReading: boolean;
+  isBusy: boolean;
+  configured: boolean;
+  onAmountChange: (symbol: string, value: string) => void;
+  onRefresh: () => void;
+  onSubmit: () => void;
+  onRetryEnrollment: () => void;
+  onComposeAnother: () => void;
+};
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    const message = error.message;
+    if (/reject|denied|declined/i.test(message)) {
+      return `Transaction rejected: ${message}`;
+    }
+    return message;
+  }
+  return fallback;
+}
+
+function phaseHash(phase: TransactionPhase): Hash | null {
+  switch (phase.kind) {
+    case "approval-pending":
+    case "mint-pending":
+    case "enrollment-pending":
+      return phase.hash;
+    default:
+      return null;
+  }
+}
+
+function formatBalance(value: bigint | undefined, decimals: number): string {
+  if (value === undefined) return "Unavailable";
+  const formatted = formatUnits(value, decimals);
+  const [whole, fraction = ""] = formatted.split(".");
+  const compactFraction = fraction.slice(0, 6).replace(/0+$/, "");
+  return compactFraction ? `${whole}.${compactFraction}` : whole;
+}
+
+function inputRows(
+  values: Record<string, string>,
+  reads: ChainReads
+): TokenAmountInput[] {
+  return ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => ({
+    ...token,
+    value: values[token.symbol] ?? "",
+    ...reads.tokens[token.symbol],
+  }));
+}
+
+async function readComposerChainState(
+  publicClient: PublicClient,
+  addresses: ComposerAddresses,
+  walletAddress: Address,
+  values: Record<string, string>
+): Promise<ChainReads> {
+  const tokenReads: Record<string, TokenRead> = {};
+
+  try {
+    const [band, balancesAndAllowances] = await Promise.all([
+      Promise.all([
+        publicClient.readContract({
+          address: addresses.assetRegistry,
+          abi: assetRegistryAbi,
+          functionName: "minPackNav",
+        }),
+        publicClient.readContract({
+          address: addresses.assetRegistry,
+          abi: assetRegistryAbi,
+          functionName: "poolMax",
+        }),
+      ]),
+      Promise.all(
+        ROBINHOOD_TESTNET_STOCK_TOKENS.map(async (token) => {
+          const [balance, allowance] = await Promise.all([
+            publicClient.readContract({
+              address: token.address,
+              abi: erc20Abi,
+              functionName: "balanceOf",
+              args: [walletAddress],
+            }),
+            publicClient.readContract({
+              address: token.address,
+              abi: erc20Abi,
+              functionName: "allowance",
+              args: [walletAddress, addresses.packCustody],
+            }),
+          ]);
+          return { token, balance, allowance };
+        })
+      ),
+    ]);
+
+    for (const { token, balance, allowance } of balancesAndAllowances) {
+      tokenReads[token.symbol] = { balance, allowance };
+    }
+
+    await Promise.all(
+      ROBINHOOD_TESTNET_STOCK_TOKENS.map(async (token) => {
+        const value = values[token.symbol] ?? "";
+        if (!value.trim()) return;
+        const parsed = parseTokenAmount(value, token.decimals);
+        if (!parsed.ok) return;
+        try {
+          tokenReads[token.symbol].quote = await publicClient.readContract({
+            address: addresses.assetRegistry,
+            abi: assetRegistryAbi,
+            functionName: "quote",
+            args: [token.address, parsed.amount],
+          });
+        } catch {
+          tokenReads[token.symbol].quoteError =
+            "live quote unavailable or stale";
+        }
+      })
+    );
+
+    return {
+      tokens: tokenReads,
+      minPackNav: band[0],
+      poolMax: band[1],
+    };
+  } catch (error) {
+    return {
+      tokens: tokenReads,
+      error: errorMessage(error, "Chain reads unavailable"),
+    };
+  }
+}
+
+function makeTransactionAdapter(
+  publicClient: PublicClient,
+  walletClient: ReturnType<typeof createWalletClient>,
+  walletAddress: Address,
+  addresses: ComposerAddresses
+): PackTransactionAdapter {
+  return {
+    approve: (token, amount) =>
+      walletClient.writeContract({
+        account: walletAddress,
+        chain: PAYMENT_CHAIN,
+        address: token,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [addresses.packCustody, amount],
+      }),
+    mint: (assets, amounts) =>
+      walletClient.writeContract({
+        account: walletAddress,
+        chain: PAYMENT_CHAIN,
+        address: addresses.packCustody,
+        abi: packCustodyAbi,
+        functionName: "mint",
+        args: [assets, amounts],
+      }),
+    enterPool: (tokenId) =>
+      walletClient.writeContract({
+        account: walletAddress,
+        chain: PAYMENT_CHAIN,
+        address: addresses.ripEngine,
+        abi: ripEngineAbi,
+        functionName: "enterPool",
+        args: [tokenId],
+      }),
+    waitForReceipt: (hash) => publicClient.waitForTransactionReceipt({ hash }),
+    getMintedTokenId: (receipt: TransactionReceipt) =>
+      getPackMintedTokenId(receipt, addresses.packCustody),
+  };
+}
+
+export function PackComposerView({
+  walletAddress,
+  values,
+  reads,
+  plan,
+  phase,
+  mintedTokenId,
+  isReading,
+  isBusy,
+  configured,
+  onAmountChange,
+  onRefresh,
+  onSubmit,
+  onRetryEnrollment,
+  onComposeAnother,
+}: ViewProps) {
+  const hash = phaseHash(phase);
+  const showErrors = Object.values(values).some((value) => value.trim());
+
+  return (
+    <section className="mt-10" aria-labelledby="pack-composer-heading">
+      <p className="text-[11px] font-bold uppercase tracking-[0.28em] text-[var(--t-green)]">
+        Maker
+      </p>
+      <h2
+        id="pack-composer-heading"
+        className="mt-2 font-[family-name:var(--font-plex-sans)] text-2xl font-black uppercase text-[var(--t-accent)]"
+      >
+        Compose a Pack
+      </h2>
+      <p className="mt-3 text-sm leading-6 text-[var(--t-muted)]">
+        The Starter Grant is MockUSD for Rips. It does not fund Maker Stock
+        Token inventory. Get Robinhood testnet Stock Tokens and gas from the{" "}
+        <a
+          className="text-[var(--t-accent)] underline underline-offset-4"
+          href={FAUCET_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Robinhood faucet
+        </a>
+        .
+      </p>
+
+      {!configured ? (
+        <p role="alert" className="mt-4 text-sm text-[var(--t-red)]">
+          Robinhood testnet contract addresses are not configured.
+        </p>
+      ) : (
+        <>
+          <div className="mt-5 space-y-3">
+            {ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => {
+              const tokenRead = reads.tokens[token.symbol] ?? {};
+              const parsed = parseTokenAmount(
+                values[token.symbol] ?? "",
+                token.decimals
+              );
+              const inputError =
+                values[token.symbol]?.trim() && !parsed.ok
+                  ? parsed.error
+                  : null;
+              return (
+                <div
+                  key={token.address}
+                  className="grid gap-2 border border-[var(--t-divider)]/50 bg-[var(--t-panel)]/40 p-3 sm:grid-cols-[5rem_1fr_auto] sm:items-center"
+                >
+                  <label
+                    htmlFor={`pack-${token.symbol}`}
+                    className="font-bold text-[var(--t-accent)]"
+                  >
+                    {token.symbol}
+                  </label>
+                  <input
+                    id={`pack-${token.symbol}`}
+                    inputMode="decimal"
+                    autoComplete="off"
+                    placeholder="0"
+                    value={values[token.symbol] ?? ""}
+                    onChange={(event) =>
+                      onAmountChange(token.symbol, event.target.value)
+                    }
+                    disabled={isBusy}
+                    aria-describedby={`pack-${token.symbol}-details`}
+                    className="min-h-11 border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 text-[var(--t-text)] outline-none focus:border-[var(--t-accent)] disabled:opacity-50"
+                  />
+                  <div
+                    id={`pack-${token.symbol}-details`}
+                    className="text-xs text-[var(--t-muted)] sm:text-right"
+                  >
+                    <p>
+                      Balance {formatBalance(tokenRead.balance, token.decimals)}
+                    </p>
+                    <p>
+                      Allowance{" "}
+                      {formatBalance(tokenRead.allowance, token.decimals)}
+                    </p>
+                    {tokenRead.quote !== undefined && (
+                      <p className="text-[var(--t-green)]">
+                        Quote {formatWadUsd(tokenRead.quote.toString())}
+                      </p>
+                    )}
+                    {inputError && (
+                      <p className="text-[var(--t-red)]">{inputError}</p>
+                    )}
+                    {tokenRead.quoteError && (
+                      <p className="text-[var(--t-red)]">
+                        Quote unavailable or stale
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mt-4 border border-[var(--t-divider)]/50 p-4 text-sm">
+            <div className="flex flex-wrap justify-between gap-2">
+              <span>Quoted basket NAV</span>
+              <strong className="text-[var(--t-accent)]">
+                {formatWadUsd(plan.nav.toString())}
+              </strong>
+            </div>
+            <div className="mt-2 flex flex-wrap justify-between gap-2 text-xs text-[var(--t-muted)]">
+              <span>
+                Live band{" "}
+                {reads.minPackNav === undefined
+                  ? "—"
+                  : formatWadUsd(reads.minPackNav.toString())}
+                {" → "}
+                {reads.poolMax === undefined
+                  ? "—"
+                  : formatWadUsd(reads.poolMax.toString())}
+              </span>
+              <span
+                className={
+                  plan.eligible
+                    ? "font-bold text-[var(--t-green)]"
+                    : "font-bold text-[var(--t-red)]"
+                }
+              >
+                {plan.eligible ? "Inside eligibility band" : "Not eligible"}
+              </span>
+            </div>
+            <p className="mt-2 text-xs text-[var(--t-muted)]">
+              {plan.approvals.length === 0
+                ? "No token approvals currently required."
+                : `Approvals required: ${plan.approvals
+                    .map((token) => token.symbol)
+                    .join(", ")}`}
+            </p>
+          </div>
+
+          {isReading && (
+            <p className="mt-3 text-xs text-[var(--t-muted)]">
+              Refreshing live balances, allowances, quotes, and band…
+            </p>
+          )}
+          {reads.error && (
+            <p role="alert" className="mt-3 text-sm text-[var(--t-red)]">
+              Chain reads unavailable: {reads.error}
+            </p>
+          )}
+          {showErrors && plan.errors.length > 0 && (
+            <ul className="mt-3 space-y-1 text-xs text-[var(--t-red)]">
+              {plan.errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          )}
+
+          <div className="mt-5 flex flex-wrap gap-3">
+            <GameButton
+              onClick={onSubmit}
+              disabled={
+                isBusy || isReading || plan.errors.length > 0 || !!mintedTokenId
+              }
+            >
+              {isBusy ? "[TRANSACTION IN PROGRESS]" : "[MINT + ENTER POOL]"}
+            </GameButton>
+            <GameButton
+              onClick={onRefresh}
+              disabled={isBusy || isReading}
+              variant="secondary"
+            >
+              [REFRESH CHAIN READS]
+            </GameButton>
+          </div>
+
+          <p
+            role={phase.kind === "error" ? "alert" : "status"}
+            className={`mt-4 text-sm ${
+              phase.kind === "error"
+                ? "text-[var(--t-red)]"
+                : phase.kind === "complete"
+                  ? "text-[var(--t-green)]"
+                  : "text-[var(--t-muted)]"
+            }`}
+          >
+            {transactionPhaseMessage(phase)}
+          </p>
+          {hash && (
+            <a
+              className="mt-1 inline-block text-xs text-[var(--t-accent)] underline underline-offset-4"
+              href={txExplorerUrl(hash)}
+              target="_blank"
+              rel="noreferrer"
+            >
+              View pending transaction
+            </a>
+          )}
+
+          {mintedTokenId !== null && phase.kind === "error" && (
+            <div className="mt-4 border border-[var(--t-amber)]/60 bg-[var(--t-accent-soft)] p-4">
+              <p className="text-sm text-[var(--t-amber)]">
+                Pack #{mintedTokenId.toString()} was confirmed on-chain. It was
+                not rolled back and will not be reminted.
+              </p>
+              <GameButton
+                className="mt-3"
+                onClick={onRetryEnrollment}
+                disabled={isBusy}
+                variant="secondary"
+                size="sm"
+              >
+                [RETRY POOL ENROLLMENT]
+              </GameButton>
+            </div>
+          )}
+
+          {phase.kind === "complete" && (
+            <GameButton
+              className="mt-4"
+              onClick={onComposeAnother}
+              variant="secondary"
+              size="sm"
+            >
+              [COMPOSE ANOTHER PACK]
+            </GameButton>
+          )}
+
+          <p className="mt-3 text-[10px] text-[var(--t-muted)]">
+            Wallet {walletAddress.slice(0, 6)}…{walletAddress.slice(-4)} ·{" "}
+            <a
+              className="hover:underline"
+              href={PAYMENT_EXPLORER_URL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Robinhood testnet explorer
+            </a>
+          </p>
+        </>
+      )}
+    </section>
+  );
+}
+
+export function PackComposer({ walletAddress }: { walletAddress: Address }) {
+  const { wallets } = useWallets();
+  const publicClient = useMemo(() => createRobinhoodPublicClient(), []);
+  const addresses = useMemo(() => {
+    try {
+      return getContractAddresses();
+    } catch {
+      return null;
+    }
+  }, []);
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => [token.symbol, ""])
+    )
+  );
+  const [reads, setReads] = useState<ChainReads>({ tokens: {} });
+  const [phase, setPhase] = useState<TransactionPhase>({ kind: "idle" });
+  const [mintedTokenId, setMintedTokenId] = useState<bigint | null>(null);
+  const [isReading, setIsReading] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const readSequence = useRef(0);
+  const valueSignature = ROBINHOOD_TESTNET_STOCK_TOKENS.map(
+    (token) => values[token.symbol] ?? ""
+  ).join("|");
+
+  const refresh = useCallback(async () => {
+    if (!addresses) return null;
+    const sequence = ++readSequence.current;
+    setIsReading(true);
+    const next = await readComposerChainState(
+      publicClient,
+      addresses,
+      walletAddress,
+      values
+    );
+    if (sequence === readSequence.current) {
+      setReads(next);
+      setIsReading(false);
+    }
+    return next;
+  }, [addresses, publicClient, walletAddress, values]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => void refresh(), 250);
+    return () => window.clearTimeout(timeout);
+  }, [refresh, valueSignature]);
+
+  const plan = useMemo(
+    () =>
+      buildPackPlan(inputRows(values, reads), reads.minPackNav, reads.poolMax),
+    [reads, values]
+  );
+
+  async function adapterForConnectedWallet() {
+    const wallet = wallets.find(
+      (candidate) =>
+        candidate.address.toLowerCase() === walletAddress.toLowerCase()
+    );
+    if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
+    const provider = await wallet.getEthereumProvider();
+    const walletClient = createWalletClient({
+      account: walletAddress,
+      chain: PAYMENT_CHAIN,
+      transport: custom(provider),
+    });
+    if (!addresses) throw new Error("Contract addresses are not configured");
+    return makeTransactionAdapter(
+      publicClient,
+      walletClient,
+      walletAddress,
+      addresses
+    );
+  }
+
+  async function onSubmit() {
+    if (!addresses || isBusy || mintedTokenId !== null) return;
+    setIsBusy(true);
+    setPhase({ kind: "idle" });
+    try {
+      const freshReads = await readComposerChainState(
+        publicClient,
+        addresses,
+        walletAddress,
+        values
+      );
+      setReads(freshReads);
+      const freshPlan = buildPackPlan(
+        inputRows(values, freshReads),
+        freshReads.minPackNav,
+        freshReads.poolMax
+      );
+      if (freshPlan.errors.length > 0) {
+        throw new Error(freshPlan.errors.join(". "));
+      }
+      const adapter = await adapterForConnectedWallet();
+      await createAndEnrollPack(freshPlan, adapter, setPhase, setMintedTokenId);
+      await refresh();
+    } catch (error) {
+      setPhase({
+        kind: "error",
+        message: errorMessage(error, "Pack creation failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function onRetryEnrollment() {
+    if (mintedTokenId === null || isBusy) return;
+    setIsBusy(true);
+    try {
+      const adapter = await adapterForConnectedWallet();
+      await enrollMintedPack(mintedTokenId, adapter, setPhase);
+      await refresh();
+    } catch (error) {
+      setPhase({
+        kind: "error",
+        message: errorMessage(error, "Pool enrollment failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <PackComposerView
+      walletAddress={walletAddress}
+      values={values}
+      reads={reads}
+      plan={plan}
+      phase={phase}
+      mintedTokenId={mintedTokenId}
+      isReading={isReading}
+      isBusy={isBusy}
+      configured={Boolean(addresses)}
+      onAmountChange={(symbol, value) => {
+        setValues((current) => ({ ...current, [symbol]: value }));
+        setReads((current) => ({
+          ...current,
+          tokens: {
+            ...current.tokens,
+            [symbol]: {
+              ...current.tokens[symbol],
+              quote: undefined,
+              quoteError: undefined,
+            },
+          },
+        }));
+      }}
+      onRefresh={() => void refresh()}
+      onSubmit={() => void onSubmit()}
+      onRetryEnrollment={() => void onRetryEnrollment()}
+      onComposeAnother={() => {
+        setValues(
+          Object.fromEntries(
+            ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => [token.symbol, ""])
+          )
+        );
+        setMintedTokenId(null);
+        setPhase({ kind: "idle" });
+      }}
+    />
+  );
+}
+
+export type { ChainReads, TokenRead, StockToken };

--- a/src/components/maker/pack-composer.ui.test.tsx
+++ b/src/components/maker/pack-composer.ui.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { maxUint256 } from "viem";
 
 import { buildPackPlan } from "@/lib/maker/pack-composer";
 import { PackComposerView, type ChainReads } from "./pack-composer";
@@ -68,6 +69,29 @@ describe("PackComposerView", () => {
     expect(html).toContain("$300.00");
     expect(html).toContain("Inside eligibility band");
     expect(html).toContain("Approvals required: AMZN");
+  });
+
+  it("contains long token metadata and labels max allowance as unlimited", () => {
+    const reads = {
+      ...READS,
+      tokens: {
+        AMZN: {
+          ...READS.tokens.AMZN,
+          balance: 123_456_789_012_345_678_901n,
+          allowance: maxUint256,
+        },
+      },
+    };
+    const html = renderView({ reads });
+
+    expect(html).toContain("Unlimited");
+    expect(html).toContain('title="Unlimited (max uint256)"');
+    expect(html).not.toContain(maxUint256.toString());
+    expect(html).toContain("123.456789…");
+    expect(html).toContain('title="123.456789012345678901"');
+    expect(html).toContain("overflow-hidden");
+    expect(html).toContain("sm:grid-cols-[5rem_minmax(0,1fr)_minmax(0,12rem)]");
+    expect(html).toContain("min-w-0 truncate tabular-nums");
   });
 
   it("shows confirmed mint and enrollment success", () => {

--- a/src/components/maker/pack-composer.ui.test.tsx
+++ b/src/components/maker/pack-composer.ui.test.tsx
@@ -1,0 +1,105 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { buildPackPlan } from "@/lib/maker/pack-composer";
+import { PackComposerView, type ChainReads } from "./pack-composer";
+
+const WALLET = "0x1234567890abcdef1234567890abcdef12345678" as const;
+const VALUES = { AMZN: "1", AMD: "", NFLX: "", PLTR: "", TSLA: "" };
+const READS: ChainReads = {
+  tokens: {
+    AMZN: {
+      balance: 2_000_000_000_000_000_000n,
+      allowance: 0n,
+      quote: 25_000_000_000_000_000_000n,
+    },
+  },
+  minPackNav: 20_000_000_000_000_000_000n,
+  poolMax: 300_000_000_000_000_000_000n,
+};
+
+function renderView(
+  overrides: Partial<Parameters<typeof PackComposerView>[0]> = {}
+) {
+  const rows = [
+    {
+      symbol: "AMZN",
+      address: "0x5884aD2f920c162CFBbACc88C9C51AA75eC09E02" as const,
+      decimals: 18,
+      value: VALUES.AMZN,
+      ...READS.tokens.AMZN,
+    },
+  ];
+  return renderToStaticMarkup(
+    <PackComposerView
+      walletAddress={WALLET}
+      values={VALUES}
+      reads={READS}
+      plan={buildPackPlan(rows, READS.minPackNav, READS.poolMax)}
+      phase={{ kind: "idle" }}
+      mintedTokenId={null}
+      isReading={false}
+      isBusy={false}
+      configured
+      onAmountChange={() => undefined}
+      onRefresh={() => undefined}
+      onSubmit={() => undefined}
+      onRetryEnrollment={() => undefined}
+      onComposeAnother={() => undefined}
+      {...overrides}
+    />
+  );
+}
+
+describe("PackComposerView", () => {
+  it("renders canonical Stock Tokens, inventory funding guidance, live band, and allowance plan", () => {
+    const html = renderView();
+
+    expect(html).toContain("Compose a Pack");
+    for (const symbol of ["AMZN", "AMD", "NFLX", "PLTR", "TSLA"]) {
+      expect(html).toContain(symbol);
+    }
+    expect(html).toContain("Starter Grant is MockUSD");
+    expect(html).toContain("does not fund Maker Stock Token inventory");
+    expect(html).toContain("https://faucet.testnet.chain.robinhood.com");
+    expect(html).toContain("Quoted basket NAV");
+    expect(html).toContain("$25.00");
+    expect(html).toContain("$20.00");
+    expect(html).toContain("$300.00");
+    expect(html).toContain("Inside eligibility band");
+    expect(html).toContain("Approvals required: AMZN");
+  });
+
+  it("shows confirmed mint and enrollment success", () => {
+    const html = renderView({
+      phase: { kind: "complete", tokenId: 42n },
+      mintedTokenId: 42n,
+    });
+
+    expect(html).toContain("Pack #42 minted and enrolled");
+    expect(html).toContain("[COMPOSE ANOTHER PACK]");
+    expect(html).not.toContain("RETRY POOL ENROLLMENT");
+  });
+
+  it("offers recoverable enrollment after a confirmed mint without suggesting rollback", () => {
+    const html = renderView({
+      phase: { kind: "error", message: "Transaction rejected" },
+      mintedTokenId: 77n,
+    });
+
+    expect(html).toContain("Pack #77 was confirmed on-chain");
+    expect(html).toContain("not rolled back and will not be reminted");
+    expect(html).toContain("[RETRY POOL ENROLLMENT]");
+  });
+
+  it("labels an accepted mint hash as pending instead of success", () => {
+    const html = renderView({
+      phase: { kind: "mint-pending", hash: `0x${"1".repeat(64)}` },
+      isBusy: true,
+    });
+
+    expect(html).toContain("Pack mint submitted — waiting for confirmation");
+    expect(html).toContain("View pending transaction");
+    expect(html).not.toContain("minted and enrolled");
+  });
+});

--- a/src/components/maker/pack-composer.ui.test.tsx
+++ b/src/components/maker/pack-composer.ui.test.tsx
@@ -94,6 +94,38 @@ describe("PackComposerView", () => {
     expect(html).toContain("min-w-0 truncate tabular-nums");
   });
 
+  it("shows a precise decoded quote failure", () => {
+    const reads: ChainReads = {
+      ...READS,
+      tokens: {
+        AMZN: {
+          balance: READS.tokens.AMZN!.balance,
+          allowance: READS.tokens.AMZN!.allowance,
+          quoteError: "Testnet price feed is paused",
+        },
+      },
+    };
+    const html = renderView({
+      reads,
+      plan: buildPackPlan(
+        [
+          {
+            symbol: "AMZN",
+            address: "0x5884aD2f920c162CFBbACc88C9C51AA75eC09E02",
+            decimals: 18,
+            value: "1",
+            ...reads.tokens.AMZN,
+          },
+        ],
+        reads.minPackNav,
+        reads.poolMax
+      ),
+    });
+
+    expect(html).toContain("Testnet price feed is paused");
+    expect(html).not.toContain("Quote unavailable or stale");
+  });
+
   it("shows confirmed mint and enrollment success", () => {
     const html = renderView({
       phase: { kind: "complete", tokenId: 42n },

--- a/src/components/maker/pack-lifecycle-actions.tsx
+++ b/src/components/maker/pack-lifecycle-actions.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useWallets } from "@privy-io/react-auth";
 import {
   PAYMENT_CHAIN,
   ROBINHOOD_TESTNET_STOCK_TOKENS,
@@ -13,16 +12,10 @@ import {
   stockSymbolForAddress,
   txExplorerUrl,
 } from "@margin-call/shared";
-import {
-  createWalletClient,
-  custom,
-  formatUnits,
-  type Address,
-  type Hash,
-  type PublicClient,
-} from "viem";
+import { formatUnits, type Address, type Hash, type PublicClient } from "viem";
 
 import { GameButton } from "@/components/ui/game-button";
+import { useMakerTransactionClient } from "@/hooks/use-maker-transaction-client";
 import { getContractAddresses } from "@/lib/contracts/addresses";
 import {
   buildTopUpPlan,
@@ -40,6 +33,14 @@ import {
   type TopUpTransactionAdapter,
 } from "@/lib/maker/pack-lifecycle";
 import { parseTokenAmount } from "@/lib/maker/pack-composer";
+import {
+  PendingTransactionError,
+  createBrowserJournalStorage,
+  ensureWorkflow,
+  listWorkflows,
+  requestFingerprint,
+  type LifecycleWorkflow,
+} from "@/lib/maker/transaction-journal";
 import { formatWadUsd } from "@/lib/pool/nav-distribution";
 
 type LifecycleAddresses = NonNullable<ReturnType<typeof getContractAddresses>>;
@@ -110,9 +111,37 @@ function phaseHash(phase: TopUpPhase | RedemptionPhase): Hash | null {
     case "exit-pending":
     case "redeem-pending":
       return phase.hash;
+    case "error":
+      return phase.hash ?? null;
     default:
       return null;
   }
+}
+
+function savedTopUpPlan(
+  workflow: LifecycleWorkflow
+): Pick<TopUpPlan, "additions" | "approvals"> {
+  const raw = workflow.context.plan;
+  if (typeof raw !== "string") throw new Error("Saved top-up plan is missing");
+  const saved = JSON.parse(raw) as Array<{
+    symbol: string;
+    address: Address;
+    amount: string;
+    allowance: string;
+    quote: string;
+    needsApproval: boolean;
+  }>;
+  const additions = saved.map((token) => ({
+    symbol: token.symbol,
+    address: token.address,
+    amount: BigInt(token.amount),
+    allowance: BigInt(token.allowance),
+    quote: BigInt(token.quote),
+  }));
+  return {
+    additions,
+    approvals: additions.filter((_, index) => saved[index]!.needsApproval),
+  };
 }
 
 function topUpInputs(
@@ -548,8 +577,10 @@ export function PackLifecycleActions({
   tokenId: number;
   walletAddress: Address;
 }) {
-  const { wallets } = useWallets();
   const publicClient = useMemo(() => createRobinhoodPublicClient(), []);
+  const { walletReady, getWalletClient, waitForReceipt } =
+    useMakerTransactionClient(walletAddress, publicClient);
+  const journalStorage = useMemo(() => createBrowserJournalStorage(), []);
   const addresses = useMemo(() => {
     try {
       return getContractAddresses();
@@ -574,6 +605,7 @@ export function PackLifecycleActions({
   const [isReading, setIsReading] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const readSequence = useRef(0);
+  const recoveryStarted = useRef(false);
   const valueSignature = ROBINHOOD_TESTNET_STOCK_TOKENS.map(
     (token) => values[token.symbol] ?? ""
   ).join("|");
@@ -618,20 +650,8 @@ export function PackLifecycleActions({
     topUp: TopUpTransactionAdapter;
     redemption: RedemptionTransactionAdapter;
   }> {
-    const wallet = wallets.find(
-      (candidate) =>
-        candidate.address.toLowerCase() === walletAddress.toLowerCase()
-    );
-    if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
     if (!addresses) throw new Error("Contract addresses are not configured");
-    const provider = await wallet.getEthereumProvider();
-    const walletClient = createWalletClient({
-      account: walletAddress,
-      chain: PAYMENT_CHAIN,
-      transport: custom(provider),
-    });
-    const waitForReceipt = (hash: Hash) =>
-      publicClient.waitForTransactionReceipt({ hash });
+    const walletClient = await getWalletClient();
 
     return {
       topUp: {
@@ -688,11 +708,113 @@ export function PackLifecycleActions({
     };
   }
 
+  async function recoverTopUp(workflow: LifecycleWorkflow) {
+    const { topUp } = await adaptersForConnectedWallet();
+    const journal = { storage: journalStorage, workflowKey: workflow.key };
+    if (workflow.completed.topUp || workflow.current?.step === "syncPackNav") {
+      setTopUpConfirmed(true);
+      await syncConfirmedTopUp(packId, topUp, setTopUpPhase, journal);
+    } else {
+      await topUpAndSyncPack(
+        packId,
+        savedTopUpPlan(workflow),
+        topUp,
+        setTopUpPhase,
+        () => setTopUpConfirmed(true),
+        journal
+      );
+    }
+    setTopUpConfirmed(false);
+    journalStorage.remove(workflow.key);
+  }
+
+  async function recoverRedemption(workflow: LifecycleWorkflow) {
+    const { redemption } = await adaptersForConnectedWallet();
+    const journal = { storage: journalStorage, workflowKey: workflow.key };
+    if (
+      workflow.completed.exitPool ||
+      workflow.current?.step === "delistAndRedeem"
+    ) {
+      setExitConfirmed(true);
+      await redeemExitedPack(packId, redemption, setRedemptionPhase, journal);
+    } else {
+      // If an exit hash is accepted, force that exact step through receipt
+      // reconciliation even when a fresh state read already sees it exited.
+      const reconcilingExit = workflow.current?.step === "exitPool";
+      const fresh = await readLifecycleState(
+        publicClient,
+        addresses!,
+        walletAddress,
+        packId,
+        values
+      );
+      await exitAndRedeemPack(
+        packId,
+        {
+          isListed: reconcilingExit ? true : fresh.isListed === true,
+          isResting: reconcilingExit ? true : fresh.isResting === true,
+        },
+        redemption,
+        setRedemptionPhase,
+        () => setExitConfirmed(true),
+        journal
+      );
+    }
+    setExitConfirmed(false);
+    journalStorage.remove(workflow.key);
+  }
+
+  useEffect(() => {
+    if (recoveryStarted.current || !addresses || !walletReady) return;
+    const workflows = listWorkflows(
+      journalStorage,
+      PAYMENT_CHAIN.id,
+      walletAddress
+    ).filter((workflow) => workflow.context.tokenId === packId.toString());
+    const workflow = workflows.find(
+      (candidate) =>
+        candidate.kind === "top-up" || candidate.kind === "redemption"
+    );
+    if (!workflow) return;
+    recoveryStarted.current = true;
+    setIsOpen(true);
+    setIsBusy(true);
+    const recover =
+      workflow.kind === "top-up"
+        ? recoverTopUp(workflow)
+        : recoverRedemption(workflow);
+    void recover
+      .then(() => refresh())
+      .catch((error) => {
+        const phase = {
+          kind: "error" as const,
+          message: errorMessage(error, "Lifecycle recovery needs attention"),
+          hash:
+            error instanceof PendingTransactionError ? error.hash : undefined,
+        };
+        if (workflow.kind === "top-up") setTopUpPhase(phase);
+        else setRedemptionPhase(phase);
+      })
+      .finally(() => setIsBusy(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addresses, journalStorage, packId, walletAddress, walletReady]);
+
   async function onTopUp() {
     if (!addresses || isBusy || topUpConfirmed) return;
     setIsBusy(true);
     setTopUpPhase({ kind: "idle" });
     try {
+      const existing = listWorkflows(
+        journalStorage,
+        PAYMENT_CHAIN.id,
+        walletAddress,
+        "top-up"
+      ).find((candidate) => candidate.context.tokenId === packId.toString());
+      if (existing) {
+        await recoverTopUp(existing);
+        await refresh();
+        return;
+      }
       const freshReads = await readLifecycleState(
         publicClient,
         addresses,
@@ -715,9 +837,40 @@ export function PackLifecycleActions({
         throw new Error(freshPlan.errors.join(". "));
       }
       const { topUp } = await adaptersForConnectedWallet();
-      await topUpAndSyncPack(packId, freshPlan, topUp, setTopUpPhase, () =>
-        setTopUpConfirmed(true)
+      const fingerprint = requestFingerprint([
+        packId,
+        ...freshPlan.additions.flatMap((token) => [
+          token.address,
+          token.amount,
+        ]),
+      ]);
+      const workflow = ensureWorkflow(journalStorage, {
+        chainId: PAYMENT_CHAIN.id,
+        wallet: walletAddress,
+        kind: "top-up",
+        requestFingerprint: fingerprint,
+        context: {
+          tokenId: packId.toString(),
+          plan: JSON.stringify(
+            freshPlan.additions.map((token) => ({
+              ...token,
+              amount: token.amount.toString(),
+              allowance: token.allowance.toString(),
+              quote: token.quote.toString(),
+              needsApproval: token.allowance < token.amount,
+            }))
+          ),
+        },
+      });
+      await topUpAndSyncPack(
+        packId,
+        freshPlan,
+        topUp,
+        setTopUpPhase,
+        () => setTopUpConfirmed(true),
+        { storage: journalStorage, workflowKey: workflow.key }
       );
+      journalStorage.remove(workflow.key);
       setTopUpConfirmed(false);
       setValues(
         Object.fromEntries(
@@ -729,6 +882,7 @@ export function PackLifecycleActions({
       setTopUpPhase({
         kind: "error",
         message: errorMessage(error, "Pack top-up failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);
@@ -740,7 +894,18 @@ export function PackLifecycleActions({
     setIsBusy(true);
     try {
       const { topUp } = await adaptersForConnectedWallet();
-      await syncConfirmedTopUp(packId, topUp, setTopUpPhase);
+      const workflow = listWorkflows(
+        journalStorage,
+        PAYMENT_CHAIN.id,
+        walletAddress,
+        "top-up"
+      ).find((candidate) => candidate.context.tokenId === packId.toString());
+      if (!workflow) throw new Error("Saved top-up workflow is unavailable");
+      await syncConfirmedTopUp(packId, topUp, setTopUpPhase, {
+        storage: journalStorage,
+        workflowKey: workflow.key,
+      });
+      journalStorage.remove(workflow.key);
       setTopUpConfirmed(false);
       setValues(
         Object.fromEntries(
@@ -752,6 +917,7 @@ export function PackLifecycleActions({
       setTopUpPhase({
         kind: "error",
         message: errorMessage(error, "Pack NAV sync failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);
@@ -779,6 +945,13 @@ export function PackLifecycleActions({
         throw new Error("Live Pack and basket state unavailable");
       }
       const { redemption } = await adaptersForConnectedWallet();
+      const workflow = ensureWorkflow(journalStorage, {
+        chainId: PAYMENT_CHAIN.id,
+        wallet: walletAddress,
+        kind: "redemption",
+        requestFingerprint: requestFingerprint([packId]),
+        context: { tokenId: packId.toString() },
+      });
       await exitAndRedeemPack(
         packId,
         {
@@ -787,14 +960,17 @@ export function PackLifecycleActions({
         },
         redemption,
         setRedemptionPhase,
-        () => setExitConfirmed(true)
+        () => setExitConfirmed(true),
+        { storage: journalStorage, workflowKey: workflow.key }
       );
+      journalStorage.remove(workflow.key);
       setExitConfirmed(false);
       await refresh();
     } catch (error) {
       setRedemptionPhase({
         kind: "error",
         message: errorMessage(error, "Pack redemption failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);
@@ -806,13 +982,26 @@ export function PackLifecycleActions({
     setIsBusy(true);
     try {
       const { redemption } = await adaptersForConnectedWallet();
-      await redeemExitedPack(packId, redemption, setRedemptionPhase);
+      const workflow = listWorkflows(
+        journalStorage,
+        PAYMENT_CHAIN.id,
+        walletAddress,
+        "redemption"
+      ).find((candidate) => candidate.context.tokenId === packId.toString());
+      if (!workflow)
+        throw new Error("Saved redemption workflow is unavailable");
+      await redeemExitedPack(packId, redemption, setRedemptionPhase, {
+        storage: journalStorage,
+        workflowKey: workflow.key,
+      });
+      journalStorage.remove(workflow.key);
       setExitConfirmed(false);
       await refresh();
     } catch (error) {
       setRedemptionPhase({
         kind: "error",
         message: errorMessage(error, "Pack redemption failed"),
+        hash: error instanceof PendingTransactionError ? error.hash : undefined,
       });
     } finally {
       setIsBusy(false);

--- a/src/components/maker/pack-lifecycle-actions.tsx
+++ b/src/components/maker/pack-lifecycle-actions.tsx
@@ -1,0 +1,869 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useWallets } from "@privy-io/react-auth";
+import {
+  PAYMENT_CHAIN,
+  ROBINHOOD_TESTNET_STOCK_TOKENS,
+  assetRegistryAbi,
+  createRobinhoodPublicClient,
+  erc20Abi,
+  packCustodyAbi,
+  ripEngineAbi,
+  stockSymbolForAddress,
+  txExplorerUrl,
+} from "@margin-call/shared";
+import {
+  createWalletClient,
+  custom,
+  formatUnits,
+  type Address,
+  type Hash,
+  type PublicClient,
+} from "viem";
+
+import { GameButton } from "@/components/ui/game-button";
+import { getContractAddresses } from "@/lib/contracts/addresses";
+import {
+  buildTopUpPlan,
+  exitAndRedeemPack,
+  redeemExitedPack,
+  redemptionPhaseMessage,
+  syncConfirmedTopUp,
+  topUpAndSyncPack,
+  topUpPhaseMessage,
+  type RedemptionPhase,
+  type RedemptionTransactionAdapter,
+  type TopUpPhase,
+  type TopUpPlan,
+  type TopUpTokenInput,
+  type TopUpTransactionAdapter,
+} from "@/lib/maker/pack-lifecycle";
+import { parseTokenAmount } from "@/lib/maker/pack-composer";
+import { formatWadUsd } from "@/lib/pool/nav-distribution";
+
+type LifecycleAddresses = NonNullable<ReturnType<typeof getContractAddresses>>;
+
+type TokenRead = {
+  approved?: boolean;
+  balance?: bigint;
+  allowance?: bigint;
+  quote?: bigint;
+  quoteError?: string;
+};
+
+export type PackLifecycleReads = {
+  isListed?: boolean;
+  isResting?: boolean;
+  basket?: Array<{ asset: Address; amount: bigint }>;
+  currentNav?: bigint;
+  minPackNav?: bigint;
+  poolMax?: bigint;
+  tokens: Record<string, TokenRead>;
+  basketError?: string;
+  error?: string;
+};
+
+type ViewProps = {
+  tokenId: bigint;
+  values: Record<string, string>;
+  reads: PackLifecycleReads;
+  plan: TopUpPlan;
+  topUpPhase: TopUpPhase;
+  redemptionPhase: RedemptionPhase;
+  topUpConfirmed: boolean;
+  exitConfirmed: boolean;
+  isReading: boolean;
+  isBusy: boolean;
+  configured: boolean;
+  onAmountChange: (symbol: string, value: string) => void;
+  onRefresh: () => void;
+  onTopUp: () => void;
+  onRetrySync: () => void;
+  onRedeem: () => void;
+  onRetryRedeem: () => void;
+};
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    if (/reject|denied|declined/i.test(error.message)) {
+      return `Transaction rejected: ${error.message}`;
+    }
+    return error.message;
+  }
+  return fallback;
+}
+
+function formatBalance(value: bigint | undefined, decimals: number): string {
+  if (value === undefined) return "Unavailable";
+  const formatted = formatUnits(value, decimals);
+  const [whole, fraction = ""] = formatted.split(".");
+  const compactFraction = fraction.slice(0, 6).replace(/0+$/, "");
+  return compactFraction ? `${whole}.${compactFraction}` : whole;
+}
+
+function phaseHash(phase: TopUpPhase | RedemptionPhase): Hash | null {
+  switch (phase.kind) {
+    case "approval-pending":
+    case "top-up-pending":
+    case "sync-pending":
+    case "exit-pending":
+    case "redeem-pending":
+      return phase.hash;
+    default:
+      return null;
+  }
+}
+
+function topUpInputs(
+  values: Record<string, string>,
+  reads: PackLifecycleReads
+): TopUpTokenInput[] {
+  return ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => ({
+    ...token,
+    value: values[token.symbol] ?? "",
+    ...reads.tokens[token.symbol],
+  }));
+}
+
+async function readLifecycleState(
+  publicClient: PublicClient,
+  addresses: LifecycleAddresses,
+  walletAddress: Address,
+  tokenId: bigint,
+  values: Record<string, string>
+): Promise<PackLifecycleReads> {
+  const tokenReads: Record<string, TokenRead> = {};
+
+  try {
+    const [isListed, isResting, basket, approvedAssets, band, walletReads] =
+      await Promise.all([
+        publicClient.readContract({
+          address: addresses.packCustody,
+          abi: packCustodyAbi,
+          functionName: "isListed",
+          args: [tokenId],
+        }),
+        publicClient.readContract({
+          address: addresses.ripEngine,
+          abi: ripEngineAbi,
+          functionName: "isResting",
+          args: [tokenId],
+        }),
+        publicClient.readContract({
+          address: addresses.packCustody,
+          abi: packCustodyAbi,
+          functionName: "basketOf",
+          args: [tokenId],
+        }),
+        publicClient.readContract({
+          address: addresses.packCustody,
+          abi: packCustodyAbi,
+          functionName: "whitelistedAssets",
+        }),
+        Promise.all([
+          publicClient.readContract({
+            address: addresses.assetRegistry,
+            abi: assetRegistryAbi,
+            functionName: "minPackNav",
+          }),
+          publicClient.readContract({
+            address: addresses.assetRegistry,
+            abi: assetRegistryAbi,
+            functionName: "poolMax",
+          }),
+        ]),
+        Promise.all(
+          ROBINHOOD_TESTNET_STOCK_TOKENS.map(async (token) => {
+            const [balance, allowance] = await Promise.all([
+              publicClient.readContract({
+                address: token.address,
+                abi: erc20Abi,
+                functionName: "balanceOf",
+                args: [walletAddress],
+              }),
+              publicClient.readContract({
+                address: token.address,
+                abi: erc20Abi,
+                functionName: "allowance",
+                args: [walletAddress, addresses.packCustody],
+              }),
+            ]);
+            return { token, balance, allowance };
+          })
+        ),
+      ]);
+
+    const approved = new Set(
+      approvedAssets.map((address) => address.toLowerCase())
+    );
+    for (const { token, balance, allowance } of walletReads) {
+      tokenReads[token.symbol] = {
+        approved: approved.has(token.address.toLowerCase()),
+        balance,
+        allowance,
+      };
+    }
+
+    const normalizedBasket = basket.map((entry) => ({
+      asset: entry.asset,
+      amount: entry.amount,
+    }));
+    let currentNav: bigint | undefined;
+    let basketError: string | undefined;
+    try {
+      const quotes = await Promise.all(
+        normalizedBasket.map((entry) =>
+          publicClient.readContract({
+            address: addresses.assetRegistry,
+            abi: assetRegistryAbi,
+            functionName: "quote",
+            args: [entry.asset, entry.amount],
+          })
+        )
+      );
+      currentNav = quotes.reduce((sum, quote) => sum + quote, 0n);
+    } catch {
+      basketError = "Existing basket quote unavailable or stale";
+    }
+
+    await Promise.all(
+      ROBINHOOD_TESTNET_STOCK_TOKENS.map(async (token) => {
+        const value = values[token.symbol] ?? "";
+        if (!value.trim()) return;
+        const parsed = parseTokenAmount(value, token.decimals);
+        if (!parsed.ok) return;
+        try {
+          tokenReads[token.symbol].quote = await publicClient.readContract({
+            address: addresses.assetRegistry,
+            abi: assetRegistryAbi,
+            functionName: "quote",
+            args: [token.address, parsed.amount],
+          });
+        } catch {
+          tokenReads[token.symbol].quoteError =
+            "live quote unavailable or stale";
+        }
+      })
+    );
+
+    return {
+      isListed,
+      isResting,
+      basket: normalizedBasket,
+      currentNav,
+      minPackNav: band[0],
+      poolMax: band[1],
+      tokens: tokenReads,
+      basketError,
+    };
+  } catch (error) {
+    return {
+      tokens: tokenReads,
+      error: errorMessage(error, "Pack chain reads unavailable"),
+    };
+  }
+}
+
+export function PackLifecycleView({
+  tokenId,
+  values,
+  reads,
+  plan,
+  topUpPhase,
+  redemptionPhase,
+  topUpConfirmed,
+  exitConfirmed,
+  isReading,
+  isBusy,
+  configured,
+  onAmountChange,
+  onRefresh,
+  onTopUp,
+  onRetrySync,
+  onRedeem,
+  onRetryRedeem,
+}: ViewProps) {
+  const topUpHash = phaseHash(topUpPhase);
+  const redemptionHash = phaseHash(redemptionPhase);
+  const showTopUpErrors = Object.values(values).some((value) => value.trim());
+  const canTopUp = reads.isListed === true && reads.isResting === true;
+  const canRedeem = reads.isListed === true;
+
+  return (
+    <div className="mt-3 border border-[var(--t-divider)]/50 bg-[var(--t-panel)]/30 p-3">
+      {!configured ? (
+        <p role="alert" className="text-xs text-[var(--t-red)]">
+          Robinhood testnet contract addresses are not configured.
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-2 text-xs">
+            <span className="text-[var(--t-muted)]">Live contract state</span>
+            <span className="font-bold uppercase text-[var(--t-text)]">
+              {reads.isListed === undefined
+                ? "Reading…"
+                : reads.isListed
+                  ? reads.isResting
+                    ? "Listed · Resting"
+                    : "Listed · Exited"
+                  : "Not listed"}
+            </span>
+          </div>
+
+          {reads.basket && reads.basket.length > 0 && (
+            <p className="mt-2 text-xs text-[var(--t-muted)]">
+              Live basket:{" "}
+              {reads.basket
+                .map((entry) => {
+                  const symbol =
+                    stockSymbolForAddress(entry.asset) ??
+                    `${entry.asset.slice(0, 6)}…${entry.asset.slice(-4)}`;
+                  return `${symbol} ${formatBalance(entry.amount, 18)}`;
+                })
+                .join(" · ")}
+            </p>
+          )}
+
+          {canTopUp && !topUpConfirmed && (
+            <div className="mt-4 border-t border-[var(--t-divider)]/40 pt-4">
+              <h4 className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+                Additions-only top-up
+              </h4>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => {
+                  const tokenRead = reads.tokens[token.symbol] ?? {};
+                  return (
+                    <label key={token.address} className="text-xs">
+                      <span className="flex justify-between gap-2 text-[var(--t-muted)]">
+                        <strong className="text-[var(--t-text)]">
+                          {token.symbol}
+                        </strong>
+                        <span>
+                          Balance{" "}
+                          {formatBalance(tokenRead.balance, token.decimals)}
+                        </span>
+                      </span>
+                      <input
+                        inputMode="decimal"
+                        autoComplete="off"
+                        placeholder="0"
+                        value={values[token.symbol] ?? ""}
+                        onChange={(event) =>
+                          onAmountChange(token.symbol, event.target.value)
+                        }
+                        disabled={isBusy || tokenRead.approved === false}
+                        className="mt-1 min-h-10 w-full border border-[var(--t-divider)] bg-[var(--t-bg)] px-3 text-[var(--t-text)] outline-none focus:border-[var(--t-accent)] disabled:opacity-50"
+                      />
+                      {tokenRead.approved === false && (
+                        <span className="mt-1 block text-[var(--t-red)]">
+                          Not currently approved
+                        </span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+
+              <div className="mt-3 text-xs text-[var(--t-muted)]">
+                <p>
+                  Live NAV {formatWadUsd(plan.currentNav.toString())} →
+                  projected{" "}
+                  <strong className="text-[var(--t-accent)]">
+                    {formatWadUsd(plan.projectedNav.toString())}
+                  </strong>
+                </p>
+                <p
+                  className={
+                    plan.eligible
+                      ? "text-[var(--t-green)]"
+                      : "text-[var(--t-red)]"
+                  }
+                >
+                  {plan.eligible
+                    ? "Projected Pack remains eligible"
+                    : "Projected Pack is not eligible"}
+                </p>
+                <p>
+                  {plan.approvals.length
+                    ? `Approvals required: ${plan.approvals.map((token) => token.symbol).join(", ")}`
+                    : "No token approvals currently required."}
+                </p>
+              </div>
+
+              {showTopUpErrors && plan.errors.length > 0 && (
+                <ul className="mt-2 space-y-1 text-xs text-[var(--t-red)]">
+                  {plan.errors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              )}
+
+              <GameButton
+                className="mt-3"
+                onClick={onTopUp}
+                disabled={isBusy || isReading || plan.errors.length > 0}
+                size="sm"
+              >
+                [TOP UP + SYNC NAV]
+              </GameButton>
+              <p
+                role={topUpPhase.kind === "error" ? "alert" : "status"}
+                className={`mt-2 text-xs ${
+                  topUpPhase.kind === "error"
+                    ? "text-[var(--t-red)]"
+                    : topUpPhase.kind === "complete"
+                      ? "text-[var(--t-green)]"
+                      : "text-[var(--t-muted)]"
+                }`}
+              >
+                {topUpPhaseMessage(topUpPhase)}
+              </p>
+              {topUpHash && (
+                <a
+                  className="text-xs text-[var(--t-accent)] underline underline-offset-4"
+                  href={txExplorerUrl(topUpHash)}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  View pending transaction
+                </a>
+              )}
+            </div>
+          )}
+
+          {topUpConfirmed && topUpPhase.kind === "error" && (
+            <div className="mt-4 border border-[var(--t-amber)]/60 bg-[var(--t-accent-soft)] p-3">
+              <p className="text-xs text-[var(--t-amber)]">
+                Pack #{tokenId.toString()} top-up confirmed on-chain. It will
+                not be repeated; only the NAV sync needs recovery.
+              </p>
+              <GameButton
+                className="mt-2"
+                onClick={onRetrySync}
+                disabled={isBusy}
+                variant="secondary"
+                size="sm"
+              >
+                [RETRY NAV SYNC]
+              </GameButton>
+            </div>
+          )}
+
+          <div className="mt-4 border-t border-[var(--t-divider)]/40 pt-4">
+            <h4 className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+              Delist and redeem
+            </h4>
+            <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">
+              Returns the entire live basket and burns this Pack. The protocol
+              charges zero redemption fee; your wallet still pays Robinhood
+              Chain gas. A resting Pack exits first so pending Acquisition Fees
+              crystallize.
+            </p>
+            <GameButton
+              className="mt-3"
+              onClick={onRedeem}
+              disabled={isBusy || isReading || !canRedeem || exitConfirmed}
+              variant="secondary"
+              size="sm"
+            >
+              [DELIST + REDEEM]
+            </GameButton>
+            {!canRedeem && reads.isListed !== undefined && (
+              <p className="mt-2 text-xs text-[var(--t-muted)]">
+                This Pack is no longer listed and cannot use Maker redemption.
+              </p>
+            )}
+            <p
+              role={redemptionPhase.kind === "error" ? "alert" : "status"}
+              className={`mt-2 text-xs ${
+                redemptionPhase.kind === "error"
+                  ? "text-[var(--t-red)]"
+                  : redemptionPhase.kind === "complete"
+                    ? "text-[var(--t-green)]"
+                    : "text-[var(--t-muted)]"
+              }`}
+            >
+              {redemptionPhaseMessage(redemptionPhase)}
+            </p>
+            {redemptionHash && (
+              <a
+                className="text-xs text-[var(--t-accent)] underline underline-offset-4"
+                href={txExplorerUrl(redemptionHash)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                View pending transaction
+              </a>
+            )}
+          </div>
+
+          {exitConfirmed && redemptionPhase.kind === "error" && (
+            <div className="mt-4 border border-[var(--t-amber)]/60 bg-[var(--t-accent-soft)] p-3">
+              <p className="text-xs text-[var(--t-amber)]">
+                Pack #{tokenId.toString()} pool exit confirmed on-chain. It will
+                not be repeated; only redemption needs recovery.
+              </p>
+              <GameButton
+                className="mt-2"
+                onClick={onRetryRedeem}
+                disabled={isBusy}
+                variant="secondary"
+                size="sm"
+              >
+                [RETRY REDEMPTION]
+              </GameButton>
+            </div>
+          )}
+
+          {isReading && (
+            <p className="mt-3 text-xs text-[var(--t-muted)]">
+              Refreshing live Pack, basket, token, quote, and eligibility data…
+            </p>
+          )}
+          {reads.error && (
+            <p role="alert" className="mt-3 text-xs text-[var(--t-red)]">
+              Chain reads unavailable: {reads.error}
+            </p>
+          )}
+          <GameButton
+            className="mt-3"
+            onClick={onRefresh}
+            disabled={isBusy || isReading}
+            variant="secondary"
+            size="sm"
+          >
+            [REFRESH LIVE STATE]
+          </GameButton>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function PackLifecycleActions({
+  tokenId,
+  walletAddress,
+}: {
+  tokenId: number;
+  walletAddress: Address;
+}) {
+  const { wallets } = useWallets();
+  const publicClient = useMemo(() => createRobinhoodPublicClient(), []);
+  const addresses = useMemo(() => {
+    try {
+      return getContractAddresses();
+    } catch {
+      return null;
+    }
+  }, []);
+  const packId = BigInt(tokenId);
+  const [isOpen, setIsOpen] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => [token.symbol, ""])
+    )
+  );
+  const [reads, setReads] = useState<PackLifecycleReads>({ tokens: {} });
+  const [topUpPhase, setTopUpPhase] = useState<TopUpPhase>({ kind: "idle" });
+  const [redemptionPhase, setRedemptionPhase] = useState<RedemptionPhase>({
+    kind: "idle",
+  });
+  const [topUpConfirmed, setTopUpConfirmed] = useState(false);
+  const [exitConfirmed, setExitConfirmed] = useState(false);
+  const [isReading, setIsReading] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const readSequence = useRef(0);
+  const valueSignature = ROBINHOOD_TESTNET_STOCK_TOKENS.map(
+    (token) => values[token.symbol] ?? ""
+  ).join("|");
+
+  const refresh = useCallback(async () => {
+    if (!addresses || !isOpen) return null;
+    const sequence = ++readSequence.current;
+    setIsReading(true);
+    const next = await readLifecycleState(
+      publicClient,
+      addresses,
+      walletAddress,
+      packId,
+      values
+    );
+    if (sequence === readSequence.current) {
+      setReads(next);
+      setIsReading(false);
+    }
+    return next;
+  }, [addresses, isOpen, packId, publicClient, values, walletAddress]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const timeout = window.setTimeout(() => void refresh(), 250);
+    return () => window.clearTimeout(timeout);
+  }, [isOpen, refresh, valueSignature]);
+
+  const plan = useMemo(
+    () =>
+      buildTopUpPlan(
+        topUpInputs(values, reads),
+        reads.currentNav,
+        reads.minPackNav,
+        reads.poolMax,
+        reads.basketError
+      ),
+    [reads, values]
+  );
+
+  async function adaptersForConnectedWallet(): Promise<{
+    topUp: TopUpTransactionAdapter;
+    redemption: RedemptionTransactionAdapter;
+  }> {
+    const wallet = wallets.find(
+      (candidate) =>
+        candidate.address.toLowerCase() === walletAddress.toLowerCase()
+    );
+    if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
+    if (!addresses) throw new Error("Contract addresses are not configured");
+    const provider = await wallet.getEthereumProvider();
+    const walletClient = createWalletClient({
+      account: walletAddress,
+      chain: PAYMENT_CHAIN,
+      transport: custom(provider),
+    });
+    const waitForReceipt = (hash: Hash) =>
+      publicClient.waitForTransactionReceipt({ hash });
+
+    return {
+      topUp: {
+        approve: (token, amount) =>
+          walletClient.writeContract({
+            account: walletAddress,
+            chain: PAYMENT_CHAIN,
+            address: token,
+            abi: erc20Abi,
+            functionName: "approve",
+            args: [addresses.packCustody, amount],
+          }),
+        topUp: (id, assets, amounts) =>
+          walletClient.writeContract({
+            account: walletAddress,
+            chain: PAYMENT_CHAIN,
+            address: addresses.packCustody,
+            abi: packCustodyAbi,
+            functionName: "topUp",
+            args: [id, assets, amounts],
+          }),
+        syncPackNav: (id) =>
+          walletClient.writeContract({
+            account: walletAddress,
+            chain: PAYMENT_CHAIN,
+            address: addresses.ripEngine,
+            abi: ripEngineAbi,
+            functionName: "syncPackNav",
+            args: [id],
+          }),
+        waitForReceipt,
+      },
+      redemption: {
+        exitPool: (id) =>
+          walletClient.writeContract({
+            account: walletAddress,
+            chain: PAYMENT_CHAIN,
+            address: addresses.ripEngine,
+            abi: ripEngineAbi,
+            functionName: "exitPool",
+            args: [id],
+          }),
+        delistAndRedeem: (id) =>
+          walletClient.writeContract({
+            account: walletAddress,
+            chain: PAYMENT_CHAIN,
+            address: addresses.packCustody,
+            abi: packCustodyAbi,
+            functionName: "delistAndRedeem",
+            args: [id],
+          }),
+        waitForReceipt,
+      },
+    };
+  }
+
+  async function onTopUp() {
+    if (!addresses || isBusy || topUpConfirmed) return;
+    setIsBusy(true);
+    setTopUpPhase({ kind: "idle" });
+    try {
+      const freshReads = await readLifecycleState(
+        publicClient,
+        addresses,
+        walletAddress,
+        packId,
+        values
+      );
+      setReads(freshReads);
+      if (freshReads.isListed !== true || freshReads.isResting !== true) {
+        throw new Error("Pack must be live, listed, and resting to top up");
+      }
+      const freshPlan = buildTopUpPlan(
+        topUpInputs(values, freshReads),
+        freshReads.currentNav,
+        freshReads.minPackNav,
+        freshReads.poolMax,
+        freshReads.basketError
+      );
+      if (freshPlan.errors.length > 0) {
+        throw new Error(freshPlan.errors.join(". "));
+      }
+      const { topUp } = await adaptersForConnectedWallet();
+      await topUpAndSyncPack(packId, freshPlan, topUp, setTopUpPhase, () =>
+        setTopUpConfirmed(true)
+      );
+      setTopUpConfirmed(false);
+      setValues(
+        Object.fromEntries(
+          ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => [token.symbol, ""])
+        )
+      );
+      await refresh();
+    } catch (error) {
+      setTopUpPhase({
+        kind: "error",
+        message: errorMessage(error, "Pack top-up failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function onRetrySync() {
+    if (!topUpConfirmed || isBusy) return;
+    setIsBusy(true);
+    try {
+      const { topUp } = await adaptersForConnectedWallet();
+      await syncConfirmedTopUp(packId, topUp, setTopUpPhase);
+      setTopUpConfirmed(false);
+      setValues(
+        Object.fromEntries(
+          ROBINHOOD_TESTNET_STOCK_TOKENS.map((token) => [token.symbol, ""])
+        )
+      );
+      await refresh();
+    } catch (error) {
+      setTopUpPhase({
+        kind: "error",
+        message: errorMessage(error, "Pack NAV sync failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function onRedeem() {
+    if (!addresses || isBusy || exitConfirmed) return;
+    setIsBusy(true);
+    setRedemptionPhase({ kind: "idle" });
+    try {
+      const freshReads = await readLifecycleState(
+        publicClient,
+        addresses,
+        walletAddress,
+        packId,
+        values
+      );
+      setReads(freshReads);
+      if (
+        freshReads.isListed === undefined ||
+        freshReads.isResting === undefined ||
+        freshReads.basket === undefined
+      ) {
+        throw new Error("Live Pack and basket state unavailable");
+      }
+      const { redemption } = await adaptersForConnectedWallet();
+      await exitAndRedeemPack(
+        packId,
+        {
+          isListed: freshReads.isListed,
+          isResting: freshReads.isResting,
+        },
+        redemption,
+        setRedemptionPhase,
+        () => setExitConfirmed(true)
+      );
+      setExitConfirmed(false);
+      await refresh();
+    } catch (error) {
+      setRedemptionPhase({
+        kind: "error",
+        message: errorMessage(error, "Pack redemption failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function onRetryRedeem() {
+    if (!exitConfirmed || isBusy) return;
+    setIsBusy(true);
+    try {
+      const { redemption } = await adaptersForConnectedWallet();
+      await redeemExitedPack(packId, redemption, setRedemptionPhase);
+      setExitConfirmed(false);
+      await refresh();
+    } catch (error) {
+      setRedemptionPhase({
+        kind: "error",
+        message: errorMessage(error, "Pack redemption failed"),
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  if (!isOpen) {
+    return (
+      <GameButton
+        className="mt-3"
+        onClick={() => setIsOpen(true)}
+        variant="secondary"
+        size="sm"
+      >
+        [MANAGE PACK]
+      </GameButton>
+    );
+  }
+
+  return (
+    <PackLifecycleView
+      tokenId={packId}
+      values={values}
+      reads={reads}
+      plan={plan}
+      topUpPhase={topUpPhase}
+      redemptionPhase={redemptionPhase}
+      topUpConfirmed={topUpConfirmed}
+      exitConfirmed={exitConfirmed}
+      isReading={isReading}
+      isBusy={isBusy}
+      configured={Boolean(addresses)}
+      onAmountChange={(symbol, value) => {
+        setValues((current) => ({ ...current, [symbol]: value }));
+        setReads((current) => ({
+          ...current,
+          tokens: {
+            ...current.tokens,
+            [symbol]: {
+              ...current.tokens[symbol],
+              quote: undefined,
+              quoteError: undefined,
+            },
+          },
+        }));
+      }}
+      onRefresh={() => void refresh()}
+      onTopUp={() => void onTopUp()}
+      onRetrySync={() => void onRetrySync()}
+      onRedeem={() => void onRedeem()}
+      onRetryRedeem={() => void onRetryRedeem()}
+    />
+  );
+}

--- a/src/components/maker/pack-lifecycle-actions.ui.test.tsx
+++ b/src/components/maker/pack-lifecycle-actions.ui.test.tsx
@@ -1,0 +1,132 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { buildTopUpPlan } from "@/lib/maker/pack-lifecycle";
+import {
+  PackLifecycleView,
+  type PackLifecycleReads,
+} from "./pack-lifecycle-actions";
+
+const TOKEN = "0x5884aD2f920c162CFBbACc88C9C51AA75eC09E02" as const;
+const VALUES = { AMZN: "1", AMD: "", NFLX: "", PLTR: "", TSLA: "" };
+const READS: PackLifecycleReads = {
+  isListed: true,
+  isResting: true,
+  basket: [{ asset: TOKEN, amount: 2_000_000_000_000_000_000n }],
+  currentNav: 50_000_000_000_000_000_000n,
+  minPackNav: 20_000_000_000_000_000_000n,
+  poolMax: 300_000_000_000_000_000_000n,
+  tokens: {
+    AMZN: {
+      approved: true,
+      balance: 2_000_000_000_000_000_000n,
+      allowance: 0n,
+      quote: 25_000_000_000_000_000_000n,
+    },
+  },
+};
+
+function renderView(
+  overrides: Partial<Parameters<typeof PackLifecycleView>[0]> = {}
+) {
+  const plan = buildTopUpPlan(
+    [
+      {
+        symbol: "AMZN",
+        address: TOKEN,
+        decimals: 18,
+        value: VALUES.AMZN,
+        ...READS.tokens.AMZN,
+      },
+    ],
+    READS.currentNav,
+    READS.minPackNav,
+    READS.poolMax
+  );
+
+  return renderToStaticMarkup(
+    <PackLifecycleView
+      tokenId={42n}
+      values={VALUES}
+      reads={READS}
+      plan={plan}
+      topUpPhase={{ kind: "idle" }}
+      redemptionPhase={{ kind: "idle" }}
+      topUpConfirmed={false}
+      exitConfirmed={false}
+      isReading={false}
+      isBusy={false}
+      configured
+      onAmountChange={() => undefined}
+      onRefresh={() => undefined}
+      onTopUp={() => undefined}
+      onRetrySync={() => undefined}
+      onRedeem={() => undefined}
+      onRetryRedeem={() => undefined}
+      {...overrides}
+    />
+  );
+}
+
+describe("PackLifecycleView", () => {
+  it("shows live basket state, additions-only projected NAV, and approval plan", () => {
+    const html = renderView();
+
+    expect(html).toContain("Listed · Resting");
+    expect(html).toContain("Live basket: AMZN 2");
+    expect(html).toContain("Additions-only top-up");
+    expect(html).toContain("Live NAV $50.00 → projected");
+    expect(html).toContain("$75.00");
+    expect(html).toContain("Projected Pack remains eligible");
+    expect(html).toContain("Approvals required: AMZN");
+    expect(html).toContain("[TOP UP + SYNC NAV]");
+  });
+
+  it("offers sync-only recovery after a confirmed top-up", () => {
+    const html = renderView({
+      topUpConfirmed: true,
+      topUpPhase: { kind: "error", message: "NAV sync rejected" },
+    });
+
+    expect(html).toContain("Pack #42 top-up confirmed on-chain");
+    expect(html).toContain("will not be repeated");
+    expect(html).toContain("[RETRY NAV SYNC]");
+    expect(html).not.toContain("[TOP UP + SYNC NAV]");
+  });
+
+  it("explains zero protocol fee versus gas and resting exit ordering", () => {
+    const html = renderView({
+      redemptionPhase: { kind: "exiting" },
+    });
+
+    expect(html).toContain("zero redemption fee");
+    expect(html).toContain("still pays Robinhood Chain gas");
+    expect(html).toContain("resting Pack exits first");
+    expect(html).toContain("crystallize pending fees");
+  });
+
+  it("offers redemption-only recovery after a confirmed exit", () => {
+    const html = renderView({
+      exitConfirmed: true,
+      redemptionPhase: { kind: "error", message: "Redeem rejected" },
+    });
+
+    expect(html).toContain("Pack #42 pool exit confirmed on-chain");
+    expect(html).toContain("will not be repeated");
+    expect(html).toContain("[RETRY REDEMPTION]");
+  });
+
+  it("disables Maker actions when live state says the Pack is unlisted", () => {
+    const html = renderView({
+      reads: {
+        ...READS,
+        isListed: false,
+        isResting: false,
+      },
+    });
+
+    expect(html).toContain("Not listed");
+    expect(html).toContain("no longer listed");
+    expect(html).not.toContain("[TOP UP + SYNC NAV]");
+  });
+});

--- a/src/components/shell/connected-shell.tsx
+++ b/src/components/shell/connected-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { StarterGrantPanel } from "@/components/grants/starter-grant-panel";
+import { MyPacksDashboard } from "@/components/maker/my-packs-dashboard";
 import { BrowsePool } from "@/components/pool/browse-pool";
 import { GameButton } from "@/components/ui/game-button";
 import { formatShortAddress } from "@/lib/utils";
@@ -11,7 +12,7 @@ type Props = {
 };
 
 /**
- * Post-auth shell: wallet + Starter Grant + Browse Pool.
+ * Post-auth shell: wallet + Starter Grant + Maker dashboard + Browse Pool.
  */
 export function ConnectedShell({ address, onLogout }: Props) {
   const convexConfigured = Boolean(process.env.NEXT_PUBLIC_CONVEX_URL);
@@ -52,7 +53,10 @@ export function ConnectedShell({ address, onLogout }: Props) {
         ) : null}
 
         {convexConfigured ? (
-          <BrowsePool />
+          <>
+            <MyPacksDashboard walletAddress={address} />
+            <BrowsePool />
+          </>
         ) : (
           <p className="mt-10 text-sm text-[var(--t-muted)]">
             Convex is not configured — pool browse unavailable.

--- a/src/components/shell/connected-shell.tsx
+++ b/src/components/shell/connected-shell.tsx
@@ -1,18 +1,21 @@
 "use client";
 
+import type { Address } from "viem";
+
 import { StarterGrantPanel } from "@/components/grants/starter-grant-panel";
 import { MyPacksDashboard } from "@/components/maker/my-packs-dashboard";
+import { PackComposer } from "@/components/maker/pack-composer";
 import { BrowsePool } from "@/components/pool/browse-pool";
 import { GameButton } from "@/components/ui/game-button";
 import { formatShortAddress } from "@/lib/utils";
 
 type Props = {
-  address: string | null;
+  address: Address | null;
   onLogout: () => void;
 };
 
 /**
- * Post-auth shell: wallet + Starter Grant + Maker dashboard + Browse Pool.
+ * Post-auth shell: wallet + Starter Grant + Maker create/dashboard + Browse Pool.
  */
 export function ConnectedShell({ address, onLogout }: Props) {
   const convexConfigured = Boolean(process.env.NEXT_PUBLIC_CONVEX_URL);
@@ -51,6 +54,8 @@ export function ConnectedShell({ address, onLogout }: Props) {
         {address && convexConfigured ? (
           <StarterGrantPanel walletAddress={address} />
         ) : null}
+
+        {address ? <PackComposer walletAddress={address} /> : null}
 
         {convexConfigured ? (
           <>

--- a/src/components/shell/connected-shell.ui.test.tsx
+++ b/src/components/shell/connected-shell.ui.test.tsx
@@ -11,6 +11,12 @@ vi.mock("@/components/maker/my-packs-dashboard", () => ({
   ),
 }));
 
+vi.mock("@/components/maker/pack-composer", () => ({
+  PackComposer: ({ walletAddress }: { walletAddress: string }) => (
+    <div>Compose a Pack for {walletAddress}</div>
+  ),
+}));
+
 vi.mock("@/components/pool/browse-pool", () => ({
   BrowsePool: () => (
     <div>
@@ -36,6 +42,7 @@ describe("ConnectedShell", () => {
     expect(html).toContain("0x1234");
     expect(html).toContain("Starter Grant panel");
     expect(html).toContain("My Packs for");
+    expect(html).toContain("Compose a Pack for");
     expect(html).toContain("0x1234567890abcdef1234567890abcdef12345678");
     expect(html).toContain("Pool Statistics");
     expect(html).toContain("[LOG OUT]");

--- a/src/components/shell/connected-shell.ui.test.tsx
+++ b/src/components/shell/connected-shell.ui.test.tsx
@@ -5,6 +5,12 @@ vi.mock("@/components/grants/starter-grant-panel", () => ({
   StarterGrantPanel: () => <div>Starter Grant panel</div>,
 }));
 
+vi.mock("@/components/maker/my-packs-dashboard", () => ({
+  MyPacksDashboard: ({ walletAddress }: { walletAddress: string | null }) => (
+    <div>My Packs for {walletAddress}</div>
+  ),
+}));
+
 vi.mock("@/components/pool/browse-pool", () => ({
   BrowsePool: () => (
     <div>
@@ -29,6 +35,8 @@ describe("ConnectedShell", () => {
     expect(html).toContain("Margin Call");
     expect(html).toContain("0x1234");
     expect(html).toContain("Starter Grant panel");
+    expect(html).toContain("My Packs for");
+    expect(html).toContain("0x1234567890abcdef1234567890abcdef12345678");
     expect(html).toContain("Pool Statistics");
     expect(html).toContain("[LOG OUT]");
     vi.unstubAllEnvs();

--- a/src/hooks/use-maker-transaction-client.ts
+++ b/src/hooks/use-maker-transaction-client.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useWallets } from "@privy-io/react-auth";
+import { PAYMENT_CHAIN } from "@margin-call/shared";
+import {
+  createWalletClient,
+  custom,
+  type Address,
+  type Hash,
+  type PublicClient,
+} from "viem";
+
+/**
+ * One Privy-to-viem boundary for every user-signed Maker lifecycle write.
+ * Transaction sequencing and durability stay in the shared operation journal;
+ * this hook only resolves the scoped signer and exact-hash receipt client.
+ */
+export function useMakerTransactionClient(
+  walletAddress: Address,
+  publicClient: PublicClient
+) {
+  const { wallets } = useWallets();
+  const wallet = useMemo(
+    () =>
+      wallets.find(
+        (candidate) =>
+          candidate.address.toLowerCase() === walletAddress.toLowerCase()
+      ),
+    [walletAddress, wallets]
+  );
+
+  const getWalletClient = useCallback(async () => {
+    if (!wallet) throw new Error("Connected Privy EVM wallet is unavailable");
+    const provider = await wallet.getEthereumProvider();
+    return createWalletClient({
+      account: walletAddress,
+      chain: PAYMENT_CHAIN,
+      transport: custom(provider),
+    });
+  }, [wallet, walletAddress]);
+
+  const waitForReceipt = useCallback(
+    (hash: Hash) => publicClient.waitForTransactionReceipt({ hash }),
+    [publicClient]
+  );
+
+  return {
+    walletReady: Boolean(wallet),
+    getWalletClient,
+    waitForReceipt,
+  };
+}

--- a/src/lib/contracts/__tests__/addresses.client-env.test.ts
+++ b/src/lib/contracts/__tests__/addresses.client-env.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const sourcePath = fileURLToPath(new URL("../addresses.ts", import.meta.url));
+const source = readFileSync(sourcePath, "utf8");
+
+const publicAddressKeys = [
+  "NEXT_PUBLIC_MOCKUSD_ADDRESS",
+  "NEXT_PUBLIC_PACKCUSTODY_ADDRESS",
+  "NEXT_PUBLIC_ASSETREGISTRY_ADDRESS",
+  "NEXT_PUBLIC_RIPENGINE_ADDRESS",
+  "NEXT_PUBLIC_GAMETOKEN_ADDRESS",
+  "NEXT_PUBLIC_DISTRIBUTOR_ADDRESS",
+] as const;
+
+describe("contract address client environment access", () => {
+  it("uses statically analyzable NEXT_PUBLIC address references", () => {
+    for (const envKey of publicAddressKeys) {
+      expect(source).toContain(`process.env.${envKey}`);
+    }
+  });
+
+  it("does not use dynamic environment lookup in the client address module", () => {
+    expect(source).not.toMatch(/process\.env\s*\[/);
+  });
+});

--- a/src/lib/contracts/abis.ts
+++ b/src/lib/contracts/abis.ts
@@ -1,10 +1,12 @@
 /**
- * Minimal ABIs for V1 Pack-rip contracts (reads + Starter Grant mint).
+ * V1 Pack-rip contract APIs.
  * Source of truth: `@margin-call/shared`.
  */
 export {
+  erc20Abi,
   mockUsdAbi,
   packCustodyAbi,
   ripEngineAbi,
   assetRegistryAbi,
+  getPackMintedTokenId,
 } from "@margin-call/shared";

--- a/src/lib/contracts/addresses.ts
+++ b/src/lib/contracts/addresses.ts
@@ -15,16 +15,22 @@ export type ContractAddresses = {
   distributor: `0x${string}`;
 };
 
-function readAddress(envKey: string): `0x${string}` | undefined {
+function readAddress(
+  envKey: string,
+  value: string | undefined
+): `0x${string}` | undefined {
   try {
-    return parseAddress(process.env[envKey]);
+    return parseAddress(value);
   } catch {
     throw new Error(`${envKey} must be a 0x-prefixed 20-byte address`);
   }
 }
 
-function requirePublicAddress(envKey: string): `0x${string}` {
-  const address = readAddress(envKey);
+function requirePublicAddress(
+  envKey: string,
+  value: string | undefined
+): `0x${string}` {
+  const address = readAddress(envKey, value);
   if (!address) {
     throw new Error(
       `${envKey} is required when NEXT_PUBLIC_MARGIN_CALL_NETWORK=${PAYMENT_CHAIN_SLUG}`
@@ -48,12 +54,30 @@ export function getContractAddresses(): ContractAddresses | null {
   }
 
   return {
-    mockUsd: requirePublicAddress("NEXT_PUBLIC_MOCKUSD_ADDRESS"),
-    packCustody: requirePublicAddress("NEXT_PUBLIC_PACKCUSTODY_ADDRESS"),
-    assetRegistry: requirePublicAddress("NEXT_PUBLIC_ASSETREGISTRY_ADDRESS"),
-    ripEngine: requirePublicAddress("NEXT_PUBLIC_RIPENGINE_ADDRESS"),
-    gameToken: requirePublicAddress("NEXT_PUBLIC_GAMETOKEN_ADDRESS"),
-    distributor: requirePublicAddress("NEXT_PUBLIC_DISTRIBUTOR_ADDRESS"),
+    mockUsd: requirePublicAddress(
+      "NEXT_PUBLIC_MOCKUSD_ADDRESS",
+      process.env.NEXT_PUBLIC_MOCKUSD_ADDRESS
+    ),
+    packCustody: requirePublicAddress(
+      "NEXT_PUBLIC_PACKCUSTODY_ADDRESS",
+      process.env.NEXT_PUBLIC_PACKCUSTODY_ADDRESS
+    ),
+    assetRegistry: requirePublicAddress(
+      "NEXT_PUBLIC_ASSETREGISTRY_ADDRESS",
+      process.env.NEXT_PUBLIC_ASSETREGISTRY_ADDRESS
+    ),
+    ripEngine: requirePublicAddress(
+      "NEXT_PUBLIC_RIPENGINE_ADDRESS",
+      process.env.NEXT_PUBLIC_RIPENGINE_ADDRESS
+    ),
+    gameToken: requirePublicAddress(
+      "NEXT_PUBLIC_GAMETOKEN_ADDRESS",
+      process.env.NEXT_PUBLIC_GAMETOKEN_ADDRESS
+    ),
+    distributor: requirePublicAddress(
+      "NEXT_PUBLIC_DISTRIBUTOR_ADDRESS",
+      process.env.NEXT_PUBLIC_DISTRIBUTOR_ADDRESS
+    ),
   };
 }
 

--- a/src/lib/maker/acquisition-fees.test.ts
+++ b/src/lib/maker/acquisition-fees.test.ts
@@ -3,12 +3,18 @@ import type { Address, Hash } from "viem";
 
 import {
   acquisitionFeeTotal,
+  CLAIM_BATCH_SIZE,
+  MAX_RESTING_PACK_SCAN,
   claimAcquisitionFees,
   readAcquisitionFeeSnapshot,
   type AcquisitionFeeClaimAdapter,
   type AcquisitionFeeReadClient,
   type ClaimPhase,
 } from "./acquisition-fees";
+import {
+  createMemoryJournalStorage,
+  ensureWorkflow,
+} from "./transaction-journal";
 
 const WALLET = "0x0000000000000000000000000000000000000001" as Address;
 const OTHER = "0x0000000000000000000000000000000000000002" as Address;
@@ -88,6 +94,9 @@ describe("live Acquisition Fee accounting", () => {
       mockUsdBalance: 99n,
       stablecoinDecimals: 6,
       restingMakerTokenIds: [2n, 104n, 205n],
+      restingCount: 205n,
+      visibilityComplete: true,
+      visibilityLimit: MAX_RESTING_PACK_SCAN,
     });
     const makerCalls = multicall.mock.calls.filter(
       ([input]) => input.contracts[0]?.functionName === "makerOf"
@@ -101,6 +110,51 @@ describe("live Acquisition Fee accounting", () => {
     expect(
       multicall.mock.calls.every(([input]) => input.blockNumber === 123n)
     ).toBe(true);
+  });
+
+  it("does not call the deployed unpaged array read above the explicit cap", async () => {
+    const readContract = vi.fn(
+      async ({ functionName }: { functionName: string }) => {
+        switch (functionName) {
+          case "restingCount":
+            return BigInt(MAX_RESTING_PACK_SCAN + 1);
+          case "claimableFees":
+            return 12n;
+          case "balanceOf":
+            return 99n;
+          case "decimals":
+            return 6;
+          case "restingPackIds":
+            throw new Error("unbounded read must not run");
+          default:
+            throw new Error(`Unexpected read ${functionName}`);
+        }
+      }
+    );
+    const client = {
+      getBlockNumber: vi.fn().mockResolvedValue(123n),
+      readContract,
+      multicall: vi.fn(),
+    } as unknown as AcquisitionFeeReadClient;
+
+    await expect(
+      readAcquisitionFeeSnapshot(
+        client,
+        { ripEngine: RIP_ENGINE, mockUsd: MOCK_USD },
+        WALLET
+      )
+    ).resolves.toMatchObject({
+      crystallized: 12n,
+      pending: null,
+      total: null,
+      visibilityComplete: false,
+    });
+    expect(
+      readContract.mock.calls.some(
+        ([input]) => input.functionName === "restingPackIds"
+      )
+    ).toBe(false);
+    expect(client.multicall).not.toHaveBeenCalled();
   });
 
   it("fails instead of silently undercounting an incomplete resting set", async () => {
@@ -175,7 +229,12 @@ describe("Acquisition Fee claim lifecycle", () => {
       refresh
     );
     await vi.waitFor(() =>
-      expect(phases.at(-1)).toEqual({ kind: "pending", hash: HASH })
+      expect(phases.at(-1)).toEqual({
+        kind: "pending",
+        hash: HASH,
+        batch: 1,
+        totalBatches: 1,
+      })
     );
     expect(refresh).not.toHaveBeenCalled();
 
@@ -213,7 +272,89 @@ describe("Acquisition Fee claim lifecycle", () => {
 
     await expect(
       claimAcquisitionFees([1n], adapter, () => undefined, refresh)
-    ).rejects.toThrow("Acquisition Fee claim transaction reverted");
+    ).rejects.toThrow("Acquisition Fee claim batch 1 reverted");
     expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("claims in bounded batches", async () => {
+    const ids = Array.from({ length: CLAIM_BATCH_SIZE * 2 + 1 }, (_, index) =>
+      BigInt(index + 1)
+    );
+    let hashIndex = 0;
+    const adapter: AcquisitionFeeClaimAdapter = {
+      claim: vi.fn(
+        async () => `0x${(++hashIndex).toString(16).padStart(64, "0")}` as Hash
+      ),
+      waitForReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+    };
+
+    await claimAcquisitionFees(
+      ids,
+      adapter,
+      () => undefined,
+      async () => {}
+    );
+
+    expect(adapter.claim).toHaveBeenCalledTimes(3);
+    expect(
+      vi.mocked(adapter.claim).mock.calls.map(([batch]) => batch.length)
+    ).toEqual([CLAIM_BATCH_SIZE, CLAIM_BATCH_SIZE, 1]);
+  });
+
+  it("resumes a partial multi-batch claim without duplicating confirmed or accepted writes", async () => {
+    const ids = Array.from({ length: CLAIM_BATCH_SIZE * 2 + 1 }, (_, index) =>
+      BigInt(index + 1)
+    );
+    const storage = createMemoryJournalStorage();
+    const workflow = ensureWorkflow(storage, {
+      chainId: 46630,
+      wallet: WALLET,
+      kind: "claim",
+      requestFingerprint: "fees",
+      context: {},
+    });
+    const hashes = [
+      `0x${"1".repeat(64)}` as Hash,
+      `0x${"2".repeat(64)}` as Hash,
+      `0x${"3".repeat(64)}` as Hash,
+    ];
+    let submits = 0;
+    let failSecond = true;
+    const adapter: AcquisitionFeeClaimAdapter = {
+      claim: vi.fn(async () => hashes[submits++]!),
+      waitForReceipt: vi.fn(async (hash) => {
+        if (hash === hashes[1] && failSecond) {
+          throw new Error("RPC unavailable");
+        }
+        return { status: "success" as const };
+      }),
+    };
+    const journal = { storage, workflowKey: workflow.key };
+
+    await expect(
+      claimAcquisitionFees(
+        ids,
+        adapter,
+        () => undefined,
+        async () => {},
+        journal
+      )
+    ).rejects.toThrow("still unresolved");
+    expect(adapter.claim).toHaveBeenCalledTimes(2);
+
+    failSecond = false;
+    await claimAcquisitionFees(
+      ids,
+      adapter,
+      () => undefined,
+      async () => {},
+      journal
+    );
+    expect(adapter.claim).toHaveBeenCalledTimes(3);
+    expect(storage.get(workflow.key)?.completed).toMatchObject({
+      "claim:0": hashes[0],
+      "claim:1": hashes[1],
+      "claim:2": hashes[2],
+    });
   });
 });

--- a/src/lib/maker/acquisition-fees.test.ts
+++ b/src/lib/maker/acquisition-fees.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Address, Hash } from "viem";
+
+import {
+  acquisitionFeeTotal,
+  claimAcquisitionFees,
+  readAcquisitionFeeSnapshot,
+  type AcquisitionFeeClaimAdapter,
+  type AcquisitionFeeReadClient,
+  type ClaimPhase,
+} from "./acquisition-fees";
+
+const WALLET = "0x0000000000000000000000000000000000000001" as Address;
+const OTHER = "0x0000000000000000000000000000000000000002" as Address;
+const RIP_ENGINE = "0x0000000000000000000000000000000000000003" as Address;
+const MOCK_USD = "0x0000000000000000000000000000000000000004" as Address;
+const HASH = `0x${"1".repeat(64)}` as Hash;
+
+describe("live Acquisition Fee accounting", () => {
+  it("adds crystallized and per-Pack pending stablecoin amounts", () => {
+    expect(acquisitionFeeTotal(12n, [3n, 4n, 5n])).toEqual({
+      pending: 12n,
+      total: 24n,
+    });
+  });
+
+  it("filters the complete live resting set by Maker and chunks multicalls", async () => {
+    const restingPackIds = Array.from({ length: 205 }, (_, index) =>
+      BigInt(index + 1)
+    );
+    const makerIds = new Set([2n, 104n, 205n]);
+    const readContract = vi.fn(
+      async ({
+        functionName,
+      }: {
+        functionName: string;
+        blockNumber: bigint;
+      }) => {
+        switch (functionName) {
+          case "restingPackIds":
+            return restingPackIds;
+          case "restingCount":
+            return 205n;
+          case "claimableFees":
+            return 7n;
+          case "balanceOf":
+            return 99n;
+          case "decimals":
+            return 6;
+          default:
+            throw new Error(`Unexpected read ${functionName}`);
+        }
+      }
+    );
+    const multicall = vi.fn(
+      async ({
+        contracts,
+      }: {
+        contracts: Array<Record<string, unknown>>;
+        blockNumber: bigint;
+      }) =>
+        contracts.map((contract) => {
+          const tokenId = (contract.args as [bigint])[0];
+          return contract.functionName === "makerOf"
+            ? makerIds.has(tokenId)
+              ? WALLET
+              : OTHER
+            : tokenId;
+        })
+    );
+    const client = {
+      getBlockNumber: vi.fn().mockResolvedValue(123n),
+      readContract,
+      multicall,
+    } as unknown as AcquisitionFeeReadClient;
+
+    const snapshot = await readAcquisitionFeeSnapshot(
+      client,
+      { ripEngine: RIP_ENGINE, mockUsd: MOCK_USD },
+      WALLET
+    );
+
+    expect(snapshot).toEqual({
+      blockNumber: 123n,
+      crystallized: 7n,
+      pending: 311n,
+      total: 318n,
+      mockUsdBalance: 99n,
+      stablecoinDecimals: 6,
+      restingMakerTokenIds: [2n, 104n, 205n],
+    });
+    const makerCalls = multicall.mock.calls.filter(
+      ([input]) => input.contracts[0]?.functionName === "makerOf"
+    );
+    expect(makerCalls.map(([input]) => input.contracts.length)).toEqual([
+      100, 100, 5,
+    ]);
+    expect(
+      readContract.mock.calls.every(([input]) => input.blockNumber === 123n)
+    ).toBe(true);
+    expect(
+      multicall.mock.calls.every(([input]) => input.blockNumber === 123n)
+    ).toBe(true);
+  });
+
+  it("fails instead of silently undercounting an incomplete resting set", async () => {
+    const client = {
+      getBlockNumber: vi.fn().mockResolvedValue(123n),
+      readContract: vi.fn(
+        async ({ functionName }: { functionName: string }) => {
+          switch (functionName) {
+            case "restingPackIds":
+              return [1n];
+            case "restingCount":
+              return 2n;
+            case "claimableFees":
+            case "balanceOf":
+              return 0n;
+            case "decimals":
+              return 6;
+            default:
+              throw new Error(`Unexpected read ${functionName}`);
+          }
+        }
+      ),
+      multicall: vi.fn(),
+    } as unknown as AcquisitionFeeReadClient;
+
+    await expect(
+      readAcquisitionFeeSnapshot(
+        client,
+        { ripEngine: RIP_ENGINE, mockUsd: MOCK_USD },
+        WALLET
+      )
+    ).rejects.toThrow(
+      "Incomplete live resting set: expected 2 Packs, received 1"
+    );
+    expect(client.multicall).not.toHaveBeenCalled();
+  });
+});
+
+describe("Acquisition Fee claim lifecycle", () => {
+  it("submits an empty token list for a crystallized-only claim", async () => {
+    const adapter: AcquisitionFeeClaimAdapter = {
+      claim: vi.fn().mockResolvedValue(HASH),
+      waitForReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+    };
+
+    await claimAcquisitionFees(
+      [],
+      adapter,
+      () => undefined,
+      async () => undefined
+    );
+
+    expect(adapter.claim).toHaveBeenCalledWith([]);
+  });
+
+  it("keeps a submitted hash pending and refreshes only after confirmation", async () => {
+    let resolveReceipt!: (receipt: { status: "success" }) => void;
+    const receiptPromise = new Promise<{ status: "success" }>((resolve) => {
+      resolveReceipt = resolve;
+    });
+    const phases: ClaimPhase[] = [];
+    const refresh = vi.fn();
+    const adapter: AcquisitionFeeClaimAdapter = {
+      claim: vi.fn().mockResolvedValue(HASH),
+      waitForReceipt: vi.fn().mockReturnValue(receiptPromise),
+    };
+
+    const claiming = claimAcquisitionFees(
+      [42n],
+      adapter,
+      (phase) => phases.push(phase),
+      refresh
+    );
+    await vi.waitFor(() =>
+      expect(phases.at(-1)).toEqual({ kind: "pending", hash: HASH })
+    );
+    expect(refresh).not.toHaveBeenCalled();
+
+    resolveReceipt({ status: "success" });
+    await claiming;
+
+    expect(phases.map((phase) => phase.kind)).toEqual([
+      "signing",
+      "pending",
+      "complete",
+    ]);
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces wallet rejection without waiting or refreshing", async () => {
+    const adapter: AcquisitionFeeClaimAdapter = {
+      claim: vi.fn().mockRejectedValue(new Error("User rejected request")),
+      waitForReceipt: vi.fn(),
+    };
+    const refresh = vi.fn();
+
+    await expect(
+      claimAcquisitionFees([1n], adapter, () => undefined, refresh)
+    ).rejects.toThrow("User rejected request");
+    expect(adapter.waitForReceipt).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("treats a reverted receipt as failure and does not refresh", async () => {
+    const adapter: AcquisitionFeeClaimAdapter = {
+      claim: vi.fn().mockResolvedValue(HASH),
+      waitForReceipt: vi.fn().mockResolvedValue({ status: "reverted" }),
+    };
+    const refresh = vi.fn();
+
+    await expect(
+      claimAcquisitionFees([1n], adapter, () => undefined, refresh)
+    ).rejects.toThrow("Acquisition Fee claim transaction reverted");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/maker/acquisition-fees.ts
+++ b/src/lib/maker/acquisition-fees.ts
@@ -6,8 +6,14 @@ import {
 } from "viem";
 
 import { erc20Abi, mockUsdAbi, ripEngineAbi } from "@margin-call/shared";
+import {
+  executeMakerWrite,
+  type LifecycleJournalRun,
+} from "./transaction-journal";
 
 const MULTICALL_CHUNK_SIZE = 100;
+export const MAX_RESTING_PACK_SCAN = 500;
+export const CLAIM_BATCH_SIZE = 25;
 
 export type AcquisitionFeeAddresses = {
   ripEngine: Address;
@@ -17,11 +23,14 @@ export type AcquisitionFeeAddresses = {
 export type AcquisitionFeeSnapshot = {
   blockNumber: bigint;
   crystallized: bigint;
-  pending: bigint;
-  total: bigint;
+  pending: bigint | null;
+  total: bigint | null;
   mockUsdBalance: bigint;
   stablecoinDecimals: number;
   restingMakerTokenIds: bigint[];
+  restingCount: bigint;
+  visibilityComplete: boolean;
+  visibilityLimit: number;
 };
 
 export type AcquisitionFeeReadClient = Pick<
@@ -31,15 +40,16 @@ export type AcquisitionFeeReadClient = Pick<
 
 export type ClaimPhase =
   | { kind: "idle" }
-  | { kind: "signing" }
-  | { kind: "pending"; hash: Hash }
-  | { kind: "complete" }
+  | { kind: "signing"; batch: number; totalBatches: number }
+  | { kind: "pending"; hash: Hash; batch: number; totalBatches: number }
+  | { kind: "complete"; batches: number }
   | { kind: "refresh-error"; message: string }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; hash?: Hash };
 
 export type AcquisitionFeeClaimAdapter = {
   claim: (tokenIds: bigint[]) => Promise<Hash>;
   waitForReceipt: (hash: Hash) => Promise<{ status: "success" | "reverted" }>;
+  hasClaimable?: (tokenIds: bigint[]) => Promise<boolean>;
 };
 
 function chunks<T>(values: readonly T[], size: number): T[][] {
@@ -82,8 +92,8 @@ export function acquisitionFeeTotal(
 
 /**
  * Read one coherent, live Acquisition Fee snapshot directly from the chain.
- * The full resting set is discovered first; Maker and pending reads are then
- * explicitly chunked to bound each Multicall3 payload.
+ * The deployed full-array read is used only after a same-block count proves it
+ * is within the hard cap; Maker and pending reads are explicitly chunked.
  */
 export async function readAcquisitionFeeSnapshot(
   client: AcquisitionFeeReadClient,
@@ -91,46 +101,59 @@ export async function readAcquisitionFeeSnapshot(
   walletAddress: Address
 ): Promise<AcquisitionFeeSnapshot> {
   const blockNumber = await client.getBlockNumber();
-  const [
-    restingPackIds,
-    restingCount,
-    crystallized,
-    mockUsdBalance,
-    stablecoinDecimals,
-  ] = await Promise.all([
-    client.readContract({
-      address: addresses.ripEngine,
-      abi: ripEngineAbi,
-      functionName: "restingPackIds",
+  const [restingCount, crystallized, mockUsdBalance, stablecoinDecimals] =
+    await Promise.all([
+      client.readContract({
+        address: addresses.ripEngine,
+        abi: ripEngineAbi,
+        functionName: "restingCount",
+        blockNumber,
+      }),
+      client.readContract({
+        address: addresses.ripEngine,
+        abi: ripEngineAbi,
+        functionName: "claimableFees",
+        args: [walletAddress],
+        blockNumber,
+      }),
+      client.readContract({
+        address: addresses.mockUsd,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [walletAddress],
+        blockNumber,
+      }),
+      client.readContract({
+        address: addresses.mockUsd,
+        abi: mockUsdAbi,
+        functionName: "decimals",
+        blockNumber,
+      }),
+    ]);
+
+  if (restingCount > BigInt(MAX_RESTING_PACK_SCAN)) {
+    return {
       blockNumber,
-    }),
-    client.readContract({
-      address: addresses.ripEngine,
-      abi: ripEngineAbi,
-      functionName: "restingCount",
-      blockNumber,
-    }),
-    client.readContract({
-      address: addresses.ripEngine,
-      abi: ripEngineAbi,
-      functionName: "claimableFees",
-      args: [walletAddress],
-      blockNumber,
-    }),
-    client.readContract({
-      address: addresses.mockUsd,
-      abi: erc20Abi,
-      functionName: "balanceOf",
-      args: [walletAddress],
-      blockNumber,
-    }),
-    client.readContract({
-      address: addresses.mockUsd,
-      abi: mockUsdAbi,
-      functionName: "decimals",
-      blockNumber,
-    }),
-  ]);
+      crystallized,
+      pending: null,
+      total: null,
+      mockUsdBalance,
+      stablecoinDecimals,
+      restingMakerTokenIds: [],
+      restingCount,
+      visibilityComplete: false,
+      visibilityLimit: MAX_RESTING_PACK_SCAN,
+    };
+  }
+
+  // The deployed contract has no indexed/page read. Only call the unbounded ABI
+  // after proving at this exact block that the response is within our hard cap.
+  const restingPackIds = await client.readContract({
+    address: addresses.ripEngine,
+    abi: ripEngineAbi,
+    functionName: "restingPackIds",
+    blockNumber,
+  });
 
   if (BigInt(restingPackIds.length) !== restingCount) {
     throw new Error(
@@ -149,12 +172,12 @@ export async function readAcquisitionFeeSnapshot(
     })),
     blockNumber
   );
-  const restingMakerTokenIds = tokenIds.filter((_, index) =>
+  const makerTokenIds = tokenIds.filter((_, index) =>
     isAddressEqual(makers[index], walletAddress)
   );
   const pendingAmounts = await readChunkedContracts<bigint>(
     client,
-    restingMakerTokenIds.map((tokenId) => ({
+    makerTokenIds.map((tokenId) => ({
       address: addresses.ripEngine,
       abi: ripEngineAbi,
       functionName: "pendingOf",
@@ -163,6 +186,9 @@ export async function readAcquisitionFeeSnapshot(
     blockNumber
   );
   const totals = acquisitionFeeTotal(crystallized, pendingAmounts);
+  const restingMakerTokenIds = makerTokenIds.filter(
+    (_, index) => pendingAmounts[index]! > 0n
+  );
 
   return {
     blockNumber,
@@ -172,6 +198,9 @@ export async function readAcquisitionFeeSnapshot(
     mockUsdBalance,
     stablecoinDecimals,
     restingMakerTokenIds,
+    restingCount,
+    visibilityComplete: true,
+    visibilityLimit: MAX_RESTING_PACK_SCAN,
   };
 }
 
@@ -179,17 +208,53 @@ export async function claimAcquisitionFees(
   tokenIds: bigint[],
   adapter: AcquisitionFeeClaimAdapter,
   onPhase: (phase: ClaimPhase) => void,
-  refreshAfterConfirmation: () => Promise<void>
+  refreshAfterConfirmation: () => Promise<void>,
+  journal?: LifecycleJournalRun
 ): Promise<void> {
-  onPhase({ kind: "signing" });
-  const hash = await adapter.claim(tokenIds);
-  onPhase({ kind: "pending", hash });
-  const receipt = await adapter.waitForReceipt(hash);
-  if (receipt.status !== "success") {
-    throw new Error("Acquisition Fee claim transaction reverted");
+  const batches = chunks(tokenIds, CLAIM_BATCH_SIZE);
+  if (batches.length === 0) batches.push([]);
+  let confirmedBatches = 0;
+
+  for (let index = 0; index < batches.length; index += 1) {
+    const batchNumber = index + 1;
+    const step = `claim:${index}`;
+    const saved = journal?.storage.get(journal.workflowKey);
+    const mustReconcile = Boolean(
+      saved?.completed[step] || saved?.current?.step === step
+    );
+    if (
+      !mustReconcile &&
+      adapter.hasClaimable &&
+      !(await adapter.hasClaimable(batches[index]!))
+    ) {
+      continue;
+    }
+    onPhase({
+      kind: "signing",
+      batch: batchNumber,
+      totalBatches: batches.length,
+    });
+    const receipt = await executeMakerWrite({
+      journal,
+      step,
+      action: "claim",
+      submit: () => adapter.claim(batches[index]!),
+      reconcile: adapter.waitForReceipt,
+      onAccepted: (hash) =>
+        onPhase({
+          kind: "pending",
+          hash,
+          batch: batchNumber,
+          totalBatches: batches.length,
+        }),
+    });
+    if (receipt.status !== "success") {
+      throw new Error(`Acquisition Fee claim batch ${batchNumber} reverted`);
+    }
+    confirmedBatches += 1;
   }
 
-  onPhase({ kind: "complete" });
+  onPhase({ kind: "complete", batches: confirmedBatches });
   try {
     await refreshAfterConfirmation();
   } catch (error) {
@@ -208,11 +273,11 @@ export function claimPhaseMessage(phase: ClaimPhase): string {
     case "idle":
       return "Ready to claim Acquisition Fees";
     case "signing":
-      return "Confirm the Acquisition Fee claim in your wallet";
+      return `Confirm claim batch ${phase.batch} of ${phase.totalBatches} in your wallet`;
     case "pending":
-      return "Claim submitted — waiting for confirmation";
+      return `Claim batch ${phase.batch} of ${phase.totalBatches} submitted — waiting for confirmation`;
     case "complete":
-      return "Acquisition Fee claim confirmed";
+      return `${phase.batches} Acquisition Fee claim batch${phase.batches === 1 ? "" : "es"} confirmed`;
     case "refresh-error":
     case "error":
       return phase.message;

--- a/src/lib/maker/acquisition-fees.ts
+++ b/src/lib/maker/acquisition-fees.ts
@@ -1,0 +1,220 @@
+import {
+  isAddressEqual,
+  type Address,
+  type Hash,
+  type PublicClient,
+} from "viem";
+
+import { erc20Abi, mockUsdAbi, ripEngineAbi } from "@margin-call/shared";
+
+const MULTICALL_CHUNK_SIZE = 100;
+
+export type AcquisitionFeeAddresses = {
+  ripEngine: Address;
+  mockUsd: Address;
+};
+
+export type AcquisitionFeeSnapshot = {
+  blockNumber: bigint;
+  crystallized: bigint;
+  pending: bigint;
+  total: bigint;
+  mockUsdBalance: bigint;
+  stablecoinDecimals: number;
+  restingMakerTokenIds: bigint[];
+};
+
+export type AcquisitionFeeReadClient = Pick<
+  PublicClient,
+  "getBlockNumber" | "readContract" | "multicall"
+>;
+
+export type ClaimPhase =
+  | { kind: "idle" }
+  | { kind: "signing" }
+  | { kind: "pending"; hash: Hash }
+  | { kind: "complete" }
+  | { kind: "refresh-error"; message: string }
+  | { kind: "error"; message: string };
+
+export type AcquisitionFeeClaimAdapter = {
+  claim: (tokenIds: bigint[]) => Promise<Hash>;
+  waitForReceipt: (hash: Hash) => Promise<{ status: "success" | "reverted" }>;
+};
+
+function chunks<T>(values: readonly T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size));
+  }
+  return result;
+}
+
+async function readChunkedContracts<T>(
+  client: AcquisitionFeeReadClient,
+  contracts: readonly {
+    address: Address;
+    abi: typeof ripEngineAbi;
+    functionName: "makerOf" | "pendingOf";
+    args: readonly [bigint];
+  }[],
+  blockNumber: bigint
+): Promise<T[]> {
+  const values: T[] = [];
+  for (const contractChunk of chunks(contracts, MULTICALL_CHUNK_SIZE)) {
+    const result = await client.multicall({
+      contracts: contractChunk,
+      allowFailure: false,
+      blockNumber,
+    });
+    values.push(...(result as T[]));
+  }
+  return values;
+}
+
+export function acquisitionFeeTotal(
+  crystallized: bigint,
+  pendingAmounts: readonly bigint[]
+): { pending: bigint; total: bigint } {
+  const pending = pendingAmounts.reduce((sum, amount) => sum + amount, 0n);
+  return { pending, total: crystallized + pending };
+}
+
+/**
+ * Read one coherent, live Acquisition Fee snapshot directly from the chain.
+ * The full resting set is discovered first; Maker and pending reads are then
+ * explicitly chunked to bound each Multicall3 payload.
+ */
+export async function readAcquisitionFeeSnapshot(
+  client: AcquisitionFeeReadClient,
+  addresses: AcquisitionFeeAddresses,
+  walletAddress: Address
+): Promise<AcquisitionFeeSnapshot> {
+  const blockNumber = await client.getBlockNumber();
+  const [
+    restingPackIds,
+    restingCount,
+    crystallized,
+    mockUsdBalance,
+    stablecoinDecimals,
+  ] = await Promise.all([
+    client.readContract({
+      address: addresses.ripEngine,
+      abi: ripEngineAbi,
+      functionName: "restingPackIds",
+      blockNumber,
+    }),
+    client.readContract({
+      address: addresses.ripEngine,
+      abi: ripEngineAbi,
+      functionName: "restingCount",
+      blockNumber,
+    }),
+    client.readContract({
+      address: addresses.ripEngine,
+      abi: ripEngineAbi,
+      functionName: "claimableFees",
+      args: [walletAddress],
+      blockNumber,
+    }),
+    client.readContract({
+      address: addresses.mockUsd,
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [walletAddress],
+      blockNumber,
+    }),
+    client.readContract({
+      address: addresses.mockUsd,
+      abi: mockUsdAbi,
+      functionName: "decimals",
+      blockNumber,
+    }),
+  ]);
+
+  if (BigInt(restingPackIds.length) !== restingCount) {
+    throw new Error(
+      `Incomplete live resting set: expected ${restingCount.toString()} Packs, received ${restingPackIds.length}`
+    );
+  }
+
+  const tokenIds = [...restingPackIds];
+  const makers = await readChunkedContracts<Address>(
+    client,
+    tokenIds.map((tokenId) => ({
+      address: addresses.ripEngine,
+      abi: ripEngineAbi,
+      functionName: "makerOf",
+      args: [tokenId],
+    })),
+    blockNumber
+  );
+  const restingMakerTokenIds = tokenIds.filter((_, index) =>
+    isAddressEqual(makers[index], walletAddress)
+  );
+  const pendingAmounts = await readChunkedContracts<bigint>(
+    client,
+    restingMakerTokenIds.map((tokenId) => ({
+      address: addresses.ripEngine,
+      abi: ripEngineAbi,
+      functionName: "pendingOf",
+      args: [tokenId],
+    })),
+    blockNumber
+  );
+  const totals = acquisitionFeeTotal(crystallized, pendingAmounts);
+
+  return {
+    blockNumber,
+    crystallized,
+    pending: totals.pending,
+    total: totals.total,
+    mockUsdBalance,
+    stablecoinDecimals,
+    restingMakerTokenIds,
+  };
+}
+
+export async function claimAcquisitionFees(
+  tokenIds: bigint[],
+  adapter: AcquisitionFeeClaimAdapter,
+  onPhase: (phase: ClaimPhase) => void,
+  refreshAfterConfirmation: () => Promise<void>
+): Promise<void> {
+  onPhase({ kind: "signing" });
+  const hash = await adapter.claim(tokenIds);
+  onPhase({ kind: "pending", hash });
+  const receipt = await adapter.waitForReceipt(hash);
+  if (receipt.status !== "success") {
+    throw new Error("Acquisition Fee claim transaction reverted");
+  }
+
+  onPhase({ kind: "complete" });
+  try {
+    await refreshAfterConfirmation();
+  } catch (error) {
+    onPhase({
+      kind: "refresh-error",
+      message:
+        error instanceof Error
+          ? `Claim confirmed, but live balances could not refresh: ${error.message}`
+          : "Claim confirmed, but live balances could not refresh",
+    });
+  }
+}
+
+export function claimPhaseMessage(phase: ClaimPhase): string {
+  switch (phase.kind) {
+    case "idle":
+      return "Ready to claim Acquisition Fees";
+    case "signing":
+      return "Confirm the Acquisition Fee claim in your wallet";
+    case "pending":
+      return "Claim submitted — waiting for confirmation";
+    case "complete":
+      return "Acquisition Fee claim confirmed";
+    case "refresh-error":
+    case "error":
+      return phase.message;
+  }
+}

--- a/src/lib/maker/pack-composer.test.ts
+++ b/src/lib/maker/pack-composer.test.ts
@@ -119,7 +119,7 @@ describe("Pack composer amount and NAV validation", () => {
           value: "2",
           balance: 100n,
           allowance: 100n,
-          quoteError: "live quote unavailable or stale",
+          quoteError: "Testnet price is stale — operator action is required",
         },
       ],
       20n,
@@ -138,13 +138,15 @@ describe("Pack composer amount and NAV validation", () => {
           value: "1",
           balance: 100n,
           allowance: 100n,
-          quoteError: "live quote unavailable or stale",
+          quoteError: "Testnet price is stale — operator action is required",
         },
       ],
       20n,
       300n
     );
-    expect(stale.errors).toContain("AAA: live quote unavailable or stale");
+    expect(stale.errors).toContain(
+      "AAA: Testnet price is stale — operator action is required"
+    );
 
     const outside = buildPackPlan(
       [

--- a/src/lib/maker/pack-composer.test.ts
+++ b/src/lib/maker/pack-composer.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Address, Hash, TransactionReceipt } from "viem";
+
+import {
+  buildPackPlan,
+  createAndEnrollPack,
+  enrollMintedPack,
+  isNavInBand,
+  parseTokenAmount,
+  transactionPhaseMessage,
+  type PackTransactionAdapter,
+  type TransactionPhase,
+} from "./pack-composer";
+
+const TOKEN_A = "0x0000000000000000000000000000000000000001" as Address;
+const TOKEN_B = "0x0000000000000000000000000000000000000002" as Address;
+const HASH_A = `0x${"1".repeat(64)}` as Hash;
+const HASH_B = `0x${"2".repeat(64)}` as Hash;
+const HASH_C = `0x${"3".repeat(64)}` as Hash;
+
+function receipt(status: "success" | "reverted" = "success") {
+  return { status, logs: [] } as unknown as TransactionReceipt;
+}
+
+describe("Pack composer amount and NAV validation", () => {
+  it("parses decimal strings exactly into raw token units", () => {
+    expect(parseTokenAmount("1.25", 6)).toEqual({
+      ok: true,
+      amount: 1_250_000n,
+    });
+    expect(parseTokenAmount("0.000001", 6)).toEqual({
+      ok: true,
+      amount: 1n,
+    });
+    expect(parseTokenAmount("0", 18)).toEqual({
+      ok: false,
+      error: "Amount must be greater than zero",
+    });
+    expect(parseTokenAmount("1.0000001", 6)).toEqual({
+      ok: false,
+      error: "Maximum 6 decimal places",
+    });
+    expect(parseTokenAmount("1e3", 18).ok).toBe(false);
+  });
+
+  it("uses an inclusive live NAV band", () => {
+    expect(isNavInBand(20n, 20n, 300n)).toBe(true);
+    expect(isNavInBand(300n, 20n, 300n)).toBe(true);
+    expect(isNavInBand(19n, 20n, 300n)).toBe(false);
+    expect(isNavInBand(301n, 20n, 300n)).toBe(false);
+  });
+
+  it("plans only insufficient allowances and sums quoted NAV", () => {
+    const plan = buildPackPlan(
+      [
+        {
+          symbol: "AAA",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "2.5",
+          balance: 500n,
+          allowance: 249n,
+          quote: 25n,
+        },
+        {
+          symbol: "BBB",
+          address: TOKEN_B,
+          decimals: 2,
+          value: "1",
+          balance: 100n,
+          allowance: 100n,
+          quote: 10n,
+        },
+      ],
+      20n,
+      300n
+    );
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.nav).toBe(35n);
+    expect(plan.eligible).toBe(true);
+    expect(plan.approvals.map((token) => token.symbol)).toEqual(["AAA"]);
+  });
+
+  it("rejects empty, zero, over-balance, stale quote, and out-of-band baskets", () => {
+    expect(
+      buildPackPlan(
+        [
+          {
+            symbol: "AAA",
+            address: TOKEN_A,
+            decimals: 18,
+            value: "",
+          },
+        ],
+        20n,
+        300n
+      ).errors
+    ).toContain("Add at least one Stock Token to the Pack");
+
+    const plan = buildPackPlan(
+      [
+        {
+          symbol: "AAA",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "0",
+          balance: 100n,
+          allowance: 100n,
+        },
+        {
+          symbol: "BBB",
+          address: TOKEN_B,
+          decimals: 2,
+          value: "2",
+          balance: 100n,
+          allowance: 100n,
+          quoteError: "live quote unavailable or stale",
+        },
+      ],
+      20n,
+      300n
+    );
+
+    expect(plan.errors).toContain("AAA: Amount must be greater than zero");
+    expect(plan.errors).toContain("BBB: amount exceeds wallet balance");
+
+    const stale = buildPackPlan(
+      [
+        {
+          symbol: "AAA",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "1",
+          balance: 100n,
+          allowance: 100n,
+          quoteError: "live quote unavailable or stale",
+        },
+      ],
+      20n,
+      300n
+    );
+    expect(stale.errors).toContain("AAA: live quote unavailable or stale");
+
+    const outside = buildPackPlan(
+      [
+        {
+          symbol: "AAA",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "1",
+          balance: 100n,
+          allowance: 100n,
+          quote: 10n,
+        },
+      ],
+      20n,
+      300n
+    );
+    expect(outside.errors).toContain(
+      "Basket NAV is outside the live eligibility band"
+    );
+  });
+});
+
+describe("Pack composer transaction lifecycle", () => {
+  it("labels accepted hashes as pending confirmations", () => {
+    expect(
+      transactionPhaseMessage({
+        kind: "approval-pending",
+        symbol: "AMZN",
+        hash: HASH_A,
+      })
+    ).toContain("waiting for confirmation");
+    expect(
+      transactionPhaseMessage({ kind: "mint-pending", hash: HASH_B })
+    ).toContain("waiting for confirmation");
+    expect(
+      transactionPhaseMessage({
+        kind: "enrollment-pending",
+        tokenId: 42n,
+        hash: HASH_C,
+      })
+    ).toContain("waiting for confirmation");
+  });
+
+  it("confirms approvals, mint, decoded token ID, and enrollment in order", async () => {
+    const phases: TransactionPhase[] = [];
+    const approve = vi.fn().mockResolvedValue(HASH_A);
+    const mint = vi.fn().mockResolvedValue(HASH_B);
+    const enterPool = vi.fn().mockResolvedValue(HASH_C);
+    const waitForReceipt = vi.fn().mockResolvedValue(receipt());
+    const adapter: PackTransactionAdapter = {
+      approve,
+      mint,
+      enterPool,
+      waitForReceipt,
+      getMintedTokenId: () => 42n,
+    };
+    const token = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 0n,
+      quote: 25n,
+    };
+    let minted: bigint | null = null;
+
+    await expect(
+      createAndEnrollPack(
+        { selected: [token], approvals: [token] },
+        adapter,
+        (phase) => phases.push(phase),
+        (tokenId) => {
+          minted = tokenId;
+        }
+      )
+    ).resolves.toBe(42n);
+
+    expect(approve).toHaveBeenCalledWith(TOKEN_A, 5n);
+    expect(mint).toHaveBeenCalledWith([TOKEN_A], [5n]);
+    expect(enterPool).toHaveBeenCalledWith(42n);
+    expect(waitForReceipt.mock.calls.map(([hash]) => hash)).toEqual([
+      HASH_A,
+      HASH_B,
+      HASH_C,
+    ]);
+    expect(minted).toBe(42n);
+    expect(phases.map((phase) => phase.kind)).toEqual([
+      "approving",
+      "approval-pending",
+      "minting",
+      "mint-pending",
+      "enrolling",
+      "enrollment-pending",
+      "complete",
+    ]);
+  });
+
+  it("preserves a confirmed minted ID when enrollment fails and retries without reminting", async () => {
+    const mint = vi.fn().mockResolvedValue(HASH_B);
+    const enterPool = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("User rejected enrollment"))
+      .mockResolvedValueOnce(HASH_C);
+    const adapter: PackTransactionAdapter = {
+      approve: vi.fn(),
+      mint,
+      enterPool,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+      getMintedTokenId: () => 77n,
+    };
+    const token = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 5n,
+      quote: 25n,
+    };
+    let minted: bigint | null = null;
+
+    await expect(
+      createAndEnrollPack(
+        { selected: [token], approvals: [] },
+        adapter,
+        () => undefined,
+        (tokenId) => {
+          minted = tokenId;
+        }
+      )
+    ).rejects.toThrow("User rejected enrollment");
+    expect(minted).toBe(77n);
+    expect(mint).toHaveBeenCalledTimes(1);
+
+    await expect(
+      enrollMintedPack(77n, adapter, () => undefined)
+    ).resolves.toBeUndefined();
+    expect(enterPool).toHaveBeenCalledTimes(2);
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not advance after a reverted receipt", async () => {
+    const enterPool = vi.fn();
+    const adapter: PackTransactionAdapter = {
+      approve: vi.fn().mockResolvedValue(HASH_A),
+      mint: vi.fn(),
+      enterPool,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt("reverted")),
+      getMintedTokenId: () => 1n,
+    };
+    const token = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 1n,
+      allowance: 0n,
+      quote: 20n,
+    };
+
+    await expect(
+      createAndEnrollPack(
+        { selected: [token], approvals: [token] },
+        adapter,
+        () => undefined,
+        () => undefined
+      )
+    ).rejects.toThrow("AMZN approval transaction reverted");
+    expect(adapter.mint).not.toHaveBeenCalled();
+    expect(enterPool).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/maker/pack-composer.test.ts
+++ b/src/lib/maker/pack-composer.test.ts
@@ -11,6 +11,10 @@ import {
   type PackTransactionAdapter,
   type TransactionPhase,
 } from "./pack-composer";
+import {
+  createMemoryJournalStorage,
+  ensureWorkflow,
+} from "./transaction-journal";
 
 const TOKEN_A = "0x0000000000000000000000000000000000000001" as Address;
 const TOKEN_B = "0x0000000000000000000000000000000000000002" as Address;
@@ -277,6 +281,58 @@ describe("Pack composer transaction lifecycle", () => {
     ).resolves.toBeUndefined();
     expect(enterPool).toHaveBeenCalledTimes(2);
     expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers a confirmed mint after remount without duplicate submission", async () => {
+    const storage = createMemoryJournalStorage();
+    const workflow = ensureWorkflow(storage, {
+      chainId: 46630,
+      wallet: "0x1234567890abcdef1234567890abcdef12345678",
+      kind: "create",
+      requestFingerprint: "pack-77",
+      context: {},
+    });
+    const journal = { storage, workflowKey: workflow.key };
+    const mint = vi.fn().mockResolvedValue(HASH_B);
+    const enterPool = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("wallet unavailable after reload"))
+      .mockResolvedValueOnce(HASH_C);
+    const adapter: PackTransactionAdapter = {
+      approve: vi.fn(),
+      mint,
+      enterPool,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+      getMintedTokenId: () => 77n,
+    };
+    const token = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 5n,
+      quote: 25n,
+    };
+
+    await expect(
+      createAndEnrollPack(
+        { selected: [token], approvals: [] },
+        adapter,
+        () => undefined,
+        () => undefined,
+        journal
+      )
+    ).rejects.toThrow("wallet unavailable after reload");
+    expect(storage.get(workflow.key)?.completed.mint).toBe(HASH_B);
+
+    await createAndEnrollPack(
+      { selected: [token], approvals: [] },
+      adapter,
+      () => undefined,
+      () => undefined,
+      journal
+    );
+    expect(mint).toHaveBeenCalledOnce();
+    expect(enterPool).toHaveBeenCalledTimes(2);
   });
 
   it("does not advance after a reverted receipt", async () => {

--- a/src/lib/maker/pack-composer.ts
+++ b/src/lib/maker/pack-composer.ts
@@ -1,5 +1,10 @@
 import type { Address, Hash, TransactionReceipt } from "viem";
 
+import {
+  executeMakerWrite,
+  type LifecycleJournalRun,
+} from "./transaction-journal";
+
 export type TokenAmountInput = {
   symbol: string;
   address: Address;
@@ -36,7 +41,7 @@ export type TransactionPhase =
   | { kind: "enrolling"; tokenId: bigint }
   | { kind: "enrollment-pending"; tokenId: bigint; hash: Hash }
   | { kind: "complete"; tokenId: bigint }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; hash?: Hash };
 
 export type PackTransactionAdapter = {
   approve: (token: Address, amount: bigint) => Promise<Hash>;
@@ -188,12 +193,19 @@ function requireSuccessfulReceipt(receipt: TransactionReceipt, label: string) {
 export async function enrollMintedPack(
   tokenId: bigint,
   adapter: PackTransactionAdapter,
-  onPhase: (phase: TransactionPhase) => void
+  onPhase: (phase: TransactionPhase) => void,
+  journal?: LifecycleJournalRun
 ): Promise<void> {
   onPhase({ kind: "enrolling", tokenId });
-  const hash = await adapter.enterPool(tokenId);
-  onPhase({ kind: "enrollment-pending", tokenId, hash });
-  const receipt = await adapter.waitForReceipt(hash);
+  const receipt = await executeMakerWrite({
+    journal,
+    step: "enterPool",
+    action: "enterPool",
+    submit: () => adapter.enterPool(tokenId),
+    reconcile: adapter.waitForReceipt,
+    onAccepted: (hash) =>
+      onPhase({ kind: "enrollment-pending", tokenId, hash }),
+  });
   requireSuccessfulReceipt(receipt, "Pool enrollment");
   onPhase({ kind: "complete", tokenId });
 }
@@ -202,27 +214,40 @@ export async function createAndEnrollPack(
   plan: Pick<PackPlan, "selected" | "approvals">,
   adapter: PackTransactionAdapter,
   onPhase: (phase: TransactionPhase) => void,
-  onMinted: (tokenId: bigint) => void
+  onMinted: (tokenId: bigint) => void,
+  journal?: LifecycleJournalRun
 ): Promise<bigint> {
   for (const token of plan.approvals) {
     onPhase({ kind: "approving", symbol: token.symbol });
-    const hash = await adapter.approve(token.address, token.amount);
-    onPhase({ kind: "approval-pending", symbol: token.symbol, hash });
-    const receipt = await adapter.waitForReceipt(hash);
+    const receipt = await executeMakerWrite({
+      journal,
+      step: `approve:${token.address.toLowerCase()}:${token.amount}`,
+      action: "approve",
+      submit: () => adapter.approve(token.address, token.amount),
+      reconcile: adapter.waitForReceipt,
+      onAccepted: (hash) =>
+        onPhase({ kind: "approval-pending", symbol: token.symbol, hash }),
+    });
     requireSuccessfulReceipt(receipt, `${token.symbol} approval`);
   }
 
   onPhase({ kind: "minting" });
-  const mintHash = await adapter.mint(
-    plan.selected.map((token) => token.address),
-    plan.selected.map((token) => token.amount)
-  );
-  onPhase({ kind: "mint-pending", hash: mintHash });
-  const mintReceipt = await adapter.waitForReceipt(mintHash);
+  const mintReceipt = await executeMakerWrite({
+    journal,
+    step: "mint",
+    action: "mint",
+    submit: () =>
+      adapter.mint(
+        plan.selected.map((token) => token.address),
+        plan.selected.map((token) => token.amount)
+      ),
+    reconcile: adapter.waitForReceipt,
+    onAccepted: (hash) => onPhase({ kind: "mint-pending", hash }),
+  });
   requireSuccessfulReceipt(mintReceipt, "Pack mint");
 
   const tokenId = adapter.getMintedTokenId(mintReceipt);
   onMinted(tokenId);
-  await enrollMintedPack(tokenId, adapter, onPhase);
+  await enrollMintedPack(tokenId, adapter, onPhase, journal);
   return tokenId;
 }

--- a/src/lib/maker/pack-composer.ts
+++ b/src/lib/maker/pack-composer.ts
@@ -1,0 +1,228 @@
+import type { Address, Hash, TransactionReceipt } from "viem";
+
+export type TokenAmountInput = {
+  symbol: string;
+  address: Address;
+  decimals: number;
+  value: string;
+  balance?: bigint;
+  allowance?: bigint;
+  quote?: bigint;
+  quoteError?: string;
+};
+
+export type SelectedPackToken = {
+  symbol: string;
+  address: Address;
+  amount: bigint;
+  allowance: bigint;
+  quote: bigint;
+};
+
+export type PackPlan = {
+  selected: SelectedPackToken[];
+  nav: bigint;
+  approvals: SelectedPackToken[];
+  errors: string[];
+  eligible: boolean;
+};
+
+export type TransactionPhase =
+  | { kind: "idle" }
+  | { kind: "approving"; symbol: string }
+  | { kind: "approval-pending"; symbol: string; hash: Hash }
+  | { kind: "minting" }
+  | { kind: "mint-pending"; hash: Hash }
+  | { kind: "enrolling"; tokenId: bigint }
+  | { kind: "enrollment-pending"; tokenId: bigint; hash: Hash }
+  | { kind: "complete"; tokenId: bigint }
+  | { kind: "error"; message: string };
+
+export type PackTransactionAdapter = {
+  approve: (token: Address, amount: bigint) => Promise<Hash>;
+  mint: (assets: Address[], amounts: bigint[]) => Promise<Hash>;
+  enterPool: (tokenId: bigint) => Promise<Hash>;
+  waitForReceipt: (hash: Hash) => Promise<TransactionReceipt>;
+  getMintedTokenId: (receipt: TransactionReceipt) => bigint;
+};
+
+export function parseTokenAmount(
+  value: string,
+  decimals: number
+): { ok: true; amount: bigint } | { ok: false; error: string } {
+  const normalized = value.trim();
+  if (!normalized) return { ok: false, error: "Enter an amount" };
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    return { ok: false, error: "Invalid token decimals" };
+  }
+
+  const match = /^(0|[1-9]\d*)(?:\.(\d+))?$/.exec(normalized);
+  if (!match) {
+    return { ok: false, error: "Use a positive decimal amount" };
+  }
+
+  const fraction = match[2] ?? "";
+  if (fraction.length > decimals) {
+    return { ok: false, error: `Maximum ${decimals} decimal places` };
+  }
+
+  const whole = BigInt(match[1]);
+  const paddedFraction = fraction.padEnd(decimals, "0");
+  const amount =
+    whole * 10n ** BigInt(decimals) +
+    (paddedFraction ? BigInt(paddedFraction) : 0n);
+
+  if (amount === 0n) {
+    return { ok: false, error: "Amount must be greater than zero" };
+  }
+
+  return { ok: true, amount };
+}
+
+export function isNavInBand(
+  nav: bigint,
+  minPackNav: bigint,
+  poolMax: bigint
+): boolean {
+  return nav >= minPackNav && nav <= poolMax;
+}
+
+export function buildPackPlan(
+  inputs: TokenAmountInput[],
+  minPackNav?: bigint,
+  poolMax?: bigint
+): PackPlan {
+  const errors: string[] = [];
+  const selected: SelectedPackToken[] = [];
+
+  for (const input of inputs) {
+    if (!input.value.trim()) continue;
+    const parsed = parseTokenAmount(input.value, input.decimals);
+    if (!parsed.ok) {
+      errors.push(`${input.symbol}: ${parsed.error}`);
+      continue;
+    }
+    if (input.balance === undefined) {
+      errors.push(`${input.symbol}: wallet balance unavailable`);
+      continue;
+    }
+    if (parsed.amount > input.balance) {
+      errors.push(`${input.symbol}: amount exceeds wallet balance`);
+      continue;
+    }
+    if (input.allowance === undefined) {
+      errors.push(`${input.symbol}: allowance unavailable`);
+      continue;
+    }
+    if (input.quoteError || input.quote === undefined) {
+      errors.push(
+        `${input.symbol}: ${input.quoteError ?? "live quote unavailable"}`
+      );
+      continue;
+    }
+    selected.push({
+      symbol: input.symbol,
+      address: input.address,
+      amount: parsed.amount,
+      allowance: input.allowance,
+      quote: input.quote,
+    });
+  }
+
+  if (inputs.every((input) => !input.value.trim())) {
+    errors.push("Add at least one Stock Token to the Pack");
+  } else if (selected.length === 0 && errors.length === 0) {
+    errors.push("The Pack basket cannot be empty");
+  }
+
+  const nav = selected.reduce((sum, token) => sum + token.quote, 0n);
+  let eligible = false;
+  if (minPackNav === undefined || poolMax === undefined) {
+    errors.push("Live Pack eligibility band unavailable");
+  } else if (selected.length > 0) {
+    const navInBand = isNavInBand(nav, minPackNav, poolMax);
+    eligible = errors.length === 0 && navInBand;
+    if (!navInBand) {
+      errors.push("Basket NAV is outside the live eligibility band");
+    }
+  }
+
+  return {
+    selected,
+    nav,
+    approvals: selected.filter((token) => token.allowance < token.amount),
+    errors,
+    eligible,
+  };
+}
+
+export function transactionPhaseMessage(phase: TransactionPhase): string {
+  switch (phase.kind) {
+    case "idle":
+      return "Ready to create a Pack";
+    case "approving":
+      return `Approve ${phase.symbol} in your wallet`;
+    case "approval-pending":
+      return `${phase.symbol} approval submitted — waiting for confirmation`;
+    case "minting":
+      return "Confirm Pack mint in your wallet";
+    case "mint-pending":
+      return "Pack mint submitted — waiting for confirmation";
+    case "enrolling":
+      return `Pack #${phase.tokenId} minted. Confirm pool enrollment`;
+    case "enrollment-pending":
+      return `Pack #${phase.tokenId} enrollment submitted — waiting for confirmation`;
+    case "complete":
+      return `Pack #${phase.tokenId} minted and enrolled`;
+    case "error":
+      return phase.message;
+  }
+}
+
+function requireSuccessfulReceipt(receipt: TransactionReceipt, label: string) {
+  if (receipt.status !== "success") {
+    throw new Error(`${label} transaction reverted`);
+  }
+}
+
+export async function enrollMintedPack(
+  tokenId: bigint,
+  adapter: PackTransactionAdapter,
+  onPhase: (phase: TransactionPhase) => void
+): Promise<void> {
+  onPhase({ kind: "enrolling", tokenId });
+  const hash = await adapter.enterPool(tokenId);
+  onPhase({ kind: "enrollment-pending", tokenId, hash });
+  const receipt = await adapter.waitForReceipt(hash);
+  requireSuccessfulReceipt(receipt, "Pool enrollment");
+  onPhase({ kind: "complete", tokenId });
+}
+
+export async function createAndEnrollPack(
+  plan: Pick<PackPlan, "selected" | "approvals">,
+  adapter: PackTransactionAdapter,
+  onPhase: (phase: TransactionPhase) => void,
+  onMinted: (tokenId: bigint) => void
+): Promise<bigint> {
+  for (const token of plan.approvals) {
+    onPhase({ kind: "approving", symbol: token.symbol });
+    const hash = await adapter.approve(token.address, token.amount);
+    onPhase({ kind: "approval-pending", symbol: token.symbol, hash });
+    const receipt = await adapter.waitForReceipt(hash);
+    requireSuccessfulReceipt(receipt, `${token.symbol} approval`);
+  }
+
+  onPhase({ kind: "minting" });
+  const mintHash = await adapter.mint(
+    plan.selected.map((token) => token.address),
+    plan.selected.map((token) => token.amount)
+  );
+  onPhase({ kind: "mint-pending", hash: mintHash });
+  const mintReceipt = await adapter.waitForReceipt(mintHash);
+  requireSuccessfulReceipt(mintReceipt, "Pack mint");
+
+  const tokenId = adapter.getMintedTokenId(mintReceipt);
+  onMinted(tokenId);
+  await enrollMintedPack(tokenId, adapter, onPhase);
+  return tokenId;
+}

--- a/src/lib/maker/pack-composer.ts
+++ b/src/lib/maker/pack-composer.ts
@@ -121,7 +121,7 @@ export function buildPackPlan(
     }
     if (input.quoteError || input.quote === undefined) {
       errors.push(
-        `${input.symbol}: ${input.quoteError ?? "live quote unavailable"}`
+        `${input.symbol}: ${input.quoteError ?? "testnet quote unavailable"}`
       );
       continue;
     }

--- a/src/lib/maker/pack-lifecycle.test.ts
+++ b/src/lib/maker/pack-lifecycle.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Address, Hash, TransactionReceipt } from "viem";
+
+import {
+  buildTopUpPlan,
+  exitAndRedeemPack,
+  redeemExitedPack,
+  syncConfirmedTopUp,
+  topUpAndSyncPack,
+  type RedemptionPhase,
+  type RedemptionTransactionAdapter,
+  type TopUpPhase,
+  type TopUpTransactionAdapter,
+} from "./pack-lifecycle";
+
+const TOKEN_A = "0x0000000000000000000000000000000000000001" as Address;
+const HASH_A = `0x${"1".repeat(64)}` as Hash;
+const HASH_B = `0x${"2".repeat(64)}` as Hash;
+const HASH_C = `0x${"3".repeat(64)}` as Hash;
+
+function receipt(status: "success" | "reverted" = "success") {
+  return { status, logs: [] } as unknown as TransactionReceipt;
+}
+
+describe("Pack top-up validation", () => {
+  it("validates approved additions, balances, allowances, quotes, and projected NAV", () => {
+    const plan = buildTopUpPlan(
+      [
+        {
+          symbol: "AMZN",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "2.5",
+          approved: true,
+          balance: 500n,
+          allowance: 249n,
+          quote: 25n,
+        },
+      ],
+      50n,
+      20n,
+      100n
+    );
+
+    expect(plan.errors).toEqual([]);
+    expect(plan.currentNav).toBe(50n);
+    expect(plan.projectedNav).toBe(75n);
+    expect(plan.eligible).toBe(true);
+    expect(plan.approvals.map((token) => token.symbol)).toEqual(["AMZN"]);
+  });
+
+  it("fails closed for unapproved tokens, insufficient balances, stale basket quotes, and ineligible NAV", () => {
+    const unapproved = buildTopUpPlan(
+      [
+        {
+          symbol: "AMZN",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "1",
+          approved: false,
+          balance: 100n,
+          allowance: 100n,
+          quote: 10n,
+        },
+      ],
+      50n,
+      20n,
+      100n
+    );
+    expect(unapproved.errors).toContain(
+      "AMZN: token is not currently approved"
+    );
+
+    const invalid = buildTopUpPlan(
+      [
+        {
+          symbol: "AMZN",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "2",
+          approved: true,
+          balance: 100n,
+          allowance: 100n,
+          quoteError: "live quote unavailable or stale",
+        },
+      ],
+      undefined,
+      20n,
+      100n,
+      "Existing basket quote unavailable or stale"
+    );
+    expect(invalid.errors).toContain("AMZN: amount exceeds wallet balance");
+    expect(invalid.errors).toContain(
+      "Existing basket quote unavailable or stale"
+    );
+
+    const outside = buildTopUpPlan(
+      [
+        {
+          symbol: "AMZN",
+          address: TOKEN_A,
+          decimals: 2,
+          value: "1",
+          approved: true,
+          balance: 100n,
+          allowance: 100n,
+          quote: 60n,
+        },
+      ],
+      50n,
+      20n,
+      100n
+    );
+    expect(outside.errors).toContain(
+      "Projected Pack NAV is outside the live eligibility band"
+    );
+  });
+});
+
+describe("Pack top-up transaction lifecycle", () => {
+  it("confirms approval, top-up, and NAV sync in order", async () => {
+    const calls: string[] = [];
+    const phases: TopUpPhase[] = [];
+    const adapter: TopUpTransactionAdapter = {
+      approve: vi.fn(async () => {
+        calls.push("approve");
+        return HASH_A;
+      }),
+      topUp: vi.fn(async () => {
+        calls.push("topUp");
+        return HASH_B;
+      }),
+      syncPackNav: vi.fn(async () => {
+        calls.push("sync");
+        return HASH_C;
+      }),
+      waitForReceipt: vi.fn(async (hash) => {
+        calls.push(`receipt:${hash}`);
+        return receipt();
+      }),
+    };
+    const addition = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 0n,
+      quote: 25n,
+    };
+    const confirmed = vi.fn();
+
+    await topUpAndSyncPack(
+      42n,
+      { additions: [addition], approvals: [addition] },
+      adapter,
+      (phase) => phases.push(phase),
+      confirmed
+    );
+
+    expect(calls).toEqual([
+      "approve",
+      `receipt:${HASH_A}`,
+      "topUp",
+      `receipt:${HASH_B}`,
+      "sync",
+      `receipt:${HASH_C}`,
+    ]);
+    expect(confirmed).toHaveBeenCalledOnce();
+    expect(phases.map((phase) => phase.kind)).toEqual([
+      "approving",
+      "approval-pending",
+      "topping-up",
+      "top-up-pending",
+      "syncing",
+      "sync-pending",
+      "complete",
+    ]);
+  });
+
+  it("retries sync after a confirmed top-up without repeating the top-up", async () => {
+    const topUp = vi.fn().mockResolvedValue(HASH_B);
+    const syncPackNav = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Sync rejected"))
+      .mockResolvedValueOnce(HASH_C);
+    const adapter: TopUpTransactionAdapter = {
+      approve: vi.fn(),
+      topUp,
+      syncPackNav,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+    };
+    const confirmed = vi.fn();
+    const addition = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 5n,
+      quote: 25n,
+    };
+
+    await expect(
+      topUpAndSyncPack(
+        42n,
+        { additions: [addition], approvals: [] },
+        adapter,
+        () => undefined,
+        confirmed
+      )
+    ).rejects.toThrow("Sync rejected");
+    expect(confirmed).toHaveBeenCalledOnce();
+
+    await syncConfirmedTopUp(42n, adapter, () => undefined);
+    expect(topUp).toHaveBeenCalledOnce();
+    expect(syncPackNav).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after a reverted top-up receipt", async () => {
+    const adapter: TopUpTransactionAdapter = {
+      approve: vi.fn(),
+      topUp: vi.fn().mockResolvedValue(HASH_B),
+      syncPackNav: vi.fn(),
+      waitForReceipt: vi.fn().mockResolvedValue(receipt("reverted")),
+    };
+    const addition = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 5n,
+      quote: 25n,
+    };
+
+    await expect(
+      topUpAndSyncPack(
+        42n,
+        { additions: [addition], approvals: [] },
+        adapter,
+        () => undefined,
+        () => undefined
+      )
+    ).rejects.toThrow("Pack top-up transaction reverted");
+    expect(adapter.syncPackNav).not.toHaveBeenCalled();
+  });
+});
+
+describe("Pack redemption transaction lifecycle", () => {
+  it("exits a resting Pack before redeeming and confirms both receipts", async () => {
+    const phases: RedemptionPhase[] = [];
+    const adapter: RedemptionTransactionAdapter = {
+      exitPool: vi.fn().mockResolvedValue(HASH_A),
+      delistAndRedeem: vi.fn().mockResolvedValue(HASH_B),
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+    };
+    const exited = vi.fn();
+
+    await exitAndRedeemPack(
+      42n,
+      { isResting: true, isListed: true },
+      adapter,
+      (phase) => phases.push(phase),
+      exited
+    );
+
+    expect(adapter.exitPool).toHaveBeenCalledWith(42n);
+    expect(adapter.delistAndRedeem).toHaveBeenCalledWith(42n);
+    expect(adapter.waitForReceipt).toHaveBeenNthCalledWith(1, HASH_A);
+    expect(adapter.waitForReceipt).toHaveBeenNthCalledWith(2, HASH_B);
+    expect(exited).toHaveBeenCalledOnce();
+    expect(phases.map((phase) => phase.kind)).toEqual([
+      "exiting",
+      "exit-pending",
+      "redeeming",
+      "redeem-pending",
+      "complete",
+    ]);
+  });
+
+  it("redeems an already-exited listed Pack directly", async () => {
+    const adapter: RedemptionTransactionAdapter = {
+      exitPool: vi.fn(),
+      delistAndRedeem: vi.fn().mockResolvedValue(HASH_B),
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+    };
+
+    await exitAndRedeemPack(
+      42n,
+      { isResting: false, isListed: true },
+      adapter,
+      () => undefined,
+      () => undefined
+    );
+
+    expect(adapter.exitPool).not.toHaveBeenCalled();
+    expect(adapter.delistAndRedeem).toHaveBeenCalledOnce();
+  });
+
+  it("retries redemption after confirmed exit without repeating exit", async () => {
+    const exitPool = vi.fn().mockResolvedValue(HASH_A);
+    const delistAndRedeem = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Redeem rejected"))
+      .mockResolvedValueOnce(HASH_B);
+    const adapter: RedemptionTransactionAdapter = {
+      exitPool,
+      delistAndRedeem,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+    };
+    const exited = vi.fn();
+
+    await expect(
+      exitAndRedeemPack(
+        42n,
+        { isResting: true, isListed: true },
+        adapter,
+        () => undefined,
+        exited
+      )
+    ).rejects.toThrow("Redeem rejected");
+    expect(exited).toHaveBeenCalledOnce();
+
+    await redeemExitedPack(42n, adapter, () => undefined);
+    expect(exitPool).toHaveBeenCalledOnce();
+    expect(delistAndRedeem).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not redeem after a reverted exit receipt", async () => {
+    const adapter: RedemptionTransactionAdapter = {
+      exitPool: vi.fn().mockResolvedValue(HASH_A),
+      delistAndRedeem: vi.fn(),
+      waitForReceipt: vi.fn().mockResolvedValue(receipt("reverted")),
+    };
+
+    await expect(
+      exitAndRedeemPack(
+        42n,
+        { isResting: true, isListed: true },
+        adapter,
+        () => undefined,
+        () => undefined
+      )
+    ).rejects.toThrow("Pool exit transaction reverted");
+    expect(adapter.delistAndRedeem).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/maker/pack-lifecycle.test.ts
+++ b/src/lib/maker/pack-lifecycle.test.ts
@@ -12,6 +12,10 @@ import {
   type TopUpPhase,
   type TopUpTransactionAdapter,
 } from "./pack-lifecycle";
+import {
+  createMemoryJournalStorage,
+  ensureWorkflow,
+} from "./transaction-journal";
 
 const TOKEN_A = "0x0000000000000000000000000000000000000001" as Address;
 const HASH_A = `0x${"1".repeat(64)}` as Hash;
@@ -213,6 +217,59 @@ describe("Pack top-up transaction lifecycle", () => {
     expect(syncPackNav).toHaveBeenCalledTimes(2);
   });
 
+  it("recovers confirmed top-up through NAV sync after remount", async () => {
+    const storage = createMemoryJournalStorage();
+    const workflow = ensureWorkflow(storage, {
+      chainId: 46630,
+      wallet: "0x1234567890abcdef1234567890abcdef12345678",
+      kind: "top-up",
+      requestFingerprint: "pack-42-topup",
+      context: { tokenId: "42" },
+    });
+    const journal = { storage, workflowKey: workflow.key };
+    const topUp = vi.fn().mockResolvedValue(HASH_B);
+    const syncPackNav = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("wallet unavailable after reload"))
+      .mockResolvedValueOnce(HASH_C);
+    const adapter: TopUpTransactionAdapter = {
+      approve: vi.fn(),
+      topUp,
+      syncPackNav,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+    };
+    const addition = {
+      symbol: "AMZN",
+      address: TOKEN_A,
+      amount: 5n,
+      allowance: 5n,
+      quote: 25n,
+    };
+
+    await expect(
+      topUpAndSyncPack(
+        42n,
+        { additions: [addition], approvals: [] },
+        adapter,
+        () => undefined,
+        () => undefined,
+        journal
+      )
+    ).rejects.toThrow("wallet unavailable after reload");
+    expect(storage.get(workflow.key)?.completed.topUp).toBe(HASH_B);
+
+    await topUpAndSyncPack(
+      42n,
+      { additions: [addition], approvals: [] },
+      adapter,
+      () => undefined,
+      () => undefined,
+      journal
+    );
+    expect(topUp).toHaveBeenCalledOnce();
+    expect(syncPackNav).toHaveBeenCalledTimes(2);
+  });
+
   it("stops after a reverted top-up receipt", async () => {
     const adapter: TopUpTransactionAdapter = {
       approve: vi.fn(),
@@ -317,6 +374,44 @@ describe("Pack redemption transaction lifecycle", () => {
     expect(exited).toHaveBeenCalledOnce();
 
     await redeemExitedPack(42n, adapter, () => undefined);
+    expect(exitPool).toHaveBeenCalledOnce();
+    expect(delistAndRedeem).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers a confirmed exit through redemption after remount", async () => {
+    const storage = createMemoryJournalStorage();
+    const workflow = ensureWorkflow(storage, {
+      chainId: 46630,
+      wallet: "0x1234567890abcdef1234567890abcdef12345678",
+      kind: "redemption",
+      requestFingerprint: "pack-42-redeem",
+      context: { tokenId: "42" },
+    });
+    const journal = { storage, workflowKey: workflow.key };
+    const exitPool = vi.fn().mockResolvedValue(HASH_A);
+    const delistAndRedeem = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("wallet unavailable after reload"))
+      .mockResolvedValueOnce(HASH_B);
+    const adapter: RedemptionTransactionAdapter = {
+      exitPool,
+      delistAndRedeem,
+      waitForReceipt: vi.fn().mockResolvedValue(receipt()),
+    };
+
+    await expect(
+      exitAndRedeemPack(
+        42n,
+        { isResting: true, isListed: true },
+        adapter,
+        () => undefined,
+        () => undefined,
+        journal
+      )
+    ).rejects.toThrow("wallet unavailable after reload");
+    expect(storage.get(workflow.key)?.completed.exitPool).toBe(HASH_A);
+
+    await redeemExitedPack(42n, adapter, () => undefined, journal);
     expect(exitPool).toHaveBeenCalledOnce();
     expect(delistAndRedeem).toHaveBeenCalledTimes(2);
   });

--- a/src/lib/maker/pack-lifecycle.ts
+++ b/src/lib/maker/pack-lifecycle.ts
@@ -1,0 +1,274 @@
+import type { Address, Hash, TransactionReceipt } from "viem";
+
+import { isNavInBand, parseTokenAmount } from "./pack-composer";
+
+export type TopUpTokenInput = {
+  symbol: string;
+  address: Address;
+  decimals: number;
+  value: string;
+  approved?: boolean;
+  balance?: bigint;
+  allowance?: bigint;
+  quote?: bigint;
+  quoteError?: string;
+};
+
+export type TopUpToken = {
+  symbol: string;
+  address: Address;
+  amount: bigint;
+  allowance: bigint;
+  quote: bigint;
+};
+
+export type TopUpPlan = {
+  additions: TopUpToken[];
+  approvals: TopUpToken[];
+  currentNav: bigint;
+  projectedNav: bigint;
+  eligible: boolean;
+  errors: string[];
+};
+
+export type TopUpPhase =
+  | { kind: "idle" }
+  | { kind: "approving"; symbol: string }
+  | { kind: "approval-pending"; symbol: string; hash: Hash }
+  | { kind: "topping-up" }
+  | { kind: "top-up-pending"; hash: Hash }
+  | { kind: "syncing" }
+  | { kind: "sync-pending"; hash: Hash }
+  | { kind: "complete" }
+  | { kind: "error"; message: string };
+
+export type TopUpTransactionAdapter = {
+  approve: (token: Address, amount: bigint) => Promise<Hash>;
+  topUp: (
+    tokenId: bigint,
+    assets: Address[],
+    amounts: bigint[]
+  ) => Promise<Hash>;
+  syncPackNav: (tokenId: bigint) => Promise<Hash>;
+  waitForReceipt: (hash: Hash) => Promise<TransactionReceipt>;
+};
+
+export type RedemptionPhase =
+  | { kind: "idle" }
+  | { kind: "exiting" }
+  | { kind: "exit-pending"; hash: Hash }
+  | { kind: "redeeming" }
+  | { kind: "redeem-pending"; hash: Hash }
+  | { kind: "complete" }
+  | { kind: "error"; message: string };
+
+export type RedemptionTransactionAdapter = {
+  exitPool: (tokenId: bigint) => Promise<Hash>;
+  delistAndRedeem: (tokenId: bigint) => Promise<Hash>;
+  waitForReceipt: (hash: Hash) => Promise<TransactionReceipt>;
+};
+
+export function buildTopUpPlan(
+  inputs: TopUpTokenInput[],
+  currentNav?: bigint,
+  minPackNav?: bigint,
+  poolMax?: bigint,
+  basketError?: string
+): TopUpPlan {
+  const errors: string[] = [];
+  const additions: TopUpToken[] = [];
+
+  if (basketError) errors.push(basketError);
+  if (currentNav === undefined) errors.push("Live basket NAV unavailable");
+
+  for (const input of inputs) {
+    if (!input.value.trim()) continue;
+    const parsed = parseTokenAmount(input.value, input.decimals);
+    if (!parsed.ok) {
+      errors.push(`${input.symbol}: ${parsed.error}`);
+      continue;
+    }
+    if (input.approved !== true) {
+      errors.push(`${input.symbol}: token is not currently approved`);
+      continue;
+    }
+    if (input.balance === undefined) {
+      errors.push(`${input.symbol}: wallet balance unavailable`);
+      continue;
+    }
+    if (parsed.amount > input.balance) {
+      errors.push(`${input.symbol}: amount exceeds wallet balance`);
+      continue;
+    }
+    if (input.allowance === undefined) {
+      errors.push(`${input.symbol}: allowance unavailable`);
+      continue;
+    }
+    if (input.quoteError || input.quote === undefined) {
+      errors.push(
+        `${input.symbol}: ${input.quoteError ?? "live quote unavailable"}`
+      );
+      continue;
+    }
+    additions.push({
+      symbol: input.symbol,
+      address: input.address,
+      amount: parsed.amount,
+      allowance: input.allowance,
+      quote: input.quote,
+    });
+  }
+
+  if (inputs.every((input) => !input.value.trim())) {
+    errors.push("Add at least one approved Stock Token");
+  }
+
+  const baseNav = currentNav ?? 0n;
+  const projectedNav = additions.reduce(
+    (sum, token) => sum + token.quote,
+    baseNav
+  );
+  let eligible = false;
+  if (minPackNav === undefined || poolMax === undefined) {
+    errors.push("Live Pack eligibility band unavailable");
+  } else if (additions.length > 0 && currentNav !== undefined) {
+    eligible =
+      errors.length === 0 && isNavInBand(projectedNav, minPackNav, poolMax);
+    if (!isNavInBand(projectedNav, minPackNav, poolMax)) {
+      errors.push("Projected Pack NAV is outside the live eligibility band");
+    }
+  }
+
+  return {
+    additions,
+    approvals: additions.filter((token) => token.allowance < token.amount),
+    currentNav: baseNav,
+    projectedNav,
+    eligible,
+    errors,
+  };
+}
+
+function requireSuccessfulReceipt(receipt: TransactionReceipt, label: string) {
+  if (receipt.status !== "success") {
+    throw new Error(`${label} transaction reverted`);
+  }
+}
+
+export async function syncConfirmedTopUp(
+  tokenId: bigint,
+  adapter: TopUpTransactionAdapter,
+  onPhase: (phase: TopUpPhase) => void
+): Promise<void> {
+  onPhase({ kind: "syncing" });
+  const hash = await adapter.syncPackNav(tokenId);
+  onPhase({ kind: "sync-pending", hash });
+  const receipt = await adapter.waitForReceipt(hash);
+  requireSuccessfulReceipt(receipt, "Pack NAV sync");
+  onPhase({ kind: "complete" });
+}
+
+export async function topUpAndSyncPack(
+  tokenId: bigint,
+  plan: Pick<TopUpPlan, "additions" | "approvals">,
+  adapter: TopUpTransactionAdapter,
+  onPhase: (phase: TopUpPhase) => void,
+  onTopUpConfirmed: () => void
+): Promise<void> {
+  for (const token of plan.approvals) {
+    onPhase({ kind: "approving", symbol: token.symbol });
+    const hash = await adapter.approve(token.address, token.amount);
+    onPhase({ kind: "approval-pending", symbol: token.symbol, hash });
+    const receipt = await adapter.waitForReceipt(hash);
+    requireSuccessfulReceipt(receipt, `${token.symbol} approval`);
+  }
+
+  onPhase({ kind: "topping-up" });
+  const hash = await adapter.topUp(
+    tokenId,
+    plan.additions.map((token) => token.address),
+    plan.additions.map((token) => token.amount)
+  );
+  onPhase({ kind: "top-up-pending", hash });
+  const receipt = await adapter.waitForReceipt(hash);
+  requireSuccessfulReceipt(receipt, "Pack top-up");
+  onTopUpConfirmed();
+
+  await syncConfirmedTopUp(tokenId, adapter, onPhase);
+}
+
+export async function redeemExitedPack(
+  tokenId: bigint,
+  adapter: RedemptionTransactionAdapter,
+  onPhase: (phase: RedemptionPhase) => void
+): Promise<void> {
+  onPhase({ kind: "redeeming" });
+  const hash = await adapter.delistAndRedeem(tokenId);
+  onPhase({ kind: "redeem-pending", hash });
+  const receipt = await adapter.waitForReceipt(hash);
+  requireSuccessfulReceipt(receipt, "Pack redemption");
+  onPhase({ kind: "complete" });
+}
+
+export async function exitAndRedeemPack(
+  tokenId: bigint,
+  state: { isResting: boolean; isListed: boolean },
+  adapter: RedemptionTransactionAdapter,
+  onPhase: (phase: RedemptionPhase) => void,
+  onExitConfirmed: () => void
+): Promise<void> {
+  if (!state.isListed) throw new Error("Pack is no longer listed");
+
+  if (state.isResting) {
+    onPhase({ kind: "exiting" });
+    const hash = await adapter.exitPool(tokenId);
+    onPhase({ kind: "exit-pending", hash });
+    const receipt = await adapter.waitForReceipt(hash);
+    requireSuccessfulReceipt(receipt, "Pool exit");
+    onExitConfirmed();
+  }
+
+  await redeemExitedPack(tokenId, adapter, onPhase);
+}
+
+export function topUpPhaseMessage(phase: TopUpPhase): string {
+  switch (phase.kind) {
+    case "idle":
+      return "Ready to add Stock Tokens";
+    case "approving":
+      return `Approve ${phase.symbol} in your wallet`;
+    case "approval-pending":
+      return `${phase.symbol} approval submitted — waiting for confirmation`;
+    case "topping-up":
+      return "Confirm Pack top-up in your wallet";
+    case "top-up-pending":
+      return "Pack top-up submitted — waiting for confirmation";
+    case "syncing":
+      return "Top-up confirmed. Confirm NAV sync in your wallet";
+    case "sync-pending":
+      return "NAV sync submitted — waiting for confirmation";
+    case "complete":
+      return "Pack top-up and NAV sync confirmed";
+    case "error":
+      return phase.message;
+  }
+}
+
+export function redemptionPhaseMessage(phase: RedemptionPhase): string {
+  switch (phase.kind) {
+    case "idle":
+      return "Ready to delist and redeem";
+    case "exiting":
+      return "Confirm pool exit to crystallize pending fees";
+    case "exit-pending":
+      return "Pool exit submitted — waiting for confirmation";
+    case "redeeming":
+      return "Confirm zero-fee Pack redemption in your wallet";
+    case "redeem-pending":
+      return "Pack redemption submitted — waiting for confirmation";
+    case "complete":
+      return "Pack delisted and basket redeemed";
+    case "error":
+      return phase.message;
+  }
+}

--- a/src/lib/maker/pack-lifecycle.ts
+++ b/src/lib/maker/pack-lifecycle.ts
@@ -1,6 +1,10 @@
 import type { Address, Hash, TransactionReceipt } from "viem";
 
 import { isNavInBand, parseTokenAmount } from "./pack-composer";
+import {
+  executeMakerWrite,
+  type LifecycleJournalRun,
+} from "./transaction-journal";
 
 export type TopUpTokenInput = {
   symbol: string;
@@ -40,7 +44,7 @@ export type TopUpPhase =
   | { kind: "syncing" }
   | { kind: "sync-pending"; hash: Hash }
   | { kind: "complete" }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; hash?: Hash };
 
 export type TopUpTransactionAdapter = {
   approve: (token: Address, amount: bigint) => Promise<Hash>;
@@ -60,7 +64,7 @@ export type RedemptionPhase =
   | { kind: "redeeming" }
   | { kind: "redeem-pending"; hash: Hash }
   | { kind: "complete" }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; hash?: Hash };
 
 export type RedemptionTransactionAdapter = {
   exitPool: (tokenId: bigint) => Promise<Hash>;
@@ -158,12 +162,18 @@ function requireSuccessfulReceipt(receipt: TransactionReceipt, label: string) {
 export async function syncConfirmedTopUp(
   tokenId: bigint,
   adapter: TopUpTransactionAdapter,
-  onPhase: (phase: TopUpPhase) => void
+  onPhase: (phase: TopUpPhase) => void,
+  journal?: LifecycleJournalRun
 ): Promise<void> {
   onPhase({ kind: "syncing" });
-  const hash = await adapter.syncPackNav(tokenId);
-  onPhase({ kind: "sync-pending", hash });
-  const receipt = await adapter.waitForReceipt(hash);
+  const receipt = await executeMakerWrite({
+    journal,
+    step: "syncPackNav",
+    action: "syncPackNav",
+    submit: () => adapter.syncPackNav(tokenId),
+    reconcile: adapter.waitForReceipt,
+    onAccepted: (hash) => onPhase({ kind: "sync-pending", hash }),
+  });
   requireSuccessfulReceipt(receipt, "Pack NAV sync");
   onPhase({ kind: "complete" });
 }
@@ -173,39 +183,58 @@ export async function topUpAndSyncPack(
   plan: Pick<TopUpPlan, "additions" | "approvals">,
   adapter: TopUpTransactionAdapter,
   onPhase: (phase: TopUpPhase) => void,
-  onTopUpConfirmed: () => void
+  onTopUpConfirmed: () => void,
+  journal?: LifecycleJournalRun
 ): Promise<void> {
   for (const token of plan.approvals) {
     onPhase({ kind: "approving", symbol: token.symbol });
-    const hash = await adapter.approve(token.address, token.amount);
-    onPhase({ kind: "approval-pending", symbol: token.symbol, hash });
-    const receipt = await adapter.waitForReceipt(hash);
+    const receipt = await executeMakerWrite({
+      journal,
+      step: `approve:${token.address.toLowerCase()}:${token.amount}`,
+      action: "approve",
+      submit: () => adapter.approve(token.address, token.amount),
+      reconcile: adapter.waitForReceipt,
+      onAccepted: (hash) =>
+        onPhase({ kind: "approval-pending", symbol: token.symbol, hash }),
+    });
     requireSuccessfulReceipt(receipt, `${token.symbol} approval`);
   }
 
   onPhase({ kind: "topping-up" });
-  const hash = await adapter.topUp(
-    tokenId,
-    plan.additions.map((token) => token.address),
-    plan.additions.map((token) => token.amount)
-  );
-  onPhase({ kind: "top-up-pending", hash });
-  const receipt = await adapter.waitForReceipt(hash);
+  const receipt = await executeMakerWrite({
+    journal,
+    step: "topUp",
+    action: "topUp",
+    submit: () =>
+      adapter.topUp(
+        tokenId,
+        plan.additions.map((token) => token.address),
+        plan.additions.map((token) => token.amount)
+      ),
+    reconcile: adapter.waitForReceipt,
+    onAccepted: (hash) => onPhase({ kind: "top-up-pending", hash }),
+  });
   requireSuccessfulReceipt(receipt, "Pack top-up");
   onTopUpConfirmed();
 
-  await syncConfirmedTopUp(tokenId, adapter, onPhase);
+  await syncConfirmedTopUp(tokenId, adapter, onPhase, journal);
 }
 
 export async function redeemExitedPack(
   tokenId: bigint,
   adapter: RedemptionTransactionAdapter,
-  onPhase: (phase: RedemptionPhase) => void
+  onPhase: (phase: RedemptionPhase) => void,
+  journal?: LifecycleJournalRun
 ): Promise<void> {
   onPhase({ kind: "redeeming" });
-  const hash = await adapter.delistAndRedeem(tokenId);
-  onPhase({ kind: "redeem-pending", hash });
-  const receipt = await adapter.waitForReceipt(hash);
+  const receipt = await executeMakerWrite({
+    journal,
+    step: "delistAndRedeem",
+    action: "delistAndRedeem",
+    submit: () => adapter.delistAndRedeem(tokenId),
+    reconcile: adapter.waitForReceipt,
+    onAccepted: (hash) => onPhase({ kind: "redeem-pending", hash }),
+  });
   requireSuccessfulReceipt(receipt, "Pack redemption");
   onPhase({ kind: "complete" });
 }
@@ -215,20 +244,26 @@ export async function exitAndRedeemPack(
   state: { isResting: boolean; isListed: boolean },
   adapter: RedemptionTransactionAdapter,
   onPhase: (phase: RedemptionPhase) => void,
-  onExitConfirmed: () => void
+  onExitConfirmed: () => void,
+  journal?: LifecycleJournalRun
 ): Promise<void> {
   if (!state.isListed) throw new Error("Pack is no longer listed");
 
   if (state.isResting) {
     onPhase({ kind: "exiting" });
-    const hash = await adapter.exitPool(tokenId);
-    onPhase({ kind: "exit-pending", hash });
-    const receipt = await adapter.waitForReceipt(hash);
+    const receipt = await executeMakerWrite({
+      journal,
+      step: "exitPool",
+      action: "exitPool",
+      submit: () => adapter.exitPool(tokenId),
+      reconcile: adapter.waitForReceipt,
+      onAccepted: (hash) => onPhase({ kind: "exit-pending", hash }),
+    });
     requireSuccessfulReceipt(receipt, "Pool exit");
     onExitConfirmed();
   }
 
-  await redeemExitedPack(tokenId, adapter, onPhase);
+  await redeemExitedPack(tokenId, adapter, onPhase, journal);
 }
 
 export function topUpPhaseMessage(phase: TopUpPhase): string {

--- a/src/lib/maker/quote-errors.test.ts
+++ b/src/lib/maker/quote-errors.test.ts
@@ -1,0 +1,74 @@
+import { assetRegistryAbi } from "@margin-call/shared";
+import {
+  ContractFunctionExecutionError,
+  ContractFunctionRevertedError,
+  encodeErrorResult,
+  type Address,
+} from "viem";
+import { describe, expect, it } from "vitest";
+
+import { describeAssetRegistryQuoteError } from "./quote-errors";
+
+const TOKEN = "0x0000000000000000000000000000000000000001" as Address;
+
+function reverted(
+  errorName:
+    | "FeedStale"
+    | "FeedPaused"
+    | "FeedInvalid"
+    | "FeedZeroPrice"
+    | "AssetNotListed"
+    | "AssetNotInPriceBasket",
+  args: readonly unknown[]
+) {
+  return new ContractFunctionRevertedError({
+    abi: assetRegistryAbi,
+    data: encodeErrorResult({
+      abi: assetRegistryAbi,
+      errorName,
+      args: args as never,
+    }),
+    functionName: "quote",
+  });
+}
+
+describe("AssetRegistry quote errors", () => {
+  it.each([
+    [
+      reverted("FeedStale", [TOKEN, 1n, 3_600n, 3_602n]),
+      "Testnet price is stale — operator action is required",
+    ],
+    [reverted("FeedPaused", [TOKEN]), "Testnet price feed is paused"],
+    [reverted("FeedInvalid", [TOKEN]), "Testnet price feed is marked invalid"],
+    [reverted("FeedZeroPrice", [TOKEN]), "Testnet price feed returned zero"],
+    [reverted("AssetNotListed", [TOKEN]), "Stock Token is not listed"],
+    [
+      reverted("AssetNotInPriceBasket", [TOKEN, 2]),
+      "Stock Token is not currently eligible",
+    ],
+  ])("maps a decoded custom error", (error, message) => {
+    expect(describeAssetRegistryQuoteError(error)).toContain(message);
+  });
+
+  it("keeps transport failures distinct from feed failures", () => {
+    expect(describeAssetRegistryQuoteError(new Error("RPC unavailable"))).toBe(
+      "Testnet quote unavailable — check the network connection and try again"
+    );
+  });
+
+  it("finds the decoded error inside viem's readContract wrapper", () => {
+    const error = new ContractFunctionExecutionError(
+      reverted("FeedPaused", [TOKEN]),
+      {
+        abi: assetRegistryAbi,
+        args: [TOKEN, 1n],
+        contractAddress: TOKEN,
+        functionName: "quote",
+      }
+    );
+
+    expect(describeAssetRegistryQuoteError(error)).toBe(
+      "Testnet price feed is paused"
+    );
+  });
+});

--- a/src/lib/maker/quote-errors.ts
+++ b/src/lib/maker/quote-errors.ts
@@ -1,0 +1,27 @@
+import { BaseError, ContractFunctionRevertedError } from "viem";
+
+const quoteErrorMessages: Record<string, string> = {
+  FeedStale: "Testnet price is stale — operator action is required",
+  FeedPaused: "Testnet price feed is paused",
+  FeedInvalid: "Testnet price feed is marked invalid",
+  FeedZeroPrice: "Testnet price feed returned zero",
+  AssetNotListed: "Stock Token is not listed for Pack pricing",
+  AssetNotInPriceBasket:
+    "Stock Token is not currently eligible for Pack pricing",
+};
+
+export function describeAssetRegistryQuoteError(error: unknown): string {
+  if (error instanceof BaseError) {
+    const revert = error.walk(
+      (cause) => cause instanceof ContractFunctionRevertedError
+    );
+    if (revert instanceof ContractFunctionRevertedError) {
+      const errorName = revert.data?.errorName;
+      if (errorName && quoteErrorMessages[errorName]) {
+        return quoteErrorMessages[errorName];
+      }
+    }
+  }
+
+  return "Testnet quote unavailable — check the network connection and try again";
+}

--- a/src/lib/maker/transaction-journal.test.ts
+++ b/src/lib/maker/transaction-journal.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PendingTransactionError,
+  createMemoryJournalStorage,
+  ensureWorkflow,
+  runJournaledStep,
+} from "./transaction-journal";
+
+const HASH = `0x${"11".repeat(32)}` as const;
+
+describe("Maker transaction journal", () => {
+  it("persists the accepted hash before receipt polling and never resubmits after timeout", async () => {
+    const storage = createMemoryJournalStorage();
+    const workflow = ensureWorkflow(storage, {
+      chainId: 46630,
+      wallet: "0x1234567890abcdef1234567890abcdef12345678",
+      kind: "create",
+      requestFingerprint: "pack-a",
+      context: {},
+    });
+    const submit = vi.fn().mockResolvedValue(HASH);
+    const timeout = vi.fn().mockRejectedValue(new Error("receipt timeout"));
+
+    await expect(
+      runJournaledStep({
+        storage,
+        workflowKey: workflow.key,
+        step: "mint",
+        action: "mint",
+        submit,
+        reconcile: timeout,
+      })
+    ).rejects.toBeInstanceOf(PendingTransactionError);
+
+    expect(storage.get(workflow.key)?.current?.hash).toBe(HASH);
+    expect(submit).toHaveBeenCalledOnce();
+
+    const receipt = { status: "success" as const };
+    await expect(
+      runJournaledStep({
+        storage,
+        workflowKey: workflow.key,
+        step: "mint",
+        action: "mint",
+        submit,
+        reconcile: vi.fn().mockResolvedValue(receipt),
+      })
+    ).resolves.toMatchObject({ hash: HASH, recovered: true, receipt });
+    expect(submit).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an RPC-failed accepted hash across a remount-like storage reuse", async () => {
+    const storage = createMemoryJournalStorage();
+    const workflow = ensureWorkflow(storage, {
+      chainId: 46630,
+      wallet: "0x1234567890abcdef1234567890abcdef12345678",
+      kind: "redemption",
+      requestFingerprint: "pack-42",
+      context: { tokenId: "42" },
+    });
+    const submit = vi.fn().mockResolvedValue(HASH);
+    const args = {
+      storage,
+      workflowKey: workflow.key,
+      step: "exit",
+      action: "exitPool" as const,
+      submit,
+    };
+
+    await expect(
+      runJournaledStep({
+        ...args,
+        reconcile: vi.fn().mockRejectedValue(new Error("RPC unavailable")),
+      })
+    ).rejects.toMatchObject({ hash: HASH });
+
+    await runJournaledStep({
+      ...args,
+      reconcile: vi.fn().mockResolvedValue({ status: "success" as const }),
+    });
+    expect(submit).toHaveBeenCalledOnce();
+    expect(storage.get(workflow.key)?.completed.exit).toBe(HASH);
+  });
+});

--- a/src/lib/maker/transaction-journal.ts
+++ b/src/lib/maker/transaction-journal.ts
@@ -1,0 +1,295 @@
+import type { Hash } from "viem";
+
+export const JOURNAL_PREFIX = "margin-call:maker-lifecycle:v1:";
+
+export type MakerWriteAction =
+  | "approve"
+  | "mint"
+  | "enterPool"
+  | "topUp"
+  | "syncPackNav"
+  | "exitPool"
+  | "delistAndRedeem"
+  | "claim";
+
+export type WorkflowKind = "create" | "top-up" | "redemption" | "claim";
+
+export type WorkflowContext = Record<
+  string,
+  string | number | boolean | string[] | undefined
+>;
+
+export type AcceptedTransaction = {
+  step: string;
+  action: MakerWriteAction;
+  hash: Hash;
+  acceptedAt: number;
+};
+
+export type LifecycleWorkflow = {
+  key: string;
+  chainId: number;
+  wallet: string;
+  kind: WorkflowKind;
+  requestFingerprint: string;
+  context: WorkflowContext;
+  completed: Record<string, Hash>;
+  current?: AcceptedTransaction;
+  lastRevert?: AcceptedTransaction;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type JournalStorage = {
+  get: (key: string) => LifecycleWorkflow | null;
+  set: (workflow: LifecycleWorkflow) => void;
+  remove: (key: string) => void;
+  list: () => LifecycleWorkflow[];
+};
+
+export type JournalReceipt = { status: "success" | "reverted" };
+
+export type LifecycleJournalRun = {
+  storage: JournalStorage;
+  workflowKey: string;
+};
+
+export class PendingTransactionError extends Error {
+  readonly hash: Hash;
+
+  constructor(hash: Hash, cause: unknown) {
+    super(
+      `Transaction ${hash} is still unresolved. Reconciliation will retry without resubmitting.`,
+      { cause }
+    );
+    this.name = "PendingTransactionError";
+    this.hash = hash;
+  }
+}
+
+export class RevertedTransactionError extends Error {
+  readonly hash: Hash;
+
+  constructor(hash: Hash, action: MakerWriteAction) {
+    super(`${action} transaction ${hash} reverted`);
+    this.name = "RevertedTransactionError";
+    this.hash = hash;
+  }
+}
+
+function normalizeWallet(wallet: string): string {
+  return wallet.trim().toLowerCase();
+}
+
+function fnv1a(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export function requestFingerprint(
+  parts: readonly (string | bigint)[]
+): string {
+  return fnv1a(parts.map(String).join("\u001f"));
+}
+
+export function workflowKey(args: {
+  chainId: number;
+  wallet: string;
+  kind: WorkflowKind;
+  requestFingerprint: string;
+}): string {
+  return `${JOURNAL_PREFIX}${args.chainId}:${normalizeWallet(args.wallet)}:${args.kind}:${args.requestFingerprint}`;
+}
+
+export function createMemoryJournalStorage(): JournalStorage {
+  const values = new Map<string, LifecycleWorkflow>();
+  return {
+    get: (key) => values.get(key) ?? null,
+    set: (workflow) => values.set(workflow.key, structuredClone(workflow)),
+    remove: (key) => values.delete(key),
+    list: () => [...values.values()].map((value) => structuredClone(value)),
+  };
+}
+
+export function createBrowserJournalStorage(): JournalStorage {
+  const storage = window.localStorage;
+  return {
+    get(key) {
+      const raw = storage.getItem(key);
+      return raw ? (JSON.parse(raw) as LifecycleWorkflow) : null;
+    },
+    set(workflow) {
+      storage.setItem(workflow.key, JSON.stringify(workflow));
+    },
+    remove(key) {
+      storage.removeItem(key);
+    },
+    list() {
+      const workflows: LifecycleWorkflow[] = [];
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        if (!key?.startsWith(JOURNAL_PREFIX)) continue;
+        const raw = storage.getItem(key);
+        if (raw) workflows.push(JSON.parse(raw) as LifecycleWorkflow);
+      }
+      return workflows;
+    },
+  };
+}
+
+export function ensureWorkflow(
+  storage: JournalStorage,
+  args: {
+    chainId: number;
+    wallet: string;
+    kind: WorkflowKind;
+    requestFingerprint: string;
+    context: WorkflowContext;
+  }
+): LifecycleWorkflow {
+  const key = workflowKey(args);
+  const existing = storage.get(key);
+  if (existing) return existing;
+  const now = Date.now();
+  const workflow: LifecycleWorkflow = {
+    key,
+    chainId: args.chainId,
+    wallet: normalizeWallet(args.wallet),
+    kind: args.kind,
+    requestFingerprint: args.requestFingerprint,
+    context: args.context,
+    completed: {},
+    createdAt: now,
+    updatedAt: now,
+  };
+  storage.set(workflow);
+  return workflow;
+}
+
+export function listWorkflows(
+  storage: JournalStorage,
+  chainId: number,
+  wallet: string,
+  kind?: WorkflowKind
+): LifecycleWorkflow[] {
+  const normalized = normalizeWallet(wallet);
+  return storage
+    .list()
+    .filter(
+      (workflow) =>
+        workflow.chainId === chainId &&
+        workflow.wallet === normalized &&
+        (!kind || workflow.kind === kind)
+    )
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export async function runJournaledStep<TReceipt extends JournalReceipt>(args: {
+  storage: JournalStorage;
+  workflowKey: string;
+  step: string;
+  action: MakerWriteAction;
+  submit: () => Promise<Hash>;
+  reconcile: (hash: Hash) => Promise<TReceipt>;
+  onAccepted?: (hash: Hash, recovered: boolean) => void;
+}): Promise<{ hash: Hash; receipt: TReceipt; recovered: boolean }> {
+  let workflow = args.storage.get(args.workflowKey);
+  if (!workflow) throw new Error("Lifecycle workflow is missing");
+
+  const completedHash = workflow.completed[args.step];
+  if (completedHash) {
+    args.onAccepted?.(completedHash, true);
+    let receipt: TReceipt;
+    try {
+      receipt = await args.reconcile(completedHash);
+    } catch (error) {
+      throw new PendingTransactionError(completedHash, error);
+    }
+    if (receipt.status !== "success") {
+      throw new Error(
+        `Previously confirmed ${args.action} no longer has a successful receipt`
+      );
+    }
+    return { hash: completedHash, receipt, recovered: true };
+  }
+
+  if (workflow.current && workflow.current.step !== args.step) {
+    throw new PendingTransactionError(
+      workflow.current.hash,
+      new Error(`Resolve ${workflow.current.action} before ${args.action}`)
+    );
+  }
+
+  const recovered = Boolean(workflow.current);
+  let accepted = workflow.current;
+  if (!accepted) {
+    const hash = await args.submit();
+    accepted = {
+      step: args.step,
+      action: args.action,
+      hash,
+      acceptedAt: Date.now(),
+    };
+    workflow = { ...workflow, current: accepted, updatedAt: Date.now() };
+    // This synchronous write is intentionally before any receipt polling.
+    args.storage.set(workflow);
+  }
+  args.onAccepted?.(accepted.hash, recovered);
+
+  let receipt: TReceipt;
+  try {
+    receipt = await args.reconcile(accepted.hash);
+  } catch (error) {
+    throw new PendingTransactionError(accepted.hash, error);
+  }
+
+  workflow = args.storage.get(args.workflowKey);
+  if (!workflow)
+    throw new Error("Lifecycle workflow disappeared during reconciliation");
+  if (receipt.status === "reverted") {
+    args.storage.set({
+      ...workflow,
+      current: undefined,
+      lastRevert: accepted,
+      updatedAt: Date.now(),
+    });
+    throw new RevertedTransactionError(accepted.hash, accepted.action);
+  }
+
+  args.storage.set({
+    ...workflow,
+    current: undefined,
+    completed: { ...workflow.completed, [args.step]: accepted.hash },
+    updatedAt: Date.now(),
+  });
+  return { hash: accepted.hash, receipt, recovered };
+}
+
+export async function executeMakerWrite<TReceipt extends JournalReceipt>(args: {
+  journal?: LifecycleJournalRun;
+  step: string;
+  action: MakerWriteAction;
+  submit: () => Promise<Hash>;
+  reconcile: (hash: Hash) => Promise<TReceipt>;
+  onAccepted: (hash: Hash, recovered: boolean) => void;
+}): Promise<TReceipt> {
+  if (!args.journal) {
+    const hash = await args.submit();
+    args.onAccepted(hash, false);
+    return await args.reconcile(hash);
+  }
+  const result = await runJournaledStep({
+    storage: args.journal.storage,
+    workflowKey: args.journal.workflowKey,
+    step: args.step,
+    action: args.action,
+    submit: args.submit,
+    reconcile: args.reconcile,
+    onAccepted: args.onAccepted,
+  });
+  return result.receipt;
+}

--- a/src/lib/token-display.test.ts
+++ b/src/lib/token-display.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { maxUint256 } from "viem";
+
+import {
+  formatAllowanceDisplay,
+  formatTokenAmountDisplay,
+} from "./token-display";
+
+describe("token display formatting", () => {
+  it("labels a max uint256 ERC-20 allowance as unlimited", () => {
+    expect(formatAllowanceDisplay(maxUint256, 18)).toEqual({
+      compact: "Unlimited",
+      exact: "Unlimited (max uint256)",
+    });
+  });
+
+  it("compacts long values without presenting a rounded value as exact", () => {
+    expect(formatTokenAmountDisplay(123_456_789_012_345_678_901n, 18)).toEqual({
+      compact: "123.456789…",
+      exact: "123.456789012345678901",
+    });
+    expect(formatTokenAmountDisplay(1n, 18)).toEqual({
+      compact: "1.00000e-18",
+      exact: "0.000000000000000001",
+    });
+    expect(formatTokenAmountDisplay(10n ** 48n, 18)).toEqual({
+      compact: "1.00000e+30",
+      exact: "1000000000000000000000000000000",
+    });
+    expect(formatTokenAmountDisplay(10n ** 48n + 1n, 18)).toEqual({
+      compact: "1.00000…e+30",
+      exact: "1000000000000000000000000000000.000000000000000001",
+    });
+  });
+});

--- a/src/lib/token-display.ts
+++ b/src/lib/token-display.ts
@@ -1,0 +1,71 @@
+import { formatUnits, maxUint256 } from "viem";
+
+const MAX_VISIBLE_FRACTION_DIGITS = 6;
+const MAX_VISIBLE_WHOLE_DIGITS = 12;
+const SCIENTIFIC_SIGNIFICANT_DIGITS = 6;
+
+export type TokenAmountDisplay = {
+  compact: string;
+  exact: string;
+};
+
+function compactWholeNumber(whole: string, fraction: string): string {
+  if (whole.length <= MAX_VISIBLE_WHOLE_DIGITS) return whole;
+
+  const significant = whole.slice(0, SCIENTIFIC_SIGNIFICANT_DIGITS);
+  const rest = whole.slice(SCIENTIFIC_SIGNIFICANT_DIGITS);
+  const coefficient = `${significant[0]}.${significant.slice(1)}`;
+  const omission = /[1-9]/.test(rest) || /[1-9]/.test(fraction) ? "…" : "";
+  return `${coefficient}${omission}e+${whole.length - 1}`;
+}
+
+function compactFraction(whole: string, fraction: string): string {
+  const meaningfulFraction = fraction.replace(/0+$/, "");
+  if (!meaningfulFraction) return whole;
+  if (meaningfulFraction.length <= MAX_VISIBLE_FRACTION_DIGITS) {
+    return `${whole}.${meaningfulFraction}`;
+  }
+
+  const visible = meaningfulFraction.slice(0, MAX_VISIBLE_FRACTION_DIGITS);
+  if (/[1-9]/.test(visible)) return `${whole}.${visible}…`;
+
+  const firstNonZero = meaningfulFraction.search(/[1-9]/);
+  const significant = meaningfulFraction
+    .slice(firstNonZero, firstNonZero + SCIENTIFIC_SIGNIFICANT_DIGITS)
+    .padEnd(SCIENTIFIC_SIGNIFICANT_DIGITS, "0");
+  const rest = meaningfulFraction.slice(
+    firstNonZero + SCIENTIFIC_SIGNIFICANT_DIGITS
+  );
+  const coefficient = `${significant[0]}.${significant.slice(1)}`;
+  const omission = /[1-9]/.test(rest) ? "…" : "";
+  return `${coefficient}${omission}e-${firstNonZero + 1}`;
+}
+
+export function formatTokenAmountDisplay(
+  value: bigint | undefined,
+  decimals: number
+): TokenAmountDisplay {
+  if (value === undefined) {
+    return { compact: "Unavailable", exact: "Unavailable" };
+  }
+
+  const exact = formatUnits(value, decimals);
+  const [whole, fraction = ""] = exact.split(".");
+  return {
+    compact:
+      whole.length > MAX_VISIBLE_WHOLE_DIGITS
+        ? compactWholeNumber(whole, fraction)
+        : compactFraction(whole, fraction),
+    exact,
+  };
+}
+
+export function formatAllowanceDisplay(
+  value: bigint | undefined,
+  decimals: number
+): TokenAmountDisplay {
+  if (value === maxUint256) {
+    return { compact: "Unlimited", exact: "Unlimited (max uint256)" };
+  }
+  return formatTokenAmountDisplay(value, decimals);
+}

--- a/tests/convex/pool-indexer-scan.test.ts
+++ b/tests/convex/pool-indexer-scan.test.ts
@@ -9,8 +9,9 @@ import {
 import { describe, expect, it, vi } from "vitest";
 
 import type { ActionCtx } from "../../convex/_generated/server";
-import { ripEngineAbi } from "../../convex/lib/chain/abis";
+import { packCustodyAbi, ripEngineAbi } from "../../convex/lib/chain/abis";
 import {
+  applyPackCustodyLog,
   applyRipEngineLog,
   isContractCallRevert,
   MAX_BLOCK_SPAN,
@@ -28,7 +29,7 @@ const PACK = "0x00000000000000000000000000000000000000bb" as const;
 function makeCtx(overrides?: {
   cursor?: number | null;
   onSetCursor?: (blockNumber: number) => void;
-  onUpsertPack?: () => Promise<void>;
+  onUpsertPack?: (args: Record<string, unknown>) => Promise<void>;
 }): ActionCtx {
   const setCursor = vi.fn(
     async (_ref: unknown, args: { key: string; blockNumber: number }) => {
@@ -36,8 +37,8 @@ function makeCtx(overrides?: {
       return null;
     }
   );
-  const upsertPack = vi.fn(async () => {
-    if (overrides?.onUpsertPack) await overrides.onUpsertPack();
+  const upsertPack = vi.fn(async (args: Record<string, unknown>) => {
+    if (overrides?.onUpsertPack) await overrides.onUpsertPack(args);
     return null;
   });
 
@@ -59,11 +60,31 @@ function makeCtx(overrides?: {
         "tokenId" in args &&
         "status" in args
       ) {
-        return upsertPack();
+        return upsertPack(args as Record<string, unknown>);
       }
       return null;
     }),
   } as unknown as ActionCtx;
+}
+
+function eventLog(
+  abi: typeof ripEngineAbi | typeof packCustodyAbi,
+  eventName: "PackExited" | "PackUnlisted",
+  args: Record<string, unknown>,
+  address: `0x${string}`
+): Log {
+  const topics = encodeEventTopics({ abi, eventName, args } as never);
+  return {
+    address,
+    blockHash: `0x${"11".repeat(32)}`,
+    blockNumber: 100n,
+    data: "0x",
+    logIndex: 0,
+    transactionHash: `0x${"22".repeat(32)}`,
+    transactionIndex: 0,
+    removed: false,
+    topics: topics as [`0x${string}`, ...`0x${string}`[]],
+  };
 }
 
 function makeClient(overrides?: {
@@ -278,6 +299,49 @@ describe("applyRipEngineLog error boundary", () => {
         Date.now()
       )
     ).rejects.toThrow("db write failed");
+  });
+});
+
+describe("Pack exit and unlist indexing", () => {
+  it("models a listed exit separately until PackCustody reports unlisting", async () => {
+    const statuses: string[] = [];
+    const ctx = makeCtx({
+      onUpsertPack: async (args) => {
+        statuses.push(String(args.status));
+      },
+    });
+    const client = makeClient({
+      readContract: async ({ functionName }) => {
+        if (functionName === "basketOf") {
+          return [{ asset: ZERO_ADDR, amount: 1n }];
+        }
+        if (functionName === "navOfPack") return 100n;
+        if (functionName === "creatorOf") return ZERO_ADDR;
+        throw new Error(`unexpected ${functionName}`);
+      },
+    });
+
+    await applyRipEngineLog(
+      ctx,
+      client,
+      { packCustody: PACK, ripEngine: RIP },
+      eventLog(
+        ripEngineAbi,
+        "PackExited",
+        { tokenId: 42n, maker: ZERO_ADDR },
+        RIP
+      ),
+      1
+    );
+    await applyPackCustodyLog(
+      ctx,
+      client,
+      PACK,
+      eventLog(packCustodyAbi, "PackUnlisted", { tokenId: 42n }, PACK),
+      2
+    );
+
+    expect(statuses).toEqual(["exited", "unlisted"]);
   });
 });
 

--- a/tests/convex/pool-indexer-scan.test.ts
+++ b/tests/convex/pool-indexer-scan.test.ts
@@ -312,6 +312,7 @@ describe("Pack exit and unlist indexing", () => {
     });
     const client = makeClient({
       readContract: async ({ functionName }) => {
+        if (functionName === "isListed") return true;
         if (functionName === "basketOf") {
           return [{ asset: ZERO_ADDR, amount: 1n }];
         }
@@ -342,6 +343,43 @@ describe("Pack exit and unlist indexing", () => {
     );
 
     expect(statuses).toEqual(["exited", "unlisted"]);
+  });
+
+  it("does not regress an already-unlisted Pack when a later purge emits PackExited", async () => {
+    const upserts: Record<string, unknown>[] = [];
+    const ctx = makeCtx({
+      onUpsertPack: async (args) => {
+        upserts.push(args);
+      },
+    });
+    const readContract = vi.fn(async ({ functionName }) => {
+      if (functionName === "isListed") return false;
+      throw new Error(`unexpected ${functionName}`);
+    });
+    const client = makeClient({ readContract });
+
+    await applyRipEngineLog(
+      ctx,
+      client,
+      { packCustody: PACK, ripEngine: RIP },
+      eventLog(
+        ripEngineAbi,
+        "PackExited",
+        { tokenId: 42n, maker: ZERO_ADDR },
+        RIP
+      ),
+      3
+    );
+
+    expect(upserts).toEqual([]);
+    expect(readContract).toHaveBeenCalledOnce();
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "isListed",
+        args: [42n],
+        blockNumber: 100n,
+      })
+    );
   });
 });
 

--- a/tests/convex/pool-maker-query.test.ts
+++ b/tests/convex/pool-maker-query.test.ts
@@ -1,0 +1,104 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+
+import { api } from "../../convex/_generated/api";
+import schema from "../../convex/schema";
+
+const modules = import.meta.glob("../../convex/**/*.ts");
+
+const MAKER = "0x1234567890abcdef1234567890abcdef12345678";
+const OTHER_MAKER = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+
+type PackStatus = "resting" | "ripped" | "unlisted";
+
+async function insertPack(
+  t: ReturnType<typeof convexTest>,
+  tokenId: number,
+  maker: string,
+  status: PackStatus
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("packs", {
+      tokenId,
+      maker,
+      basket: [
+        {
+          asset: "0x0000000000000000000000000000000000000001",
+          amount: "1000000000000000000",
+          symbol: "TEST",
+        },
+      ],
+      navUsdWad: `${tokenId}000000000000000000`,
+      status,
+      eligible: status === "resting",
+      updatedAt: tokenId,
+    });
+  });
+}
+
+describe("pool.listPacksByMaker", () => {
+  it("normalizes the wallet and paginates only that Maker's Packs", async () => {
+    const t = convexTest(schema, modules);
+    await insertPack(t, 1, MAKER, "resting");
+    await insertPack(t, 2, MAKER, "ripped");
+    await insertPack(t, 3, MAKER, "unlisted");
+    await insertPack(t, 4, OTHER_MAKER, "resting");
+
+    const firstPage = await t.query(api.pool.listPacksByMaker, {
+      maker: `  0x${MAKER.slice(2).toUpperCase()}  `,
+      paginationOpts: { cursor: null, numItems: 2 },
+    });
+
+    expect(firstPage.page).toHaveLength(2);
+    expect(firstPage.isDone).toBe(false);
+    expect(firstPage.page.every((pack) => pack.maker === MAKER)).toBe(true);
+
+    const secondPage = await t.query(api.pool.listPacksByMaker, {
+      maker: MAKER,
+      paginationOpts: {
+        cursor: firstPage.continueCursor,
+        numItems: 2,
+      },
+    });
+
+    expect(secondPage.isDone).toBe(true);
+    expect(
+      [...firstPage.page, ...secondPage.page]
+        .map((pack) => pack.tokenId)
+        .sort((a, b) => a - b)
+    ).toEqual([1, 2, 3]);
+  });
+
+  it("uses the composite index to filter by Maker and lifecycle status", async () => {
+    const t = convexTest(schema, modules);
+    await insertPack(t, 10, MAKER, "resting");
+    await insertPack(t, 11, MAKER, "ripped");
+    await insertPack(t, 12, OTHER_MAKER, "ripped");
+
+    const result = await t.query(api.pool.listPacksByMaker, {
+      maker: MAKER,
+      status: "ripped",
+      paginationOpts: { cursor: null, numItems: 20 },
+    });
+
+    expect(result.page.map((pack) => pack.tokenId)).toEqual([11]);
+    expect(result.page[0]).toMatchObject({
+      maker: MAKER,
+      status: "ripped",
+      eligible: false,
+    });
+  });
+
+  it("rejects a malformed Maker address", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.query(api.pool.listPacksByMaker, {
+        maker: "not-a-wallet",
+        paginationOpts: { cursor: null, numItems: 20 },
+      })
+    ).rejects.toThrow("Invalid wallet address");
+  });
+});

--- a/tests/convex/pool-maker-query.test.ts
+++ b/tests/convex/pool-maker-query.test.ts
@@ -3,7 +3,7 @@
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 
-import { api } from "../../convex/_generated/api";
+import { api, internal } from "../../convex/_generated/api";
 import schema from "../../convex/schema";
 
 const modules = import.meta.glob("../../convex/**/*.ts");
@@ -11,7 +11,7 @@ const modules = import.meta.glob("../../convex/**/*.ts");
 const MAKER = "0x1234567890abcdef1234567890abcdef12345678";
 const OTHER_MAKER = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
 
-type PackStatus = "resting" | "ripped" | "unlisted";
+type PackStatus = "resting" | "exited" | "ripped" | "unlisted";
 
 async function insertPack(
   t: ReturnType<typeof convexTest>,
@@ -44,7 +44,8 @@ describe("pool.listPacksByMaker", () => {
     await insertPack(t, 1, MAKER, "resting");
     await insertPack(t, 2, MAKER, "ripped");
     await insertPack(t, 3, MAKER, "unlisted");
-    await insertPack(t, 4, OTHER_MAKER, "resting");
+    await insertPack(t, 4, MAKER, "exited");
+    await insertPack(t, 5, OTHER_MAKER, "resting");
 
     const firstPage = await t.query(api.pool.listPacksByMaker, {
       maker: `  0x${MAKER.slice(2).toUpperCase()}  `,
@@ -68,7 +69,7 @@ describe("pool.listPacksByMaker", () => {
       [...firstPage.page, ...secondPage.page]
         .map((pack) => pack.tokenId)
         .sort((a, b) => a - b)
-    ).toEqual([1, 2, 3]);
+    ).toEqual([1, 2, 3, 4]);
   });
 
   it("uses the composite index to filter by Maker and lifecycle status", async () => {
@@ -100,5 +101,45 @@ describe("pool.listPacksByMaker", () => {
         paginationOpts: { cursor: null, numItems: 20 },
       })
     ).rejects.toThrow("Invalid wallet address");
+  });
+});
+
+describe("pool index lifecycle precedence", () => {
+  it("does not let a delayed PackExited overwrite unlisted or ripped", async () => {
+    const t = convexTest(schema, modules);
+    const base = {
+      tokenId: 42,
+      maker: MAKER,
+      basket: [],
+      navUsdWad: null,
+      eligible: false,
+      updatedAt: 1,
+    };
+    await t.mutation(internal.poolIndexer.upsertPack, {
+      ...base,
+      status: "unlisted",
+    });
+    await t.mutation(internal.poolIndexer.upsertPack, {
+      ...base,
+      status: "exited",
+      updatedAt: 2,
+    });
+    expect((await t.query(api.pool.getPack, { tokenId: 42 }))?.status).toBe(
+      "unlisted"
+    );
+
+    await t.mutation(internal.poolIndexer.upsertPack, {
+      ...base,
+      status: "ripped",
+      updatedAt: 3,
+    });
+    await t.mutation(internal.poolIndexer.upsertPack, {
+      ...base,
+      status: "unlisted",
+      updatedAt: 4,
+    });
+    expect((await t.query(api.pool.getPack, { tokenId: 42 }))?.status).toBe(
+      "ripped"
+    );
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "src/**/*.test.ts",
       "src/**/*.test.tsx",
       "packages/shared/**/*.test.ts",
+      "scripts/**/*.test.ts",
       "tests/convex/**/*.test.ts",
     ],
     exclude: ["**/node_modules/**"],


### PR DESCRIPTION
## Summary

- add a wallet-scoped Maker dashboard and live Pack composer with NAV and eligibility validation
- add confirmed, resumable create/enroll, top-up/NAV sync, and exit/redeem transaction flows
- show and claim live Acquisition Fees using complete block-pinned on-chain accounting
- centralize Maker lifecycle ABIs and add focused Convex, helper, and UI coverage

Closes #306

## Validation

- `pnpm check:codegen`
- `pnpm typecheck`
- `pnpm lint` (0 errors; 4 existing generated-file warnings)
- `pnpm test` (126 passed)
- `pnpm build`
- `git diff --check origin/main...HEAD`

## Manual verification

- [ ] Funded Robinhood testnet + Privy smoke test for create → top-up → fee claim → delist/redeem
