### PR TITLE
Align smoke test with AC 22: expired-round refund + cold-wallet start

### DIFF
--- a/docs/2026-08-08-margin-call-crash-technical-design.md
+++ b/docs/2026-08-08-margin-call-crash-technical-design.md
@@ -394,4 +394,4 @@ If the keeper fails, players or another caller can perform the same transitions.
 
 ### Base Sepolia smoke test
 
-Record a complete 60-second round with player approval, direct vault receipt, reservation, Inco handle, lock, attestation, finalization, and claim or loss settlement. Separately record an LP deposit, a free-liquidity withdrawal, and a rejected withdrawal that exceeds free liquidity. Preserve contract addresses and transaction hashes in the deployment record.
+Starting from a cold wallet that claims from the in-app faucet, record a complete 60-second round with player approval, direct vault receipt, reservation, Inco handle, lock, attestation, finalization, and claim or loss settlement. Record a second live round deliberately left unfinalized past `expiresAt`: the expiry transition followed by the ticket owner's refund, so the smoke test exercises the expiry-refund path the PRD's acceptance criterion 22 requires. Separately record an LP deposit, a free-liquidity withdrawal, and a rejected withdrawal that exceeds free liquidity. Preserve contract addresses and transaction hashes in the deployment record.


### PR DESCRIPTION
## Summary

Follow-up to #337, surfaced while ticketing the implementation (#338/#351): PRD acceptance criterion 22 requires the Base Sepolia end-to-end smoke test to cover the expiry refund, but technical design §13 described only one complete round plus LP flows.

The smoke test now:
- starts from a cold wallet claiming from the in-app faucet (matching AC 3's cold-wallet promise),
- records a second live round deliberately left unfinalized past `expiresAt`, with the expiry transition and the ticket owner's refund receipt.

Matches the scope already specified in implementation issue #351.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)