### PR TITLE
Update Base Sepolia deployment after entry-interface redeploy

### DIFF
--- a/contracts/deployments/base_sepolia.json
+++ b/contracts/deployments/base_sepolia.json
@@ -13,10 +13,10 @@
   "tokenDeploymentBlock": 45313049,
   "token": "0xDa0A5f6FC5238c6D8018fc1d22846460c2cFd085",
   "faucet": "0xcfc9Bf8Ea84c153C518DA6Cc4E35D8a212d8E356",
-  "bankrollVault": "0xB5b599104650924Ec4b0f3aFC560e80A7DA93afe",
-  "marginCallCrash": "0x7DFec2b446DdDB485eb5DDE0C4d0709A4f96bA87",
-  "marginCallCrashDeploymentBlock": 45345367,
-  "marginCallCrashEpochOrigin": 1786459380,
+  "bankrollVault": "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21",
+  "marginCallCrash": "0xD74a89e199da9E45399ec913441b25A1b4120d44",
+  "marginCallCrashDeploymentBlock": 45351025,
+  "marginCallCrashEpochOrigin": 1786470660,
   "marginCallCrashRoundDuration": 60,
   "marginCallCrashEntryWindow": 45,
   "marginCallCrashExpiryDelay": 900,
@@ -34,9 +34,9 @@
   "deployer": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
   "bankrollSeedAmount": 25000000000,
   "bankrollVaultSeedDepositor": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
-  "bankrollVaultSeedAssets": 25000000000,
-  "bankrollVaultMintedShares": 25000000000,
-  "bankrollVaultDeploymentBlock": 45313117,
+  "bankrollVaultSeedAssets": 20000000000,
+  "bankrollVaultMintedShares": 20000000000,
+  "bankrollVaultDeploymentBlock": 45351004,
   "bankrollVaultDepositSelector": "0x6e553f65",
   "faucetClaimAmount": 100000000,
   "faucetClaimCooldown": 3600,
