### PR TITLE
Enable safe BankrollVault withdrawals

### DIFF
--- a/contracts/src/BankrollVault.sol
+++ b/contracts/src/BankrollVault.sol
@@ -56,13 +56,15 @@ contract BankrollVault is ERC4626 {
         return assets.mulDiv(SAFETY_BUFFER_NUMERATOR, SAFETY_BUFFER_DENOMINATOR, Math.Rounding.Ceil);
     }
 
-    /// @notice Returns gross assets available for LP withdrawal after player liabilities and the safety buffer.
-    /// @dev Protects reserved and pending payouts plus unrecognized margin — none of them are LP value, so
-    ///      withdrawals must never draw down the assets backing them.
+    /// @notice Returns gross assets available for LP withdrawal after reservations and the safety buffer.
+    /// @dev Reservations transitively cover pending obligations and unrecognized margin: a reservation is
+    ///      consumed only when its payout or refund actually transfers, so `pendingObligations +
+    ///      unrecognizedMargin` never exceeds `reservedLiabilities` (technical design §8). The game-only
+    ///      mutation paths must preserve that invariant; subtracting those terms here as well would
+    ///      double-count liabilities and suppress valid LP withdrawals.
     function freeLiquidity() public view returns (uint256) {
         uint256 assets = grossAssets();
-        uint256 protectedAssets =
-            reservedLiabilities + pendingObligations + unrecognizedMargin + _safetyBuffer(assets);
+        uint256 protectedAssets = reservedLiabilities + _safetyBuffer(assets);
 
         return assets > protectedAssets ? assets - protectedAssets : 0;
     }

