### PR TITLE
Add reveal-window freeze on LP share operations (#347)

### DIFF
--- a/contracts/src/BankrollVault.sol
+++ b/contracts/src/BankrollVault.sol
@@ -485,13 +485,8 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
             cursor = _blocking[cursor].next;
         }
 
-        _blocking[roundId] = BlockingRound({
-            expiresAt: expiresAt,
-            revealFrozen: false,
-            prev: prev,
-            next: cursor,
-            present: true
-        });
+        _blocking[roundId] =
+            BlockingRound({expiresAt: expiresAt, revealFrozen: false, prev: prev, next: cursor, present: true});
 
         if (prev == NO_BLOCKING_ROUND) {
             _blockingHead = roundId;

--- a/contracts/src/BankrollVault.sol
+++ b/contracts/src/BankrollVault.sol
@@ -34,6 +34,16 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
     /// @notice Received player margin that has not yet been recognized as vault value.
     uint256 public unrecognizedMargin;
 
+    /// @notice Cumulative verified game P&L: sum over finalizations of `totalMargin − winningLiability`.
+    /// @dev Expiry is pricing-neutral and does not change this value. Positive means LPs gained.
+    int256 public realizedGamePnl;
+
+    /// @notice Number of exposed rounds currently in `RevealRequested` that still block share ops.
+    uint256 public frozenRoundCount;
+
+    /// @notice Sentinel for an empty blocking-round list / end of traversal.
+    uint256 public constant NO_BLOCKING_ROUND = type(uint256).max;
+
     /// @notice Deployer allowed to set the authorized game exactly once.
     address public immutable gameConfigurer;
 
@@ -49,12 +59,23 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         uint256 leverageBps;
     }
 
+    /// @dev Unresolved exposed rounds ordered by round id (expiresAt is monotone in id).
+    struct BlockingRound {
+        uint64 expiresAt;
+        bool revealFrozen;
+        uint256 prev;
+        uint256 next;
+        bool present;
+    }
+
     mapping(uint256 ticketId => TicketReservation reservation) private _reservations;
     mapping(uint256 roundId => uint256 reservedPayout) public reservedPayoutByRound;
     mapping(uint256 roundId => mapping(uint256 leverageBps => uint256 reservedPayout)) public
         reservedPayoutByRoundAndTier;
     /// @dev Shared guard for finalize and expire: a round's obligations may be marked exactly once.
     mapping(uint256 roundId => bool marked) private _roundObligationsMarked;
+    mapping(uint256 roundId => BlockingRound blocking) private _blocking;
+    uint256 private _blockingHead = NO_BLOCKING_ROUND;
 
     error UnauthorizedGameConfigurer(address caller);
     error AuthorizedGameAlreadySet();
@@ -76,6 +97,10 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
     error InsufficientFreeLiquidity(uint256 freeLiquidity, uint256 required);
     error RoundReservationExceeded(uint256 roundId, uint256 reservedPayout, uint256 limit);
     error TicketReservationExceeded(uint256 maximumPayout, uint256 limit);
+    error ShareOperationsFrozen(uint256 oldestBlockingRound_, uint256 frozenRoundCount_);
+    error BlockingRoundAlreadyRegistered(uint256 roundId);
+    error BlockingRoundMissing(uint256 roundId);
+    error BlockingRoundAlreadyRevealFrozen(uint256 roundId);
 
     event AuthorizedGameChanged(address indexed previousGame, address indexed newGame);
     event LiabilityReserved(
@@ -148,6 +173,35 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         return assets > protectedAssets ? assets - protectedAssets : 0;
     }
 
+    /// @notice Returns reserved maximum payout for a round, or zero when none remains.
+    function roundExposure(uint256 roundId) external view returns (uint256) {
+        return reservedPayoutByRound[roundId];
+    }
+
+    /// @notice Oldest unresolved exposed round id, or `NO_BLOCKING_ROUND` when none remain.
+    function oldestBlockingRound() public view returns (uint256) {
+        return _blockingHead;
+    }
+
+    /// @notice True while any exposed reveal is outstanding or an exposed round is expiry-eligible.
+    function shareOperationsFrozen() public view returns (bool) {
+        if (frozenRoundCount > 0) return true;
+        uint256 head = _blockingHead;
+        if (head == NO_BLOCKING_ROUND) return false;
+        return block.timestamp >= _blocking[head].expiresAt;
+    }
+
+    /// @notice Blocking-round cursor for LP Desk traversal. `nextRoundId` is `NO_BLOCKING_ROUND` at end.
+    function getBlockingRound(uint256 roundId)
+        external
+        view
+        returns (bool present, uint64 expiresAt, bool revealFrozen, uint256 nextRoundId)
+    {
+        BlockingRound storage blocking = _blocking[roundId];
+        if (!blocking.present) return (false, 0, false, NO_BLOCKING_ROUND);
+        return (true, blocking.expiresAt, blocking.revealFrozen, blocking.next);
+    }
+
     /// @notice Returns a stored ticket reservation, or an empty record when none exists.
     function getReservation(uint256 ticketId) external view returns (TicketReservation memory) {
         return _reservations[ticketId];
@@ -174,11 +228,34 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         emit LiabilityReserved(roundId, ticketId, player, margin, maximumPayout, leverageBps);
     }
 
+    /// @notice Records an exposed round so share ops freeze on its reveal or expiry eligibility.
+    function registerExposure(uint256 roundId, uint64 expiresAt) external nonReentrant {
+        _requireAuthorizedGameCaller();
+        if (_blocking[roundId].present) revert BlockingRoundAlreadyRegistered(roundId);
+        _insertBlockingRound(roundId, expiresAt);
+    }
+
+    /// @notice Increments the reveal freeze for a registered exposed round exactly once.
+    function noteRevealRequested(uint256 roundId) external nonReentrant {
+        _requireAuthorizedGameCaller();
+        BlockingRound storage blocking = _blocking[roundId];
+        if (!blocking.present) revert BlockingRoundMissing(roundId);
+        if (blocking.revealFrozen) revert BlockingRoundAlreadyRevealFrozen(roundId);
+
+        blocking.revealFrozen = true;
+        unchecked {
+            ++frozenRoundCount;
+        }
+    }
+
     /// @notice Marks a finalized round into share pricing before any claim is pulled.
     /// @dev Winning liability is the O(tiers) sum of reserved payouts at or below `crashPointBps`.
     function markRoundFinalized(uint256 roundId, uint256 totalMargin, uint256 crashPointBps) external nonReentrant {
         _requireAuthorizedGameCaller();
-        _markRoundObligations(roundId, totalMargin, _winningLiability(roundId, crashPointBps));
+        uint256 winningLiability = _winningLiability(roundId, crashPointBps);
+        // Checked arithmetic: liability never exceeds total reserved payout for the round.
+        realizedGamePnl += int256(totalMargin) - int256(winningLiability);
+        _markRoundObligations(roundId, totalMargin, winningLiability);
     }
 
     /// @notice Marks an expired round's margins into pending refund obligations.
@@ -191,6 +268,7 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
 
     /// @dev Moves a round's margin out of unrecognizedMargin and records its payout obligation.
     ///      Enforces the once-per-round marking invariant shared by finalize and expire.
+    ///      Clears that round's freeze contribution atomically after obligations update.
     function _markRoundObligations(uint256 roundId, uint256 totalMargin, uint256 obligation) internal {
         if (_roundObligationsMarked[roundId]) revert RoundAlreadyMarked(roundId);
         uint256 currentUnrecognized = unrecognizedMargin;
@@ -201,6 +279,7 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         _roundObligationsMarked[roundId] = true;
         unrecognizedMargin = currentUnrecognized - totalMargin;
         pendingObligations += obligation;
+        _clearBlockingRound(roundId);
     }
 
     /// @notice Pays a winning ticket within its reservation and consumes the reservation.
@@ -330,14 +409,26 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         reservedPayoutByRoundAndTier[roundId][leverageBps] += maximumPayout;
     }
 
+    /// @notice Returns the maximum assets a depositor may add right now.
+    function maxDeposit(address) public view override returns (uint256) {
+        return shareOperationsFrozen() ? 0 : type(uint256).max;
+    }
+
+    /// @notice Returns the maximum shares a depositor may mint right now.
+    function maxMint(address) public view override returns (uint256) {
+        return shareOperationsFrozen() ? 0 : type(uint256).max;
+    }
+
     /// @notice Returns the owner's immediately executable asset withdrawal limit.
     function maxWithdraw(address owner) public view override returns (uint256) {
+        if (shareOperationsFrozen()) return 0;
         (uint256 maxAssets,) = _withdrawalLimits(owner);
         return maxAssets;
     }
 
     /// @notice Returns the owner's immediately executable share redemption limit.
     function maxRedeem(address owner) public view override returns (uint256) {
+        if (shareOperationsFrozen()) return 0;
         uint256 ownerShares = balanceOf(owner);
         (uint256 maxAssets, uint256 ownerAssets) = _withdrawalLimits(owner);
 
@@ -347,6 +438,30 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         return Math.min(ownerShares, maxShares);
     }
 
+    /// @inheritdoc ERC4626
+    function deposit(uint256 assets, address receiver) public override returns (uint256) {
+        _requireShareOperationsThawed();
+        return super.deposit(assets, receiver);
+    }
+
+    /// @inheritdoc ERC4626
+    function mint(uint256 shares, address receiver) public override returns (uint256) {
+        _requireShareOperationsThawed();
+        return super.mint(shares, receiver);
+    }
+
+    /// @inheritdoc ERC4626
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256) {
+        _requireShareOperationsThawed();
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    /// @inheritdoc ERC4626
+    function redeem(uint256 shares, address receiver, address owner) public override returns (uint256) {
+        _requireShareOperationsThawed();
+        return super.redeem(shares, receiver, owner);
+    }
+
     function _withdrawalLimits(address owner) internal view returns (uint256 maxAssets, uint256 ownerAssets) {
         uint256 supply = totalSupply();
         if (supply == 0) return (0, 0);
@@ -354,5 +469,61 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         uint256 ownerShares = balanceOf(owner);
         ownerAssets = convertToAssets(ownerShares);
         maxAssets = Math.min(ownerAssets, freeLiquidity().mulDiv(ownerShares, supply));
+    }
+
+    function _requireShareOperationsThawed() internal view {
+        if (!shareOperationsFrozen()) return;
+        revert ShareOperationsFrozen(oldestBlockingRound(), frozenRoundCount);
+    }
+
+    /// @dev Inserts `roundId` into the ascending linked list of unresolved exposed rounds.
+    function _insertBlockingRound(uint256 roundId, uint64 expiresAt) internal {
+        uint256 prev = NO_BLOCKING_ROUND;
+        uint256 cursor = _blockingHead;
+        while (cursor != NO_BLOCKING_ROUND && cursor < roundId) {
+            prev = cursor;
+            cursor = _blocking[cursor].next;
+        }
+
+        _blocking[roundId] = BlockingRound({
+            expiresAt: expiresAt,
+            revealFrozen: false,
+            prev: prev,
+            next: cursor,
+            present: true
+        });
+
+        if (prev == NO_BLOCKING_ROUND) {
+            _blockingHead = roundId;
+        } else {
+            _blocking[prev].next = roundId;
+        }
+        if (cursor != NO_BLOCKING_ROUND) {
+            _blocking[cursor].prev = roundId;
+        }
+    }
+
+    /// @dev Removes a marked round from the freeze list and decrements the reveal counter when needed.
+    function _clearBlockingRound(uint256 roundId) internal {
+        BlockingRound storage blocking = _blocking[roundId];
+        if (!blocking.present) return;
+
+        if (blocking.revealFrozen) {
+            unchecked {
+                --frozenRoundCount;
+            }
+        }
+
+        uint256 prev = blocking.prev;
+        uint256 next = blocking.next;
+        if (prev == NO_BLOCKING_ROUND) {
+            _blockingHead = next;
+        } else {
+            _blocking[prev].next = next;
+        }
+        if (next != NO_BLOCKING_ROUND) {
+            _blocking[next].prev = prev;
+        }
+        delete _blocking[roundId];
     }
 }

--- a/contracts/src/BankrollVault.sol
+++ b/contracts/src/BankrollVault.sol
@@ -173,11 +173,6 @@ contract BankrollVault is ERC4626, ReentrancyGuard {
         return assets > protectedAssets ? assets - protectedAssets : 0;
     }
 