@@ -45,17 +45,21 @@
   "verification": {
     "token": "https://sepolia.basescan.org/address/0xDa0A5f6FC5238c6D8018fc1d22846460c2cFd085#code",
     "faucet": "https://sepolia.basescan.org/address/0xcfc9Bf8Ea84c153C518DA6Cc4E35D8a212d8E356#code",
-    "bankrollVault": "https://sepolia.basescan.org/address/0xB5b599104650924Ec4b0f3aFC560e80A7DA93afe#code",
-    "marginCallCrash": "https://sepolia.basescan.org/address/0x7DFec2b446DdDB485eb5DDE0C4d0709A4f96bA87#code"
+    "bankrollVault": "https://sepolia.basescan.org/address/0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21#code",
+    "marginCallCrash": "https://sepolia.basescan.org/address/0xD74a89e199da9E45399ec913441b25A1b4120d44#code"
   },
   "transactions": {
     "deployToken": "0x52d47a026c289a580eb2fb329f31667bc6282af10c1bc345dcc99b4e7b6ae9cb",
     "deployFaucet": "0xcd278e2676df8fea5e43dd8d8521b8ce931c4a8917c0e5351009ab79c01bae1a",
     "configureFaucet": "0xb67efea780bc376f1fac20433fc666793d3dab3099635f52b2683cb424a8d348",
-    "deployBankrollVault": "0x41ee9bb43f7acd02f4cbe3d9b7bd7222d1f35482e24b551dde32bf625e19e3d4",
+    "deployBankrollVault": "0x270e4fe7724217535f237eeb963151946a9e614161929da116a43ca873828105",
     "approveBankrollVault": "0xcfe51188a2040cd8f13e1f4c176b82e939b48519a257830a986a55d3062b00f4",
     "seedBankrollVault": "0x2675ceccfe5443da7bf1a67bdfe80bc08a518e5be54b22c5557e71db91fa31d3",
-    "deployMarginCallCrash": "0x0fb1eb320775dc6a39ccc5ae1294bc6c57b164f3412f0f286c45e404976e6e84"
+    "deployMarginCallCrash": "0x1d83518ce4d39cba9083400d5ef4a03fd8ddb499c01d6a3d4a320a60cc06f0df",
+    "withdrawOldBankrollVault": "0x9b4beaa1ca892d5ae54ff419df6e8c3525ba6cde8477e68994062441017dd0b3",
+    "setAuthorizedGame": "0x3fb1e6165dbe5ee2b27d10299205005b7b27dc61f9458d62bc3fceace871e78d",
+    "openRound0": "0xb2b0f1103bbab6482018c4a62fb5e91d9d628789d1209813c64601c8608bcda9",
+    "openRound1": "0x221fc558fed98f1106c5b39e53b177d94006aa04cec8b1bfb821fc92bf4f4e31"
   },
   "privySponsorship": {
     "appId": "cmmfbu7o900c10cjme09a31h4",
@@ -65,24 +69,12 @@
     "contractSelectorAllowlist": "not-exposed-by-dashboard"
   },
   "smokeTest": {
-    "status": "passed-lifecycle-343",
-    "game": "0x7DFec2b446DdDB485eb5DDE0C4d0709A4f96bA87",
-    "issue": 343,
-    "verifiedSource": true,
-    "round0": {
-      "openTx": "0x7330bd04a58a5b6b1862f3e3d091dd412272a1503e0e1352262346093479cd24",
-      "revealTx": "0x95cd24e571e7533ae5a4795cad04513a18a618df3df06272cee7ff11af5a2703",
-      "finalizeTx": "0x5fa00ab3b3b9b3f3e958c89d693cf7a0ac0e83a5f76b742172544340fe695bc3",
-      "crashRandom": "0x223efd8388f83ad4be579c8215eb07c637c4fc48883bd9d3e7424b4385770800",
-      "plaintext": 1269,
-      "crashPointBps": 11338,
-      "status": 3
-    },
-    "round1": {
-      "openTx": "0x65660e7a6b605e28ce8bd31c04f81bbde2650b6a9f1b244d3134044698b63abb",
-      "expireTx": "0x6bdde357b0f19cbb2f7e31c8326fc1336a96b337905a7083beb4620d2dd0649b",
-      "status": 4
-    }
+    "status": "rounds-preopened-pending-ui-entry",
+    "game": "0xD74a89e199da9E45399ec913441b25A1b4120d44",
+    "vault": "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21",
+    "issue": 351,
+    "openRound0": "0xb2b0f1103bbab6482018c4a62fb5e91d9d628789d1209813c64601c8608bcda9",
+    "openRound1": "0x221fc558fed98f1106c5b39e53b177d94006aa04cec8b1bfb821fc92bf4f4e31"
   },
   "supersedes": {
     "sourceCommit": "4b1108c4f5c806c67c189003b3093c4dd3ac0483",
@@ -93,5 +85,24 @@
     "marginCallCrashDeploymentBlock": 45342715,
     "marginCallCrashEpochOrigin": 1786454100,
     "deployMarginCallCrash": "0x982be82965b26a23bf583f36466d618ea19e151899dbd49327c173415a197485"
-  }
+  },
+  "supersededLiveBeforeEntryRedeploy": {
+    "bankrollVault": "0xB5b599104650924Ec4b0f3aFC560e80A7DA93afe",
+    "bankrollVaultDeploymentBlock": 45313117,
+    "bankrollVaultSeedAssets": 25000000000,
+    "bankrollVaultMintedShares": 25000000000,
+    "marginCallCrash": "0x7DFec2b446DdDB485eb5DDE0C4d0709A4f96bA87",
+    "marginCallCrashDeploymentBlock": 45345367,
+    "marginCallCrashEpochOrigin": 1786459380,
+    "transactions": {
+      "deployToken": "0x52d47a026c289a580eb2fb329f31667bc6282af10c1bc345dcc99b4e7b6ae9cb",
+      "deployFaucet": "0xcd278e2676df8fea5e43dd8d8521b8ce931c4a8917c0e5351009ab79c01bae1a",
+      "configureFaucet": "0xb67efea780bc376f1fac20433fc666793d3dab3099635f52b2683cb424a8d348",
+      "deployBankrollVault": "0x41ee9bb43f7acd02f4cbe3d9b7bd7222d1f35482e24b551dde32bf625e19e3d4",
+      "approveBankrollVault": "0xcfe51188a2040cd8f13e1f4c176b82e939b48519a257830a986a55d3062b00f4",
+      "seedBankrollVault": "0x2675ceccfe5443da7bf1a67bdfe80bc08a518e5be54b22c5557e71db91fa31d3",
+      "deployMarginCallCrash": "0x0fb1eb320775dc6a39ccc5ae1294bc6c57b164f3412f0f286c45e404976e6e84"
+    }
+  },
+  "entryInterfaceNote": "Live entry redeploy after slice-6: vault+game with acceptEntry/enter; seeded with 20,000 tUSD withdrawn from prior vault (5k remains as old-vault buffer)."
 }


### PR DESCRIPTION
## Summary
- Records the live Base Sepolia redeploy for entry-enabled `BankrollVault` and `MarginCallCrash` contracts.
- Updates deployment provenance (addresses, blocks, tx hashes, seed amounts) and smoke-test status to `rounds-preopened-pending-ui-entry`.
- Preserves the pre-entry live contracts under `supersededLiveBeforeEntryRedeploy` for auditability.

## Test plan
- [ ] Verify `contracts/deployments/base_sepolia.json` addresses match Base Sepolia on-chain deployments
- [ ] Update Vercel env vars to match:
  - `NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS=0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21`
  - `NEXT_PUBLIC_MARGIN_CALL_CRASH_ADDRESS=0xD74a89e199da9E45399ec913441b25A1b4120d44`
  - `NEXT_PUBLIC_MARGIN_CALL_CRASH_DEPLOYMENT_BLOCK=45351025`
- [ ] Confirm rounds 0/1 are open on the new game contract
- [ ] Smoke-test Crash entry flow against the new addresses after env cutover


Made with [Cursor](https://cursor.com)