--- a/contracts/src/BankrollVault.sol
+++ b/contracts/src/BankrollVault.sol
@@ -49,13 +49,20 @@ contract BankrollVault is ERC4626 {
     /// @notice Returns the minimum gross-asset buffer that remains in the vault after LP withdrawals.
     /// @dev Rounds up so the buffer is never below 20% of gross assets.
     function safetyBuffer() public view returns (uint256) {
-        return grossAssets().mulDiv(SAFETY_BUFFER_NUMERATOR, SAFETY_BUFFER_DENOMINATOR, Math.Rounding.Ceil);
+        return _safetyBuffer(grossAssets());
     }
 
-    /// @notice Returns gross assets available for LP withdrawal after reservations and the safety buffer.
+    function _safetyBuffer(uint256 assets) internal pure returns (uint256) {
+        return assets.mulDiv(SAFETY_BUFFER_NUMERATOR, SAFETY_BUFFER_DENOMINATOR, Math.Rounding.Ceil);
+    }
+
+    /// @notice Returns gross assets available for LP withdrawal after player liabilities and the safety buffer.
+    /// @dev Protects reserved and pending payouts plus unrecognized margin — none of them are LP value, so
+    ///      withdrawals must never draw down the assets backing them.
     function freeLiquidity() public view returns (uint256) {
-        uint256 protectedAssets = reservedLiabilities + safetyBuffer();
         uint256 assets = grossAssets();
+        uint256 protectedAssets =
+            reservedLiabilities + pendingObligations + unrecognizedMargin + _safetyBuffer(assets);
 
         return assets > protectedAssets ? assets - protectedAssets : 0;
     }
@@ -63,11 +70,8 @@ contract BankrollVault is ERC4626 {
     /// @notice Returns the owner's immediately executable asset withdrawal limit.
     /// @dev This cap preserves ERC-4626 conversions while partitioning free liquidity by share ownership.
     function maxWithdraw(address owner) public view override returns (uint256) {
-        uint256 supply = totalSupply();
-        if (supply == 0) return 0;
-
-        uint256 ownerLimit = freeLiquidity().mulDiv(balanceOf(owner), supply);
-        return Math.min(convertToAssets(balanceOf(owner)), ownerLimit);
+        (uint256 maxAssets,) = _withdrawalLimits(owner);
+        return maxAssets;
     }
 
     /// @notice Returns the owner's immediately executable share redemption limit.
@@ -75,11 +79,22 @@ contract BankrollVault is ERC4626 {
     ///      redeemed assets do not exceed `maxWithdraw(owner)`.
     function maxRedeem(address owner) public view override returns (uint256) {
         uint256 ownerShares = balanceOf(owner);
-        uint256 maxAssets = maxWithdraw(owner);
+        (uint256 maxAssets, uint256 ownerAssets) = _withdrawalLimits(owner);
 
-        if (maxAssets == convertToAssets(ownerShares)) return ownerShares;
+        if (maxAssets == ownerAssets) return ownerShares;
 
-        uint256 maxShares = Math.mulDiv(maxAssets + 1, totalSupply() + 1, totalAssets() + 1, Math.Rounding.Ceil) - 1;
+        uint256 maxShares = _convertToShares(maxAssets + 1, Math.Rounding.Ceil) - 1;
         return Math.min(ownerShares, maxShares);
+    }
+
+    /// @dev Shared by `maxWithdraw` and `maxRedeem` so the owner's limit and full asset value come from one
+    ///      set of balance and supply reads.
+    function _withdrawalLimits(address owner) internal view returns (uint256 maxAssets, uint256 ownerAssets) {
+        uint256 supply = totalSupply();
+        if (supply == 0) return (0, 0);
+
+        uint256 ownerShares = balanceOf(owner);
+        ownerAssets = convertToAssets(ownerShares);
+        maxAssets = Math.min(ownerAssets, freeLiquidity().mulDiv(ownerShares, supply));
     }
 }

--- a/contracts/src/BankrollVault.sol
+++ b/contracts/src/BankrollVault.sol
@@ -12,7 +12,12 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 contract BankrollVault is ERC4626 {
     using Math for uint256;
 
-    error WithdrawalsDisabledInDepositsOnlySlice();
+    uint256 internal constant SAFETY_BUFFER_NUMERATOR = 20;
+    uint256 internal constant SAFETY_BUFFER_DENOMINATOR = 100;
+
+    /// @notice Total maximum payouts reserved for unresolved player tickets.
+    /// @dev Reservation mutation is restricted to the future game-only entry and settlement paths.
+    uint256 public reservedLiabilities;
 
     /// @notice Payouts owed from finalized or expired tickets but not yet transferred.
     uint256 public pendingObligations;
@@ -41,23 +46,40 @@ contract BankrollVault is ERC4626 {
         return supply == 0 ? scale : totalAssets().mulDiv(scale, supply);
     }
 
-    /// @notice Withdrawals are intentionally unavailable until the free-liquidity controls ship.
-    function withdraw(uint256, address, address) public pure override returns (uint256) {
-        revert WithdrawalsDisabledInDepositsOnlySlice();
+    /// @notice Returns the minimum gross-asset buffer that remains in the vault after LP withdrawals.
+    /// @dev Rounds up so the buffer is never below 20% of gross assets.
+    function safetyBuffer() public view returns (uint256) {
+        return grossAssets().mulDiv(SAFETY_BUFFER_NUMERATOR, SAFETY_BUFFER_DENOMINATOR, Math.Rounding.Ceil);
     }
 
-    /// @notice Redemptions are intentionally unavailable until the free-liquidity controls ship.
-    function redeem(uint256, address, address) public pure override returns (uint256) {
-        revert WithdrawalsDisabledInDepositsOnlySlice();
+    /// @notice Returns gross assets available for LP withdrawal after reservations and the safety buffer.
+    function freeLiquidity() public view returns (uint256) {
+        uint256 protectedAssets = reservedLiabilities + safetyBuffer();
+        uint256 assets = grossAssets();
+
+        return assets > protectedAssets ? assets - protectedAssets : 0;
     }
 
-    /// @notice Returns zero while withdrawals are disabled for this slice.
-    function maxWithdraw(address) public pure override returns (uint256) {
-        return 0;
+    /// @notice Returns the owner's immediately executable asset withdrawal limit.
+    /// @dev This cap preserves ERC-4626 conversions while partitioning free liquidity by share ownership.
+    function maxWithdraw(address owner) public view override returns (uint256) {
+        uint256 supply = totalSupply();
+        if (supply == 0) return 0;
+
+        uint256 ownerLimit = freeLiquidity().mulDiv(balanceOf(owner), supply);
+        return Math.min(convertToAssets(balanceOf(owner)), ownerLimit);
     }
 
-    /// @notice Returns zero while redemptions are disabled for this slice.
-    function maxRedeem(address) public pure override returns (uint256) {
-        return 0;
+    /// @notice Returns the owner's immediately executable share redemption limit.
+    /// @dev Inverts ERC-4626's virtual-share `previewRedeem` rounding so this is the greatest share amount whose
+    ///      redeemed assets do not exceed `maxWithdraw(owner)`.
+    function maxRedeem(address owner) public view override returns (uint256) {
+        uint256 ownerShares = balanceOf(owner);
+        uint256 maxAssets = maxWithdraw(owner);
+
+        if (maxAssets == convertToAssets(ownerShares)) return ownerShares;
+
+        uint256 maxShares = Math.mulDiv(maxAssets + 1, totalSupply() + 1, totalAssets() + 1, Math.Rounding.Ceil) - 1;
+        return Math.min(ownerShares, maxShares);
     }
 }

--- a/contracts/test/BankrollVault.t.sol
+++ b/contracts/test/BankrollVault.t.sol
@@ -4,9 +4,22 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 
 import {BankrollVault} from "../src/BankrollVault.sol";
 import {DeskDollars} from "../src/DeskDollars.sol";
+
+contract BankrollVaultHarness is BankrollVault {
+    constructor(DeskDollars asset_) BankrollVault(asset_) {}
+
+    function setReservedLiabilitiesForTest(uint256 amount) external {
+        reservedLiabilities = amount;
+    }
+
+    function setPendingObligationsForTest(uint256 amount) external {
+        pendingObligations = amount;
+    }
+}
 
 contract BankrollVaultTest is Test {
     uint256 internal constant ONE_TUSD = 1_000_000;
@@ -17,11 +30,11 @@ contract BankrollVaultTest is Test {
     address internal constant CAROL = address(0xCA401);
 
     DeskDollars internal token;
-    BankrollVault internal vault;
+    BankrollVaultHarness internal vault;
 
     function setUp() public {
         token = new DeskDollars(BANKROLL);
-        vault = new BankrollVault(token);
+        vault = new BankrollVaultHarness(token);
 
         vm.startPrank(BANKROLL);
         assertTrue(token.transfer(ALICE, 1_000 * ONE_TUSD));
@@ -45,6 +58,9 @@ contract BankrollVaultTest is Test {
         assertEq(vault.assetsPerShare(), ONE_TUSD);
         assertEq(vault.pendingObligations(), 0);
         assertEq(vault.unrecognizedMargin(), 0);
+        assertEq(vault.reservedLiabilities(), 0);
+        assertEq(vault.safetyBuffer(), 0);
+        assertEq(vault.freeLiquidity(), 0);
 
         uint256 assets = 125 * ONE_TUSD;
         vm.prank(ALICE);
@@ -94,20 +110,213 @@ contract BankrollVaultTest is Test {
         assertEq(vault.balanceOf(BOB), depositedShares + mintShares);
     }
 
-    function testWithdrawAndRedeemAreDisabled() public {
+    function testSafetyBufferRoundsUpAtExactlyTwentyPercent() public {
+        vm.prank(ALICE);
+        vault.deposit(4, ALICE);
+
+        assertEq(vault.safetyBuffer(), 1);
+        assertEq(vault.freeLiquidity(), 3);
+
+        vm.prank(ALICE);
+        vault.deposit(1, ALICE);
+
+        assertEq(vault.safetyBuffer(), 1);
+        assertEq(vault.freeLiquidity(), 4);
+    }
+
+    function testFreeLiquiditySaturatesAtZeroForReservationsAndBuffer() public {
         vm.prank(ALICE);
         vault.deposit(100 * ONE_TUSD, ALICE);
 
+        vault.setReservedLiabilitiesForTest(80 * ONE_TUSD);
+
+        assertEq(vault.safetyBuffer(), 20 * ONE_TUSD);
+        assertEq(vault.freeLiquidity(), 0);
         assertEq(vault.maxWithdraw(ALICE), 0);
         assertEq(vault.maxRedeem(ALICE), 0);
+    }
 
-        vm.expectRevert(BankrollVault.WithdrawalsDisabledInDepositsOnlySlice.selector);
+    function testMaxWithdrawPartitionsFreeLiquidityProportionally() public {
         vm.prank(ALICE);
-        vault.withdraw(ONE_TUSD, ALICE, ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
 
-        vm.expectRevert(BankrollVault.WithdrawalsDisabledInDepositsOnlySlice.selector);
+        vm.prank(BOB);
+        vault.deposit(300 * ONE_TUSD, BOB);
+
+        vault.setReservedLiabilitiesForTest(80 * ONE_TUSD);
+
+        assertEq(vault.grossAssets(), 400 * ONE_TUSD);
+        assertEq(vault.safetyBuffer(), 80 * ONE_TUSD);
+        assertEq(vault.freeLiquidity(), 240 * ONE_TUSD);
+        assertEq(vault.maxWithdraw(ALICE), 60 * ONE_TUSD);
+        assertEq(vault.maxWithdraw(BOB), 180 * ONE_TUSD);
+    }
+
+    function testNonzeroReservationsUseGrossAssetsInsteadOfNetPricingAssets() public {
         vm.prank(ALICE);
-        vault.redeem(ONE_TUSD, ALICE, ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+
+        assertEq(vault.totalAssets(), 100 * ONE_TUSD);
+        assertEq(vault.safetyBuffer(), 20 * ONE_TUSD);
+        assertEq(vault.freeLiquidity(), 50 * ONE_TUSD);
+        assertEq(vault.maxWithdraw(ALICE), 50 * ONE_TUSD);
+    }
+
+    function testMaxLimitsAndPreviewsAreConsistentWithExecution() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+
+        uint256 maxAssets = vault.maxWithdraw(ALICE);
+        uint256 maxShares = vault.maxRedeem(ALICE);
+        uint256 expectedBurnedShares = vault.previewWithdraw(maxAssets);
+
+        assertEq(maxAssets, 50 * ONE_TUSD);
+        assertEq(maxShares, expectedBurnedShares);
+        assertLe(vault.previewRedeem(maxShares), maxAssets);
+
+        uint256 aliceAssetsBefore = token.balanceOf(ALICE);
+        vm.prank(ALICE);
+        uint256 burnedShares = vault.withdraw(maxAssets, ALICE, ALICE);
+
+        assertEq(burnedShares, expectedBurnedShares);
+        assertEq(token.balanceOf(ALICE), aliceAssetsBefore + maxAssets);
+        assertEq(vault.balanceOf(ALICE), 100 * ONE_TUSD - burnedShares);
+    }
+
+    function testRedeemExecutesAtItsEnforceableLimit() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+
+        uint256 maxShares = vault.maxRedeem(ALICE);
+        uint256 expectedAssets = vault.previewRedeem(maxShares);
+        uint256 aliceAssetsBefore = token.balanceOf(ALICE);
+
+        vm.prank(ALICE);
+        uint256 assets = vault.redeem(maxShares, ALICE, ALICE);
+
+        assertEq(assets, expectedAssets);
+        assertEq(token.balanceOf(ALICE), aliceAssetsBefore + expectedAssets);
+        assertEq(vault.balanceOf(ALICE), 100 * ONE_TUSD - maxShares);
+    }
+
+    function testMaxRedeemIncludesAllSharesWhoseRoundedDownAssetsFitTheLimitAfterALoss() public {
+        vm.prank(ALICE);
+        vault.deposit(4, ALICE);
+
+        vault.setReservedLiabilitiesForTest(2);
+        vault.setPendingObligationsForTest(2);
+
+        assertEq(vault.totalSupply(), 4);
+        assertEq(vault.totalAssets(), 2);
+        assertEq(vault.maxWithdraw(ALICE), 1);
+        assertEq(vault.previewRedeem(3), 1);
+        assertEq(vault.maxRedeem(ALICE), 3);
+        assertGt(vault.previewRedeem(vault.maxRedeem(ALICE) + 1), vault.maxWithdraw(ALICE));
+
+        vm.prank(ALICE);
+        assertEq(vault.redeem(3, ALICE, ALICE), 1);
+    }
+
+    function testDelegatedWithdrawUsesOwnerLimitAndAllowance() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+        uint256 assets = vault.maxWithdraw(ALICE);
+        uint256 shares = vault.previewWithdraw(assets);
+
+        vm.prank(ALICE);
+        vault.approve(BOB, shares);
+
+        vm.prank(BOB);
+        vault.withdraw(assets, CAROL, ALICE);
+
+        assertEq(token.balanceOf(CAROL), assets);
+        assertEq(vault.balanceOf(ALICE), 100 * ONE_TUSD - shares);
+        assertEq(vault.allowance(ALICE, BOB), 0);
+    }
+
+    function testOverLimitWithdrawRevertsAtomicallyAtTheErc4626Boundary() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+        uint256 maxAssets = vault.maxWithdraw(ALICE);
+        uint256 balanceBefore = token.balanceOf(ALICE);
+        uint256 sharesBefore = vault.balanceOf(ALICE);
+        uint256 grossAssetsBefore = vault.grossAssets();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC4626.ERC4626ExceededMaxWithdraw.selector, ALICE, maxAssets + 1, maxAssets)
+        );
+        vm.prank(ALICE);
+        vault.withdraw(maxAssets + 1, ALICE, ALICE);
+
+        assertEq(token.balanceOf(ALICE), balanceBefore);
+        assertEq(vault.balanceOf(ALICE), sharesBefore);
+        assertEq(vault.grossAssets(), grossAssetsBefore);
+        assertEq(vault.reservedLiabilities(), 30 * ONE_TUSD);
+        assertEq(vault.safetyBuffer(), 20 * ONE_TUSD);
+    }
+
+    function testOverLimitRedeemDoesNotConsumeDelegatedAllowance() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+        uint256 maxShares = vault.maxRedeem(ALICE);
+
+        vm.prank(ALICE);
+        vault.approve(BOB, maxShares + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC4626.ERC4626ExceededMaxRedeem.selector, ALICE, maxShares + 1, maxShares)
+        );
+        vm.prank(BOB);
+        vault.redeem(maxShares + 1, CAROL, ALICE);
+
+        assertEq(vault.balanceOf(ALICE), 100 * ONE_TUSD);
+        assertEq(vault.allowance(ALICE, BOB), maxShares + 1);
+        assertEq(token.balanceOf(CAROL), 0);
+    }
+
+    function testWithdrawPreservesReservationsAndRequiredBuffer() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        vault.setReservedLiabilitiesForTest(30 * ONE_TUSD);
+
+        uint256 assets = vault.maxWithdraw(ALICE);
+        vm.prank(ALICE);
+        vault.withdraw(assets, ALICE, ALICE);
+
+        assertEq(vault.reservedLiabilities(), 30 * ONE_TUSD);
+        assertEq(vault.grossAssets(), 50 * ONE_TUSD);
+        assertEq(vault.safetyBuffer(), 10 * ONE_TUSD);
+        assertEq(vault.freeLiquidity(), 10 * ONE_TUSD);
+    }
+
+    function testStandardWithdrawEventReconstructsDelegatedWithdrawal() public {
+        vm.prank(ALICE);
+        vault.deposit(100 * ONE_TUSD, ALICE);
+
+        uint256 assets = vault.maxWithdraw(ALICE);
+        uint256 shares = vault.previewWithdraw(assets);
+
+        vm.expectEmit(true, true, true, true, address(vault));
+        emit IERC4626.Withdraw(ALICE, CAROL, ALICE, assets, shares);
+
+        vm.prank(ALICE);
+        vault.withdraw(assets, CAROL, ALICE);
+
+        assertEq(token.balanceOf(CAROL), assets);
+        assertEq(vault.balanceOf(ALICE), 100 * ONE_TUSD - shares);
     }
 
     function testStandardDepositEventReconstructsDepositForAnotherReceiver() public {

--- a/contracts/test/BankrollVault.t.sol
+++ b/contracts/test/BankrollVault.t.sol
@@ -19,6 +19,10 @@ contract BankrollVaultHarness is BankrollVault {
     function setPendingObligationsForTest(uint256 amount) external {
         pendingObligations = amount;
     }
+
+    function setUnrecognizedMarginForTest(uint256 amount) external {
+        unrecognizedMargin = amount;
+    }
 }
 
 contract BankrollVaultTest is Test {
@@ -207,20 +211,42 @@ contract BankrollVaultTest is Test {
 
     function testMaxRedeemIncludesAllSharesWhoseRoundedDownAssetsFitTheLimitAfterALoss() public {
         vm.prank(ALICE);
+        vault.deposit(8, ALICE);
+
+        vault.setReservedLiabilitiesForTest(2);
+        vault.setPendingObligationsForTest(2);
+
+        assertEq(vault.totalSupply(), 8);
+        assertEq(vault.totalAssets(), 6);
+        assertEq(vault.freeLiquidity(), 2);
+        assertEq(vault.maxWithdraw(ALICE), 2);
+        assertEq(vault.previewRedeem(3), 2);
+        assertEq(vault.maxRedeem(ALICE), 3);
+        assertGt(vault.previewRedeem(vault.maxRedeem(ALICE) + 1), vault.maxWithdraw(ALICE));
+
+        vm.prank(ALICE);
+        assertEq(vault.redeem(3, ALICE, ALICE), 2);
+    }
+
+    function testFreeLiquidityProtectsPendingObligationsAndUnrecognizedMargin() public {
+        vm.prank(ALICE);
         vault.deposit(4, ALICE);
 
         vault.setReservedLiabilitiesForTest(2);
         vault.setPendingObligationsForTest(2);
 
-        assertEq(vault.totalSupply(), 4);
-        assertEq(vault.totalAssets(), 2);
-        assertEq(vault.maxWithdraw(ALICE), 1);
-        assertEq(vault.previewRedeem(3), 1);
-        assertEq(vault.maxRedeem(ALICE), 3);
-        assertGt(vault.previewRedeem(vault.maxRedeem(ALICE) + 1), vault.maxWithdraw(ALICE));
+        // Reserved plus pending payouts already equal gross assets, so no LP
+        // withdrawal may drain the funds owed to players. maxRedeem may allow
+        // dust shares whose rounded-down asset value is zero.
+        assertEq(vault.freeLiquidity(), 0);
+        assertEq(vault.maxWithdraw(ALICE), 0);
+        assertEq(vault.previewRedeem(vault.maxRedeem(ALICE)), 0);
 
-        vm.prank(ALICE);
-        assertEq(vault.redeem(3, ALICE, ALICE), 1);
+        vault.setPendingObligationsForTest(0);
+        vault.setUnrecognizedMarginForTest(2);
+
+        assertEq(vault.freeLiquidity(), 0);
+        assertEq(vault.maxWithdraw(ALICE), 0);
     }
 
     function testDelegatedWithdrawUsesOwnerLimitAndAllowance() public {

--- a/contracts/test/BankrollVault.t.sol
+++ b/contracts/test/BankrollVault.t.sol
@@ -211,42 +211,43 @@ contract BankrollVaultTest is Test {
 
     function testMaxRedeemIncludesAllSharesWhoseRoundedDownAssetsFitTheLimitAfterALoss() public {
         vm.prank(ALICE);
-        vault.deposit(8, ALICE);
-
-        vault.setReservedLiabilitiesForTest(2);
-        vault.setPendingObligationsForTest(2);
-
-        assertEq(vault.totalSupply(), 8);
-        assertEq(vault.totalAssets(), 6);
-        assertEq(vault.freeLiquidity(), 2);
-        assertEq(vault.maxWithdraw(ALICE), 2);
-        assertEq(vault.previewRedeem(3), 2);
-        assertEq(vault.maxRedeem(ALICE), 3);
-        assertGt(vault.previewRedeem(vault.maxRedeem(ALICE) + 1), vault.maxWithdraw(ALICE));
-
-        vm.prank(ALICE);
-        assertEq(vault.redeem(3, ALICE, ALICE), 2);
-    }
-
-    function testFreeLiquidityProtectsPendingObligationsAndUnrecognizedMargin() public {
-        vm.prank(ALICE);
         vault.deposit(4, ALICE);
 
         vault.setReservedLiabilitiesForTest(2);
         vault.setPendingObligationsForTest(2);
 
-        // Reserved plus pending payouts already equal gross assets, so no LP
-        // withdrawal may drain the funds owed to players. maxRedeem may allow
-        // dust shares whose rounded-down asset value is zero.
-        assertEq(vault.freeLiquidity(), 0);
-        assertEq(vault.maxWithdraw(ALICE), 0);
-        assertEq(vault.previewRedeem(vault.maxRedeem(ALICE)), 0);
+        assertEq(vault.totalSupply(), 4);
+        assertEq(vault.totalAssets(), 2);
+        assertEq(vault.maxWithdraw(ALICE), 1);
+        assertEq(vault.previewRedeem(3), 1);
+        assertEq(vault.maxRedeem(ALICE), 3);
+        assertGt(vault.previewRedeem(vault.maxRedeem(ALICE) + 1), vault.maxWithdraw(ALICE));
 
-        vault.setPendingObligationsForTest(0);
-        vault.setUnrecognizedMarginForTest(2);
+        vm.prank(ALICE);
+        assertEq(vault.redeem(3, ALICE, ALICE), 1);
+    }
 
-        assertEq(vault.freeLiquidity(), 0);
-        assertEq(vault.maxWithdraw(ALICE), 0);
+    function testFreeLiquidityKeepsPendingPayoutsFundedUnderTheReservationInvariant() public {
+        vm.prank(ALICE);
+        vault.deposit(4, ALICE);
+
+        // Design invariant (technical design §8): pendingObligations +
+        // unrecognizedMargin never exceeds reservedLiabilities, because a
+        // reservation is consumed only when its payout or refund transfers.
+        // Under it, subtracting reservations alone keeps every pending payout
+        // and refund funded after a maximum LP withdrawal.
+        vault.setReservedLiabilitiesForTest(2);
+        vault.setPendingObligationsForTest(1);
+        vault.setUnrecognizedMarginForTest(1);
+
+        assertEq(vault.freeLiquidity(), 1);
+        uint256 assets = vault.maxWithdraw(ALICE);
+        assertEq(assets, 1);
+
+        vm.prank(ALICE);
+        vault.withdraw(assets, ALICE, ALICE);
+
+        assertGe(vault.grossAssets(), vault.pendingObligations() + vault.unrecognizedMargin());
     }
 
     function testDelegatedWithdrawUsesOwnerLimitAndAllowance() public {

--- a/src/components/lp-desk/lp-desk.test.tsx
+++ b/src/components/lp-desk/lp-desk.test.tsx
@@ -2,33 +2,20 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  BankrollVaultDepositStatus,
+  BankrollVaultRetryAction,
+  BankrollVaultWithdrawalRecovery,
+} from "@/hooks/use-bankroll-vault-deposit";
 
 type VaultFixture = {
-  status:
-    | "unavailable"
-    | "loading"
-    | "ready"
-    | "approval-submitting"
-    | "approval-pending"
-    | "deposit-submitting"
-    | "deposit-pending"
-    | "withdrawal-submitting"
-    | "withdrawal-pending"
-    | "withdrawal-confirmed"
-    | "confirmed"
-    | "error";
+  status: BankrollVaultDepositStatus;
   error: string | null;
   canDeposit: boolean;
   canWithdraw: boolean;
   canRetry: boolean;
-  withdrawalStatus:
-    | "idle"
-    | "submitting"
-    | "pending-receipt"
-    | "confirmed"
-    | "reverted-or-failed"
-    | "confirmation-unknown"
-    | "refresh-after-confirmation";
+  withdrawalRecovery: BankrollVaultWithdrawalRecovery | null;
+  retryAction: BankrollVaultRetryAction | null;
   tUsdBalance: bigint | undefined;
   shareBalance: bigint;
   assetsPerShare: bigint;
@@ -53,7 +40,8 @@ const sdk = vi.hoisted(() => {
     canDeposit: true,
     canWithdraw: true,
     canRetry: false,
-    withdrawalStatus: "idle",
+    withdrawalRecovery: null,
+    retryAction: null,
     tUsdBalance: 123450000n,
     shareBalance: 50000000n,
     assetsPerShare: 1000000n,
@@ -217,7 +205,6 @@ describe("LpDesk", () => {
     sdk.vault = {
       ...sdk.vault,
       status: "withdrawal-pending",
-      withdrawalStatus: "pending-receipt",
       canDeposit: false,
       canWithdraw: false,
     };
@@ -244,7 +231,6 @@ describe("LpDesk", () => {
     sdk.vault = {
       ...sdk.vault,
       status: "withdrawal-submitting",
-      withdrawalStatus: "submitting",
       canDeposit: false,
       canWithdraw: false,
     };
@@ -253,7 +239,6 @@ describe("LpDesk", () => {
     sdk.vault = {
       ...sdk.vault,
       status: "withdrawal-confirmed",
-      withdrawalStatus: "confirmed",
     };
     rerender(<LpDesk />);
     expect(
@@ -262,7 +247,8 @@ describe("LpDesk", () => {
     sdk.vault = {
       ...sdk.vault,
       status: "error",
-      withdrawalStatus: "confirmation-unknown",
+      withdrawalRecovery: "confirmation-unknown",
+      retryAction: "withdrawal-receipt-check",
       error: "receipt lookup timed out",
       canRetry: true,
     };
@@ -276,7 +262,8 @@ describe("LpDesk", () => {
     expect(sdk.vault.retry).toHaveBeenCalledOnce();
     sdk.vault = {
       ...sdk.vault,
-      withdrawalStatus: "reverted-or-failed",
+      withdrawalRecovery: "reverted-or-failed",
+      retryAction: "withdrawal",
       error: "reverted",
       canRetry: false,
       canWithdraw: true,
@@ -299,7 +286,8 @@ describe("LpDesk", () => {
     expect(sdk.vault.withdraw).toHaveBeenCalledWith(10000000n);
     sdk.vault = {
       ...sdk.vault,
-      withdrawalStatus: "refresh-after-confirmation",
+      withdrawalRecovery: "refresh-after-confirmation",
+      retryAction: "refresh-after-withdrawal-confirmation",
       error: "refresh failed",
       canRetry: true,
       canWithdraw: false,
@@ -327,12 +315,15 @@ describe("LpDesk", () => {
       error: "confirmed but refresh failed",
       canRetry: true,
       canDeposit: false,
+      retryAction: "refresh-after-confirmation",
     };
     rerender(<LpDesk />);
     expect(screen.getByRole("alert").textContent).toContain(
       "confirmed but refresh failed"
     );
-    fireEvent.click(screen.getByRole("button", { name: "Retry deposit" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh confirmed deposit" })
+    );
     expect(sdk.vault.retry).toHaveBeenCalledOnce();
     sdk.vault = {
       ...sdk.vault,
@@ -344,11 +335,27 @@ describe("LpDesk", () => {
     expect(screen.getByRole("alert").textContent).toContain("not configured");
   });
 
-  it("does not let a stale confirmed withdrawal mask deposit recovery", () => {
+  it("labels a plain state-reload retry neutrally after a failed initial load", () => {
+    sdk.vault = {
+      ...sdk.ready(),
+      status: "error",
+      error: "load failed",
+      canDeposit: false,
+      canWithdraw: false,
+      canRetry: true,
+      retryAction: "refresh",
+    };
+    render(<LpDesk />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(sdk.vault.retry).toHaveBeenCalledOnce();
+  });
+
+  it("shows a deposit refresh error as itself right after a withdrawal flow", () => {
     sdk.vault = {
       ...sdk.vault,
       status: "error",
-      withdrawalStatus: "confirmed",
+      withdrawalRecovery: null,
+      retryAction: "refresh-after-confirmation",
       error:
         "Your deposit was confirmed, but we couldn't refresh the Bankroll Vault.",
       canDeposit: false,
@@ -362,15 +369,16 @@ describe("LpDesk", () => {
       screen.queryByText("LP withdrawal confirmed on Base Sepolia.")
     ).toBeNull();
     expect(
-      screen.getByRole("button", { name: "Retry deposit" })
+      screen.getByRole("button", { name: "Refresh confirmed deposit" })
     ).not.toBeNull();
   });
 
-  it("clears stale withdrawal recovery copy after an authoritative refresh", () => {
+  it("never renders withdrawal recovery copy outside an error state", () => {
     sdk.vault = {
       ...sdk.vault,
       status: "ready",
-      withdrawalStatus: "refresh-after-confirmation",
+      withdrawalRecovery: "refresh-after-confirmation",
+      retryAction: null,
       error: null,
       canRetry: false,
     };

--- a/src/components/lp-desk/lp-desk.test.tsx
+++ b/src/components/lp-desk/lp-desk.test.tsx
@@ -12,11 +12,23 @@ type VaultFixture = {
     | "approval-pending"
     | "deposit-submitting"
     | "deposit-pending"
+    | "withdrawal-submitting"
+    | "withdrawal-pending"
+    | "withdrawal-confirmed"
     | "confirmed"
     | "error";
   error: string | null;
   canDeposit: boolean;
+  canWithdraw: boolean;
   canRetry: boolean;
+  withdrawalStatus:
+    | "idle"
+    | "submitting"
+    | "pending-receipt"
+    | "confirmed"
+    | "reverted-or-failed"
+    | "confirmation-unknown"
+    | "refresh-after-confirmation";
   tUsdBalance: bigint | undefined;
   shareBalance: bigint;
   assetsPerShare: bigint;
@@ -25,7 +37,12 @@ type VaultFixture = {
   totalSupply: bigint;
   pendingObligations: bigint;
   unrecognizedMargin: bigint;
+  reservedLiabilities: bigint;
+  safetyBuffer: bigint;
+  freeLiquidity: bigint;
+  maxWithdraw: bigint;
   deposit: ReturnType<typeof vi.fn>;
+  withdraw: ReturnType<typeof vi.fn>;
   retry: ReturnType<typeof vi.fn>;
 };
 
@@ -34,7 +51,9 @@ const sdk = vi.hoisted(() => {
     status: "ready",
     error: null,
     canDeposit: true,
+    canWithdraw: true,
     canRetry: false,
+    withdrawalStatus: "idle",
     tUsdBalance: 123450000n,
     shareBalance: 50000000n,
     assetsPerShare: 1000000n,
@@ -43,7 +62,12 @@ const sdk = vi.hoisted(() => {
     totalSupply: 25000000000n,
     pendingObligations: 0n,
     unrecognizedMargin: 0n,
+    reservedLiabilities: 1250000000n,
+    safetyBuffer: 5000000000n,
+    freeLiquidity: 18750000000n,
+    maxWithdraw: 37500000n,
     deposit: vi.fn(),
+    withdraw: vi.fn(),
     retry: vi.fn(),
   });
   return { vault: ready(), ready };
@@ -87,6 +111,22 @@ describe("LpDesk", () => {
     expect(
       screen.getByText("Gross assets").nextElementSibling?.textContent
     ).toBe("25000 tUSD");
+    expect(
+      screen.getByText("Reserved liabilities").nextElementSibling?.textContent
+    ).toBe("1250 tUSD");
+    expect(
+      screen.getByText("Safety buffer").nextElementSibling?.textContent
+    ).toBe("5000 tUSD");
+    expect(
+      screen.getByText("Global free liquidity").nextElementSibling?.textContent
+    ).toBe("18750 tUSD");
+    expect(
+      screen.getByText("Your immediately withdrawable tUSD").nextElementSibling
+        ?.textContent
+    ).toBe("37.5 tUSD");
+    expect(
+      screen.getByText(/Global free liquidity is the vault-wide capacity/)
+    ).not.toBeNull();
     expect(
       screen.getByText(
         /vault-share value can decline as game results are realized/i
@@ -149,6 +189,130 @@ describe("LpDesk", () => {
     ).toBe("50 vault shares");
   });
 
+  it("parses and submits an exact six-decimal tUSD withdrawal within maxWithdraw", () => {
+    render(<LpDesk />);
+    const input = screen.getByLabelText("LP withdrawal amount (tUSD)");
+    fireEvent.change(input, { target: { value: "12.345678" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(sdk.vault.withdraw).toHaveBeenCalledWith(12345678n);
+  });
+
+  it("validates positive withdrawals and the authoritative maxWithdraw limit", () => {
+    render(<LpDesk />);
+    const input = screen.getByLabelText("LP withdrawal amount (tUSD)");
+    fireEvent.change(input, { target: { value: "0" } });
+    expect(screen.getByText("Enter a positive tUSD amount.")).not.toBeNull();
+    fireEvent.change(input, { target: { value: "37.500001" } });
+    expect(
+      screen.getByText(/cannot exceed your immediately withdrawable tUSD limit/)
+    ).not.toBeNull();
+    fireEvent.change(input, { target: { value: "1.0000001" } });
+    expect(screen.getAllByText(/no more than 6 decimal places/)).toHaveLength(
+      1
+    );
+    expect(sdk.vault.withdraw).not.toHaveBeenCalled();
+  });
+
+  it("keeps wallet assets and limits authoritative while a withdrawal receipt is pending", () => {
+    sdk.vault = {
+      ...sdk.vault,
+      status: "withdrawal-pending",
+      withdrawalStatus: "pending-receipt",
+      canDeposit: false,
+      canWithdraw: false,
+    };
+    render(<LpDesk />);
+    expect(
+      screen.getByText(
+        /LP withdrawal pending until its Base Sepolia receipt succeeds/
+      )
+    ).not.toBeNull();
+    expect(
+      screen.getByText("Wallet Desk Dollars").nextElementSibling?.textContent
+    ).toBe("123.45 tUSD");
+    expect(
+      screen.getByText("Wallet vault shares").nextElementSibling?.textContent
+    ).toBe("50 vault shares");
+    expect(
+      screen.getByText("Your immediately withdrawable tUSD").nextElementSibling
+        ?.textContent
+    ).toBe("37.5 tUSD");
+  });
+
+  it("renders withdrawal lifecycle, corrected-limit recovery, and unambiguous retry actions", () => {
+    const { rerender } = render(<LpDesk />);
+    sdk.vault = {
+      ...sdk.vault,
+      status: "withdrawal-submitting",
+      withdrawalStatus: "submitting",
+      canDeposit: false,
+      canWithdraw: false,
+    };
+    rerender(<LpDesk />);
+    expect(screen.getByText("Submitting your LP withdrawal…")).not.toBeNull();
+    sdk.vault = {
+      ...sdk.vault,
+      status: "withdrawal-confirmed",
+      withdrawalStatus: "confirmed",
+    };
+    rerender(<LpDesk />);
+    expect(
+      screen.getByText("LP withdrawal confirmed on Base Sepolia.")
+    ).not.toBeNull();
+    sdk.vault = {
+      ...sdk.vault,
+      status: "error",
+      withdrawalStatus: "confirmation-unknown",
+      error: "receipt lookup timed out",
+      canRetry: true,
+    };
+    rerender(<LpDesk />);
+    expect(screen.getByRole("alert").textContent).toContain(
+      "receipt is still unconfirmed"
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry withdrawal receipt check" })
+    );
+    expect(sdk.vault.retry).toHaveBeenCalledOnce();
+    sdk.vault = {
+      ...sdk.vault,
+      withdrawalStatus: "reverted-or-failed",
+      error: "reverted",
+      canRetry: false,
+      canWithdraw: true,
+      maxWithdraw: 10000000n,
+    };
+    rerender(<LpDesk />);
+    expect(
+      screen.getByText(/authoritative withdrawable limit was refreshed/)
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Retry withdrawal" })
+    ).toBeNull();
+    const input = screen.getByLabelText("LP withdrawal amount (tUSD)");
+    fireEvent.change(input, { target: { value: "12" } });
+    expect(
+      screen.getByText(/cannot exceed your immediately withdrawable tUSD limit/)
+    ).not.toBeNull();
+    fireEvent.change(input, { target: { value: "10" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(sdk.vault.withdraw).toHaveBeenCalledWith(10000000n);
+    sdk.vault = {
+      ...sdk.vault,
+      withdrawalStatus: "refresh-after-confirmation",
+      error: "refresh failed",
+      canRetry: true,
+      canWithdraw: false,
+    };
+    rerender(<LpDesk />);
+    expect(
+      screen.getByText(/withdrawal was confirmed, but the refreshed balances/)
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Refresh confirmed withdrawal" })
+    ).not.toBeNull();
+  });
+
   it("renders approval, confirmation, safe retry, and unavailable configuration states", () => {
     const { rerender } = render(<LpDesk />);
     sdk.vault = { ...sdk.vault, status: "approval-pending", canDeposit: false };
@@ -168,7 +332,7 @@ describe("LpDesk", () => {
     expect(screen.getByRole("alert").textContent).toContain(
       "confirmed but refresh failed"
     );
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry deposit" }));
     expect(sdk.vault.retry).toHaveBeenCalledOnce();
     sdk.vault = {
       ...sdk.vault,
@@ -178,5 +342,43 @@ describe("LpDesk", () => {
     };
     rerender(<LpDesk />);
     expect(screen.getByRole("alert").textContent).toContain("not configured");
+  });
+
+  it("does not let a stale confirmed withdrawal mask deposit recovery", () => {
+    sdk.vault = {
+      ...sdk.vault,
+      status: "error",
+      withdrawalStatus: "confirmed",
+      error:
+        "Your deposit was confirmed, but we couldn't refresh the Bankroll Vault.",
+      canDeposit: false,
+      canRetry: true,
+    };
+    render(<LpDesk />);
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Your deposit was confirmed"
+    );
+    expect(
+      screen.queryByText("LP withdrawal confirmed on Base Sepolia.")
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Retry deposit" })
+    ).not.toBeNull();
+  });
+
+  it("clears stale withdrawal recovery copy after an authoritative refresh", () => {
+    sdk.vault = {
+      ...sdk.vault,
+      status: "ready",
+      withdrawalStatus: "refresh-after-confirmation",
+      error: null,
+      canRetry: false,
+    };
+    render(<LpDesk />);
+    expect(
+      screen.queryByText(/withdrawal was confirmed, but the refreshed balances/)
+    ).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("button", { name: /retry|refresh/i })).toBeNull();
   });
 });

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -5,6 +5,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import {
   useBankrollVaultDeposit,
   type BankrollVaultDepositStatus,
+  type BankrollVaultWithdrawalStatus,
 } from "@/hooks/use-bankroll-vault-deposit";
 import {
   formatDeskDollars,
@@ -41,6 +42,25 @@ function validateAmount(
   return null;
 }
 
+function validateWithdrawalAmount(
+  amount: string,
+  parsed: bigint | null,
+  maxWithdraw: bigint | undefined,
+  status: BankrollVaultDepositStatus
+): string | null {
+  if (amount.length === 0) return null;
+  if (parsed === null)
+    return `Enter a tUSD amount with no more than ${TUSD_DECIMALS} decimal places.`;
+  if (parsed <= 0n) return "Enter a positive tUSD amount.";
+  if (maxWithdraw === undefined)
+    return status === "loading"
+      ? "Your withdrawable tUSD limit is still loading."
+      : null;
+  if (parsed > maxWithdraw)
+    return "Withdrawal amount cannot exceed your immediately withdrawable tUSD limit.";
+  return null;
+}
+
 const statusCopy: Partial<Record<BankrollVaultDepositStatus, string>> = {
   loading: "Loading your Bankroll Vault balances…",
   "approval-submitting": "Submitting an exact tUSD approval…",
@@ -52,11 +72,27 @@ const statusCopy: Partial<Record<BankrollVaultDepositStatus, string>> = {
   confirmed: "LP deposit confirmed on Base Sepolia.",
 };
 
+const withdrawalStatusCopy: Partial<
+  Record<BankrollVaultWithdrawalStatus, string>
+> = {
+  submitting: "Submitting your LP withdrawal…",
+  "pending-receipt":
+    "LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet tUSD, shares, and limits will not update until confirmation.",
+  confirmed: "LP withdrawal confirmed on Base Sepolia.",
+  "confirmation-unknown":
+    "Your LP withdrawal was submitted, but its receipt is still unconfirmed. Retry checks that same withdrawal.",
+  "reverted-or-failed":
+    "LP withdrawal did not complete. Your authoritative withdrawable limit was refreshed; enter an amount within that limit to try again.",
+  "refresh-after-confirmation":
+    "LP withdrawal was confirmed, but the refreshed balances and limits could not be loaded. Retry refreshes the confirmed withdrawal state.",
+};
+
 export function LpDesk() {
   const { user } = usePrivy();
   const walletAddress = getEvmWalletAddress(user);
   const vault = useBankrollVaultDeposit(walletAddress);
   const [amount, setAmount] = useState("");
+  const [withdrawalAmount, setWithdrawalAmount] = useState("");
   const parsedAmount = parseTUsdInput(amount);
   const validationError = validateAmount(
     amount,
@@ -66,17 +102,59 @@ export function LpDesk() {
   );
   const canSubmit =
     vault.canDeposit && parsedAmount !== null && !validationError;
+  const parsedWithdrawalAmount = parseTUsdInput(withdrawalAmount);
+  const withdrawalValidationError = validateWithdrawalAmount(
+    withdrawalAmount,
+    parsedWithdrawalAmount,
+    vault.maxWithdraw,
+    vault.status
+  );
+  const canWithdraw =
+    vault.canWithdraw &&
+    parsedWithdrawalAmount !== null &&
+    !withdrawalValidationError;
 
   const submit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canSubmit || parsedAmount === null) return;
     void vault.deposit(parsedAmount);
   };
+  const submitWithdrawal = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canWithdraw || parsedWithdrawalAmount === null) return;
+    void vault.withdraw(parsedWithdrawalAmount);
+  };
 
-  const isAlert = vault.status === "error" || vault.status === "unavailable";
+  const isWithdrawalStatus = vault.status.startsWith("withdrawal-");
+  const isWithdrawalRecoveryStatus =
+    vault.withdrawalStatus === "confirmation-unknown" ||
+    vault.withdrawalStatus === "reverted-or-failed" ||
+    vault.withdrawalStatus === "refresh-after-confirmation";
+  const showsWithdrawalStatus =
+    isWithdrawalStatus ||
+    (vault.status === "error" && isWithdrawalRecoveryStatus);
+  const isAlert =
+    vault.status === "unavailable" ||
+    (vault.status === "error" && !isWithdrawalRecoveryStatus);
   const statusMessage = isAlert
     ? vault.error
-    : (statusCopy[vault.status] ?? null);
+    : isWithdrawalStatus
+      ? null
+      : (statusCopy[vault.status] ?? null);
+  const withdrawalMessage = showsWithdrawalStatus
+    ? (withdrawalStatusCopy[vault.withdrawalStatus] ??
+      (vault.status === "error" ? vault.error : null))
+    : null;
+  const withdrawalIsAlert =
+    vault.status === "error" && isWithdrawalRecoveryStatus;
+  const retryLabel =
+    vault.withdrawalStatus === "confirmation-unknown"
+      ? "Retry withdrawal receipt check"
+      : vault.withdrawalStatus === "refresh-after-confirmation"
+        ? "Refresh confirmed withdrawal"
+        : vault.withdrawalStatus === "reverted-or-failed"
+          ? "Retry withdrawal"
+          : "Retry deposit";
 
   return (
     <section
@@ -133,10 +211,33 @@ export function LpDesk() {
           <dt className="text-[var(--t-muted)]">Unrecognized margin</dt>
           <dd>{formatAmount(vault.unrecognizedMargin, "tUSD")}</dd>
         </div>
+        <div>
+          <dt className="text-[var(--t-muted)]">Reserved liabilities</dt>
+          <dd>{formatAmount(vault.reservedLiabilities, "tUSD")}</dd>
+        </div>
+        <div>
+          <dt className="text-[var(--t-muted)]">Safety buffer</dt>
+          <dd>{formatAmount(vault.safetyBuffer, "tUSD")}</dd>
+        </div>
+        <div>
+          <dt className="text-[var(--t-muted)]">Global free liquidity</dt>
+          <dd>{formatAmount(vault.freeLiquidity, "tUSD")}</dd>
+        </div>
+        <div>
+          <dt className="text-[var(--t-muted)]">
+            Your immediately withdrawable tUSD
+          </dt>
+          <dd>{formatAmount(vault.maxWithdraw, "tUSD")}</dd>
+        </div>
       </dl>
       <p className="mt-3 text-xs text-[var(--t-muted)]">
         Gross assets are live vault tUSD. Net total assets price shares after
         pending obligations and unrecognized margin.
+      </p>
+      <p className="mt-2 text-xs text-[var(--t-muted)]">
+        Global free liquidity is the vault-wide capacity after reservations and
+        its safety buffer. Your immediately withdrawable limit is your
+        proportional, authoritative maxWithdraw amount and may be lower.
       </p>
 
       <form
@@ -177,6 +278,54 @@ export function LpDesk() {
         </button>
       </form>
 
+      <form
+        className="mt-6 border-t border-[var(--t-muted)] pt-5"
+        onSubmit={submitWithdrawal}
+      >
+        <label
+          className="block text-sm font-bold"
+          htmlFor="lp-withdrawal-amount"
+        >
+          LP withdrawal amount (tUSD)
+        </label>
+        <input
+          aria-describedby="lp-withdrawal-help lp-withdrawal-validation"
+          className="mt-2 w-full rounded-sm border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+          id="lp-withdrawal-amount"
+          inputMode="decimal"
+          onChange={(event) => setWithdrawalAmount(event.target.value)}
+          placeholder="0.000000"
+          value={withdrawalAmount}
+        />
+        <p
+          id="lp-withdrawal-help"
+          className="mt-2 text-xs text-[var(--t-muted)]"
+        >
+          Withdraw tUSD, not shares, up to your authoritative immediately
+          withdrawable limit. This limit is separate from global free liquidity.
+        </p>
+        {withdrawalValidationError ? (
+          <p
+            id="lp-withdrawal-validation"
+            role="alert"
+            className="mt-2 text-sm"
+          >
+            {withdrawalValidationError}
+          </p>
+        ) : null}
+        <button
+          className="mt-4 rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
+          disabled={!canWithdraw}
+          type="submit"
+        >
+          {vault.withdrawalStatus === "submitting"
+            ? "Withdrawal submitting…"
+            : vault.withdrawalStatus === "pending-receipt"
+              ? "Withdrawal pending…"
+              : "Withdraw tUSD"}
+        </button>
+      </form>
+
       {statusMessage ? (
         <p
           aria-live={isAlert ? undefined : "polite"}
@@ -186,13 +335,22 @@ export function LpDesk() {
           {statusMessage}
         </p>
       ) : null}
+      {withdrawalMessage ? (
+        <p
+          aria-live={withdrawalIsAlert ? undefined : "polite"}
+          className="mt-4 text-sm"
+          role={withdrawalIsAlert ? "alert" : undefined}
+        >
+          {withdrawalMessage}
+        </p>
+      ) : null}
       {vault.canRetry ? (
         <button
           className="mt-3 rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
           onClick={() => void vault.retry()}
           type="button"
         >
-          Retry
+          {retryLabel}
         </button>
       ) : null}
     </section>

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -5,7 +5,8 @@ import { usePrivy } from "@privy-io/react-auth";
 import {
   useBankrollVaultDeposit,
   type BankrollVaultDepositStatus,
-  type BankrollVaultWithdrawalStatus,
+  type BankrollVaultRetryAction,
+  type BankrollVaultWithdrawalRecovery,
 } from "@/hooks/use-bankroll-vault-deposit";
 import {
   formatDeskDollars,
@@ -20,44 +21,34 @@ function formatAmount(value: bigint | undefined, unit: string) {
     : `${formatDeskDollars(value, TUSD_DECIMALS)} ${unit}`;
 }
 
+const depositAmountCopy = {
+  limitLoading: "Your Desk Dollars balance is still loading.",
+  overLimit: "Deposit amount cannot exceed your wallet Desk Dollars balance.",
+};
+
+const withdrawalAmountCopy = {
+  limitLoading: "Your withdrawable tUSD limit is still loading.",
+  overLimit:
+    "Withdrawal amount cannot exceed your immediately withdrawable tUSD limit.",
+};
+
 function validateAmount(
   amount: string,
   parsed: bigint | null,
-  balance: bigint | undefined,
-  status: BankrollVaultDepositStatus
+  limit: bigint | undefined,
+  status: BankrollVaultDepositStatus,
+  copy: { limitLoading: string; overLimit: string }
 ): string | null {
   if (amount.length === 0) return null;
   if (parsed === null)
     return `Enter a tUSD amount with no more than ${TUSD_DECIMALS} decimal places.`;
   if (parsed <= 0n) return "Enter a positive tUSD amount.";
-  if (balance === undefined) {
+  if (limit === undefined) {
     // Unavailable and load-error states already render their own notice;
     // only a load that is genuinely in progress warrants "still loading".
-    return status === "loading"
-      ? "Your Desk Dollars balance is still loading."
-      : null;
+    return status === "loading" ? copy.limitLoading : null;
   }
-  if (parsed > balance)
-    return "Deposit amount cannot exceed your wallet Desk Dollars balance.";
-  return null;
-}
-
-function validateWithdrawalAmount(
-  amount: string,
-  parsed: bigint | null,
-  maxWithdraw: bigint | undefined,
-  status: BankrollVaultDepositStatus
-): string | null {
-  if (amount.length === 0) return null;
-  if (parsed === null)
-    return `Enter a tUSD amount with no more than ${TUSD_DECIMALS} decimal places.`;
-  if (parsed <= 0n) return "Enter a positive tUSD amount.";
-  if (maxWithdraw === undefined)
-    return status === "loading"
-      ? "Your withdrawable tUSD limit is still loading."
-      : null;
-  if (parsed > maxWithdraw)
-    return "Withdrawal amount cannot exceed your immediately withdrawable tUSD limit.";
+  if (parsed > limit) return copy.overLimit;
   return null;
 }
 
@@ -72,19 +63,31 @@ const statusCopy: Partial<Record<BankrollVaultDepositStatus, string>> = {
   confirmed: "LP deposit confirmed on Base Sepolia.",
 };
 
-const withdrawalStatusCopy: Partial<
-  Record<BankrollVaultWithdrawalStatus, string>
-> = {
-  submitting: "Submitting your LP withdrawal…",
-  "pending-receipt":
-    "LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet tUSD, shares, and limits will not update until confirmation.",
-  confirmed: "LP withdrawal confirmed on Base Sepolia.",
-  "confirmation-unknown":
-    "Your LP withdrawal was submitted, but its receipt is still unconfirmed. Retry checks that same withdrawal.",
-  "reverted-or-failed":
-    "LP withdrawal did not complete. Your authoritative withdrawable limit was refreshed; enter an amount within that limit to try again.",
-  "refresh-after-confirmation":
-    "LP withdrawal was confirmed, but the refreshed balances and limits could not be loaded. Retry refreshes the confirmed withdrawal state.",
+const withdrawalPhaseCopy: Partial<Record<BankrollVaultDepositStatus, string>> =
+  {
+    "withdrawal-submitting": "Submitting your LP withdrawal…",
+    "withdrawal-pending":
+      "LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet tUSD, shares, and limits will not update until confirmation.",
+    "withdrawal-confirmed": "LP withdrawal confirmed on Base Sepolia.",
+  };
+
+const withdrawalRecoveryCopy: Record<BankrollVaultWithdrawalRecovery, string> =
+  {
+    "confirmation-unknown":
+      "Your LP withdrawal was submitted, but its receipt is still unconfirmed. Retry checks that same withdrawal.",
+    "reverted-or-failed":
+      "LP withdrawal did not complete. Your authoritative withdrawable limit was refreshed; enter an amount within that limit to try again.",
+    "refresh-after-confirmation":
+      "LP withdrawal was confirmed, but the refreshed balances and limits could not be loaded. Retry refreshes the confirmed withdrawal state.",
+  };
+
+const retryLabels: Record<BankrollVaultRetryAction, string> = {
+  refresh: "Retry",
+  "refresh-after-confirmation": "Refresh confirmed deposit",
+  "refresh-after-withdrawal-confirmation": "Refresh confirmed withdrawal",
+  deposit: "Retry deposit",
+  withdrawal: "Retry withdrawal",
+  "withdrawal-receipt-check": "Retry withdrawal receipt check",
 };
 
 export function LpDesk() {
@@ -98,16 +101,18 @@ export function LpDesk() {
     amount,
     parsedAmount,
     vault.tUsdBalance,
-    vault.status
+    vault.status,
+    depositAmountCopy
   );
   const canSubmit =
     vault.canDeposit && parsedAmount !== null && !validationError;
   const parsedWithdrawalAmount = parseTUsdInput(withdrawalAmount);
-  const withdrawalValidationError = validateWithdrawalAmount(
+  const withdrawalValidationError = validateAmount(
     withdrawalAmount,
     parsedWithdrawalAmount,
     vault.maxWithdraw,
-    vault.status
+    vault.status,
+    withdrawalAmountCopy
   );
   const canWithdraw =
     vault.canWithdraw &&
@@ -125,36 +130,21 @@ export function LpDesk() {
     void vault.withdraw(parsedWithdrawalAmount);
   };
 
-  const isWithdrawalStatus = vault.status.startsWith("withdrawal-");
-  const isWithdrawalRecoveryStatus =
-    vault.withdrawalStatus === "confirmation-unknown" ||
-    vault.withdrawalStatus === "reverted-or-failed" ||
-    vault.withdrawalStatus === "refresh-after-confirmation";
-  const showsWithdrawalStatus =
-    isWithdrawalStatus ||
-    (vault.status === "error" && isWithdrawalRecoveryStatus);
+  const withdrawalRecovery =
+    vault.status === "error" ? vault.withdrawalRecovery : null;
   const isAlert =
     vault.status === "unavailable" ||
-    (vault.status === "error" && !isWithdrawalRecoveryStatus);
+    (vault.status === "error" && !withdrawalRecovery);
   const statusMessage = isAlert
     ? vault.error
-    : isWithdrawalStatus
-      ? null
-      : (statusCopy[vault.status] ?? null);
-  const withdrawalMessage = showsWithdrawalStatus
-    ? (withdrawalStatusCopy[vault.withdrawalStatus] ??
-      (vault.status === "error" ? vault.error : null))
-    : null;
-  const withdrawalIsAlert =
-    vault.status === "error" && isWithdrawalRecoveryStatus;
-  const retryLabel =
-    vault.withdrawalStatus === "confirmation-unknown"
-      ? "Retry withdrawal receipt check"
-      : vault.withdrawalStatus === "refresh-after-confirmation"
-        ? "Refresh confirmed withdrawal"
-        : vault.withdrawalStatus === "reverted-or-failed"
-          ? "Retry withdrawal"
-          : "Retry deposit";
+    : (statusCopy[vault.status] ?? null);
+  const withdrawalMessage =
+    withdrawalPhaseCopy[vault.status] ??
+    (withdrawalRecovery ? withdrawalRecoveryCopy[withdrawalRecovery] : null);
+  const withdrawalIsAlert = withdrawalRecovery !== null;
+  const retryLabel = vault.retryAction
+    ? retryLabels[vault.retryAction]
+    : "Retry";
 
   return (
     <section
@@ -318,9 +308,9 @@ export function LpDesk() {
           disabled={!canWithdraw}
           type="submit"
         >
-          {vault.withdrawalStatus === "submitting"
+          {vault.status === "withdrawal-submitting"
             ? "Withdrawal submitting…"
-            : vault.withdrawalStatus === "pending-receipt"
+            : vault.status === "withdrawal-pending"
               ? "Withdrawal pending…"
               : "Withdraw tUSD"}
         </button>

--- a/src/hooks/use-bankroll-vault-deposit.test.tsx
+++ b/src/hooks/use-bankroll-vault-deposit.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { encodeFunctionData } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sdk = vi.hoisted(() => ({
@@ -23,6 +24,11 @@ const readyValues = (allowance = 0n) => ({
   assetsPerShare: 1000000n,
   pendingObligations: 0n,
   unrecognizedMargin: 0n,
+  reservedLiabilities: 0n,
+  safetyBuffer: 5000000000n,
+  freeLiquidity: 20000000000n,
+  maxWithdraw: 20000000000n,
+  maxRedeem: 20000000000n,
 });
 
 vi.mock("@/lib/base-sepolia", () => ({
@@ -41,6 +47,17 @@ vi.mock("@/lib/bankroll-vault", () => ({
       inputs: [
         { name: "assets", type: "uint256" },
         { name: "receiver", type: "address" },
+      ],
+      outputs: [{ name: "shares", type: "uint256" }],
+    },
+    {
+      type: "function",
+      name: "withdraw",
+      stateMutability: "nonpayable",
+      inputs: [
+        { name: "assets", type: "uint256" },
+        { name: "receiver", type: "address" },
+        { name: "owner", type: "address" },
       ],
       outputs: [{ name: "shares", type: "uint256" }],
     },
@@ -181,6 +198,9 @@ describe("useBankrollVaultDeposit", () => {
     );
     expect(result.current.canDeposit).toBe(false);
     expect(result.current.canRetry).toBe(true);
+    await expect(result.current.deposit(50n)).resolves.toBe(false);
+    await expect(result.current.withdraw(50n)).resolves.toBe(false);
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
     await act(async () => {
       await result.current.retry();
     });
@@ -188,6 +208,30 @@ describe("useBankrollVaultDeposit", () => {
     expect(sdk.wait).toHaveBeenCalledTimes(2);
     expect(sdk.wait).toHaveBeenNthCalledWith(2, { hash: "0xbbb" });
     expect(result.current.status).toBe("ready");
+  });
+
+  it("keeps an unresolved approval as the only recoverable operation", async () => {
+    sdk.getSubmittedHash
+      .mockReset()
+      .mockReturnValueOnce("0xapproval")
+      .mockReturnValueOnce("0xdeposit");
+    sdk.wait
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockResolvedValueOnce({ status: "success" })
+      .mockResolvedValueOnce({ status: "success" });
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await act(async () => {
+      await result.current.deposit(123n);
+    });
+    await expect(result.current.deposit(50n)).resolves.toBe(false);
+    await expect(result.current.withdraw(50n)).resolves.toBe(false);
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.wait).toHaveBeenNthCalledWith(2, { hash: "0xapproval" });
+    expect(sdk.submit).toHaveBeenCalledTimes(2);
   });
 
   it("accepts a different amount after a resolved deposit failure", async () => {
@@ -283,5 +327,149 @@ describe("useBankrollVaultDeposit", () => {
     });
     expect(sdk.submit).toHaveBeenCalledTimes(1);
     expect(sdk.read).toHaveBeenCalledTimes(3);
+  });
+
+  it("submits exact asset-denominated withdrawal calldata and leaves balances authoritative until receipt confirmation", async () => {
+    let resolveWait: (receipt: { status: string }) => void;
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xwithdraw");
+    sdk.wait.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveWait = resolve;
+        })
+    );
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    const before = result.current.tUsdBalance;
+    let withdrawal: Promise<boolean>;
+    act(() => {
+      withdrawal = result.current.withdraw(123n);
+    });
+    await waitFor(() =>
+      expect(result.current.status).toBe("withdrawal-pending")
+    );
+    expect(result.current.tUsdBalance).toBe(before);
+    expect(sdk.submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: vault,
+        chainId: 84532,
+        data: encodeFunctionData({
+          abi: [
+            {
+              type: "function",
+              name: "withdraw",
+              stateMutability: "nonpayable",
+              inputs: [
+                { name: "assets", type: "uint256" },
+                { name: "receiver", type: "address" },
+                { name: "owner", type: "address" },
+              ],
+              outputs: [{ name: "shares", type: "uint256" }],
+            },
+          ],
+          functionName: "withdraw",
+          args: [123n, wallet, wallet],
+        }),
+      })
+    );
+    await act(async () => {
+      resolveWait!({ status: "success" });
+      await withdrawal!;
+    });
+    expect(sdk.read).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-checks an unresolved withdrawal hash instead of resubmitting it", async () => {
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xwithdraw");
+    sdk.wait
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockResolvedValueOnce({ status: "success" });
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await act(async () => {
+      await result.current.withdraw(123n);
+    });
+    expect(result.current.canWithdraw).toBe(false);
+    expect(result.current.withdrawalStatus).toBe("confirmation-unknown");
+    await expect(result.current.deposit(50n)).resolves.toBe(false);
+    await expect(result.current.withdraw(50n)).resolves.toBe(false);
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    expect(sdk.wait).toHaveBeenNthCalledWith(2, { hash: "0xwithdraw" });
+  });
+
+  it("refreshes the authoritative limit after a reverted withdrawal before accepting a corrected retry", async () => {
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xwithdraw");
+    sdk.read
+      .mockResolvedValueOnce(readyValues())
+      .mockResolvedValueOnce({
+        ...readyValues(),
+        maxWithdraw: 50n,
+        freeLiquidity: 50n,
+      })
+      .mockResolvedValueOnce(readyValues());
+    sdk.wait
+      .mockResolvedValueOnce({ status: "reverted" })
+      .mockResolvedValueOnce({ status: "success" });
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await act(async () => {
+      await result.current.withdraw(123n);
+    });
+    expect(result.current.maxWithdraw).toBe(50n);
+    expect(result.current.canWithdraw).toBe(true);
+    expect(result.current.canRetry).toBe(false);
+    await expect(result.current.retry()).resolves.toBe(false);
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await result.current.withdraw(50n);
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries only the authoritative refresh after a confirmed withdrawal", async () => {
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xwithdraw");
+    sdk.read
+      .mockResolvedValueOnce(readyValues())
+      .mockRejectedValueOnce(new Error("rpc"))
+      .mockResolvedValueOnce(readyValues());
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await act(async () => {
+      await result.current.withdraw(123n);
+    });
+    expect(result.current.status).toBe("error");
+    expect(result.current.withdrawalStatus).toBe("refresh-after-confirmation");
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses duplicate in-flight withdrawals", async () => {
+    let resolveSubmit: (value: boolean) => void;
+    sdk.submit.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSubmit = resolve;
+        })
+    );
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    let first: Promise<boolean>;
+    let duplicate: Promise<boolean>;
+    act(() => {
+      first = result.current.withdraw(123n);
+      duplicate = result.current.withdraw(123n);
+    });
+    await expect(duplicate!).resolves.toBe(false);
+    await act(async () => {
+      resolveSubmit!(true);
+      await first!;
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/use-bankroll-vault-deposit.test.tsx
+++ b/src/hooks/use-bankroll-vault-deposit.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, erc4626Abi } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sdk = vi.hoisted(() => ({
@@ -28,7 +28,6 @@ const readyValues = (allowance = 0n) => ({
   safetyBuffer: 5000000000n,
   freeLiquidity: 20000000000n,
   maxWithdraw: 20000000000n,
-  maxRedeem: 20000000000n,
 });
 
 vi.mock("@/lib/base-sepolia", () => ({
@@ -37,31 +36,9 @@ vi.mock("@/lib/base-sepolia", () => ({
     waitForTransactionReceipt: (...args: unknown[]) => sdk.wait(...args),
   },
 }));
-vi.mock("@/lib/bankroll-vault", () => ({
+vi.mock("@/lib/bankroll-vault", async () => ({
   getBankrollVaultConfig: () => ({ tokenAddress: token, vaultAddress: vault }),
-  bankrollVaultAbi: [
-    {
-      type: "function",
-      name: "deposit",
-      stateMutability: "nonpayable",
-      inputs: [
-        { name: "assets", type: "uint256" },
-        { name: "receiver", type: "address" },
-      ],
-      outputs: [{ name: "shares", type: "uint256" }],
-    },
-    {
-      type: "function",
-      name: "withdraw",
-      stateMutability: "nonpayable",
-      inputs: [
-        { name: "assets", type: "uint256" },
-        { name: "receiver", type: "address" },
-        { name: "owner", type: "address" },
-      ],
-      outputs: [{ name: "shares", type: "uint256" }],
-    },
-  ],
+  bankrollVaultAbi: (await import("viem")).erc4626Abi,
   readBankrollVaultState: (...args: unknown[]) => sdk.read(...args),
 }));
 vi.mock("./use-privy-sponsored-transaction", () => ({
@@ -354,19 +331,7 @@ describe("useBankrollVaultDeposit", () => {
         to: vault,
         chainId: 84532,
         data: encodeFunctionData({
-          abi: [
-            {
-              type: "function",
-              name: "withdraw",
-              stateMutability: "nonpayable",
-              inputs: [
-                { name: "assets", type: "uint256" },
-                { name: "receiver", type: "address" },
-                { name: "owner", type: "address" },
-              ],
-              outputs: [{ name: "shares", type: "uint256" }],
-            },
-          ],
+          abi: erc4626Abi,
           functionName: "withdraw",
           args: [123n, wallet, wallet],
         }),
@@ -390,7 +355,8 @@ describe("useBankrollVaultDeposit", () => {
       await result.current.withdraw(123n);
     });
     expect(result.current.canWithdraw).toBe(false);
-    expect(result.current.withdrawalStatus).toBe("confirmation-unknown");
+    expect(result.current.withdrawalRecovery).toBe("confirmation-unknown");
+    expect(result.current.retryAction).toBe("withdrawal-receipt-check");
     await expect(result.current.deposit(50n)).resolves.toBe(false);
     await expect(result.current.withdraw(50n)).resolves.toBe(false);
     expect(sdk.submit).toHaveBeenCalledTimes(1);
@@ -420,7 +386,11 @@ describe("useBankrollVaultDeposit", () => {
       await result.current.withdraw(123n);
     });
     expect(result.current.maxWithdraw).toBe(50n);
+    expect(result.current.withdrawalRecovery).toBe("reverted-or-failed");
     expect(result.current.canWithdraw).toBe(true);
+    // A failed withdrawal must not lock out deposits — the one action that
+    // could restore free liquidity.
+    expect(result.current.canDeposit).toBe(true);
     expect(result.current.canRetry).toBe(false);
     await expect(result.current.retry()).resolves.toBe(false);
     expect(sdk.submit).toHaveBeenCalledTimes(1);
@@ -442,10 +412,71 @@ describe("useBankrollVaultDeposit", () => {
       await result.current.withdraw(123n);
     });
     expect(result.current.status).toBe("error");
-    expect(result.current.withdrawalStatus).toBe("refresh-after-confirmation");
+    expect(result.current.withdrawalRecovery).toBe(
+      "refresh-after-confirmation"
+    );
+    expect(result.current.retryAction).toBe(
+      "refresh-after-withdrawal-confirmation"
+    );
     await act(async () => {
       await result.current.retry();
     });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("ready");
+    // Recovery copy must not linger to mislabel a later deposit error.
+    expect(result.current.withdrawalRecovery).toBeNull();
+  });
+
+  it("keeps the receipt-check retry available when a fresh read lowers the limit below the unresolved amount", async () => {
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xwithdraw");
+    sdk.wait
+      .mockReset()
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockResolvedValueOnce({ status: "success" });
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await act(async () => {
+      await result.current.withdraw(123n);
+    });
+    expect(result.current.withdrawalRecovery).toBe("confirmation-unknown");
+    sdk.read.mockResolvedValue({ ...readyValues(), maxWithdraw: 50n });
+    await act(async () => {
+      notifyWalletBalancesChanged();
+    });
+    await waitFor(() => expect(result.current.maxWithdraw).toBe(50n));
+    expect(result.current.canRetry).toBe(true);
+    expect(result.current.retryAction).toBe("withdrawal-receipt-check");
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    expect(sdk.wait).toHaveBeenNthCalledWith(2, { hash: "0xwithdraw" });
+  });
+
+  it("reports the failed post-revert refresh instead of claiming the limit was refreshed", async () => {
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xwithdraw");
+    sdk.read
+      .mockReset()
+      .mockResolvedValueOnce(readyValues())
+      .mockRejectedValueOnce(new Error("rpc"))
+      .mockResolvedValueOnce(readyValues());
+    sdk.wait.mockReset().mockResolvedValueOnce({ status: "reverted" });
+    const { result } = renderHook(() => useBankrollVaultDeposit(wallet));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await act(async () => {
+      await result.current.withdraw(123n);
+    });
+    expect(result.current.status).toBe("error");
+    expect(result.current.withdrawalRecovery).toBeNull();
+    expect(result.current.error).toBe(
+      "Your LP withdrawal did not complete, and we couldn't reload your balances and limits. Retry reloads them."
+    );
+    expect(result.current.canWithdraw).toBe(false);
+    expect(result.current.retryAction).toBe("refresh");
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(result.current.status).toBe("ready");
     expect(sdk.submit).toHaveBeenCalledTimes(1);
   });
 

--- a/src/hooks/use-bankroll-vault-deposit.ts
+++ b/src/hooks/use-bankroll-vault-deposit.ts
@@ -33,25 +33,31 @@ export type BankrollVaultDepositStatus =
   | "confirmed"
   | "error";
 
-export type BankrollVaultWithdrawalStatus =
-  | "idle"
-  | "submitting"
-  | "pending-receipt"
-  | "confirmed"
-  | "reverted-or-failed"
-  | "confirmation-unknown"
-  | "refresh-after-confirmation";
+// How a withdrawal that ended in `status: "error"` can recover. In-progress
+// withdrawal phases live in the `withdrawal-*` status values above; this field
+// only ever accompanies an error and is cleared when any new stage starts.
+export type BankrollVaultWithdrawalRecovery =
+  "confirmation-unknown" | "reverted-or-failed" | "refresh-after-confirmation";
+
+// What retry() will actually perform, so UI labels can describe it truthfully.
+export type BankrollVaultRetryAction =
+  | "refresh"
+  | "refresh-after-confirmation"
+  | "refresh-after-withdrawal-confirmation"
+  | "deposit"
+  | "withdrawal"
+  | "withdrawal-receipt-check";
 
 type Stage = "approval" | "deposit" | "withdrawal";
 type VaultValues = Awaited<ReturnType<typeof readBankrollVaultState>>;
 type State = Partial<VaultValues> & {
   status: BankrollVaultDepositStatus;
-  withdrawalStatus: BankrollVaultWithdrawalStatus;
+  withdrawalRecovery: BankrollVaultWithdrawalRecovery | null;
   error: string | null;
 };
 const initialState: State = {
   status: "loading",
-  withdrawalStatus: "idle",
+  withdrawalRecovery: null,
   error: null,
 };
 const unavailable =
@@ -61,6 +67,8 @@ const refreshFailed =
   "Your deposit was confirmed, but we couldn't refresh the Bankroll Vault. Please try again.";
 const withdrawalRefreshFailed =
   "Your withdrawal was confirmed, but we couldn't refresh the Bankroll Vault. Please try again.";
+const withdrawalFailedAndRefreshFailed =
+  "Your LP withdrawal did not complete, and we couldn't reload your balances and limits. Retry reloads them.";
 const stageCopy: Record<Stage, { failed: string; unconfirmed: string }> = {
   approval: {
     failed: "We couldn't approve this exact tUSD amount. Please try again.",
@@ -81,18 +89,39 @@ const stageCopy: Record<Stage, { failed: string; unconfirmed: string }> = {
   },
 };
 
+// Maps a sponsored-call outcome to the stage's error copy. Clears the pending
+// stage on any definitive outcome; an unknown confirmation keeps it as the
+// recovery handle for Retry.
+function applyStageResult(
+  pendingStage: { current: { stage: Stage; hash: Hex } | null },
+  stage: Stage,
+  result: SponsoredCallResult
+) {
+  if (result.outcome === "confirmed") {
+    pendingStage.current = null;
+    return;
+  }
+  if (result.outcome === "confirmation-unknown")
+    throw new Error(stageCopy[stage].unconfirmed);
+  pendingStage.current = null;
+  if (result.outcome === "submission-failed")
+    throw new Error(result.message ?? stageCopy[stage].failed);
+  throw new Error(stageCopy[stage].failed);
+}
+
 export function useBankrollVaultDeposit(walletAddress: Address | null) {
   const transaction = usePrivySponsoredTransaction();
   const config = useMemo(() => getBankrollVaultConfig(), []);
   const [state, setState] = useState<State>(initialState);
   const inFlight = useRef(false);
   const retryKind = useRef<
-    Stage | "refresh" | "refresh-after-confirmation" | null
+    | Stage
+    | "refresh"
+    | "refresh-after-confirmation"
+    | "refresh-after-withdrawal-confirmation"
+    | null
   >(null);
   const retryAmount = useRef<bigint | null>(null);
-  const confirmedRefreshOperation = useRef<"deposit" | "withdrawal" | null>(
-    null
-  );
   // A stage whose transaction was submitted but whose receipt is unresolved.
   // Retry must re-check this hash — resubmitting could double-deposit.
   const pendingStage = useRef<{ stage: Stage; hash: Hex } | null>(null);
@@ -108,25 +137,27 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
       try {
         const values = await readBankrollVaultState(config, walletAddress);
         retryKind.current = null;
-        confirmedRefreshOperation.current = null;
         setState((current) => ({
           ...current,
           ...values,
           status: "ready",
+          withdrawalRecovery: null,
           error: null,
         }));
         return true;
       } catch {
         retryKind.current = preserveConfirmation
-          ? "refresh-after-confirmation"
+          ? operation === "withdrawal"
+            ? "refresh-after-withdrawal-confirmation"
+            : "refresh-after-confirmation"
           : "refresh";
-        if (preserveConfirmation) confirmedRefreshOperation.current = operation;
         setState((current) => ({
           ...current,
           status: "error",
-          ...(preserveConfirmation && operation === "withdrawal"
-            ? { withdrawalStatus: "refresh-after-confirmation" as const }
-            : {}),
+          withdrawalRecovery:
+            preserveConfirmation && operation === "withdrawal"
+              ? "refresh-after-confirmation"
+              : null,
           error: preserveConfirmation
             ? operation === "withdrawal"
               ? withdrawalRefreshFailed
@@ -160,6 +191,31 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
     [config, walletAddress]
   );
 
+  // Shared submit → pending-receipt → outcome scaffolding for every stage.
+  // Starting a stage clears prior withdrawal-recovery copy so a stale flavor
+  // can never describe a newer operation's error.
+  const runStage = useCallback(
+    async (stage: Stage, request: { to: Address; data: Hex }) => {
+      retryKind.current = stage;
+      setState((current) => ({
+        ...current,
+        status: `${stage}-submitting`,
+        withdrawalRecovery: null,
+        error: null,
+      }));
+      const result = await submitSponsoredCall(transaction, request, (hash) => {
+        pendingStage.current = { stage, hash };
+        setState((current) => ({
+          ...current,
+          status: `${stage}-pending`,
+          error: null,
+        }));
+      });
+      applyStageResult(pendingStage, stage, result);
+    },
+    [transaction]
+  );
+
   const submitDeposit = useCallback(
     async (
       assets: bigint,
@@ -176,44 +232,6 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
       inFlight.current = true;
       retryAmount.current = assets;
 
-      const applyStageResult = (stage: Stage, result: SponsoredCallResult) => {
-        if (result.outcome === "confirmed") {
-          pendingStage.current = null;
-          return;
-        }
-        if (result.outcome === "confirmation-unknown")
-          throw new Error(stageCopy[stage].unconfirmed);
-        pendingStage.current = null;
-        if (result.outcome === "submission-failed")
-          throw new Error(result.message ?? stageCopy[stage].failed);
-        throw new Error(stageCopy[stage].failed);
-      };
-
-      const runStage = async (
-        stage: Stage,
-        request: { to: Address; data: Hex }
-      ) => {
-        retryKind.current = stage;
-        setState((current) => ({
-          ...current,
-          status: `${stage}-submitting`,
-          error: null,
-        }));
-        const result = await submitSponsoredCall(
-          transaction,
-          request,
-          (hash) => {
-            pendingStage.current = { stage, hash };
-            setState((current) => ({
-              ...current,
-              status: `${stage}-pending`,
-              error: null,
-            }));
-          }
-        );
-        applyStageResult(stage, result);
-      };
-
       try {
         let depositConfirmed = false;
         if (mode === "resume" && pending) {
@@ -221,9 +239,11 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
           setState((current) => ({
             ...current,
             status: `${pending.stage}-pending`,
+            withdrawalRecovery: null,
             error: null,
           }));
           applyStageResult(
+            pendingStage,
             pending.stage,
             await confirmSponsoredCall(pending.hash)
           );
@@ -269,7 +289,7 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
         inFlight.current = false;
       }
     },
-    [config, refresh, state.allowance, transaction, walletAddress]
+    [config, refresh, runStage, state.allowance, walletAddress]
   );
 
   const deposit = useCallback(
@@ -291,55 +311,32 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
       retryAmount.current = assets;
       retryKind.current = "withdrawal";
       try {
-        let result: SponsoredCallResult;
         if (mode === "resume") {
           setState((current) => ({
             ...current,
             status: "withdrawal-pending",
-            withdrawalStatus: "pending-receipt",
+            withdrawalRecovery: null,
             error: null,
           }));
-          result = await confirmSponsoredCall(pending!.hash);
-        } else {
-          setState((current) => ({
-            ...current,
-            status: "withdrawal-submitting",
-            withdrawalStatus: "submitting",
-            error: null,
-          }));
-          result = await submitSponsoredCall(
-            transaction,
-            {
-              to: config.vaultAddress,
-              data: encodeFunctionData({
-                abi: bankrollVaultAbi,
-                functionName: "withdraw",
-                args: [assets, walletAddress, walletAddress],
-              }) as Hex,
-            },
-            (hash) => {
-              pendingStage.current = { stage: "withdrawal", hash };
-              setState((current) => ({
-                ...current,
-                status: "withdrawal-pending",
-                withdrawalStatus: "pending-receipt",
-                error: null,
-              }));
-            }
+          applyStageResult(
+            pendingStage,
+            "withdrawal",
+            await confirmSponsoredCall(pending!.hash)
           );
+        } else {
+          await runStage("withdrawal", {
+            to: config.vaultAddress,
+            data: encodeFunctionData({
+              abi: bankrollVaultAbi,
+              functionName: "withdraw",
+              args: [assets, walletAddress, walletAddress],
+            }) as Hex,
+          });
         }
-        if (result.outcome === "confirmation-unknown")
-          throw new Error(stageCopy.withdrawal.unconfirmed);
-        pendingStage.current = null;
-        if (result.outcome === "submission-failed")
-          throw new Error(result.message ?? stageCopy.withdrawal.failed);
-        if (result.outcome === "reverted")
-          throw new Error(stageCopy.withdrawal.failed);
-
         setState((current) => ({
           ...current,
           status: "withdrawal-confirmed",
-          withdrawalStatus: "confirmed",
+          withdrawalRecovery: null,
           error: null,
         }));
         notifyWalletBalancesChanged();
@@ -357,23 +354,25 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
               ...current,
               ...values,
               status: "error",
-              withdrawalStatus: "reverted-or-failed",
+              withdrawalRecovery: "reverted-or-failed",
               error: message,
             }));
           } catch {
+            // The on-screen limit is stale, so don't invite a corrected
+            // amount; Retry reloads state before anything else can happen.
             retryKind.current = "refresh";
             setState((current) => ({
               ...current,
               status: "error",
-              withdrawalStatus: "reverted-or-failed",
-              error: loadFailed,
+              withdrawalRecovery: null,
+              error: withdrawalFailedAndRefreshFailed,
             }));
           }
         } else {
           setState((current) => ({
             ...current,
             status: "error",
-            withdrawalStatus: "confirmation-unknown",
+            withdrawalRecovery: "confirmation-unknown",
             error: message,
           }));
         }
@@ -382,12 +381,14 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
         inFlight.current = false;
       }
     },
-    [config, refresh, transaction, walletAddress]
+    [config, refresh, runStage, walletAddress]
   );
   const retry = useCallback(() => {
     if (retryKind.current === "refresh") return refresh();
     if (retryKind.current === "refresh-after-confirmation")
-      return refresh(true, confirmedRefreshOperation.current ?? "deposit");
+      return refresh(true);
+    if (retryKind.current === "refresh-after-withdrawal-confirmation")
+      return refresh(true, "withdrawal");
     const amount = retryAmount.current;
     if (!amount) return Promise.resolve(false);
     if (pendingStage.current?.stage === "withdrawal")
@@ -406,38 +407,54 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
     );
   }, [refresh, state.maxWithdraw, submitDeposit, withdraw]);
 
-  // After a resolved approval/deposit failure the form accepts a new amount.
-  // An unresolved receipt keeps deposits closed: Retry must settle it first.
-  const canDepositAfterError =
+  // After any resolved stage failure both forms accept a new amount — a failed
+  // withdrawal must not lock out the deposit that could restore liquidity. An
+  // unresolved receipt keeps both closed: Retry must settle it first.
+  const canSubmitAfterError =
     state.status === "error" &&
-    (retryKind.current === "approval" || retryKind.current === "deposit") &&
+    (retryKind.current === "approval" ||
+      retryKind.current === "deposit" ||
+      retryKind.current === "withdrawal") &&
     pendingStage.current === null;
-  const canWithdrawAfterError =
-    state.status === "error" &&
-    retryKind.current === "withdrawal" &&
-    pendingStage.current === null;
+  // An unresolved withdrawal hash is exempt from the limit gate: Retry only
+  // re-checks that receipt, which stays valid however the limit moves.
   const canRetryWithdrawal =
     retryKind.current !== "withdrawal" ||
+    pendingStage.current !== null ||
     ((retryAmount.current ?? 0n) > 0n &&
       (retryAmount.current ?? 0n) <= (state.maxWithdraw ?? 0n));
+  // Mirrors retry()'s dispatch so labels always describe the real action.
+  const retryAction: BankrollVaultRetryAction | null =
+    retryKind.current === null
+      ? null
+      : retryKind.current === "refresh" ||
+          retryKind.current === "refresh-after-confirmation" ||
+          retryKind.current === "refresh-after-withdrawal-confirmation"
+        ? retryKind.current
+        : pendingStage.current?.stage === "withdrawal"
+          ? "withdrawal-receipt-check"
+          : retryKind.current === "withdrawal"
+            ? "withdrawal"
+            : "deposit";
 
   return {
     ...state,
     canDeposit:
       !!config &&
       !!walletAddress &&
-      (state.status === "ready" || canDepositAfterError) &&
+      (state.status === "ready" || canSubmitAfterError) &&
       !inFlight.current,
     canWithdraw:
       !!config &&
       !!walletAddress &&
-      (state.status === "ready" || canWithdrawAfterError) &&
+      (state.status === "ready" || canSubmitAfterError) &&
       !inFlight.current,
     canRetry:
       state.status === "error" &&
       retryKind.current !== null &&
       canRetryWithdrawal &&
       !inFlight.current,
+    retryAction,
     deposit,
     withdraw,
     retry,

--- a/src/hooks/use-bankroll-vault-deposit.ts
+++ b/src/hooks/use-bankroll-vault-deposit.ts
@@ -27,17 +27,31 @@ export type BankrollVaultDepositStatus =
   | "approval-pending"
   | "deposit-submitting"
   | "deposit-pending"
+  | "withdrawal-submitting"
+  | "withdrawal-pending"
+  | "withdrawal-confirmed"
   | "confirmed"
   | "error";
 
-type Stage = "approval" | "deposit";
+export type BankrollVaultWithdrawalStatus =
+  | "idle"
+  | "submitting"
+  | "pending-receipt"
+  | "confirmed"
+  | "reverted-or-failed"
+  | "confirmation-unknown"
+  | "refresh-after-confirmation";
+
+type Stage = "approval" | "deposit" | "withdrawal";
 type VaultValues = Awaited<ReturnType<typeof readBankrollVaultState>>;
 type State = Partial<VaultValues> & {
   status: BankrollVaultDepositStatus;
+  withdrawalStatus: BankrollVaultWithdrawalStatus;
   error: string | null;
 };
 const initialState: State = {
   status: "loading",
+  withdrawalStatus: "idle",
   error: null,
 };
 const unavailable =
@@ -45,6 +59,8 @@ const unavailable =
 const loadFailed = "We couldn't load the Bankroll Vault. Please try again.";
 const refreshFailed =
   "Your deposit was confirmed, but we couldn't refresh the Bankroll Vault. Please try again.";
+const withdrawalRefreshFailed =
+  "Your withdrawal was confirmed, but we couldn't refresh the Bankroll Vault. Please try again.";
 const stageCopy: Record<Stage, { failed: string; unconfirmed: string }> = {
   approval: {
     failed: "We couldn't approve this exact tUSD amount. Please try again.",
@@ -57,6 +73,12 @@ const stageCopy: Record<Stage, { failed: string; unconfirmed: string }> = {
     unconfirmed:
       "Your LP deposit was submitted, but we couldn't confirm it yet. Retry to check its status.",
   },
+  withdrawal: {
+    failed:
+      "We couldn't complete your Bankroll Vault withdrawal. We refreshed your available amount so you can retry safely.",
+    unconfirmed:
+      "Your LP withdrawal was submitted, but we couldn't confirm it yet. Retry to check its status.",
+  },
 };
 
 export function useBankrollVaultDeposit(walletAddress: Address | null) {
@@ -68,18 +90,25 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
     Stage | "refresh" | "refresh-after-confirmation" | null
   >(null);
   const retryAmount = useRef<bigint | null>(null);
+  const confirmedRefreshOperation = useRef<"deposit" | "withdrawal" | null>(
+    null
+  );
   // A stage whose transaction was submitted but whose receipt is unresolved.
   // Retry must re-check this hash — resubmitting could double-deposit.
   const pendingStage = useRef<{ stage: Stage; hash: Hex } | null>(null);
 
   const refresh = useCallback(
-    async (preserveConfirmation = false) => {
+    async (
+      preserveConfirmation = false,
+      operation: "deposit" | "withdrawal" = "deposit"
+    ) => {
       if (!config || !walletAddress) return false;
       if (!preserveConfirmation)
         setState((current) => ({ ...current, status: "loading", error: null }));
       try {
         const values = await readBankrollVaultState(config, walletAddress);
         retryKind.current = null;
+        confirmedRefreshOperation.current = null;
         setState((current) => ({
           ...current,
           ...values,
@@ -91,10 +120,18 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
         retryKind.current = preserveConfirmation
           ? "refresh-after-confirmation"
           : "refresh";
+        if (preserveConfirmation) confirmedRefreshOperation.current = operation;
         setState((current) => ({
           ...current,
           status: "error",
-          error: preserveConfirmation ? refreshFailed : loadFailed,
+          ...(preserveConfirmation && operation === "withdrawal"
+            ? { withdrawalStatus: "refresh-after-confirmation" as const }
+            : {}),
+          error: preserveConfirmation
+            ? operation === "withdrawal"
+              ? withdrawalRefreshFailed
+              : refreshFailed
+            : loadFailed,
         }));
         return false;
       }
@@ -129,6 +166,12 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
       mode: "auto" | "skip-approval" | "resume" = "auto"
     ): Promise<boolean> => {
       if (!config || !walletAddress || assets <= 0n || inFlight.current)
+        return false;
+      const pending = pendingStage.current;
+      // A submitted hash is the recovery handle for an operation whose receipt
+      // is unresolved. Do not let any public entry point replace it.
+      if (pending && mode !== "resume") return false;
+      if (mode === "resume" && (!pending || pending.stage === "withdrawal"))
         return false;
       inFlight.current = true;
       retryAmount.current = assets;
@@ -173,7 +216,6 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
 
       try {
         let depositConfirmed = false;
-        const pending = pendingStage.current;
         if (mode === "resume" && pending) {
           retryKind.current = pending.stage;
           setState((current) => ({
@@ -234,18 +276,135 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
     (assets: bigint) => submitDeposit(assets),
     [submitDeposit]
   );
+  const withdraw = useCallback(
+    async (
+      assets: bigint,
+      mode: "new" | "resume" = "new"
+    ): Promise<boolean> => {
+      if (!config || !walletAddress || assets <= 0n || inFlight.current)
+        return false;
+      const pending = pendingStage.current;
+      if (pending && mode !== "resume") return false;
+      if (mode === "resume" && (!pending || pending.stage !== "withdrawal"))
+        return false;
+      inFlight.current = true;
+      retryAmount.current = assets;
+      retryKind.current = "withdrawal";
+      try {
+        let result: SponsoredCallResult;
+        if (mode === "resume") {
+          setState((current) => ({
+            ...current,
+            status: "withdrawal-pending",
+            withdrawalStatus: "pending-receipt",
+            error: null,
+          }));
+          result = await confirmSponsoredCall(pending!.hash);
+        } else {
+          setState((current) => ({
+            ...current,
+            status: "withdrawal-submitting",
+            withdrawalStatus: "submitting",
+            error: null,
+          }));
+          result = await submitSponsoredCall(
+            transaction,
+            {
+              to: config.vaultAddress,
+              data: encodeFunctionData({
+                abi: bankrollVaultAbi,
+                functionName: "withdraw",
+                args: [assets, walletAddress, walletAddress],
+              }) as Hex,
+            },
+            (hash) => {
+              pendingStage.current = { stage: "withdrawal", hash };
+              setState((current) => ({
+                ...current,
+                status: "withdrawal-pending",
+                withdrawalStatus: "pending-receipt",
+                error: null,
+              }));
+            }
+          );
+        }
+        if (result.outcome === "confirmation-unknown")
+          throw new Error(stageCopy.withdrawal.unconfirmed);
+        pendingStage.current = null;
+        if (result.outcome === "submission-failed")
+          throw new Error(result.message ?? stageCopy.withdrawal.failed);
+        if (result.outcome === "reverted")
+          throw new Error(stageCopy.withdrawal.failed);
+
+        setState((current) => ({
+          ...current,
+          status: "withdrawal-confirmed",
+          withdrawalStatus: "confirmed",
+          error: null,
+        }));
+        notifyWalletBalancesChanged();
+        return refresh(true, "withdrawal");
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : stageCopy.withdrawal.failed;
+        // A definitive failure may have raced a changed free-liquidity limit.
+        // Refresh before exposing a corrected amount; an unresolved hash never
+        // reaches this branch because it remains in pendingStage.
+        if (pendingStage.current === null) {
+          try {
+            const values = await readBankrollVaultState(config, walletAddress);
+            setState((current) => ({
+              ...current,
+              ...values,
+              status: "error",
+              withdrawalStatus: "reverted-or-failed",
+              error: message,
+            }));
+          } catch {
+            retryKind.current = "refresh";
+            setState((current) => ({
+              ...current,
+              status: "error",
+              withdrawalStatus: "reverted-or-failed",
+              error: loadFailed,
+            }));
+          }
+        } else {
+          setState((current) => ({
+            ...current,
+            status: "error",
+            withdrawalStatus: "confirmation-unknown",
+            error: message,
+          }));
+        }
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [config, refresh, transaction, walletAddress]
+  );
   const retry = useCallback(() => {
     if (retryKind.current === "refresh") return refresh();
     if (retryKind.current === "refresh-after-confirmation")
-      return refresh(true);
+      return refresh(true, confirmedRefreshOperation.current ?? "deposit");
     const amount = retryAmount.current;
     if (!amount) return Promise.resolve(false);
+    if (pendingStage.current?.stage === "withdrawal")
+      return withdraw(amount, "resume");
+    if (retryKind.current === "withdrawal") {
+      // The failed call may have raced a reduced free-liquidity limit. The
+      // corrected-amount withdrawal entry point is the recovery path when the
+      // original amount no longer fits the authoritative post-failure read.
+      if (amount > (state.maxWithdraw ?? 0n)) return Promise.resolve(false);
+      return withdraw(amount);
+    }
     if (pendingStage.current) return submitDeposit(amount, "resume");
     return submitDeposit(
       amount,
       retryKind.current === "deposit" ? "skip-approval" : "auto"
     );
-  }, [refresh, submitDeposit]);
+  }, [refresh, state.maxWithdraw, submitDeposit, withdraw]);
 
   // After a resolved approval/deposit failure the form accepts a new amount.
   // An unresolved receipt keeps deposits closed: Retry must settle it first.
@@ -253,6 +412,14 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
     state.status === "error" &&
     (retryKind.current === "approval" || retryKind.current === "deposit") &&
     pendingStage.current === null;
+  const canWithdrawAfterError =
+    state.status === "error" &&
+    retryKind.current === "withdrawal" &&
+    pendingStage.current === null;
+  const canRetryWithdrawal =
+    retryKind.current !== "withdrawal" ||
+    ((retryAmount.current ?? 0n) > 0n &&
+      (retryAmount.current ?? 0n) <= (state.maxWithdraw ?? 0n));
 
   return {
     ...state,
@@ -261,11 +428,18 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
       !!walletAddress &&
       (state.status === "ready" || canDepositAfterError) &&
       !inFlight.current,
+    canWithdraw:
+      !!config &&
+      !!walletAddress &&
+      (state.status === "ready" || canWithdrawAfterError) &&
+      !inFlight.current,
     canRetry:
       state.status === "error" &&
       retryKind.current !== null &&
+      canRetryWithdrawal &&
       !inFlight.current,
     deposit,
+    withdraw,
     retry,
   };
 }

--- a/src/lib/bankroll-vault.test.ts
+++ b/src/lib/bankroll-vault.test.ts
@@ -1,9 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const sdk = vi.hoisted(() => ({ readContract: vi.fn() }));
+
+vi.mock("./base-sepolia", () => ({
+  baseSepoliaPublicClient: {
+    readContract: (...args: unknown[]) => sdk.readContract(...args),
+  },
+}));
+
 describe("Bankroll Vault public configuration and reads", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
+    sdk.readContract.mockReset();
   });
 
   it("requires statically named valid public tUSD and vault addresses", async () => {
@@ -27,5 +36,72 @@ describe("Bankroll Vault public configuration and reads", () => {
     vi.stubEnv("NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS", "");
     const { getBankrollVaultConfig } = await import("./bankroll-vault");
     expect(getBankrollVaultConfig()).toBeNull();
+  });
+
+  it("reads the complete authoritative withdrawal state from the configured vault", async () => {
+    vi.stubEnv(
+      "NEXT_PUBLIC_DESK_DOLLARS_ADDRESS",
+      "0x0000000000000000000000000000000000000001"
+    );
+    vi.stubEnv(
+      "NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS",
+      "0x0000000000000000000000000000000000000002"
+    );
+    sdk.readContract
+      .mockResolvedValueOnce(1n)
+      .mockResolvedValueOnce(2n)
+      .mockResolvedValueOnce(3n)
+      .mockResolvedValueOnce(4n)
+      .mockResolvedValueOnce(5n)
+      .mockResolvedValueOnce(6n)
+      .mockResolvedValueOnce(7n)
+      .mockResolvedValueOnce(8n)
+      .mockResolvedValueOnce(9n)
+      .mockResolvedValueOnce(10n)
+      .mockResolvedValueOnce(11n)
+      .mockResolvedValueOnce(12n)
+      .mockResolvedValueOnce(13n)
+      .mockResolvedValueOnce(14n);
+    const { getBankrollVaultConfig, readBankrollVaultState } =
+      await import("./bankroll-vault");
+    const config = getBankrollVaultConfig()!;
+    await expect(
+      readBankrollVaultState(
+        config,
+        "0x0000000000000000000000000000000000000003"
+      )
+    ).resolves.toMatchObject({
+      reservedLiabilities: 10n,
+      safetyBuffer: 11n,
+      freeLiquidity: 12n,
+      maxWithdraw: 13n,
+      maxRedeem: 14n,
+    });
+    expect(sdk.readContract).toHaveBeenCalledTimes(14);
+    expect(
+      sdk.readContract.mock.calls.map(([request]) => request.functionName)
+    ).toEqual([
+      "balanceOf",
+      "balanceOf",
+      "allowance",
+      "grossAssets",
+      "totalAssets",
+      "totalSupply",
+      "assetsPerShare",
+      "pendingObligations",
+      "unrecognizedMargin",
+      "reservedLiabilities",
+      "safetyBuffer",
+      "freeLiquidity",
+      "maxWithdraw",
+      "maxRedeem",
+    ]);
+    expect(sdk.readContract).toHaveBeenNthCalledWith(
+      13,
+      expect.objectContaining({
+        address: config.vaultAddress,
+        args: ["0x0000000000000000000000000000000000000003"],
+      })
+    );
   });
 });

--- a/src/lib/bankroll-vault.test.ts
+++ b/src/lib/bankroll-vault.test.ts
@@ -60,8 +60,7 @@ describe("Bankroll Vault public configuration and reads", () => {
       .mockResolvedValueOnce(10n)
       .mockResolvedValueOnce(11n)
       .mockResolvedValueOnce(12n)
-      .mockResolvedValueOnce(13n)
-      .mockResolvedValueOnce(14n);
+      .mockResolvedValueOnce(13n);
     const { getBankrollVaultConfig, readBankrollVaultState } =
       await import("./bankroll-vault");
     const config = getBankrollVaultConfig()!;
@@ -75,9 +74,8 @@ describe("Bankroll Vault public configuration and reads", () => {
       safetyBuffer: 11n,
       freeLiquidity: 12n,
       maxWithdraw: 13n,
-      maxRedeem: 14n,
     });
-    expect(sdk.readContract).toHaveBeenCalledTimes(14);
+    expect(sdk.readContract).toHaveBeenCalledTimes(13);
     expect(
       sdk.readContract.mock.calls.map(([request]) => request.functionName)
     ).toEqual([
@@ -94,7 +92,6 @@ describe("Bankroll Vault public configuration and reads", () => {
       "safetyBuffer",
       "freeLiquidity",
       "maxWithdraw",
-      "maxRedeem",
     ]);
     expect(sdk.readContract).toHaveBeenNthCalledWith(
       13,
@@ -103,5 +100,40 @@ describe("Bankroll Vault public configuration and reads", () => {
         args: ["0x0000000000000000000000000000000000000003"],
       })
     );
+  });
+
+  it("degrades the liquidity views a not-yet-redeployed vault lacks instead of failing the load", async () => {
+    vi.stubEnv(
+      "NEXT_PUBLIC_DESK_DOLLARS_ADDRESS",
+      "0x0000000000000000000000000000000000000001"
+    );
+    vi.stubEnv(
+      "NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS",
+      "0x0000000000000000000000000000000000000002"
+    );
+    const legacyViews = [
+      "reservedLiabilities",
+      "safetyBuffer",
+      "freeLiquidity",
+    ];
+    sdk.readContract.mockImplementation(({ functionName }) =>
+      legacyViews.includes(functionName)
+        ? Promise.reject(new Error("function does not exist on this vault"))
+        : Promise.resolve(1n)
+    );
+    const { getBankrollVaultConfig, readBankrollVaultState } =
+      await import("./bankroll-vault");
+    await expect(
+      readBankrollVaultState(
+        getBankrollVaultConfig()!,
+        "0x0000000000000000000000000000000000000003"
+      )
+    ).resolves.toMatchObject({
+      tUsdBalance: 1n,
+      reservedLiabilities: undefined,
+      safetyBuffer: undefined,
+      freeLiquidity: undefined,
+      maxWithdraw: 1n,
+    });
   });
 });

--- a/src/lib/bankroll-vault.ts
+++ b/src/lib/bankroll-vault.ts
@@ -81,21 +81,24 @@ type VaultViewName =
   | "unrecognizedMargin"
   | "reservedLiabilities"
   | "safetyBuffer"
-  | "freeLiquidity"
-  | "maxWithdraw"
-  | "maxRedeem";
+  | "freeLiquidity";
 
 export async function readBankrollVaultState(
   config: BankrollVaultConfig,
   walletAddress: Address
 ) {
-  const readVault = (functionName: VaultViewName, args?: readonly [Address]) =>
+  const readVault = (functionName: VaultViewName) =>
     baseSepoliaPublicClient.readContract({
       address: config.vaultAddress,
       abi: bankrollVaultAbi,
       functionName,
-      ...(args ? { args } : {}),
-    } as never) as Promise<bigint>;
+    });
+  // The deposits-only vault deployed today predates these accounting views.
+  // They degrade to undefined instead of failing the whole load, so the LP
+  // Desk (and deposits) keep working until the contract redeploy and the
+  // NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS cutover land.
+  const readVaultIfDeployed = (functionName: VaultViewName) =>
+    readVault(functionName).catch(() => undefined);
   const [
     tUsdBalance,
     shareBalance,
@@ -110,7 +113,6 @@ export async function readBankrollVaultState(
     safetyBuffer,
     freeLiquidity,
     maxWithdraw,
-    maxRedeem,
   ] = await Promise.all([
     baseSepoliaPublicClient.readContract({
       address: config.tokenAddress,
@@ -136,11 +138,15 @@ export async function readBankrollVaultState(
     readVault("assetsPerShare"),
     readVault("pendingObligations"),
     readVault("unrecognizedMargin"),
-    readVault("reservedLiabilities"),
-    readVault("safetyBuffer"),
-    readVault("freeLiquidity"),
-    readVault("maxWithdraw", [walletAddress]),
-    readVault("maxRedeem", [walletAddress]),
+    readVaultIfDeployed("reservedLiabilities"),
+    readVaultIfDeployed("safetyBuffer"),
+    readVaultIfDeployed("freeLiquidity"),
+    baseSepoliaPublicClient.readContract({
+      address: config.vaultAddress,
+      abi: bankrollVaultAbi,
+      functionName: "maxWithdraw",
+      args: [walletAddress],
+    }),
   ]);
   return {
     tUsdBalance,
@@ -156,6 +162,5 @@ export async function readBankrollVaultState(
     safetyBuffer,
     freeLiquidity,
     maxWithdraw,
-    maxRedeem,
   };
 }

--- a/src/lib/bankroll-vault.ts
+++ b/src/lib/bankroll-vault.ts
@@ -34,6 +34,27 @@ export const bankrollVaultAbi = [
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
   },
+  {
+    type: "function",
+    name: "reservedLiabilities",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "safetyBuffer",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "freeLiquidity",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
 ] as const;
 
 export type BankrollVaultConfig = {
@@ -57,18 +78,24 @@ type VaultViewName =
   | "totalSupply"
   | "assetsPerShare"
   | "pendingObligations"
-  | "unrecognizedMargin";
+  | "unrecognizedMargin"
+  | "reservedLiabilities"
+  | "safetyBuffer"
+  | "freeLiquidity"
+  | "maxWithdraw"
+  | "maxRedeem";
 
 export async function readBankrollVaultState(
   config: BankrollVaultConfig,
   walletAddress: Address
 ) {
-  const readVault = (functionName: VaultViewName) =>
+  const readVault = (functionName: VaultViewName, args?: readonly [Address]) =>
     baseSepoliaPublicClient.readContract({
       address: config.vaultAddress,
       abi: bankrollVaultAbi,
       functionName,
-    });
+      ...(args ? { args } : {}),
+    } as never) as Promise<bigint>;
   const [
     tUsdBalance,
     shareBalance,
@@ -79,6 +106,11 @@ export async function readBankrollVaultState(
     assetsPerShare,
     pendingObligations,
     unrecognizedMargin,
+    reservedLiabilities,
+    safetyBuffer,
+    freeLiquidity,
+    maxWithdraw,
+    maxRedeem,
   ] = await Promise.all([
     baseSepoliaPublicClient.readContract({
       address: config.tokenAddress,
@@ -104,6 +136,11 @@ export async function readBankrollVaultState(
     readVault("assetsPerShare"),
     readVault("pendingObligations"),
     readVault("unrecognizedMargin"),
+    readVault("reservedLiabilities"),
+    readVault("safetyBuffer"),
+    readVault("freeLiquidity"),
+    readVault("maxWithdraw", [walletAddress]),
+    readVault("maxRedeem", [walletAddress]),
   ]);
   return {
     tUsdBalance,
@@ -115,5 +152,10 @@ export async function readBankrollVaultState(
     assetsPerShare,
     pendingObligations,
     unrecognizedMargin,
+    reservedLiabilities,
+    safetyBuffer,
+    freeLiquidity,
+    maxWithdraw,
+    maxRedeem,
   };
 }


### PR DESCRIPTION
## Summary

- enable ERC-4626 `withdraw` and `redeem` behind the 20% safety buffer, reserved-liability-aware free liquidity, and proportional owner limits
- expose authoritative vault liquidity and withdrawal limits to the client
- add receipt-safe Privy-sponsored withdrawal execution with same-hash recovery and corrected-limit retries
- add LP Desk liquidity metrics, an asset-denominated withdrawal form, and operation-specific recovery states

## Contract behavior

- `safetyBuffer = ceil(20% × grossAssets)`
- `freeLiquidity = max(grossAssets − reservedLiabilities − safetyBuffer, 0)`
- owner withdrawal limit is proportional to share ownership
- standard ERC-4626 previews, conversions, allowance behavior, and `Withdraw` event remain authoritative
- over-limit withdrawal or redemption reverts atomically without moving assets, shares, or allowance

## Validation

- `pnpm test` — 89 tests passed
- `pnpm test:contracts:ci` — 37 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — 0 errors; 4 pre-existing generated Convex warnings
- `pnpm build` — passed
- `git diff --check origin/main...HEAD` — passed
- pre-push `pnpm check:ci` — passed

## Scope notes

- reveal-window freezing remains owned by #347
- game-driven reservation mutation remains owned by #344
- fresh deployment and live zero-ETH sponsorship verification remain owned by #351

Closes #341