-    /// @notice Returns reserved maximum payout for a round, or zero when none remains.
-    function roundExposure(uint256 roundId) external view returns (uint256) {
-        return reservedPayoutByRound[roundId];
-    }
-
     /// @notice Oldest unresolved exposed round id, or `NO_BLOCKING_ROUND` when none remain.
     function oldestBlockingRound() public view returns (uint256) {
         return _blockingHead;

--- a/contracts/src/MarginCallCrash.sol
+++ b/contracts/src/MarginCallCrash.sol
@@ -177,8 +177,12 @@ contract MarginCallCrash is ReentrancyGuard {
 
         uint256 maximumPayout = (margin * leverageBps) / LEVERAGE_SCALE;
         uint256 ticketId = nextTicketId++;
+        bool firstExposure = round.totalMargin == 0;
 
         vault.acceptEntry(roundId, ticketId, msg.sender, margin, leverageBps, maximumPayout);
+        if (firstExposure) {
+            vault.registerExposure(roundId, round.expiresAt);
+        }
 
         _tickets[ticketId] = Ticket({
             id: ticketId,
@@ -212,6 +216,9 @@ contract MarginCallCrash is ReentrancyGuard {
 
         e.reveal(euint256.wrap(round.crashRandom));
         round.status = RoundStatus.RevealRequested;
+        if (round.totalMargin > 0) {
+            vault.noteRevealRequested(roundId);
+        }
         emit RevealRequested(roundId, round.crashRandom);
     }
 

--- a/contracts/src/interfaces/IBankrollVault.sol
+++ b/contracts/src/interfaces/IBankrollVault.sol
@@ -12,6 +12,13 @@ interface IBankrollVault {
         uint256 maximumPayout
     ) external;
 
+    /// @notice Records an exposed round so share ops can freeze at reveal or expiry.
+    /// @dev Called exactly once, on the round's first accepted ticket.
+    function registerExposure(uint256 roundId, uint64 expiresAt) external;
+
+    /// @notice Increments the reveal-window freeze for an already-registered exposed round.
+    function noteRevealRequested(uint256 roundId) external;
+
     /// @notice Marks a round's result into share pricing before any claim.
     /// @dev Releases `totalMargin` from unrecognizedMargin and adds O(tiers) winning
     ///      liability at or below `crashPointBps` into pendingObligations.

--- a/contracts/test/RevealWindowFreeze.t.sol
+++ b/contracts/test/RevealWindowFreeze.t.sol
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+
+import {inco} from "@inco/lightning/src/Lib.sol";
+
+import {BankrollVault} from "../src/BankrollVault.sol";
+import {DeskDollars} from "../src/DeskDollars.sol";
+import {IBankrollVault} from "../src/interfaces/IBankrollVault.sol";
+import {MarginCallCrash} from "../src/MarginCallCrash.sol";
+import {IncoRandomMock} from "./mocks/IncoRandomMock.sol";
+import {IncoVerifierMock} from "./mocks/IncoVerifierMock.sol";
+
+contract RevealWindowFreezeTest is Test {
+    uint64 internal constant EPOCH_ORIGIN = 1_000_000;
+    uint256 internal constant INCO_FEE = 1e12;
+    bytes32 internal constant RANDOM_HANDLE = bytes32(uint256(0xCAFE));
+    uint256 internal constant ONE_TUSD = 1_000_000;
+
+    address internal constant ALICE = address(0xA11CE);
+    address internal constant BOB = address(0xB0B);
+    address internal constant LP = address(0x1A);
+
+    DeskDollars internal token;
+    BankrollVault internal vault;
+    MarginCallCrash internal game;
+    IncoRandomMock internal incoMock;
+
+    function setUp() public {
+        IncoRandomMock mock = new IncoRandomMock();
+        vm.etch(address(inco), address(mock).code);
+        incoMock = IncoRandomMock(address(inco));
+        incoMock.configure(INCO_FEE, RANDOM_HANDLE);
+
+        IncoVerifierMock verifier = new IncoVerifierMock();
+        incoMock.setVerifier(address(verifier));
+
+        token = new DeskDollars(LP);
+        vault = new BankrollVault(token);
+        game = new MarginCallCrash(EPOCH_ORIGIN, IBankrollVault(address(vault)));
+        vault.setAuthorizedGame(address(game));
+
+        vm.startPrank(LP);
+        assertTrue(token.transfer(ALICE, 1_000 * ONE_TUSD));
+        assertTrue(token.transfer(BOB, 1_000 * ONE_TUSD));
+        token.approve(address(vault), type(uint256).max);
+        vault.deposit(12_000 * ONE_TUSD, LP);
+        vm.stopPrank();
+
+        vm.prank(ALICE);
+        token.approve(address(vault), type(uint256).max);
+        vm.prank(BOB);
+        token.approve(address(vault), type(uint256).max);
+
+        vm.deal(ALICE, 10 ether);
+        vm.deal(BOB, 10 ether);
+        vm.warp(EPOCH_ORIGIN);
+    }
+
+    function testExposedRevealFreezesShareOpsAndZeroesMaxLimits() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        (, uint64 lockAt,) = game.roundTimes(0);
+        vm.warp(lockAt);
+        game.requestReveal(0);
+
+        assertTrue(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 1);
+        assertEq(vault.oldestBlockingRound(), 0);
+        assertEq(vault.maxDeposit(LP), 0);
+        assertEq(vault.maxMint(LP), 0);
+        assertEq(vault.maxWithdraw(LP), 0);
+        assertEq(vault.maxRedeem(LP), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(BankrollVault.ShareOperationsFrozen.selector, 0, 1));
+        vm.prank(LP);
+        vault.deposit(ONE_TUSD, LP);
+
+        vm.expectRevert(abi.encodeWithSelector(BankrollVault.ShareOperationsFrozen.selector, 0, 1));
+        vm.prank(LP);
+        vault.mint(ONE_TUSD, LP);
+
+        vm.expectRevert(abi.encodeWithSelector(BankrollVault.ShareOperationsFrozen.selector, 0, 1));
+        vm.prank(LP);
+        vault.withdraw(ONE_TUSD, LP, LP);
+
+        vm.expectRevert(abi.encodeWithSelector(BankrollVault.ShareOperationsFrozen.selector, 0, 1));
+        vm.prank(LP);
+        vault.redeem(ONE_TUSD, LP, LP);
+    }
+
+    function testTicketlessRevealAndExpireNeverFreeze() public {
+        IncoRandomMock(address(inco)).configure(INCO_FEE, bytes32(uint256(0xBEEF)));
+        game.openRound{value: INCO_FEE}(0);
+
+        (, uint64 lockAt, uint64 expiresAt) = game.roundTimes(0);
+        vm.warp(lockAt);
+        game.requestReveal(0);
+
+        assertFalse(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertGt(vault.maxWithdraw(LP), 0);
+
+        vm.warp(expiresAt);
+        game.expireRound(0);
+
+        assertFalse(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+    }
+
+    function testExposedOpenPastExpiryBlocksUntilExpired() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        (,, uint64 expiresAt) = game.roundTimes(0);
+
+        assertFalse(vault.shareOperationsFrozen());
+        vm.warp(expiresAt);
+        assertTrue(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), 0);
+        assertEq(vault.maxDeposit(LP), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(BankrollVault.ShareOperationsFrozen.selector, 0, 0));
+        vm.prank(LP);
+        vault.deposit(ONE_TUSD, LP);
+
+        game.expireRound(0);
+
+        assertFalse(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertEq(vault.pendingObligations(), ONE_TUSD);
+        assertGt(vault.maxWithdraw(LP), 0);
+    }
+
+    function testFinalizeClearsFreezeAtomicallyWithObligations() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        (, uint64 lockAt,) = game.roundTimes(0);
+        vm.warp(lockAt);
+        game.requestReveal(0);
+        assertTrue(vault.shareOperationsFrozen());
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
+        // r=2080 => 1.25x; winning liability equals reserved payout.
+        game.finalizeRound(0, 2_080, signatures);
+
+        assertFalse(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertEq(vault.pendingObligations(), 1_250_000);
+        assertEq(vault.unrecognizedMargin(), 0);
+        assertEq(vault.realizedGamePnl(), int256(ONE_TUSD) - int256(1_250_000));
+        assertGt(vault.maxDeposit(LP), 0);
+    }
+
+    function testExpireFromRevealClearsFreezeAtomically() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        (, uint64 lockAt, uint64 expiresAt) = game.roundTimes(0);
+        vm.warp(lockAt);
+        game.requestReveal(0);
+        vm.warp(expiresAt);
+        assertEq(vault.frozenRoundCount(), 1);
+
+        game.expireRound(0);
+
+        assertFalse(vault.shareOperationsFrozen());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertEq(vault.pendingObligations(), ONE_TUSD);
+        assertEq(vault.realizedGamePnl(), 0);
+    }
+
+    function testOverlappingRevealsStayFrozenUntilLastBlockerResolves() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        _enter(1, BOB, ONE_TUSD, 15_000);
+
+        (, uint64 lock0,) = game.roundTimes(0);
+        vm.warp(lock0);
+        game.requestReveal(0);
+        (, uint64 lock1,) = game.roundTimes(1);
+        vm.warp(lock1);
+        game.requestReveal(1);
+
+        assertEq(vault.frozenRoundCount(), 2);
+        assertEq(vault.oldestBlockingRound(), 0);
+        assertTrue(vault.shareOperationsFrozen());
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
+        game.finalizeRound(0, 2_080, signatures);
+
+        assertEq(vault.frozenRoundCount(), 1);
+        assertEq(vault.oldestBlockingRound(), 1);
+        assertTrue(vault.shareOperationsFrozen());
+
+        game.finalizeRound(1, 3_400, signatures);
+
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertFalse(vault.shareOperationsFrozen());
+    }
+
+    function testOutOfOrderResolutionAdvancesOldestBlockingRound() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        _enter(1, BOB, ONE_TUSD, 15_000);
+
+        // Register next before current can already happen; also resolve higher id first.
+        (, uint64 lock1,) = game.roundTimes(1);
+        vm.warp(lock1);
+        game.requestReveal(1);
+        game.requestReveal(0);
+
+        assertEq(vault.oldestBlockingRound(), 0);
+        assertEq(vault.frozenRoundCount(), 2);
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
+        game.finalizeRound(1, 3_400, signatures);
+
+        assertEq(vault.oldestBlockingRound(), 0);
+        assertEq(vault.frozenRoundCount(), 1);
+        assertTrue(vault.shareOperationsFrozen());
+
+        (,, uint64 expires0) = game.roundTimes(0);
+        vm.warp(expires0);
+        game.expireRound(0);
+
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertEq(vault.frozenRoundCount(), 0);
+        assertFalse(vault.shareOperationsFrozen());
+    }
+
+    function testRegisterNextBeforeCurrentKeepsAscendingOldest() public {
+        // Enter round 1 first, then round 0 — insertion must keep ascending order.
+        IncoRandomMock(address(inco)).configure(INCO_FEE, bytes32(uint256(0x1001)));
+        vm.warp(EPOCH_ORIGIN);
+        game.openRound{value: INCO_FEE}(1);
+        vm.prank(BOB);
+        game.enter(1, ONE_TUSD, 15_000);
+
+        assertEq(vault.oldestBlockingRound(), 1);
+
+        IncoRandomMock(address(inco)).configure(INCO_FEE, bytes32(uint256(0x1000)));
+        game.openRound{value: INCO_FEE}(0);
+        vm.prank(ALICE);
+        game.enter(0, ONE_TUSD, 12_500);
+
+        assertEq(vault.oldestBlockingRound(), 0);
+        (bool present, uint64 expiresAt,, uint256 nextRoundId) = vault.getBlockingRound(0);
+        assertTrue(present);
+        assertEq(nextRoundId, 1);
+        (,, uint64 expectedExpires) = game.roundTimes(0);
+        assertEq(expiresAt, expectedExpires);
+    }
+
+    function testFreezeCounterRecoveryAcrossInterleavings(uint8 pattern) public {
+        // Four overlapping exposed rounds; each step is reveal, finalize, or expire.
+        // Pattern nibbles pick an action per round while skipping impossible transitions.
+        uint256 roundCount = 3;
+        for (uint256 i = 0; i < roundCount; ++i) {
+            _enter(i, i % 2 == 0 ? ALICE : BOB, ONE_TUSD, 12_500);
+        }
+
+        bool[3] memory revealed;
+        bool[3] memory resolved;
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
+
+        for (uint256 step = 0; step < 12; ++step) {
+            uint256 roundId = (uint256(pattern) + step) % roundCount;
+            if (resolved[roundId]) continue;
+
+            (uint64 openAt, uint64 lockAt, uint64 expiresAt) = game.roundTimes(roundId);
+            uint256 action = (uint256(pattern) >> (step % 5)) % 3;
+
+            if (!revealed[roundId] && action == 0) {
+                if (block.timestamp < lockAt) vm.warp(lockAt);
+                if (block.timestamp >= expiresAt) {
+                    game.expireRound(roundId);
+                    resolved[roundId] = true;
+                } else {
+                    game.requestReveal(roundId);
+                    revealed[roundId] = true;
+                }
+            } else if (revealed[roundId] && !resolved[roundId] && action == 1) {
+                if (block.timestamp >= expiresAt) {
+                    game.expireRound(roundId);
+                } else {
+                    game.finalizeRound(roundId, 2_080, signatures);
+                }
+                resolved[roundId] = true;
+            } else if (!resolved[roundId] && action == 2) {
+                if (block.timestamp < expiresAt) vm.warp(expiresAt);
+                game.expireRound(roundId);
+                resolved[roundId] = true;
+            } else if (!revealed[roundId]) {
+                if (block.timestamp < openAt) vm.warp(openAt);
+                if (block.timestamp < lockAt) vm.warp(lockAt);
+                if (block.timestamp >= expiresAt) {
+                    game.expireRound(roundId);
+                    resolved[roundId] = true;
+                } else {
+                    game.requestReveal(roundId);
+                    revealed[roundId] = true;
+                }
+            } else {
+                if (block.timestamp < expiresAt) vm.warp(expiresAt);
+                game.expireRound(roundId);
+                resolved[roundId] = true;
+            }
+
+            _assertFreezeInvariants();
+        }
+
+        for (uint256 i = 0; i < roundCount; ++i) {
+            if (!resolved[i]) {
+                (,, uint64 expiresAt) = game.roundTimes(i);
+                if (block.timestamp < expiresAt) vm.warp(expiresAt);
+                game.expireRound(i);
+            }
+        }
+
+        assertEq(vault.frozenRoundCount(), 0);
+        assertEq(vault.oldestBlockingRound(), vault.NO_BLOCKING_ROUND());
+        assertFalse(vault.shareOperationsFrozen());
+    }
+
+    function testRealizedGamePnlTracksNetWinningAndLosingRounds() public {
+        assertEq(vault.realizedGamePnl(), 0);
+
+        // Losing ticket at 10x with low crash point → LP gain of margin.
+        _enter(0, ALICE, ONE_TUSD, 100_000);
+        (, uint64 lock0,) = game.roundTimes(0);
+        vm.warp(lock0);
+        game.requestReveal(0);
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
+        // plaintext 0 → crash well below 10x.
+        game.finalizeRound(0, 0, signatures);
+        assertEq(vault.realizedGamePnl(), int256(ONE_TUSD));
+
+        // Winning 1.25x ticket → LP loss of payout − margin.
+        _enter(1, BOB, ONE_TUSD, 12_500);
+        (, uint64 lock1,) = game.roundTimes(1);
+        vm.warp(lock1);
+        game.requestReveal(1);
+        game.finalizeRound(1, 2_080, signatures);
+        assertEq(vault.realizedGamePnl(), int256(ONE_TUSD) + int256(ONE_TUSD) - int256(1_250_000));
+    }
+
+    function testRoundExposureMatchesReservedPayout() public {
+        _enter(0, ALICE, ONE_TUSD, 12_500);
+        assertEq(vault.roundExposure(0), 1_250_000);
+        assertEq(vault.roundExposure(1), 0);
+    }
+
+    function _assertFreezeInvariants() internal view {
+        uint256 count;
+        uint256 cursor = vault.oldestBlockingRound();
+        uint256 previous = 0;
+        bool hasPrevious;
+        while (cursor != vault.NO_BLOCKING_ROUND()) {
+            (bool present, uint64 expiresAt, bool revealFrozen, uint256 nextRoundId) = vault.getBlockingRound(cursor);
+            assertTrue(present);
+            if (hasPrevious) assertGt(cursor, previous);
+            if (revealFrozen) ++count;
+            if (vault.frozenRoundCount() == 0 && vault.shareOperationsFrozen()) {
+                assertGe(block.timestamp, expiresAt);
+            }
+            previous = cursor;
+            hasPrevious = true;
+            cursor = nextRoundId;
+        }
+        assertEq(count, vault.frozenRoundCount());
+        if (vault.frozenRoundCount() > 0) assertTrue(vault.shareOperationsFrozen());
+        if (vault.oldestBlockingRound() == vault.NO_BLOCKING_ROUND()) {
+            assertEq(vault.frozenRoundCount(), 0);
+            assertFalse(vault.shareOperationsFrozen());
+        }
+    }
+
+    function _enter(uint256 roundId, address player, uint256 margin, uint256 leverageBps)
+        internal
+        returns (uint256 ticketId)
+    {
+        IncoRandomMock(address(inco)).configure(INCO_FEE, bytes32(uint256(0xA0000) + roundId));
+        uint64 openAt = EPOCH_ORIGIN + uint64(roundId * 60);
+        vm.warp(openAt);
+        game.openRound{value: INCO_FEE}(roundId);
+        vm.prank(player);
+        game.enter(roundId, margin, leverageBps);
+        ticketId = game.getTicketId(roundId, player);
+    }
+}

--- a/contracts/test/RevealWindowFreeze.t.sol
+++ b/contracts/test/RevealWindowFreeze.t.sol
@@ -350,12 +350,6 @@ contract RevealWindowFreezeTest is Test {
         assertEq(vault.realizedGamePnl(), int256(ONE_TUSD) + int256(ONE_TUSD) - int256(1_250_000));
     }
 
-    function testRoundExposureMatchesReservedPayout() public {
-        _enter(0, ALICE, ONE_TUSD, 12_500);
-        assertEq(vault.roundExposure(0), 1_250_000);
-        assertEq(vault.roundExposure(1), 0);
-    }
-
     function _assertFreezeInvariants() internal view {
         uint256 count;
         uint256 cursor = vault.oldestBlockingRound();

--- a/src/components/lp-desk/lp-desk.test.tsx
+++ b/src/components/lp-desk/lp-desk.test.tsx
@@ -28,9 +28,26 @@ type VaultFixture = {
   safetyBuffer: bigint;
   freeLiquidity: bigint;
   maxWithdraw: bigint;
+  realizedGamePnl: bigint;
+  shareOperationsFrozen: boolean;
+  blockingRounds: Array<{
+    roundId: bigint;
+    expiresAt: bigint;
+    revealFrozen: boolean;
+    expiryEligible: boolean;
+  }>;
+  earliestExpiry: bigint | undefined;
+  chainTimestamp: bigint | undefined;
+  utilizationBps: bigint;
+  tierCapacity: Array<{
+    leverageBps: bigint;
+    label: string;
+    maxMargin: bigint;
+  }>;
   deposit: ReturnType<typeof vi.fn>;
   withdraw: ReturnType<typeof vi.fn>;
   retry: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
 };
 
 const sdk = vi.hoisted(() => {
@@ -54,11 +71,41 @@ const sdk = vi.hoisted(() => {
     safetyBuffer: 5000000000n,
     freeLiquidity: 18750000000n,
     maxWithdraw: 37500000n,
+    realizedGamePnl: -250000n,
+    shareOperationsFrozen: false,
+    blockingRounds: [],
+    earliestExpiry: undefined,
+    chainTimestamp: 1_000_000n,
+    utilizationBps: 500n,
+    tierCapacity: [
+      { leverageBps: 12_500n, label: "1.25x", maxMargin: 80_000_000n },
+      { leverageBps: 15_000n, label: "1.50x", maxMargin: 66_666_666n },
+      { leverageBps: 20_000n, label: "2.00x", maxMargin: 50_000_000n },
+      { leverageBps: 30_000n, label: "3.00x", maxMargin: 33_333_333n },
+      { leverageBps: 50_000n, label: "5.00x", maxMargin: 20_000_000n },
+      { leverageBps: 100_000n, label: "10.00x", maxMargin: 10_000_000n },
+    ],
     deposit: vi.fn(),
     withdraw: vi.fn(),
     retry: vi.fn(),
+    refresh: vi.fn(),
   });
-  return { vault: ready(), ready };
+  return {
+    vault: ready(),
+    ready,
+    freeze: {
+      status: "idle" as const,
+      error: null as string | null,
+      activeRoundId: null as bigint | null,
+      canAct: true,
+      canRetry: false,
+      retryAction: null as null,
+      finalizeRound: vi.fn(),
+      expireRound: vi.fn(),
+      resolveBlockingRound: vi.fn(),
+      retry: vi.fn(),
+    },
+  };
 });
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -75,16 +122,27 @@ vi.mock("@privy-io/react-auth", () => ({
 vi.mock("@/hooks/use-bankroll-vault-deposit", () => ({
   useBankrollVaultDeposit: () => sdk.vault,
 }));
+vi.mock("@/hooks/use-lp-freeze-actions", () => ({
+  useLpFreezeActions: () => sdk.freeze,
+}));
 
 import { LpDesk } from "./lp-desk";
 
 beforeEach(() => {
   sdk.vault = sdk.ready();
+  sdk.freeze.resolveBlockingRound.mockReset();
+  sdk.freeze.retry.mockReset();
+  sdk.freeze.status = "idle";
+  sdk.freeze.error = null;
+  sdk.freeze.canAct = true;
+  sdk.freeze.canRetry = false;
+  sdk.freeze.retryAction = null;
+  sdk.freeze.activeRoundId = null;
 });
 afterEach(() => cleanup());
 
 describe("LpDesk", () => {
-  it("shows the authenticated wallet and meaningful pre-game vault accounting", () => {
+  it("shows the authenticated wallet and complete vault risk display", () => {
     render(<LpDesk />);
     expect(
       screen.getByText("Wallet Desk Dollars").nextElementSibling?.textContent
@@ -96,6 +154,10 @@ describe("LpDesk", () => {
       screen.getByText("Share price (assets per share)").nextElementSibling
         ?.textContent
     ).toBe("1 tUSD");
+    expect(
+      screen.getByText("Realized vault gain/loss").nextElementSibling
+        ?.textContent
+    ).toBe("−0.25 tUSD");
     expect(
       screen.getByText("Gross assets").nextElementSibling?.textContent
     ).toBe("25000 tUSD");
@@ -109,18 +171,83 @@ describe("LpDesk", () => {
       screen.getByText("Global free liquidity").nextElementSibling?.textContent
     ).toBe("18750 tUSD");
     expect(
+      screen.getByText("Utilization").nextElementSibling?.textContent
+    ).toBe("5.00%");
+    expect(
       screen.getByText("Your immediately withdrawable tUSD").nextElementSibling
         ?.textContent
     ).toBe("37.5 tUSD");
+    expect(screen.getByText("1.25x")).not.toBeNull();
+    expect(screen.getByText(/80 tUSD max margin/)).not.toBeNull();
     expect(
       screen.getByText(/Global free liquidity is the vault-wide capacity/)
     ).not.toBeNull();
     expect(
-      screen.getByText(
-        /vault-share value can decline as game results are realized/i
-      )
+      screen.getByText(/Liquidity providers can lose tUSD when players win/i)
     ).not.toBeNull();
     expect(screen.getByText(/Base Sepolia/)).not.toBeNull();
+  });
+
+  it("shows the freeze banner with honest overlapping-outage copy and actions", () => {
+    sdk.vault = {
+      ...sdk.ready(),
+      canDeposit: false,
+      canWithdraw: false,
+      shareOperationsFrozen: true,
+      earliestExpiry: 1_000_900n,
+      blockingRounds: [
+        {
+          roundId: 4n,
+          expiresAt: 1_000_900n,
+          revealFrozen: true,
+          expiryEligible: false,
+        },
+        {
+          roundId: 5n,
+          expiresAt: 1_001_000n,
+          revealFrozen: false,
+          expiryEligible: true,
+        },
+      ],
+    };
+    render(<LpDesk />);
+    expect(
+      screen.getByText(/Reveal-window freeze — LP deposits and withdrawals/)
+    ).not.toBeNull();
+    expect(
+      screen.getByText((_, element) =>
+        element?.tagName === "P"
+          ? /bounds one round's freeze, not the total/i.test(
+              element.textContent ?? ""
+            )
+          : false
+      )
+    ).not.toBeNull();
+    expect(screen.getByText(/frozen indefinitely/i)).not.toBeNull();
+    expect(screen.getByText("Round 4")).not.toBeNull();
+    expect(screen.getByText("Round 5")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Finalize round" }));
+    expect(sdk.freeze.resolveBlockingRound).toHaveBeenCalledWith(
+      expect.objectContaining({ roundId: 4n })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Expire round" }));
+    expect(sdk.freeze.resolveBlockingRound).toHaveBeenCalledWith(
+      expect.objectContaining({ roundId: 5n })
+    );
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Deposits frozen",
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Withdrawals frozen",
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
   });
 
   it("validates an exact six-decimal asset amount against the wallet balance", () => {

--- a/src/components/lp-desk/lp-desk.test.tsx
+++ b/src/components/lp-desk/lp-desk.test.tsx
@@ -36,7 +36,6 @@ type VaultFixture = {
     revealFrozen: boolean;
     expiryEligible: boolean;
   }>;
-  earliestExpiry: bigint | undefined;
   chainTimestamp: bigint | undefined;
   utilizationBps: bigint;
   tierCapacity: Array<{
@@ -74,7 +73,6 @@ const sdk = vi.hoisted(() => {
     realizedGamePnl: -250000n,
     shareOperationsFrozen: false,
     blockingRounds: [],
-    earliestExpiry: undefined,
     chainTimestamp: 1_000_000n,
     utilizationBps: 500n,
     tierCapacity: [
@@ -194,7 +192,6 @@ describe("LpDesk", () => {
       canDeposit: false,
       canWithdraw: false,
       shareOperationsFrozen: true,
-      earliestExpiry: 1_000_900n,
       blockingRounds: [
         {
           roundId: 4n,

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import {
   useBankrollVaultDeposit,
@@ -19,6 +19,7 @@ import {
   parseTUsdInput,
   TUSD_DECIMALS,
 } from "@/lib/desk-dollars";
+import { formatHundredths } from "@/lib/margin-call-crash";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 
 function formatAmount(value: bigint | undefined, unit: string) {
@@ -35,10 +36,7 @@ function formatSignedAmount(value: bigint | undefined) {
 }
 
 function formatUtilization(bps: bigint | undefined) {
-  if (bps === undefined) return "—";
-  const whole = bps / 100n;
-  const fraction = bps % 100n;
-  return `${whole.toString()}.${fraction.toString().padStart(2, "0")}%`;
+  return bps === undefined ? "—" : `${formatHundredths(bps)}%`;
 }
 
 function formatExpiry(expiresAt: bigint | undefined, chainTimestamp?: bigint) {
@@ -152,15 +150,15 @@ function Metric({ label, value }: { label: string; value: string }) {
 
 function FreezeBanner({
   blockingRounds,
-  earliestExpiry,
   chainTimestamp,
   freeze,
 }: {
   blockingRounds: BlockingRoundDetail[];
-  earliestExpiry: bigint | undefined;
   chainTimestamp: bigint | undefined;
   freeze: ReturnType<typeof useLpFreezeActions>;
 }) {
+  // The contract's blocking list is ordered, so the head expires first.
+  const earliestExpiry = blockingRounds[0]?.expiresAt;
   return (
     <div
       role="alert"
@@ -266,11 +264,9 @@ export function LpDesk() {
   const { user } = usePrivy();
   const walletAddress = getEvmWalletAddress(user);
   const vault = useBankrollVaultDeposit(walletAddress);
-  const refreshVaultBalances = vault.refresh;
-  const refreshVault = useCallback(() => {
-    void refreshVaultBalances();
-  }, [refreshVaultBalances]);
-  const freeze = useLpFreezeActions(refreshVault);
+  // Freeze resolutions notify wallet-balance subscribers, which re-read the
+  // vault state above — no explicit refresh wiring is needed.
+  const freeze = useLpFreezeActions();
   const [amount, setAmount] = useState("");
   const [withdrawalAmount, setWithdrawalAmount] = useState("");
   const parsedAmount = parseTUsdInput(amount);
@@ -349,7 +345,6 @@ export function LpDesk() {
       {isFrozen ? (
         <FreezeBanner
           blockingRounds={blockingRounds}
-          earliestExpiry={vault.earliestExpiry}
           chainTimestamp={vault.chainTimestamp}
           freeze={freeze}
         />

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import {
   useBankrollVaultDeposit,
@@ -8,6 +8,12 @@ import {
   type BankrollVaultRetryAction,
   type BankrollVaultWithdrawalRecovery,
 } from "@/hooks/use-bankroll-vault-deposit";
+import {
+  useLpFreezeActions,
+  type LpFreezeActionStatus,
+  type LpFreezeRetryAction,
+} from "@/hooks/use-lp-freeze-actions";
+import type { BlockingRoundDetail, TierCapacity } from "@/lib/bankroll-vault";
 import {
   formatDeskDollars,
   parseTUsdInput,
@@ -19,6 +25,36 @@ function formatAmount(value: bigint | undefined, unit: string) {
   return value === undefined
     ? `— ${unit}`
     : `${formatDeskDollars(value, TUSD_DECIMALS)} ${unit}`;
+}
+
+function formatSignedAmount(value: bigint | undefined) {
+  if (value === undefined) return "— tUSD";
+  const sign = value < 0n ? "−" : value > 0n ? "+" : "";
+  const abs = value < 0n ? -value : value;
+  return `${sign}${formatDeskDollars(abs, TUSD_DECIMALS)} tUSD`;
+}
+
+function formatUtilization(bps: bigint | undefined) {
+  if (bps === undefined) return "—";
+  const whole = bps / 100n;
+  const fraction = bps % 100n;
+  return `${whole.toString()}.${fraction.toString().padStart(2, "0")}%`;
+}
+
+function formatExpiry(expiresAt: bigint | undefined, chainTimestamp?: bigint) {
+  if (expiresAt === undefined) return "—";
+  const date = new Date(Number(expiresAt) * 1000);
+  const label = date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  if (chainTimestamp !== undefined && chainTimestamp >= expiresAt) {
+    return `${label} (eligible now)`;
+  }
+  return label;
 }
 
 const depositAmountCopy = {
@@ -44,8 +80,6 @@ function validateAmount(
     return `Enter a tUSD amount with no more than ${TUSD_DECIMALS} decimal places.`;
   if (parsed <= 0n) return "Enter a positive tUSD amount.";
   if (limit === undefined) {
-    // Unavailable and load-error states already render their own notice;
-    // only a load that is genuinely in progress warrants "still loading".
     return status === "loading" ? copy.limitLoading : null;
   }
   if (parsed > limit) return copy.overLimit;
@@ -90,10 +124,153 @@ const retryLabels: Record<BankrollVaultRetryAction, string> = {
   "withdrawal-receipt-check": "Retry withdrawal receipt check",
 };
 
+const freezeStatusCopy: Partial<Record<LpFreezeActionStatus, string>> = {
+  attesting: "Fetching Inco attestation for the blocking round…",
+  "finalize-submitting": "Submitting finalize for the blocking round…",
+  "finalize-pending":
+    "Finalization pending until its Base Sepolia receipt succeeds…",
+  "expire-submitting": "Submitting expire for the blocking round…",
+  "expire-pending": "Expiry pending until its Base Sepolia receipt succeeds…",
+  confirmed: "Blocking round resolved on Base Sepolia.",
+};
+
+const freezeRetryLabels: Record<LpFreezeRetryAction, string> = {
+  finalize: "Retry finalize",
+  expire: "Retry expire",
+  "finalize-receipt-check": "Retry finalize receipt check",
+  "expire-receipt-check": "Retry expire receipt check",
+};
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[var(--t-muted)]">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+function FreezeBanner({
+  blockingRounds,
+  earliestExpiry,
+  chainTimestamp,
+  freeze,
+}: {
+  blockingRounds: BlockingRoundDetail[];
+  earliestExpiry: bigint | undefined;
+  chainTimestamp: bigint | undefined;
+  freeze: ReturnType<typeof useLpFreezeActions>;
+}) {
+  return (
+    <div
+      role="alert"
+      className="mt-4 border border-[var(--t-amber)] bg-[color-mix(in_oklab,var(--t-amber)_12%,transparent)] p-4 text-sm text-[var(--t-text)]"
+    >
+      <p className="font-bold text-[var(--t-amber)]">
+        Reveal-window freeze — LP deposits and withdrawals are blocked
+      </p>
+      <p className="mt-2">
+        Share operations stay frozen while any exposed round is revealed or
+        expiry-eligible but not yet marked into vault obligations. The 15-minute
+        expiry bounds <span className="font-bold">one round&apos;s</span>{" "}
+        freeze, not the total — overlapping delayed rounds during a sustained
+        reveal outage can keep LP deposits and withdrawals frozen indefinitely.
+      </p>
+      <p className="mt-2 text-[var(--t-muted)]">
+        Earliest clearing expiry: {formatExpiry(earliestExpiry, chainTimestamp)}
+      </p>
+      <ul className="mt-3 space-y-2">
+        {blockingRounds.map((round) => {
+          const busy =
+            freeze.activeRoundId === round.roundId &&
+            freeze.status !== "idle" &&
+            freeze.status !== "confirmed" &&
+            freeze.status !== "error";
+          const actionLabel = round.expiryEligible
+            ? "Expire round"
+            : round.revealFrozen
+              ? "Finalize round"
+              : null;
+          return (
+            <li
+              key={round.roundId.toString()}
+              className="flex flex-wrap items-center justify-between gap-2 border-t border-[var(--t-muted)] pt-2"
+            >
+              <div>
+                <p className="font-bold">Round {round.roundId.toString()}</p>
+                <p className="text-xs text-[var(--t-muted)]">
+                  Expires {formatExpiry(round.expiresAt, chainTimestamp)}
+                  {round.revealFrozen ? " · reveal requested" : " · still open"}
+                  {round.expiryEligible ? " · expiry eligible" : ""}
+                </p>
+              </div>
+              {actionLabel ? (
+                <button
+                  className="rounded-sm border border-[var(--t-amber)] px-3 py-1.5 text-xs font-bold text-[var(--t-amber)] disabled:opacity-50"
+                  disabled={!freeze.canAct || busy}
+                  onClick={() => void freeze.resolveBlockingRound(round)}
+                  type="button"
+                >
+                  {busy ? "Working…" : actionLabel}
+                </button>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+      {freezeStatusCopy[freeze.status] ? (
+        <p className="mt-3" aria-live="polite">
+          {freezeStatusCopy[freeze.status]}
+        </p>
+      ) : null}
+      {freeze.status === "error" && freeze.error ? (
+        <p className="mt-3" role="alert">
+          {freeze.error}
+        </p>
+      ) : null}
+      {freeze.canRetry && freeze.retryAction ? (
+        <button
+          className="mt-3 rounded-sm border border-[var(--t-muted)] px-3 py-1.5 text-xs font-bold"
+          onClick={() => void freeze.retry()}
+          type="button"
+        >
+          {freezeRetryLabels[freeze.retryAction]}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function TierCapacityList({ tiers }: { tiers: TierCapacity[] | undefined }) {
+  if (!tiers) {
+    return (
+      <p className="mt-2 text-xs text-[var(--t-muted)]">
+        Player capacity by Arcade Leverage tier is unavailable until vault risk
+        views load.
+      </p>
+    );
+  }
+  return (
+    <ul className="mt-2 grid grid-cols-2 gap-2 text-sm sm:grid-cols-3">
+      {tiers.map((tier) => (
+        <li key={tier.label}>
+          <span className="text-[var(--t-muted)]">{tier.label}</span>
+          <div>{formatAmount(tier.maxMargin, "tUSD max margin")}</div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export function LpDesk() {
   const { user } = usePrivy();
   const walletAddress = getEvmWalletAddress(user);
   const vault = useBankrollVaultDeposit(walletAddress);
+  const refreshVaultBalances = vault.refresh;
+  const refreshVault = useCallback(() => {
+    void refreshVaultBalances();
+  }, [refreshVaultBalances]);
+  const freeze = useLpFreezeActions(refreshVault);
   const [amount, setAmount] = useState("");
   const [withdrawalAmount, setWithdrawalAmount] = useState("");
   const parsedAmount = parseTUsdInput(amount);
@@ -145,11 +322,13 @@ export function LpDesk() {
   const retryLabel = vault.retryAction
     ? retryLabels[vault.retryAction]
     : "Retry";
+  const isFrozen = vault.shareOperationsFrozen === true;
+  const blockingRounds = vault.blockingRounds ?? [];
 
   return (
     <section
       aria-labelledby="lp-desk-heading"
-      className="mt-8 rounded-sm border border-[var(--t-muted)] p-5 text-left"
+      className="mt-8 border border-[var(--t-muted)] p-5 text-left"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 id="lp-desk-heading" className="font-bold text-[var(--t-accent)]">
@@ -162,68 +341,95 @@ export function LpDesk() {
       <p className="mt-2 text-sm text-[var(--t-text)]">
         Provide Desk Dollars (tUSD) to receive vault shares.
       </p>
-      <p className="mt-3 rounded-sm border border-[var(--t-amber)] p-3 text-sm text-[var(--t-text)]">
+      <p className="mt-3 border border-[var(--t-amber)] p-3 text-sm text-[var(--t-text)]">
         Warning: vault-share value can decline as game results are realized.
+        Liquidity providers can lose tUSD when players win.
       </p>
 
+      {isFrozen ? (
+        <FreezeBanner
+          blockingRounds={blockingRounds}
+          earliestExpiry={vault.earliestExpiry}
+          chainTimestamp={vault.chainTimestamp}
+          freeze={freeze}
+        />
+      ) : null}
+
       <dl className="mt-5 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-        <div>
-          <dt className="text-[var(--t-muted)]">Wallet Desk Dollars</dt>
-          <dd>{formatAmount(vault.tUsdBalance, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Wallet vault shares</dt>
-          <dd>{formatAmount(vault.shareBalance, "vault shares")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">
-            Share price (assets per share)
-          </dt>
-          <dd>{formatAmount(vault.assetsPerShare, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Gross assets</dt>
-          <dd>{formatAmount(vault.grossAssets, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Net total assets</dt>
-          <dd>{formatAmount(vault.totalAssets, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Total supply</dt>
-          <dd>{formatAmount(vault.totalSupply, "vault shares")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Pending obligations</dt>
-          <dd>{formatAmount(vault.pendingObligations, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Unrecognized margin</dt>
-          <dd>{formatAmount(vault.unrecognizedMargin, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Reserved liabilities</dt>
-          <dd>{formatAmount(vault.reservedLiabilities, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Safety buffer</dt>
-          <dd>{formatAmount(vault.safetyBuffer, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">Global free liquidity</dt>
-          <dd>{formatAmount(vault.freeLiquidity, "tUSD")}</dd>
-        </div>
-        <div>
-          <dt className="text-[var(--t-muted)]">
-            Your immediately withdrawable tUSD
-          </dt>
-          <dd>{formatAmount(vault.maxWithdraw, "tUSD")}</dd>
-        </div>
+        <Metric
+          label="Wallet Desk Dollars"
+          value={formatAmount(vault.tUsdBalance, "tUSD")}
+        />
+        <Metric
+          label="Wallet vault shares"
+          value={formatAmount(vault.shareBalance, "vault shares")}
+        />
+        <Metric
+          label="Share price (assets per share)"
+          value={formatAmount(vault.assetsPerShare, "tUSD")}
+        />
+        <Metric
+          label="Realized vault gain/loss"
+          value={formatSignedAmount(vault.realizedGamePnl)}
+        />
+        <Metric
+          label="Gross assets"
+          value={formatAmount(vault.grossAssets, "tUSD")}
+        />
+        <Metric
+          label="Net total assets"
+          value={formatAmount(vault.totalAssets, "tUSD")}
+        />
+        <Metric
+          label="Total supply"
+          value={formatAmount(vault.totalSupply, "vault shares")}
+        />
+        <Metric
+          label="Pending obligations"
+          value={formatAmount(vault.pendingObligations, "tUSD")}
+        />
+        <Metric
+          label="Unrecognized margin"
+          value={formatAmount(vault.unrecognizedMargin, "tUSD")}
+        />
+        <Metric
+          label="Reserved liabilities"
+          value={formatAmount(vault.reservedLiabilities, "tUSD")}
+        />
+        <Metric
+          label="Safety buffer"
+          value={formatAmount(vault.safetyBuffer, "tUSD")}
+        />
+        <Metric
+          label="Global free liquidity"
+          value={formatAmount(vault.freeLiquidity, "tUSD")}
+        />
+        <Metric
+          label="Utilization"
+          value={formatUtilization(vault.utilizationBps)}
+        />
+        <Metric
+          label="Your immediately withdrawable tUSD"
+          value={formatAmount(vault.maxWithdraw, "tUSD")}
+        />
       </dl>
+
+      <div className="mt-5 border-t border-[var(--t-muted)] pt-4">
+        <h3 className="text-sm font-bold">
+          Player capacity by Arcade Leverage tier
+        </h3>
+        <p className="mt-1 text-xs text-[var(--t-muted)]">
+          Advisory remaining max margin for one new ticket from live vault
+          capacity. Transaction-time vault checks remain authoritative.
+        </p>
+        <TierCapacityList tiers={vault.tierCapacity} />
+      </div>
+
       <p className="mt-3 text-xs text-[var(--t-muted)]">
         Gross assets are live vault tUSD. Net total assets price shares after
         pending obligations and unrecognized margin. Share price marks to market
-        the moment a round finalizes — before any claim is pulled.
+        the moment a round finalizes — before any claim is pulled. Realized
+        vault gain/loss is the cumulative verified game result.
       </p>
       <p className="mt-2 text-xs text-[var(--t-muted)]">
         Global free liquidity is the vault-wide capacity after reservations and
@@ -240,7 +446,8 @@ export function LpDesk() {
         </label>
         <input
           aria-describedby="lp-deposit-help lp-deposit-validation"
-          className="mt-2 w-full rounded-sm border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+          className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+          disabled={isFrozen}
           id="lp-deposit-amount"
           inputMode="decimal"
           onChange={(event) => setAmount(event.target.value)}
@@ -248,8 +455,9 @@ export function LpDesk() {
           value={amount}
         />
         <p id="lp-deposit-help" className="mt-2 text-xs text-[var(--t-muted)]">
-          An exact tUSD approval for this deposit may occur first. The LP Desk
-          never requests unlimited approval.
+          {isFrozen
+            ? "Deposits are blocked while share operations are frozen."
+            : "An exact tUSD approval for this deposit may occur first. The LP Desk never requests unlimited approval."}
         </p>
         {validationError ? (
           <p id="lp-deposit-validation" role="alert" className="mt-2 text-sm">
@@ -257,7 +465,7 @@ export function LpDesk() {
           </p>
         ) : null}
         <button
-          className="mt-4 rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
+          className="mt-4 bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
           disabled={!canSubmit}
           type="submit"
         >
@@ -265,7 +473,9 @@ export function LpDesk() {
             ? "Approval pending…"
             : vault.status.startsWith("deposit-")
               ? "LP deposit pending…"
-              : "Deposit tUSD"}
+              : isFrozen
+                ? "Deposits frozen"
+                : "Deposit tUSD"}
         </button>
       </form>
 
@@ -281,7 +491,8 @@ export function LpDesk() {
         </label>
         <input
           aria-describedby="lp-withdrawal-help lp-withdrawal-validation"
-          className="mt-2 w-full rounded-sm border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+          className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+          disabled={isFrozen}
           id="lp-withdrawal-amount"
           inputMode="decimal"
           onChange={(event) => setWithdrawalAmount(event.target.value)}
@@ -292,8 +503,9 @@ export function LpDesk() {
           id="lp-withdrawal-help"
           className="mt-2 text-xs text-[var(--t-muted)]"
         >
-          Withdraw tUSD, not shares, up to your authoritative immediately
-          withdrawable limit. This limit is separate from global free liquidity.
+          {isFrozen
+            ? "Withdrawals are blocked while share operations are frozen."
+            : "Withdraw tUSD, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity."}
         </p>
         {withdrawalValidationError ? (
           <p
@@ -305,7 +517,7 @@ export function LpDesk() {
           </p>
         ) : null}
         <button
-          className="mt-4 rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
+          className="mt-4 bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
           disabled={!canWithdraw}
           type="submit"
         >
@@ -313,7 +525,9 @@ export function LpDesk() {
             ? "Withdrawal submitting…"
             : vault.status === "withdrawal-pending"
               ? "Withdrawal pending…"
-              : "Withdraw tUSD"}
+              : isFrozen
+                ? "Withdrawals frozen"
+                : "Withdraw tUSD"}
         </button>
       </form>
 
@@ -337,7 +551,7 @@ export function LpDesk() {
       ) : null}
       {vault.canRetry ? (
         <button
-          className="mt-3 rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
+          className="mt-3 border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
           onClick={() => void vault.retry()}
           type="button"
         >

--- a/src/hooks/use-bankroll-vault-deposit.test.tsx
+++ b/src/hooks/use-bankroll-vault-deposit.test.tsx
@@ -28,6 +28,11 @@ const readyValues = (allowance = 0n) => ({
   safetyBuffer: 5000000000n,
   freeLiquidity: 20000000000n,
   maxWithdraw: 20000000000n,
+  shareOperationsFrozen: false,
+  realizedGamePnl: 0n,
+  blockingRounds: [],
+  utilizationBps: 0n,
+  tierCapacity: [],
 });
 
 vi.mock("@/lib/base-sepolia", () => ({

--- a/src/hooks/use-bankroll-vault-deposit.ts
+++ b/src/hooks/use-bankroll-vault-deposit.ts
@@ -424,11 +424,13 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
       !!config &&
       !!walletAddress &&
       (state.status === "ready" || canSubmitAfterError) &&
+      !state.shareOperationsFrozen &&
       !inFlight.current,
     canWithdraw:
       !!config &&
       !!walletAddress &&
       (state.status === "ready" || canSubmitAfterError) &&
+      !state.shareOperationsFrozen &&
       !inFlight.current,
     canRetry:
       state.status === "error" &&
@@ -439,5 +441,6 @@ export function useBankrollVaultDeposit(walletAddress: Address | null) {
     deposit,
     withdraw,
     retry,
+    refresh,
   };
 }

--- a/src/hooks/use-lp-freeze-actions.test.tsx
+++ b/src/hooks/use-lp-freeze-actions.test.tsx
@@ -33,16 +33,6 @@ vi.mock("@/lib/inco-attestation", () => ({
   requestCrashAttestation: sdk.requestCrashAttestation,
 }));
 
-vi.mock("@/lib/bankroll-vault", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/bankroll-vault")>(
-    "@/lib/bankroll-vault"
-  );
-  return {
-    ...actual,
-    readCrashRoundForLp: sdk.readCrashRoundForLp,
-  };
-});
-
 vi.mock("@/lib/margin-call-crash", async () => {
   const actual = await vi.importActual<
     typeof import("@/lib/margin-call-crash")
@@ -53,6 +43,7 @@ vi.mock("@/lib/margin-call-crash", async () => {
       address: "0x00000000000000000000000000000000000000c8",
       deploymentBlock: 1n,
     }),
+    readCrashRoundForLp: sdk.readCrashRoundForLp,
   };
 });
 
@@ -88,8 +79,7 @@ describe("useLpFreezeActions", () => {
       totalMargin: 1n,
       reservedPayout: 1n,
     });
-    const onResolved = vi.fn();
-    const { result } = renderHook(() => useLpFreezeActions(onResolved));
+    const { result } = renderHook(() => useLpFreezeActions());
 
     await act(async () => {
       await result.current.finalizeRound(7n);
@@ -98,7 +88,6 @@ describe("useLpFreezeActions", () => {
     expect(sdk.requestCrashAttestation).toHaveBeenCalled();
     expect(sdk.transaction.submit).toHaveBeenCalled();
     expect(sdk.notifyWalletBalancesChanged).toHaveBeenCalled();
-    expect(onResolved).toHaveBeenCalled();
     expect(result.current.status).toBe("confirmed");
   });
 

--- a/src/hooks/use-lp-freeze-actions.test.tsx
+++ b/src/hooks/use-lp-freeze-actions.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Hex } from "viem";
+
+const sdk = vi.hoisted(() => ({
+  transaction: {
+    submit: vi.fn(async () => true),
+    getSubmittedHash: vi.fn(
+      () =>
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const
+    ),
+    getSubmissionError: vi.fn(() => null),
+  },
+  wait: vi.fn(async () => ({ status: "success" as const })),
+  requestCrashAttestation: vi.fn(async () => ({
+    plaintext: 2_080n,
+    signatures: ["0x01"] as Hex[],
+  })),
+  readCrashRoundForLp: vi.fn(),
+  notifyWalletBalancesChanged: vi.fn(),
+}));
+
+vi.mock("@/lib/base-sepolia", () => ({
+  BASE_SEPOLIA_CHAIN_ID: 84532,
+  baseSepoliaPublicClient: {
+    waitForTransactionReceipt: sdk.wait,
+  },
+}));
+
+vi.mock("@/lib/inco-attestation", () => ({
+  requestCrashAttestation: sdk.requestCrashAttestation,
+}));
+
+vi.mock("@/lib/bankroll-vault", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/bankroll-vault")>(
+    "@/lib/bankroll-vault"
+  );
+  return {
+    ...actual,
+    readCrashRoundForLp: sdk.readCrashRoundForLp,
+  };
+});
+
+vi.mock("@/lib/margin-call-crash", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/margin-call-crash")
+  >("@/lib/margin-call-crash");
+  return {
+    ...actual,
+    getMarginCallCrashConfig: () => ({
+      address: "0x00000000000000000000000000000000000000c8",
+      deploymentBlock: 1n,
+    }),
+  };
+});
+
+vi.mock("@/lib/wallet-balance-sync", () => ({
+  notifyWalletBalancesChanged: () => sdk.notifyWalletBalancesChanged(),
+}));
+
+vi.mock("./use-privy-sponsored-transaction", () => ({
+  usePrivySponsoredTransaction: () => sdk.transaction,
+}));
+
+import { useLpFreezeActions } from "./use-lp-freeze-actions";
+
+describe("useLpFreezeActions", () => {
+  beforeEach(() => {
+    sdk.transaction.submit.mockClear().mockResolvedValue(true);
+    sdk.wait.mockClear().mockResolvedValue({ status: "success" });
+    sdk.requestCrashAttestation.mockClear();
+    sdk.readCrashRoundForLp.mockReset();
+    sdk.notifyWalletBalancesChanged.mockClear();
+  });
+
+  it("finalizes a reveal-frozen blocker after attestation", async () => {
+    sdk.readCrashRoundForLp.mockResolvedValue({
+      id: 7n,
+      status: 2,
+      crashRandom:
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      openAt: 1n,
+      lockAt: 2n,
+      expiresAt: 3n,
+      crashPointBps: 0n,
+      totalMargin: 1n,
+      reservedPayout: 1n,
+    });
+    const onResolved = vi.fn();
+    const { result } = renderHook(() => useLpFreezeActions(onResolved));
+
+    await act(async () => {
+      await result.current.finalizeRound(7n);
+    });
+
+    expect(sdk.requestCrashAttestation).toHaveBeenCalled();
+    expect(sdk.transaction.submit).toHaveBeenCalled();
+    expect(sdk.notifyWalletBalancesChanged).toHaveBeenCalled();
+    expect(onResolved).toHaveBeenCalled();
+    expect(result.current.status).toBe("confirmed");
+  });
+
+  it("expires an expiry-eligible blocker without attestation", async () => {
+    const { result } = renderHook(() => useLpFreezeActions());
+
+    await act(async () => {
+      await result.current.resolveBlockingRound({
+        roundId: 3n,
+        expiresAt: 1n,
+        revealFrozen: false,
+        expiryEligible: true,
+      });
+    });
+
+    expect(sdk.requestCrashAttestation).not.toHaveBeenCalled();
+    expect(sdk.transaction.submit).toHaveBeenCalled();
+    await waitFor(() => expect(result.current.status).toBe("confirmed"));
+  });
+
+  it("retries an unresolved finalize receipt instead of resubmitting", async () => {
+    sdk.readCrashRoundForLp.mockResolvedValue({
+      id: 7n,
+      status: 2,
+      crashRandom:
+        "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      openAt: 1n,
+      lockAt: 2n,
+      expiresAt: 3n,
+      crashPointBps: 0n,
+      totalMargin: 1n,
+      reservedPayout: 1n,
+    });
+    sdk.wait
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce({ status: "success" });
+    const { result } = renderHook(() => useLpFreezeActions());
+
+    await act(async () => {
+      await result.current.finalizeRound(7n);
+    });
+    expect(result.current.status).toBe("error");
+    expect(result.current.retryAction).toBe("finalize-receipt-check");
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.transaction.submit).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe("confirmed");
+  });
+});

--- a/src/hooks/use-lp-freeze-actions.ts
+++ b/src/hooks/use-lp-freeze-actions.ts
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { encodeFunctionData, type Address, type Hex } from "viem";
+import { requestCrashAttestation } from "@/lib/inco-attestation";
+import {
+  readCrashRoundForLp,
+  type BlockingRoundDetail,
+} from "@/lib/bankroll-vault";
+import {
+  getMarginCallCrashConfig,
+  marginCallCrashAbi,
+  ROUND_STATUS,
+} from "@/lib/margin-call-crash";
+import {
+  applyStageResult,
+  confirmSponsoredCall,
+  submitSponsoredCall,
+  type StageErrorCopy,
+} from "@/lib/sponsored-call";
+import { notifyWalletBalancesChanged } from "@/lib/wallet-balance-sync";
+import { usePrivySponsoredTransaction } from "./use-privy-sponsored-transaction";
+
+type Stage = "finalize" | "expire";
+
+export type LpFreezeActionStatus =
+  | "idle"
+  | "attesting"
+  | `${Stage}-submitting`
+  | `${Stage}-pending`
+  | "confirmed"
+  | "error";
+
+export type LpFreezeRetryAction =
+  "finalize" | "expire" | "finalize-receipt-check" | "expire-receipt-check";
+
+const stageCopy: Record<Stage, StageErrorCopy> = {
+  finalize: {
+    failed: "We couldn't finalize the blocking round. Please try again.",
+    unconfirmed:
+      "Finalization was submitted, but we couldn't confirm it yet. Retry to check its status.",
+  },
+  expire: {
+    failed: "We couldn't expire the blocking round. Please try again.",
+    unconfirmed:
+      "Expiry was submitted, but we couldn't confirm it yet. Retry to check its status.",
+  },
+};
+
+/**
+ * Drives LP Desk one-click finalize/expire against a blocking round using the
+ * same sponsored receipt-confirmed stage machine as player settlement.
+ */
+export function useLpFreezeActions(onResolved?: () => void) {
+  const transaction = usePrivySponsoredTransaction();
+  const gameConfig = getMarginCallCrashConfig();
+  const [status, setStatus] = useState<LpFreezeActionStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [activeRoundId, setActiveRoundId] = useState<bigint | null>(null);
+  const inFlight = useRef(false);
+  const retryKind = useRef<Stage | null>(null);
+  const retryRoundId = useRef<bigint | null>(null);
+  const pendingStage = useRef<{ stage: Stage; hash: Hex } | null>(null);
+
+  const runStage = useCallback(
+    async (stage: Stage, request: { to: Address; data: Hex }) => {
+      retryKind.current = stage;
+      setStatus(`${stage}-submitting`);
+      setError(null);
+      const result = await submitSponsoredCall(transaction, request, (hash) => {
+        pendingStage.current = { stage, hash };
+        setStatus(`${stage}-pending`);
+      });
+      applyStageResult(pendingStage, stageCopy[stage], result);
+    },
+    [transaction]
+  );
+
+  const finalizeRound = useCallback(
+    async (roundId: bigint): Promise<boolean> => {
+      if (!gameConfig || inFlight.current) return false;
+      if (pendingStage.current) return false;
+      inFlight.current = true;
+      retryRoundId.current = roundId;
+      setActiveRoundId(roundId);
+      try {
+        const round = await readCrashRoundForLp(roundId);
+        if (!round) throw new Error("Blocking round is no longer available.");
+        if (round.status !== ROUND_STATUS.revealRequested) {
+          throw new Error(
+            "This round is not awaiting finalization. Expire it if it is past expiry."
+          );
+        }
+        setStatus("attesting");
+        setError(null);
+        const attestation = await requestCrashAttestation(round.crashRandom);
+        await runStage("finalize", {
+          to: gameConfig.address,
+          data: encodeFunctionData({
+            abi: marginCallCrashAbi,
+            functionName: "finalizeRound",
+            args: [roundId, attestation.plaintext, attestation.signatures],
+          }) as Hex,
+        });
+        setStatus("confirmed");
+        notifyWalletBalancesChanged();
+        onResolved?.();
+        return true;
+      } catch (caught) {
+        setStatus("error");
+        setError(
+          caught instanceof Error ? caught.message : stageCopy.finalize.failed
+        );
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [gameConfig, onResolved, runStage]
+  );
+
+  const expireRound = useCallback(
+    async (roundId: bigint): Promise<boolean> => {
+      if (!gameConfig || inFlight.current) return false;
+      if (pendingStage.current) return false;
+      inFlight.current = true;
+      retryRoundId.current = roundId;
+      setActiveRoundId(roundId);
+      try {
+        await runStage("expire", {
+          to: gameConfig.address,
+          data: encodeFunctionData({
+            abi: marginCallCrashAbi,
+            functionName: "expireRound",
+            args: [roundId],
+          }) as Hex,
+        });
+        setStatus("confirmed");
+        notifyWalletBalancesChanged();
+        onResolved?.();
+        return true;
+      } catch (caught) {
+        setStatus("error");
+        setError(
+          caught instanceof Error ? caught.message : stageCopy.expire.failed
+        );
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [gameConfig, onResolved, runStage]
+  );
+
+  const resolveBlockingRound = useCallback(
+    (round: BlockingRoundDetail) => {
+      if (round.expiryEligible) return expireRound(round.roundId);
+      if (round.revealFrozen) return finalizeRound(round.roundId);
+      return Promise.resolve(false);
+    },
+    [expireRound, finalizeRound]
+  );
+
+  const retry = useCallback(async (): Promise<boolean> => {
+    if (inFlight.current) return false;
+    const pending = pendingStage.current;
+    if (pending) {
+      inFlight.current = true;
+      setActiveRoundId(retryRoundId.current);
+      try {
+        setStatus(`${pending.stage}-pending`);
+        setError(null);
+        applyStageResult(
+          pendingStage,
+          stageCopy[pending.stage],
+          await confirmSponsoredCall(pending.hash)
+        );
+        setStatus("confirmed");
+        notifyWalletBalancesChanged();
+        onResolved?.();
+        return true;
+      } catch (caught) {
+        setStatus("error");
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : stageCopy[pending.stage].failed
+        );
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    }
+    const roundId = retryRoundId.current;
+    if (roundId === null || retryKind.current === null) return false;
+    return retryKind.current === "expire"
+      ? expireRound(roundId)
+      : finalizeRound(roundId);
+  }, [expireRound, finalizeRound, onResolved]);
+
+  const pendingReceiptStage = pendingStage.current?.stage ?? null;
+  const retryAction: LpFreezeRetryAction | null =
+    retryKind.current === null
+      ? null
+      : pendingReceiptStage
+        ? `${pendingReceiptStage}-receipt-check`
+        : retryKind.current;
+
+  return {
+    status,
+    error,
+    activeRoundId,
+    canAct: !!gameConfig && !inFlight.current && pendingStage.current === null,
+    canRetry:
+      status === "error" && retryKind.current !== null && !inFlight.current,
+    retryAction,
+    finalizeRound,
+    expireRound,
+    resolveBlockingRound,
+    retry,
+  };
+}

--- a/src/hooks/use-lp-freeze-actions.ts
+++ b/src/hooks/use-lp-freeze-actions.ts
@@ -1,21 +1,18 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { encodeFunctionData, type Address, type Hex } from "viem";
+import { encodeFunctionData, type Hex } from "viem";
 import { requestCrashAttestation } from "@/lib/inco-attestation";
-import {
-  readCrashRoundForLp,
-  type BlockingRoundDetail,
-} from "@/lib/bankroll-vault";
+import type { BlockingRoundDetail } from "@/lib/bankroll-vault";
 import {
   getMarginCallCrashConfig,
   marginCallCrashAbi,
+  readCrashRoundForLp,
   ROUND_STATUS,
 } from "@/lib/margin-call-crash";
 import {
-  applyStageResult,
-  confirmSponsoredCall,
-  submitSponsoredCall,
+  resumeSponsoredStage,
+  runSponsoredStage,
   type StageErrorCopy,
 } from "@/lib/sponsored-call";
 import { notifyWalletBalancesChanged } from "@/lib/wallet-balance-sync";
@@ -49,9 +46,10 @@ const stageCopy: Record<Stage, StageErrorCopy> = {
 
 /**
  * Drives LP Desk one-click finalize/expire against a blocking round using the
- * same sponsored receipt-confirmed stage machine as player settlement.
+ * same sponsored receipt-confirmed stage machine as player settlement. On
+ * success it notifies wallet-balance subscribers, which re-read vault state.
  */
-export function useLpFreezeActions(onResolved?: () => void) {
+export function useLpFreezeActions() {
   const transaction = usePrivySponsoredTransaction();
   const gameConfig = getMarginCallCrashConfig();
   const [status, setStatus] = useState<LpFreezeActionStatus>("idle");
@@ -62,28 +60,47 @@ export function useLpFreezeActions(onResolved?: () => void) {
   const retryRoundId = useRef<bigint | null>(null);
   const pendingStage = useRef<{ stage: Stage; hash: Hex } | null>(null);
 
-  const runStage = useCallback(
-    async (stage: Stage, request: { to: Address; data: Hex }) => {
-      retryKind.current = stage;
-      setStatus(`${stage}-submitting`);
-      setError(null);
-      const result = await submitSponsoredCall(transaction, request, (hash) => {
-        pendingStage.current = { stage, hash };
-        setStatus(`${stage}-pending`);
-      });
-      applyStageResult(pendingStage, stageCopy[stage], result);
-    },
-    [transaction]
-  );
-
-  const finalizeRound = useCallback(
-    async (roundId: bigint): Promise<boolean> => {
-      if (!gameConfig || inFlight.current) return false;
-      if (pendingStage.current) return false;
+  const runAction = useCallback(
+    async (
+      stage: Stage,
+      roundId: bigint,
+      prepareCallData: () => Promise<Hex>
+    ): Promise<boolean> => {
+      if (!gameConfig || inFlight.current || pendingStage.current) return false;
       inFlight.current = true;
       retryRoundId.current = roundId;
       setActiveRoundId(roundId);
+      setError(null);
       try {
+        const data = await prepareCallData();
+        retryKind.current = stage;
+        await runSponsoredStage<Stage>({
+          transaction,
+          pendingStage,
+          stage,
+          copy: stageCopy[stage],
+          request: { to: gameConfig.address, data },
+          onStatus: setStatus,
+        });
+        setStatus("confirmed");
+        notifyWalletBalancesChanged();
+        return true;
+      } catch (caught) {
+        setStatus("error");
+        setError(
+          caught instanceof Error ? caught.message : stageCopy[stage].failed
+        );
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [gameConfig, transaction]
+  );
+
+  const finalizeRound = useCallback(
+    (roundId: bigint) =>
+      runAction("finalize", roundId, async () => {
         const round = await readCrashRoundForLp(roundId);
         if (!round) throw new Error("Blocking round is no longer available.");
         if (round.status !== ROUND_STATUS.revealRequested) {
@@ -92,64 +109,29 @@ export function useLpFreezeActions(onResolved?: () => void) {
           );
         }
         setStatus("attesting");
-        setError(null);
         const attestation = await requestCrashAttestation(round.crashRandom);
-        await runStage("finalize", {
-          to: gameConfig.address,
-          data: encodeFunctionData({
-            abi: marginCallCrashAbi,
-            functionName: "finalizeRound",
-            args: [roundId, attestation.plaintext, attestation.signatures],
-          }) as Hex,
-        });
-        setStatus("confirmed");
-        notifyWalletBalancesChanged();
-        onResolved?.();
-        return true;
-      } catch (caught) {
-        setStatus("error");
-        setError(
-          caught instanceof Error ? caught.message : stageCopy.finalize.failed
-        );
-        return false;
-      } finally {
-        inFlight.current = false;
-      }
-    },
-    [gameConfig, onResolved, runStage]
+        return encodeFunctionData({
+          abi: marginCallCrashAbi,
+          functionName: "finalizeRound",
+          args: [roundId, attestation.plaintext, attestation.signatures],
+        }) as Hex;
+      }),
+    [runAction]
   );
 
   const expireRound = useCallback(
-    async (roundId: bigint): Promise<boolean> => {
-      if (!gameConfig || inFlight.current) return false;
-      if (pendingStage.current) return false;
-      inFlight.current = true;
-      retryRoundId.current = roundId;
-      setActiveRoundId(roundId);
-      try {
-        await runStage("expire", {
-          to: gameConfig.address,
-          data: encodeFunctionData({
+    (roundId: bigint) =>
+      runAction(
+        "expire",
+        roundId,
+        async () =>
+          encodeFunctionData({
             abi: marginCallCrashAbi,
             functionName: "expireRound",
             args: [roundId],
-          }) as Hex,
-        });
-        setStatus("confirmed");
-        notifyWalletBalancesChanged();
-        onResolved?.();
-        return true;
-      } catch (caught) {
-        setStatus("error");
-        setError(
-          caught instanceof Error ? caught.message : stageCopy.expire.failed
-        );
-        return false;
-      } finally {
-        inFlight.current = false;
-      }
-    },
-    [gameConfig, onResolved, runStage]
+          }) as Hex
+      ),
+    [runAction]
   );
 
   const resolveBlockingRound = useCallback(
@@ -167,17 +149,15 @@ export function useLpFreezeActions(onResolved?: () => void) {
     if (pending) {
       inFlight.current = true;
       setActiveRoundId(retryRoundId.current);
+      setError(null);
       try {
-        setStatus(`${pending.stage}-pending`);
-        setError(null);
-        applyStageResult(
+        await resumeSponsoredStage({
           pendingStage,
-          stageCopy[pending.stage],
-          await confirmSponsoredCall(pending.hash)
-        );
+          copyByStage: stageCopy,
+          onStatus: setStatus,
+        });
         setStatus("confirmed");
         notifyWalletBalancesChanged();
-        onResolved?.();
         return true;
       } catch (caught) {
         setStatus("error");
@@ -196,7 +176,7 @@ export function useLpFreezeActions(onResolved?: () => void) {
     return retryKind.current === "expire"
       ? expireRound(roundId)
       : finalizeRound(roundId);
-  }, [expireRound, finalizeRound, onResolved]);
+  }, [expireRound, finalizeRound]);
 
   const pendingReceiptStage = pendingStage.current?.stage ?? null;
   const retryAction: LpFreezeRetryAction | null =

--- a/src/lib/bankroll-vault.test.ts
+++ b/src/lib/bankroll-vault.test.ts
@@ -91,14 +91,10 @@ describe("Bankroll Vault public configuration and reads", () => {
           return Promise.resolve(18_750_000_000n);
         case "realizedGamePnl":
           return Promise.resolve(-250_000n);
-        case "frozenRoundCount":
-          return Promise.resolve(0n);
         case "oldestBlockingRound":
           return Promise.resolve(noBlocking);
         case "shareOperationsFrozen":
           return Promise.resolve(false);
-        case "NO_BLOCKING_ROUND":
-          return Promise.resolve(noBlocking);
         case "maxWithdraw":
           return Promise.resolve(13n);
         default:
@@ -154,11 +150,9 @@ describe("Bankroll Vault public configuration and reads", () => {
       "safetyBuffer",
       "freeLiquidity",
       "realizedGamePnl",
-      "frozenRoundCount",
       "oldestBlockingRound",
       "shareOperationsFrozen",
-      "NO_BLOCKING_ROUND",
-      "roundExposure",
+      "reservedPayoutByRound",
     ];
     sdk.readContract.mockImplementation(({ functionName }) =>
       legacyViews.includes(functionName)

--- a/src/lib/bankroll-vault.test.ts
+++ b/src/lib/bankroll-vault.test.ts
@@ -1,18 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const sdk = vi.hoisted(() => ({ readContract: vi.fn() }));
+const sdk = vi.hoisted(() => ({
+  readContract: vi.fn(),
+  getBlock: vi.fn(),
+}));
 
 vi.mock("./base-sepolia", () => ({
   baseSepoliaPublicClient: {
     readContract: (...args: unknown[]) => sdk.readContract(...args),
+    getBlock: (...args: unknown[]) => sdk.getBlock(...args),
   },
 }));
+
+vi.mock("./margin-call-crash", async () => {
+  const actual = await vi.importActual<typeof import("./margin-call-crash")>(
+    "./margin-call-crash"
+  );
+  return {
+    ...actual,
+    getMarginCallCrashConfig: () => null,
+  };
+});
 
 describe("Bankroll Vault public configuration and reads", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
     sdk.readContract.mockReset();
+    sdk.getBlock.mockReset();
+    sdk.getBlock.mockResolvedValue({ number: 10n, timestamp: 1_000_000n });
   });
 
   it("requires statically named valid public tUSD and vault addresses", async () => {
@@ -38,7 +54,7 @@ describe("Bankroll Vault public configuration and reads", () => {
     expect(getBankrollVaultConfig()).toBeNull();
   });
 
-  it("reads the complete authoritative withdrawal state from the configured vault", async () => {
+  it("reads freeze, realized PnL, and risk views from the configured vault", async () => {
     vi.stubEnv(
       "NEXT_PUBLIC_DESK_DOLLARS_ADDRESS",
       "0x0000000000000000000000000000000000000001"
@@ -47,22 +63,55 @@ describe("Bankroll Vault public configuration and reads", () => {
       "NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS",
       "0x0000000000000000000000000000000000000002"
     );
-    sdk.readContract
-      .mockResolvedValueOnce(1n)
-      .mockResolvedValueOnce(2n)
-      .mockResolvedValueOnce(3n)
-      .mockResolvedValueOnce(4n)
-      .mockResolvedValueOnce(5n)
-      .mockResolvedValueOnce(6n)
-      .mockResolvedValueOnce(7n)
-      .mockResolvedValueOnce(8n)
-      .mockResolvedValueOnce(9n)
-      .mockResolvedValueOnce(10n)
-      .mockResolvedValueOnce(11n)
-      .mockResolvedValueOnce(12n)
-      .mockResolvedValueOnce(13n);
-    const { getBankrollVaultConfig, readBankrollVaultState } =
-      await import("./bankroll-vault");
+    const noBlocking =
+      0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
+    sdk.readContract.mockImplementation(({ functionName }) => {
+      switch (functionName) {
+        case "balanceOf":
+          return Promise.resolve(1n);
+        case "allowance":
+          return Promise.resolve(2n);
+        case "grossAssets":
+          return Promise.resolve(25_000_000_000n);
+        case "totalAssets":
+          return Promise.resolve(24_000_000_000n);
+        case "totalSupply":
+          return Promise.resolve(24_000_000_000n);
+        case "assetsPerShare":
+          return Promise.resolve(1_000_000n);
+        case "pendingObligations":
+          return Promise.resolve(0n);
+        case "unrecognizedMargin":
+          return Promise.resolve(0n);
+        case "reservedLiabilities":
+          return Promise.resolve(1_250_000_000n);
+        case "safetyBuffer":
+          return Promise.resolve(5_000_000_000n);
+        case "freeLiquidity":
+          return Promise.resolve(18_750_000_000n);
+        case "realizedGamePnl":
+          return Promise.resolve(-250_000n);
+        case "frozenRoundCount":
+          return Promise.resolve(0n);
+        case "oldestBlockingRound":
+          return Promise.resolve(noBlocking);
+        case "shareOperationsFrozen":
+          return Promise.resolve(false);
+        case "NO_BLOCKING_ROUND":
+          return Promise.resolve(noBlocking);
+        case "maxWithdraw":
+          return Promise.resolve(13n);
+        default:
+          return Promise.resolve(0n);
+      }
+    });
+    const {
+      getBankrollVaultConfig,
+      readBankrollVaultState,
+      computeUtilizationBps,
+      computeRemainingPayoutCapacity,
+      computeTierPlayerCapacity,
+    } = await import("./bankroll-vault");
     const config = getBankrollVaultConfig()!;
     await expect(
       readBankrollVaultState(
@@ -70,36 +119,25 @@ describe("Bankroll Vault public configuration and reads", () => {
         "0x0000000000000000000000000000000000000003"
       )
     ).resolves.toMatchObject({
-      reservedLiabilities: 10n,
-      safetyBuffer: 11n,
-      freeLiquidity: 12n,
+      reservedLiabilities: 1_250_000_000n,
+      realizedGamePnl: -250_000n,
+      shareOperationsFrozen: false,
       maxWithdraw: 13n,
+      utilizationBps: 500n,
+      blockingRounds: [],
     });
-    expect(sdk.readContract).toHaveBeenCalledTimes(13);
+    expect(computeUtilizationBps(1_250_000_000n, 25_000_000_000n)).toBe(500n);
     expect(
-      sdk.readContract.mock.calls.map(([request]) => request.functionName)
-    ).toEqual([
-      "balanceOf",
-      "balanceOf",
-      "allowance",
-      "grossAssets",
-      "totalAssets",
-      "totalSupply",
-      "assetsPerShare",
-      "pendingObligations",
-      "unrecognizedMargin",
-      "reservedLiabilities",
-      "safetyBuffer",
-      "freeLiquidity",
-      "maxWithdraw",
-    ]);
-    expect(sdk.readContract).toHaveBeenNthCalledWith(
-      13,
-      expect.objectContaining({
-        address: config.vaultAddress,
-        args: ["0x0000000000000000000000000000000000000003"],
+      computeRemainingPayoutCapacity({
+        grossAssets: 25_000_000_000n,
+        freeLiquidity: 18_750_000_000n,
+        roundExposure: 0n,
       })
-    );
+    ).toBe(100_000_000n);
+    expect(computeTierPlayerCapacity(100_000_000n)[0]).toMatchObject({
+      label: "1.25x",
+      maxMargin: 80_000_000n,
+    });
   });
 
   it("degrades the liquidity views a not-yet-redeployed vault lacks instead of failing the load", async () => {
@@ -115,6 +153,12 @@ describe("Bankroll Vault public configuration and reads", () => {
       "reservedLiabilities",
       "safetyBuffer",
       "freeLiquidity",
+      "realizedGamePnl",
+      "frozenRoundCount",
+      "oldestBlockingRound",
+      "shareOperationsFrozen",
+      "NO_BLOCKING_ROUND",
+      "roundExposure",
     ];
     sdk.readContract.mockImplementation(({ functionName }) =>
       legacyViews.includes(functionName)
@@ -133,7 +177,10 @@ describe("Bankroll Vault public configuration and reads", () => {
       reservedLiabilities: undefined,
       safetyBuffer: undefined,
       freeLiquidity: undefined,
+      realizedGamePnl: undefined,
+      shareOperationsFrozen: false,
       maxWithdraw: 1n,
+      blockingRounds: [],
     });
   });
 });

--- a/src/lib/bankroll-vault.ts
+++ b/src/lib/bankroll-vault.ts
@@ -5,9 +5,9 @@ import {
   ENTRY_LEVERAGE_TIERS_BPS,
   formatLeverageBps,
   getMarginCallCrashConfig,
+  LEVERAGE_SCALE,
   marginCallCrashAbi,
-  ROUND_STATUS,
-  type CrashRound,
+  ONE_TUSD,
 } from "./margin-call-crash";
 
 // Standard ERC-20/4626 entries come from viem; only the vault-specific
@@ -72,13 +72,6 @@ export const bankrollVaultAbi = [
   },
   {
     type: "function",
-    name: "frozenRoundCount",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ name: "", type: "uint256" }],
-  },
-  {
-    type: "function",
     name: "oldestBlockingRound",
     stateMutability: "view",
     inputs: [],
@@ -93,14 +86,7 @@ export const bankrollVaultAbi = [
   },
   {
     type: "function",
-    name: "NO_BLOCKING_ROUND",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [{ name: "", type: "uint256" }],
-  },
-  {
-    type: "function",
-    name: "roundExposure",
+    name: "reservedPayoutByRound",
     stateMutability: "view",
     inputs: [{ name: "roundId", type: "uint256" }],
     outputs: [{ name: "", type: "uint256" }],
@@ -123,9 +109,8 @@ export const bankrollVaultAbi = [
 export const NO_BLOCKING_ROUND =
   0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
 
-const ONE_TUSD = 1_000_000n;
+/** Mirrors BankrollVault.MAX_TICKET_RESERVATION. */
 const MAX_TICKET_RESERVATION = 100n * ONE_TUSD;
-const LEVERAGE_SCALE = 10_000n;
 
 export type BankrollVaultConfig = {
   tokenAddress: Address;
@@ -168,21 +153,16 @@ type VaultViewName =
   | "safetyBuffer"
   | "freeLiquidity"
   | "realizedGamePnl"
-  | "frozenRoundCount"
-  | "oldestBlockingRound"
-  | "NO_BLOCKING_ROUND";
+  | "oldestBlockingRound";
 
 /**
  * Utilization of vault capacity by reserved liabilities, in basis points of
  * gross assets. Advisory display only.
  */
 export function computeUtilizationBps(
-  reservedLiabilities: bigint | undefined,
-  grossAssets: bigint | undefined
-): bigint | undefined {
-  if (reservedLiabilities === undefined || grossAssets === undefined) {
-    return undefined;
-  }
+  reservedLiabilities: bigint,
+  grossAssets: bigint
+): bigint {
   if (grossAssets === 0n) return 0n;
   return (reservedLiabilities * LEVERAGE_SCALE) / grossAssets;
 }
@@ -225,19 +205,12 @@ export function computeTierPlayerCapacity(
 export async function readBlockingRounds(
   config: BankrollVaultConfig,
   chainTimestamp: bigint,
-  noBlockingRound: bigint = NO_BLOCKING_ROUND
+  oldestBlockingRound: bigint
 ): Promise<BlockingRoundDetail[]> {
-  const oldest = await baseSepoliaPublicClient.readContract({
-    address: config.vaultAddress,
-    abi: bankrollVaultAbi,
-    functionName: "oldestBlockingRound",
-  });
-  if (oldest === noBlockingRound) return [];
-
   const rounds: BlockingRoundDetail[] = [];
-  let cursor = oldest;
+  let cursor = oldestBlockingRound;
   // Bound the walk so a corrupted list cannot hang the LP Desk.
-  for (let i = 0; i < 256 && cursor !== noBlockingRound; i++) {
+  for (let i = 0; i < 256 && cursor !== NO_BLOCKING_ROUND; i++) {
     const [present, expiresAt, revealFrozen, nextRoundId] =
       await baseSepoliaPublicClient.readContract({
         address: config.vaultAddress,
@@ -272,9 +245,10 @@ export async function readBankrollVaultState(
     readVault(functionName).catch(() => undefined);
 
   const gameConfig = getMarginCallCrashConfig();
-  const block = await baseSepoliaPublicClient.getBlock({ blockTag: "latest" });
 
+  // One batched round trip: the block plus every independent token/vault view.
   const [
+    block,
     tUsdBalance,
     shareBalance,
     allowance,
@@ -288,12 +262,11 @@ export async function readBankrollVaultState(
     safetyBuffer,
     freeLiquidity,
     realizedGamePnl,
-    frozenRoundCount,
     oldestBlockingRound,
-    noBlockingRound,
+    shareOperationsFrozen,
     maxWithdraw,
-    currentRoundId,
   ] = await Promise.all([
+    baseSepoliaPublicClient.getBlock({ blockTag: "latest" }),
     baseSepoliaPublicClient.readContract({
       address: config.tokenAddress,
       abi: deskDollarsAbi,
@@ -322,56 +295,61 @@ export async function readBankrollVaultState(
     readVaultIfDeployed("safetyBuffer"),
     readVaultIfDeployed("freeLiquidity"),
     readVaultIfDeployed("realizedGamePnl"),
-    readVaultIfDeployed("frozenRoundCount"),
     readVaultIfDeployed("oldestBlockingRound"),
-    readVaultIfDeployed("NO_BLOCKING_ROUND"),
+    baseSepoliaPublicClient
+      .readContract({
+        address: config.vaultAddress,
+        abi: bankrollVaultAbi,
+        functionName: "shareOperationsFrozen",
+      })
+      .catch(() => undefined),
     baseSepoliaPublicClient.readContract({
       address: config.vaultAddress,
       abi: bankrollVaultAbi,
       functionName: "maxWithdraw",
       args: [walletAddress],
     }),
-    gameConfig
-      ? baseSepoliaPublicClient
-          .readContract({
-            address: gameConfig.address,
-            abi: marginCallCrashAbi,
-            functionName: "currentRoundId",
-            blockNumber: block.number,
-          })
-          .catch(() => undefined)
-      : Promise.resolve(undefined),
   ]);
 
-  const shareOperationsFrozen = await baseSepoliaPublicClient
-    .readContract({
-      address: config.vaultAddress,
-      abi: bankrollVaultAbi,
-      functionName: "shareOperationsFrozen",
-    })
-    .catch(() => undefined);
-
-  const sentinel = noBlockingRound ?? NO_BLOCKING_ROUND;
-  const roundExposure =
-    currentRoundId === undefined
-      ? undefined
-      : await baseSepoliaPublicClient
-          .readContract({
-            address: config.vaultAddress,
-            abi: bankrollVaultAbi,
-            functionName: "roundExposure",
-            args: [currentRoundId],
-          })
-          .catch(() => undefined);
-
-  const shouldLoadBlockers =
-    shareOperationsFrozen === true ||
-    (oldestBlockingRound !== undefined && oldestBlockingRound !== sentinel);
-  const blockingRounds = shouldLoadBlockers
-    ? await readBlockingRounds(config, block.timestamp, sentinel).catch(
-        () => []
-      )
-    : [];
+  // Dependent reads run concurrently: the current round's exposure and the
+  // blocking-round walk only need results from the batch above.
+  const readCurrentRoundExposure = async () => {
+    if (!gameConfig)
+      return { currentRoundId: undefined, roundExposure: undefined };
+    const currentRoundId = await baseSepoliaPublicClient
+      .readContract({
+        address: gameConfig.address,
+        abi: marginCallCrashAbi,
+        functionName: "currentRoundId",
+        blockNumber: block.number,
+      })
+      .catch(() => undefined);
+    if (currentRoundId === undefined) {
+      return { currentRoundId, roundExposure: undefined };
+    }
+    const roundExposure = await baseSepoliaPublicClient
+      .readContract({
+        address: config.vaultAddress,
+        abi: bankrollVaultAbi,
+        functionName: "reservedPayoutByRound",
+        args: [currentRoundId],
+      })
+      .catch(() => undefined);
+    return { currentRoundId, roundExposure };
+  };
+  const [{ currentRoundId, roundExposure }, blockingRounds] = await Promise.all(
+    [
+      readCurrentRoundExposure(),
+      oldestBlockingRound !== undefined &&
+      oldestBlockingRound !== NO_BLOCKING_ROUND
+        ? readBlockingRounds(
+            config,
+            block.timestamp,
+            oldestBlockingRound
+          ).catch(() => [])
+        : Promise.resolve<BlockingRoundDetail[]>([]),
+    ]
+  );
 
   const utilizationBps =
     reservedLiabilities !== undefined
@@ -392,14 +370,6 @@ export async function readBankrollVaultState(
       ? computeTierPlayerCapacity(remainingPayoutCapacity)
       : undefined;
 
-  const earliestExpiry =
-    blockingRounds.length > 0
-      ? blockingRounds.reduce(
-          (min, round) => (round.expiresAt < min ? round.expiresAt : min),
-          blockingRounds[0]!.expiresAt
-        )
-      : undefined;
-
   return {
     tUsdBalance,
     shareBalance,
@@ -414,38 +384,15 @@ export async function readBankrollVaultState(
     safetyBuffer,
     freeLiquidity,
     realizedGamePnl,
-    frozenRoundCount,
-    oldestBlockingRound,
     shareOperationsFrozen: shareOperationsFrozen ?? false,
-    noBlockingRound: sentinel,
     maxWithdraw,
     currentRoundId,
     roundExposure,
     blockingRounds,
-    earliestExpiry,
     utilizationBps,
     remainingPayoutCapacity,
     tierCapacity,
     chainTimestamp: block.timestamp,
-  };
-}
-
-/** Loads a game round for LP finalize/expire actions. */
-export async function readCrashRoundForLp(
-  roundId: bigint
-): Promise<CrashRound | null> {
-  const gameConfig = getMarginCallCrashConfig();
-  if (!gameConfig) return null;
-  const round = await baseSepoliaPublicClient.readContract({
-    address: gameConfig.address,
-    abi: marginCallCrashAbi,
-    functionName: "getRound",
-    args: [roundId],
-  });
-  if (round.status === ROUND_STATUS.uninitialized) return null;
-  return {
-    ...round,
-    status: round.status as CrashRound["status"],
   };
 }
 

--- a/src/lib/bankroll-vault.ts
+++ b/src/lib/bankroll-vault.ts
@@ -1,6 +1,14 @@
 import { erc4626Abi, isAddress, type Address } from "viem";
 import { baseSepoliaPublicClient } from "./base-sepolia";
 import { deskDollarsAbi, getDeskDollarsTokenAddress } from "./desk-dollars";
+import {
+  ENTRY_LEVERAGE_TIERS_BPS,
+  formatLeverageBps,
+  getMarginCallCrashConfig,
+  marginCallCrashAbi,
+  ROUND_STATUS,
+  type CrashRound,
+} from "./margin-call-crash";
 
 // Standard ERC-20/4626 entries come from viem; only the vault-specific
 // accounting views need hand-written fragments.
@@ -55,11 +63,88 @@ export const bankrollVaultAbi = [
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
   },
+  {
+    type: "function",
+    name: "realizedGamePnl",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "int256" }],
+  },
+  {
+    type: "function",
+    name: "frozenRoundCount",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "oldestBlockingRound",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "shareOperationsFrozen",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "NO_BLOCKING_ROUND",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "roundExposure",
+    stateMutability: "view",
+    inputs: [{ name: "roundId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "getBlockingRound",
+    stateMutability: "view",
+    inputs: [{ name: "roundId", type: "uint256" }],
+    outputs: [
+      { name: "present", type: "bool" },
+      { name: "expiresAt", type: "uint64" },
+      { name: "revealFrozen", type: "bool" },
+      { name: "nextRoundId", type: "uint256" },
+    ],
+  },
 ] as const;
+
+/** Sentinel matching BankrollVault.NO_BLOCKING_ROUND. */
+export const NO_BLOCKING_ROUND =
+  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
+
+const ONE_TUSD = 1_000_000n;
+const MAX_TICKET_RESERVATION = 100n * ONE_TUSD;
+const LEVERAGE_SCALE = 10_000n;
 
 export type BankrollVaultConfig = {
   tokenAddress: Address;
   vaultAddress: Address;
+};
+
+export type BlockingRoundDetail = {
+  roundId: bigint;
+  expiresAt: bigint;
+  revealFrozen: boolean;
+  /** True when this round alone is past expiresAt and still unresolved. */
+  expiryEligible: boolean;
+};
+
+export type TierCapacity = {
+  leverageBps: bigint;
+  label: string;
+  /** Advisory maximum margin still admissible for one new ticket at this tier. */
+  maxMargin: bigint;
 };
 
 /** Public addresses only. Static access lets Next.js inline these in client builds. */
@@ -81,7 +166,96 @@ type VaultViewName =
   | "unrecognizedMargin"
   | "reservedLiabilities"
   | "safetyBuffer"
-  | "freeLiquidity";
+  | "freeLiquidity"
+  | "realizedGamePnl"
+  | "frozenRoundCount"
+  | "oldestBlockingRound"
+  | "NO_BLOCKING_ROUND";
+
+/**
+ * Utilization of vault capacity by reserved liabilities, in basis points of
+ * gross assets. Advisory display only.
+ */
+export function computeUtilizationBps(
+  reservedLiabilities: bigint | undefined,
+  grossAssets: bigint | undefined
+): bigint | undefined {
+  if (reservedLiabilities === undefined || grossAssets === undefined) {
+    return undefined;
+  }
+  if (grossAssets === 0n) return 0n;
+  return (reservedLiabilities * LEVERAGE_SCALE) / grossAssets;
+}
+
+/**
+ * Remaining payout headroom a new ticket may still reserve, capped by the
+ * per-ticket, per-round, and free-liquidity constraints. Advisory only.
+ */
+export function computeRemainingPayoutCapacity(args: {
+  grossAssets: bigint;
+  freeLiquidity: bigint;
+  roundExposure: bigint;
+}): bigint {
+  const { grossAssets, freeLiquidity, roundExposure } = args;
+  const ticketCap =
+    grossAssets / 100n < MAX_TICKET_RESERVATION
+      ? grossAssets / 100n
+      : MAX_TICKET_RESERVATION;
+  const roundCap = (() => {
+    const limit = (grossAssets * 25n) / 100n;
+    return limit > roundExposure ? limit - roundExposure : 0n;
+  })();
+  // Net new exposure is payout − margin; the smallest margin (1 tUSD) is the
+  // most payout-hungry case for a given free-liquidity budget.
+  const freeCap = freeLiquidity + ONE_TUSD;
+  return minBigint(ticketCap, roundCap, freeCap);
+}
+
+/** Advisory max margin at each Arcade Leverage tier from remaining payout capacity. */
+export function computeTierPlayerCapacity(
+  remainingPayoutCapacity: bigint
+): TierCapacity[] {
+  return ENTRY_LEVERAGE_TIERS_BPS.map((leverageBps) => ({
+    leverageBps,
+    label: formatLeverageBps(leverageBps),
+    maxMargin: (remainingPayoutCapacity * LEVERAGE_SCALE) / leverageBps,
+  }));
+}
+
+export async function readBlockingRounds(
+  config: BankrollVaultConfig,
+  chainTimestamp: bigint,
+  noBlockingRound: bigint = NO_BLOCKING_ROUND
+): Promise<BlockingRoundDetail[]> {
+  const oldest = await baseSepoliaPublicClient.readContract({
+    address: config.vaultAddress,
+    abi: bankrollVaultAbi,
+    functionName: "oldestBlockingRound",
+  });
+  if (oldest === noBlockingRound) return [];
+
+  const rounds: BlockingRoundDetail[] = [];
+  let cursor = oldest;
+  // Bound the walk so a corrupted list cannot hang the LP Desk.
+  for (let i = 0; i < 256 && cursor !== noBlockingRound; i++) {
+    const [present, expiresAt, revealFrozen, nextRoundId] =
+      await baseSepoliaPublicClient.readContract({
+        address: config.vaultAddress,
+        abi: bankrollVaultAbi,
+        functionName: "getBlockingRound",
+        args: [cursor],
+      });
+    if (!present) break;
+    rounds.push({
+      roundId: cursor,
+      expiresAt: BigInt(expiresAt),
+      revealFrozen,
+      expiryEligible: chainTimestamp >= BigInt(expiresAt),
+    });
+    cursor = nextRoundId;
+  }
+  return rounds;
+}
 
 export async function readBankrollVaultState(
   config: BankrollVaultConfig,
@@ -93,12 +267,13 @@ export async function readBankrollVaultState(
       abi: bankrollVaultAbi,
       functionName,
     });
-  // The deposits-only vault deployed today predates these accounting views.
-  // They degrade to undefined instead of failing the whole load, so the LP
-  // Desk (and deposits) keep working until the contract redeploy and the
-  // NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS cutover land.
+  // Newer freeze / risk views degrade when an older vault is still configured.
   const readVaultIfDeployed = (functionName: VaultViewName) =>
     readVault(functionName).catch(() => undefined);
+
+  const gameConfig = getMarginCallCrashConfig();
+  const block = await baseSepoliaPublicClient.getBlock({ blockTag: "latest" });
+
   const [
     tUsdBalance,
     shareBalance,
@@ -112,7 +287,12 @@ export async function readBankrollVaultState(
     reservedLiabilities,
     safetyBuffer,
     freeLiquidity,
+    realizedGamePnl,
+    frozenRoundCount,
+    oldestBlockingRound,
+    noBlockingRound,
     maxWithdraw,
+    currentRoundId,
   ] = await Promise.all([
     baseSepoliaPublicClient.readContract({
       address: config.tokenAddress,
@@ -141,13 +321,85 @@ export async function readBankrollVaultState(
     readVaultIfDeployed("reservedLiabilities"),
     readVaultIfDeployed("safetyBuffer"),
     readVaultIfDeployed("freeLiquidity"),
+    readVaultIfDeployed("realizedGamePnl"),
+    readVaultIfDeployed("frozenRoundCount"),
+    readVaultIfDeployed("oldestBlockingRound"),
+    readVaultIfDeployed("NO_BLOCKING_ROUND"),
     baseSepoliaPublicClient.readContract({
       address: config.vaultAddress,
       abi: bankrollVaultAbi,
       functionName: "maxWithdraw",
       args: [walletAddress],
     }),
+    gameConfig
+      ? baseSepoliaPublicClient
+          .readContract({
+            address: gameConfig.address,
+            abi: marginCallCrashAbi,
+            functionName: "currentRoundId",
+            blockNumber: block.number,
+          })
+          .catch(() => undefined)
+      : Promise.resolve(undefined),
   ]);
+
+  const shareOperationsFrozen = await baseSepoliaPublicClient
+    .readContract({
+      address: config.vaultAddress,
+      abi: bankrollVaultAbi,
+      functionName: "shareOperationsFrozen",
+    })
+    .catch(() => undefined);
+
+  const sentinel = noBlockingRound ?? NO_BLOCKING_ROUND;
+  const roundExposure =
+    currentRoundId === undefined
+      ? undefined
+      : await baseSepoliaPublicClient
+          .readContract({
+            address: config.vaultAddress,
+            abi: bankrollVaultAbi,
+            functionName: "roundExposure",
+            args: [currentRoundId],
+          })
+          .catch(() => undefined);
+
+  const shouldLoadBlockers =
+    shareOperationsFrozen === true ||
+    (oldestBlockingRound !== undefined && oldestBlockingRound !== sentinel);
+  const blockingRounds = shouldLoadBlockers
+    ? await readBlockingRounds(config, block.timestamp, sentinel).catch(
+        () => []
+      )
+    : [];
+
+  const utilizationBps =
+    reservedLiabilities !== undefined
+      ? computeUtilizationBps(reservedLiabilities, grossAssets)
+      : undefined;
+
+  const remainingPayoutCapacity =
+    freeLiquidity !== undefined && roundExposure !== undefined
+      ? computeRemainingPayoutCapacity({
+          grossAssets,
+          freeLiquidity,
+          roundExposure,
+        })
+      : undefined;
+
+  const tierCapacity =
+    remainingPayoutCapacity !== undefined
+      ? computeTierPlayerCapacity(remainingPayoutCapacity)
+      : undefined;
+
+  const earliestExpiry =
+    blockingRounds.length > 0
+      ? blockingRounds.reduce(
+          (min, round) => (round.expiresAt < min ? round.expiresAt : min),
+          blockingRounds[0]!.expiresAt
+        )
+      : undefined;
+
   return {
     tUsdBalance,
     shareBalance,
@@ -161,6 +413,42 @@ export async function readBankrollVaultState(
     reservedLiabilities,
     safetyBuffer,
     freeLiquidity,
+    realizedGamePnl,
+    frozenRoundCount,
+    oldestBlockingRound,
+    shareOperationsFrozen: shareOperationsFrozen ?? false,
+    noBlockingRound: sentinel,
     maxWithdraw,
+    currentRoundId,
+    roundExposure,
+    blockingRounds,
+    earliestExpiry,
+    utilizationBps,
+    remainingPayoutCapacity,
+    tierCapacity,
+    chainTimestamp: block.timestamp,
   };
+}
+
+/** Loads a game round for LP finalize/expire actions. */
+export async function readCrashRoundForLp(
+  roundId: bigint
+): Promise<CrashRound | null> {
+  const gameConfig = getMarginCallCrashConfig();
+  if (!gameConfig) return null;
+  const round = await baseSepoliaPublicClient.readContract({
+    address: gameConfig.address,
+    abi: marginCallCrashAbi,
+    functionName: "getRound",
+    args: [roundId],
+  });
+  if (round.status === ROUND_STATUS.uninitialized) return null;
+  return {
+    ...round,
+    status: round.status as CrashRound["status"],
+  };
+}
+
+function minBigint(a: bigint, b: bigint, c: bigint): bigint {
+  return a < b ? (a < c ? a : c) : b < c ? b : c;
 }

--- a/src/lib/margin-call-crash.ts
+++ b/src/lib/margin-call-crash.ts
@@ -37,8 +37,10 @@ export const marginCallCrashAbi = parseAbi([
   "event TicketRefunded(uint256 indexed roundId, uint256 indexed ticketId, address indexed player, address receiver, uint256 margin)",
 ]);
 
-const ONE_TUSD = 1_000_000n;
-const LEVERAGE_SCALE = 10_000n;
+/** One Desk Dollar in 6-decimal base units. */
+export const ONE_TUSD = 1_000_000n;
+/** Basis-point denominator shared by leverage and Crash Point math. */
+export const LEVERAGE_SCALE = 10_000n;
 
 /** Supported entry margins in tUSD base units (6 decimals). */
 export const ENTRY_MARGINS_TUSD = [
@@ -278,11 +280,15 @@ export function isExpiryRefundTicket(
   );
 }
 
-export function formatLeverageBps(leverageBps: bigint): string {
-  const hundredths = leverageBps / 100n;
+/** Renders a hundredths-scaled value as "W.FF" (e.g. 125 → "1.25"). */
+export function formatHundredths(hundredths: bigint): string {
   const whole = hundredths / 100n;
   const fraction = hundredths % 100n;
-  return `${whole.toString()}.${fraction.toString().padStart(2, "0")}x`;
+  return `${whole.toString()}.${fraction.toString().padStart(2, "0")}`;
+}
+
+export function formatLeverageBps(leverageBps: bigint): string {
+  return `${formatHundredths(leverageBps / 100n)}x`;
 }
 
 /**
@@ -402,10 +408,26 @@ export function formatCrashPointBps(crashPointBps: bigint): string {
       : crashPointBps > MAX_CRASH_POINT_BPS
         ? MAX_CRASH_POINT_BPS
         : crashPointBps;
-  const hundredths = bounded / 100n;
-  const whole = hundredths / 100n;
-  const fraction = hundredths % 100n;
-  return `${whole.toString()}.${fraction.toString().padStart(2, "0")}x`;
+  return `${formatHundredths(bounded / 100n)}x`;
+}
+
+/** Loads a game round for LP finalize/expire actions. */
+export async function readCrashRoundForLp(
+  roundId: bigint
+): Promise<CrashRound | null> {
+  const config = getMarginCallCrashConfig();
+  if (!config) return null;
+  const round = await baseSepoliaPublicClient.readContract({
+    address: config.address,
+    abi: marginCallCrashAbi,
+    functionName: "getRound",
+    args: [roundId],
+  });
+  if (round.status === ROUND_STATUS.uninitialized) return null;
+  return {
+    ...round,
+    status: normalizeRoundStatus(round.status),
+  };
 }
 
 export async function readCurrentCrashRound(config: MarginCallCrashConfig) {


### PR DESCRIPTION
## Summary
- Fail-closed reveal/expiry freeze on BankrollVault share ops with O(1) counter, oldest blocking round, and atomic clear on finalize/expire
- Complete LP Desk risk display: realized P&L, utilization, tier capacity, freeze banner with honest overlapping-outage copy
- One-click sponsored finalize/expire actions for LPs to clear blocking rounds

Closes #347

## Test plan
- [ ] `pnpm test`
- [ ] `pnpm typecheck`
- [ ] `pnpm build`
- [ ] `pnpm test:contracts:ci`
- [ ] Confirm exposed reveal zeroes `max*` and reverts deposit/mint/withdraw/redeem with `ShareOperationsFrozen`
- [ ] Confirm ticketless reveal/expire never freezes
- [ ] Confirm Open-past-expiry blocks until expire, then unfreezes
- [ ] Confirm overlapping blockers stay frozen until the last resolves
- [ ] Confirm LP Desk freeze banner lists blockers and Finalize/Expire work end-to-end on Base Sepolia when configured


Made with [Cursor](https://cursor.com)