### PR TITLE
Add round theater: replay curve and trading-floor presentation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -589,6 +589,65 @@
   animation: mc-flavor-fade var(--mc-dur-slow) var(--mc-ease-out) both;
 }
 
+/* ── Round theater: tier pop, margin-call flash, desk phone ── */
+
+@keyframes mc-tier-pop {
+  0% {
+    transform: scale(0.98);
+    filter: brightness(1.35);
+  }
+  55% {
+    transform: scale(1.01);
+  }
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+}
+
+.mc-tier-pop {
+  animation: mc-tier-pop var(--mc-dur-flash) var(--mc-ease-snap) both;
+}
+
+@keyframes mc-margin-call-flash {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  40% {
+    filter: brightness(1.8);
+  }
+}
+
+.mc-margin-call-flash {
+  animation: mc-margin-call-flash calc(var(--mc-dur-flash) * 2)
+    var(--mc-ease-out) both;
+}
+
+@keyframes mc-phone-ring {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  20% {
+    transform: rotate(-8deg);
+  }
+  40% {
+    transform: rotate(8deg);
+  }
+  60% {
+    transform: rotate(-5deg);
+  }
+  80% {
+    transform: rotate(5deg);
+  }
+}
+
+.mc-phone-ring {
+  animation: mc-phone-ring 420ms var(--mc-ease-out) both;
+  transform-origin: 50% 20%;
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -624,7 +683,10 @@
   .mc-moment-backdrop,
   .mc-moment-card,
   .mc-moment-edge,
-  .mc-shake {
+  .mc-shake,
+  .mc-tier-pop,
+  .mc-margin-call-flash,
+  .mc-phone-ring {
     animation: none;
     opacity: 1;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { DeskDollarsPanel } from "@/components/desk-dollars/desk-dollars-panel";
 import { GlobalHistory } from "@/components/history/global-history";
 import { PersonalHistory } from "@/components/history/personal-history";
 import { LpDesk } from "@/components/lp-desk/lp-desk";
+import { RoundTheater } from "@/components/round-theater/round-theater";
 
 export default function Home() {
   return (
@@ -21,6 +22,7 @@ export default function Home() {
           Watch each encrypted crash point commit onchain before entry closes.
         </p>
 
+        <RoundTheater />
         <CurrentRound />
         <GlobalHistory />
 

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -14,6 +14,7 @@ import {
   type CrashRoundPhase,
 } from "@/lib/margin-call-crash";
 import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { CrashLiveTicket } from "./crash-live-ticket";
 
 const statusCopy: Partial<Record<CrashEntryStatus, string>> = {
@@ -238,7 +239,7 @@ export function CrashRoundEntry({
         </button>
         {entry.canRetry ? (
           <button
-            className="border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]"
+            className={TERMINAL_ACTION_BUTTON_CLASS}
             onClick={() => void entry.retry()}
             type="button"
           >

--- a/src/components/current-round/current-round.test.tsx
+++ b/src/components/current-round/current-round.test.tsx
@@ -13,7 +13,10 @@ const sdk = vi.hoisted(() => {
       countdownSeconds: 18,
       crashRandom:
         "0x000000000000000000000000000000000000000000000000000000000000cafe",
+      crashPointBps: null,
       displayCrashPoint: null,
+      finalizedAtSeconds: null,
+      chainTimestamp: 1_000n,
       openingTransactionUrl:
         "https://sepolia.basescan.org/tx/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       revealTransactionUrl: null,

--- a/src/components/current-round/current-round.tsx
+++ b/src/components/current-round/current-round.tsx
@@ -5,6 +5,7 @@ import {
   type CurrentCrashRoundView,
 } from "@/hooks/use-current-crash-round";
 import type { CrashRoundPhase } from "@/lib/margin-call-crash";
+import { formatCountdown, TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { CrashRoundEntry } from "./crash-round-entry";
 
 type ReadyRound = Extract<CurrentCrashRoundView, { status: "ready" }>;
@@ -280,7 +281,7 @@ function CurrentRoundFailure({
       </p>
       {round.status === "error" ? (
         <button
-          className="mt-5 border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]"
+          className={`mt-5 ${TERMINAL_ACTION_BUTTON_CLASS}`}
           onClick={() => void round.retry()}
           type="button"
         >
@@ -289,12 +290,4 @@ function CurrentRoundFailure({
       ) : null}
     </section>
   );
-}
-
-function formatCountdown(seconds: number) {
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return `${minutes.toString().padStart(2, "0")}:${remainingSeconds
-    .toString()
-    .padStart(2, "0")}`;
 }

--- a/src/components/round-theater/finalize-link.tsx
+++ b/src/components/round-theater/finalize-link.tsx
@@ -1,0 +1,22 @@
+import { theaterCopy } from "./theater-copy";
+
+/** Explorer link to the finalization transaction. Renders nothing without a URL. */
+export function FinalizeLink({
+  url,
+  className,
+}: {
+  url: string | null;
+  className?: string;
+}) {
+  if (!url) return null;
+  return (
+    <a
+      className={`text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]${className ? ` ${className}` : ""}`}
+      href={url}
+      rel="noreferrer"
+      target="_blank"
+    >
+      {theaterCopy.viewFinalization}
+    </a>
+  );
+}

--- a/src/components/round-theater/margin-call-phone.tsx
+++ b/src/components/round-theater/margin-call-phone.tsx
@@ -1,0 +1,39 @@
+/**
+ * Inline red desk phone for the margin-call hard stop.
+ * Pure SVG — no asset files.
+ */
+export function MarginCallPhone({ ringing = false }: { ringing?: boolean }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`inline-flex items-center justify-center ${ringing ? "mc-phone-ring" : ""}`}
+    >
+      <svg
+        fill="none"
+        height="48"
+        viewBox="0 0 48 48"
+        width="48"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="#1a0e0c"
+          height="28"
+          rx="3"
+          stroke="var(--t-red-hot)"
+          strokeWidth="1.5"
+          width="32"
+          x="8"
+          y="14"
+        />
+        <path
+          d="M14 14c0-6 4-10 10-10s10 4 10 10"
+          stroke="var(--t-red)"
+          strokeLinecap="round"
+          strokeWidth="2"
+        />
+        <circle cx="24" cy="28" fill="var(--t-red-hot)" r="4" />
+        <rect fill="var(--t-red)" height="3" rx="1" width="18" x="15" y="18" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  ENTRY_LEVERAGE_TIERS_BPS,
+  formatCrashPointBps,
+  formatLeverageBps,
+} from "@/lib/margin-call-crash";
+import {
+  getReplayMultiplierBps,
+  getReplayPath,
+  getTierCloseProgress,
+} from "@/lib/round-replay";
+import { MarginCallPhone } from "./margin-call-phone";
+import { theaterCopy } from "./theater-copy";
+
+const VIEW_W = 100;
+const VIEW_H = 56;
+
+export type ReplayCurveProps = {
+  crashPointBps: bigint;
+  progress: number;
+  /** Dimmed looping ambiance mode (Open phase). */
+  ambiance?: boolean;
+};
+
+/**
+ * SVG multiplier climb. Axes rescale with the live multiplier; hard stop at
+ * the Crash Point with a margin-call phone stamp.
+ */
+export function ReplayCurve({
+  crashPointBps,
+  progress,
+  ambiance = false,
+}: ReplayCurveProps) {
+  const path = useMemo(
+    () =>
+      getReplayPath(crashPointBps, progress, { width: VIEW_W, height: VIEW_H }),
+    [crashPointBps, progress]
+  );
+  const multiplierBps = getReplayMultiplierBps(progress, crashPointBps);
+  const displayMultiplier = formatCrashPointBps(multiplierBps);
+  const isComplete = progress >= 1;
+  const crashLabel = formatCrashPointBps(crashPointBps);
+
+  const head = useMemo(() => {
+    // Approximate head from the final path command.
+    const match = /([\d.]+)\s+([\d.]+)$/.exec(path);
+    if (!match) return { x: 0, y: VIEW_H };
+    return { x: Number(match[1]), y: Number(match[2]) };
+  }, [path]);
+
+  const tierLines = ENTRY_LEVERAGE_TIERS_BPS.filter((tier) => {
+    const closeAt = getTierCloseProgress(tier, crashPointBps);
+    return closeAt !== null;
+  });
+
+  return (
+    <div
+      className={`terminal-panel relative overflow-hidden p-3 sm:p-4 ${ambiance ? "opacity-70" : ""}`}
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+            {ambiance
+              ? theaterCopy.openAmbiance
+              : theaterCopy.verifiedCrashPoint}
+          </p>
+          <p
+            aria-live="polite"
+            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-4xl font-bold tabular-nums sm:text-5xl ${
+              isComplete
+                ? "text-[var(--t-red-hot)]"
+                : "text-[var(--t-green-hot)]"
+            }`}
+          >
+            {isComplete ? crashLabel : displayMultiplier}
+          </p>
+        </div>
+        {isComplete && !ambiance ? (
+          <div className="flex items-center gap-3">
+            <MarginCallPhone ringing />
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-red-hot)]">
+                {theaterCopy.marginCall}
+              </p>
+              <p className="mt-1 max-w-[14rem] text-[10px] leading-4 text-[var(--t-muted)]">
+                {theaterCopy.marginCallDetail}
+              </p>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <svg
+        aria-hidden="true"
+        className="mt-4 h-40 w-full sm:h-52"
+        preserveAspectRatio="none"
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      >
+        <defs>
+          <linearGradient id="replay-stroke" x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0%" stopColor="var(--t-green)" />
+            <stop offset="100%" stopColor="var(--t-green-hot)" />
+          </linearGradient>
+        </defs>
+        {tierLines.map((tier) => {
+          const closeAt = getTierCloseProgress(tier, crashPointBps) ?? 0;
+          const y =
+            VIEW_H -
+            ((Number(tier) / 10_000 - 1) /
+              ((Number(crashPointBps < 10_000n ? 10_000n : crashPointBps) /
+                10_000) *
+                1.08 -
+                1)) *
+              VIEW_H;
+          return (
+            <g key={tier.toString()}>
+              <line
+                stroke="var(--t-divider)"
+                strokeDasharray="1 1.5"
+                strokeWidth="0.25"
+                x1="0"
+                x2={VIEW_W}
+                y1={y}
+                y2={y}
+              />
+              <text
+                fill="var(--t-muted)"
+                fontSize="2.4"
+                x="1"
+                y={Math.max(3, y - 1)}
+              >
+                {formatLeverageBps(tier)}
+              </text>
+              {closeAt <= progress ? (
+                <circle
+                  cx={closeAt * VIEW_W}
+                  cy={y}
+                  fill="var(--t-amber-hot)"
+                  r="0.9"
+                />
+              ) : null}
+            </g>
+          );
+        })}
+        <path
+          d={path}
+          fill="none"
+          stroke="url(#replay-stroke)"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.1"
+        />
+        <circle
+          className={isComplete ? "mc-margin-call-flash" : ""}
+          cx={head.x}
+          cy={head.y}
+          fill={isComplete ? "var(--t-red-hot)" : "var(--t-green-hot)"}
+          r="1.4"
+        />
+      </svg>
+
+      {!ambiance ? (
+        <p className="mt-2 text-[10px] leading-4 text-[var(--t-muted)]">
+          {theaterCopy.replayLabel}. {theaterCopy.replayDetail}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -8,8 +8,11 @@ import {
 } from "@/lib/margin-call-crash";
 import {
   getReplayMultiplierBps,
-  getReplayPath,
+  getReplayPathPoints,
   getTierCloseProgress,
+  isReplayComplete,
+  multiplierToY,
+  replayPathD,
 } from "@/lib/round-replay";
 import { MarginCallPhone } from "./margin-call-phone";
 import { theaterCopy } from "./theater-copy";
@@ -33,27 +36,29 @@ export function ReplayCurve({
   progress,
   ambiance = false,
 }: ReplayCurveProps) {
-  const path = useMemo(
-    () =>
-      getReplayPath(crashPointBps, progress, { width: VIEW_W, height: VIEW_H }),
-    [crashPointBps, progress]
-  );
+  // `progress` moves every animation frame, so memoizing on it buys nothing.
+  const points = getReplayPathPoints(crashPointBps, progress, {
+    width: VIEW_W,
+    height: VIEW_H,
+  });
+  const path = replayPathD(points);
+  const head = points[points.length - 1] ?? { x: 0, y: VIEW_H };
   const multiplierBps = getReplayMultiplierBps(progress, crashPointBps);
   const displayMultiplier = formatCrashPointBps(multiplierBps);
-  const isComplete = progress >= 1;
+  const isComplete = isReplayComplete(progress);
   const crashLabel = formatCrashPointBps(crashPointBps);
 
-  const head = useMemo(() => {
-    // Approximate head from the final path command.
-    const match = /([\d.]+)\s+([\d.]+)$/.exec(path);
-    if (!match) return { x: 0, y: VIEW_H };
-    return { x: Number(match[1]), y: Number(match[2]) };
-  }, [path]);
-
-  const tierLines = ENTRY_LEVERAGE_TIERS_BPS.filter((tier) => {
-    const closeAt = getTierCloseProgress(tier, crashPointBps);
-    return closeAt !== null;
-  });
+  const tierLines = useMemo(
+    () =>
+      ENTRY_LEVERAGE_TIERS_BPS.flatMap((tier) => {
+        const closeAt = getTierCloseProgress(tier, crashPointBps);
+        if (closeAt === null) return [];
+        return [
+          { tier, closeAt, y: multiplierToY(tier, crashPointBps, VIEW_H) },
+        ];
+      }),
+    [crashPointBps]
+  );
 
   return (
     <div
@@ -104,16 +109,7 @@ export function ReplayCurve({
             <stop offset="100%" stopColor="var(--t-green-hot)" />
           </linearGradient>
         </defs>
-        {tierLines.map((tier) => {
-          const closeAt = getTierCloseProgress(tier, crashPointBps) ?? 0;
-          const y =
-            VIEW_H -
-            ((Number(tier) / 10_000 - 1) /
-              ((Number(crashPointBps < 10_000n ? 10_000n : crashPointBps) /
-                10_000) *
-                1.08 -
-                1)) *
-              VIEW_H;
+        {tierLines.map(({ tier, closeAt, y }) => {
           return (
             <g key={tier.toString()}>
               <line

--- a/src/components/round-theater/round-result-card.tsx
+++ b/src/components/round-theater/round-result-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { TierExposure } from "@/lib/margin-call-crash";
+import { FinalizeLink } from "./finalize-link";
 import { TierCloseBoard } from "./tier-close-board";
 import { theaterCopy } from "./theater-copy";
 
@@ -53,16 +54,7 @@ export function RoundResultCard({
         {theaterCopy.marginCallDetail}
       </p>
 
-      {finalizeTransactionUrl ? (
-        <a
-          className="mt-4 inline-flex text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
-          href={finalizeTransactionUrl}
-          rel="noreferrer"
-          target="_blank"
-        >
-          {theaterCopy.viewFinalization}
-        </a>
-      ) : null}
+      <FinalizeLink className="mt-4 inline-flex" url={finalizeTransactionUrl} />
     </div>
   );
 }

--- a/src/components/round-theater/round-result-card.tsx
+++ b/src/components/round-theater/round-result-card.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { TierExposure } from "@/lib/margin-call-crash";
+import { TierCloseBoard } from "./tier-close-board";
+import { theaterCopy } from "./theater-copy";
+
+export type RoundResultCardProps = {
+  displayCrashPoint: string;
+  crashPointBps: bigint;
+  tiers: readonly TierExposure[];
+  finalizeTransactionUrl: string | null;
+};
+
+/**
+ * Reduced-motion equivalent of the climb. Carries identical facts: verified
+ * Crash Point, each tier's close-or-margin-call state and payout, and the
+ * verification link. Colour- and sound-independent.
+ */
+export function RoundResultCard({
+  displayCrashPoint,
+  crashPointBps,
+  tiers,
+  finalizeTransactionUrl,
+}: RoundResultCardProps) {
+  return (
+    <div
+      aria-label={theaterCopy.staticResult}
+      className="terminal-panel p-4 sm:p-5"
+    >
+      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+        {theaterCopy.verifiedCrashPoint}
+      </p>
+      <p
+        className="mc-live-value mt-2 font-[family-name:var(--font-plex-sans)] text-5xl font-bold tabular-nums text-[var(--t-green-hot)] sm:text-6xl"
+        data-testid="static-crash-point"
+      >
+        {displayCrashPoint}
+      </p>
+      <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">
+        {theaterCopy.replayLabel}. {theaterCopy.replayDetail}
+      </p>
+
+      <TierCloseBoard
+        crashPointBps={crashPointBps}
+        progress={1}
+        tiers={tiers}
+      />
+
+      <p className="mt-4 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-red-hot)]">
+        {theaterCopy.marginCall}
+      </p>
+      <p className="mt-1 text-xs text-[var(--t-muted)]">
+        {theaterCopy.marginCallDetail}
+      </p>
+
+      {finalizeTransactionUrl ? (
+        <a
+          className="mt-4 inline-flex text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
+          href={finalizeTransactionUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {theaterCopy.viewFinalization}
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TheaterStage } from "@/hooks/use-round-theater";
+
+const sdk = vi.hoisted(() => {
+  const emptyTiers = () =>
+    ([12_500n, 15_000n, 20_000n, 30_000n, 50_000n, 100_000n] as const).map(
+      (leverageBps) => ({
+        leverageBps,
+        ticketCount: leverageBps === 20_000n ? 1 : 0,
+        totalMargin: leverageBps === 20_000n ? 5_000_000n : 0n,
+        reservedPayout: leverageBps === 20_000n ? 10_000_000n : 0n,
+      })
+    );
+
+  const makeOpen = (): TheaterStage => ({
+    kind: "open",
+    roundId: 12n,
+    countdownSeconds: 22,
+    tape: {
+      roundId: 12n,
+      entries: [
+        {
+          ticketId: 1n,
+          player: "0x00000000000000000000000000000000000000aa",
+          margin: 1_000_000n,
+          leverageBps: 12_500n,
+          reservedPayout: 1_250_000n,
+          transactionHash: null,
+        },
+      ],
+      tiers: emptyTiers(),
+    },
+    ambiance: null,
+    chainTimestamp: 1_000n,
+    reducedMotion: false,
+    retry: vi.fn(),
+  });
+
+  return {
+    emptyTiers,
+    makeOpen,
+    stage: makeOpen() as TheaterStage,
+  };
+});
+
+vi.mock("@/hooks/use-round-theater", () => ({
+  useRoundTheater: () => sdk.stage,
+}));
+
+vi.mock("@/hooks/use-replay-clock", () => ({
+  useReplayClock: () => ({
+    progress: 1,
+    elapsedMs: 8_000,
+    durationMs: 8_000,
+    isComplete: true,
+  }),
+}));
+
+vi.mock("@/lib/theater-audio", () => {
+  let enabled = false;
+  const listeners = new Set<() => void>();
+  return {
+    readTheaterSoundEnabled: () => enabled,
+    writeTheaterSoundEnabled: (next: boolean) => {
+      enabled = next;
+    },
+    getTheaterAudio: () => ({
+      get enabled() {
+        return enabled;
+      },
+      setEnabled: (next: boolean) => {
+        enabled = next;
+      },
+      playTierClose: vi.fn(),
+      playCrashBell: vi.fn(),
+      playPhoneRing: vi.fn(),
+      dispose: vi.fn(),
+    }),
+    // Expose for tests that need to reset between cases.
+    __resetTheaterSoundForTests: () => {
+      enabled = false;
+      listeners.clear();
+    },
+  };
+});
+
+import { RoundTheater } from "./round-theater";
+
+describe("RoundTheater", () => {
+  beforeEach(() => {
+    sdk.stage = sdk.makeOpen();
+  });
+
+  afterEach(cleanup);
+
+  it("shows the Open stage with contract-derived countdown and ticket tape", () => {
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("round-theater")).toBeTruthy();
+    expect(screen.getByTestId("theater-countdown").textContent).toBe("00:22");
+    expect(screen.getByText("Live ticket tape")).toBeTruthy();
+    expect(
+      screen.getAllByText((_, el) => el?.textContent === "1 tUSD").length
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("1.25x").length).toBeGreaterThan(0);
+    // Theater never offers entry or settlement actions.
+    expect(screen.queryByRole("button", { name: /enter/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /claim/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /settle/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+  });
+
+  it("shows awaiting-attestation with no climb and no invented multiplier", () => {
+    sdk.stage = {
+      kind: "delayed",
+      roundId: 12n,
+      phaseLabel: "reveal-requested",
+      tape: null,
+      reducedMotion: false,
+      retry: vi.fn(),
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("theater-delayed")).toBeTruthy();
+    expect(screen.getByText("Awaiting attestation")).toBeTruthy();
+    expect(screen.queryByTestId("theater-finalized-replay")).toBeNull();
+    expect(screen.queryByText(/\d+\.\d+x/)).toBeNull();
+  });
+
+  it("shows expired without inventing a Crash Point", () => {
+    sdk.stage = {
+      kind: "expired",
+      roundId: 12n,
+      tape: null,
+      reducedMotion: false,
+      retry: vi.fn(),
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("theater-expired")).toBeTruthy();
+    expect(screen.getByText("Outcome unavailable")).toBeTruthy();
+    expect(screen.queryByText(/\d+\.\d+x/)).toBeNull();
+  });
+
+  it("renders the animated replay for finalized rounds with tier closes", () => {
+    sdk.stage = {
+      kind: "finalized",
+      roundId: 12n,
+      crashPointBps: 25_000n,
+      displayCrashPoint: "2.50x",
+      finalizedAtSeconds: 900n,
+      chainTimestamp: 910n,
+      finalizeTransactionUrl:
+        "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      tape: null,
+      tiers: sdk.emptyTiers(),
+      reducedMotion: false,
+      retry: vi.fn(),
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("theater-finalized-replay")).toBeTruthy();
+    expect(screen.getByText("2.50x")).toBeTruthy();
+    expect(screen.getByText("Closed 2.00x — paid")).toBeTruthy();
+    expect(screen.getByText("Closed 1.25x — paid")).toBeTruthy();
+    expect(screen.getByText("3.00x — margin call")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Replay" })).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "View finalization transaction" })
+        .getAttribute("href")
+    ).toContain("0xcccccccccccccccc");
+    expect(screen.queryByRole("button", { name: /claim/i })).toBeNull();
+  });
+
+  it("renders the static result card under reduced motion with identical facts", () => {
+    sdk.stage = {
+      kind: "finalized",
+      roundId: 12n,
+      crashPointBps: 25_000n,
+      displayCrashPoint: "2.50x",
+      finalizedAtSeconds: 900n,
+      chainTimestamp: 910n,
+      finalizeTransactionUrl:
+        "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      tape: null,
+      tiers: sdk.emptyTiers(),
+      reducedMotion: true,
+      retry: vi.fn(),
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("theater-finalized-static")).toBeTruthy();
+    expect(screen.getByTestId("static-crash-point").textContent).toBe("2.50x");
+    expect(screen.getByText("Closed 2.00x — paid")).toBeTruthy();
+    expect(screen.getByText("Closed 1.25x — paid")).toBeTruthy();
+    expect(screen.getByText("3.00x — margin call")).toBeTruthy();
+    expect(screen.getByText("Margin call")).toBeTruthy();
+    expect(screen.queryByTestId("theater-finalized-replay")).toBeNull();
+  });
+
+  it("defaults the sound toggle to off and can enable it", () => {
+    render(<RoundTheater />);
+    const toggle = screen.getByRole("button", { name: "Sound off" });
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(toggle);
+    expect(
+      screen
+        .getByRole("button", { name: "Sound on" })
+        .getAttribute("aria-pressed")
+    ).toBe("true");
+  });
+});

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -34,7 +34,6 @@ const sdk = vi.hoisted(() => {
       tiers: emptyTiers(),
     },
     ambiance: null,
-    chainTimestamp: 1_000n,
     reducedMotion: false,
     retry: vi.fn(),
   });
@@ -53,8 +52,6 @@ vi.mock("@/hooks/use-round-theater", () => ({
 vi.mock("@/hooks/use-replay-clock", () => ({
   useReplayClock: () => ({
     progress: 1,
-    elapsedMs: 8_000,
-    durationMs: 8_000,
     isComplete: true,
   }),
 }));
@@ -64,8 +61,11 @@ vi.mock("@/lib/theater-audio", () => {
   const listeners = new Set<() => void>();
   return {
     readTheaterSoundEnabled: () => enabled,
-    writeTheaterSoundEnabled: (next: boolean) => {
-      enabled = next;
+    subscribeTheaterSound: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
     },
     getTheaterAudio: () => ({
       get enabled() {
@@ -73,17 +73,13 @@ vi.mock("@/lib/theater-audio", () => {
       },
       setEnabled: (next: boolean) => {
         enabled = next;
+        for (const listener of listeners) listener();
       },
       playTierClose: vi.fn(),
       playCrashBell: vi.fn(),
       playPhoneRing: vi.fn(),
       dispose: vi.fn(),
     }),
-    // Expose for tests that need to reset between cases.
-    __resetTheaterSoundForTests: () => {
-      enabled = false;
-      listeners.clear();
-    },
   };
 });
 

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useReplayClock } from "@/hooks/use-replay-clock";
+import { useRoundTheater, type TheaterStage } from "@/hooks/use-round-theater";
+import { getClosedTiersAtProgress } from "@/lib/round-replay";
+import { ENTRY_LEVERAGE_TIERS_BPS } from "@/lib/margin-call-crash";
+import { getTheaterAudio } from "@/lib/theater-audio";
+import { delayedPhaseCopy, theaterCopy } from "./theater-copy";
+import { ReplayCurve } from "./replay-curve";
+import { RoundResultCard } from "./round-result-card";
+import { TheaterSoundToggle } from "./theater-sound-toggle";
+import { TicketTape } from "./ticket-tape";
+import { TierCloseBoard } from "./tier-close-board";
+
+/**
+ * Presentational round theater. Never offers entry or settlement — those live
+ * on CurrentRound and the settlement/refund surfaces.
+ */
+export function RoundTheater() {
+  const stage = useRoundTheater();
+
+  return (
+    <section
+      aria-labelledby="round-theater-heading"
+      className="mt-10 border-y border-[var(--t-border)] bg-[var(--t-panel)] text-left"
+      data-testid="round-theater"
+    >
+      <div className="px-5 py-6 sm:px-8 sm:py-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
+              Base Sepolia · Trading floor
+            </p>
+            <h2
+              id="round-theater-heading"
+              className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl"
+            >
+              {theaterCopy.heading}
+            </h2>
+          </div>
+          <TheaterSoundToggle />
+        </div>
+
+        <div className="mt-6">
+          <TheaterBody stage={stage} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TheaterBody({ stage }: { stage: TheaterStage }) {
+  switch (stage.kind) {
+    case "loading":
+      return (
+        <p
+          aria-busy="true"
+          className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]"
+        >
+          {theaterCopy.loading}
+        </p>
+      );
+    case "error":
+    case "unavailable":
+      return (
+        <div>
+          <p className="text-sm text-[var(--t-red)]" role="alert">
+            {stage.error}
+          </p>
+          <button
+            className="mt-4 border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]"
+            onClick={() => void stage.retry()}
+            type="button"
+          >
+            Retry theater read
+          </button>
+        </div>
+      );
+    case "open":
+      return <OpenStage stage={stage} />;
+    case "delayed":
+      return <DelayedStage stage={stage} />;
+    case "finalized":
+      return <FinalizedStage stage={stage} />;
+    case "expired":
+      return <ExpiredStage stage={stage} />;
+    default: {
+      const _exhaustive: never = stage;
+      return _exhaustive;
+    }
+  }
+}
+
+function OpenStage({
+  stage,
+}: {
+  stage: Extract<TheaterStage, { kind: "open" }>;
+}) {
+  const ambiance = stage.ambiance;
+  const clock = useReplayClock({
+    crashPointBps: ambiance?.round.crashPointBps ?? null,
+    finalizedAtSeconds: null,
+    chainTimestamp: null,
+    reducedMotion: stage.reducedMotion,
+    loop: true,
+  });
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
+      <div>
+        <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+          {theaterCopy.openCountdown}
+        </p>
+        <p
+          aria-label={`${stage.countdownSeconds} seconds until entry locks`}
+          className="mc-live-value mt-2 text-5xl font-bold tabular-nums text-[var(--t-green-hot)]"
+          data-testid="theater-countdown"
+        >
+          {formatCountdown(stage.countdownSeconds)}
+        </p>
+        <TicketTape entries={stage.tape?.entries ?? []} />
+      </div>
+      <div>
+        {ambiance && !stage.reducedMotion ? (
+          <ReplayCurve
+            ambiance
+            crashPointBps={ambiance.round.crashPointBps}
+            progress={clock.progress}
+          />
+        ) : ambiance && stage.reducedMotion ? (
+          <div className="terminal-panel p-4">
+            <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+              {theaterCopy.openAmbiance}
+            </p>
+            <p className="mc-live-value mt-2 text-3xl font-bold text-[var(--t-green-hot)]">
+              {ambiance.displayCrashPoint}
+            </p>
+          </div>
+        ) : (
+          <div className="terminal-panel p-4 text-xs text-[var(--t-muted)]">
+            {theaterCopy.openAmbianceEmpty}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DelayedStage({
+  stage,
+}: {
+  stage: Extract<TheaterStage, { kind: "delayed" }>;
+}) {
+  const copy = delayedPhaseCopy(stage.phaseLabel);
+  return (
+    <div data-testid="theater-delayed">
+      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+        Round status
+      </p>
+      <p className="mt-2 text-lg font-bold text-[var(--t-amber-hot)]">
+        {copy.title}
+      </p>
+      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
+        {copy.body}
+      </p>
+      {/* Never invent a multiplier or start a climb while delayed. */}
+      <TicketTape entries={stage.tape?.entries ?? []} />
+    </div>
+  );
+}
+
+function FinalizedStage({
+  stage,
+}: {
+  stage: Extract<TheaterStage, { kind: "finalized" }>;
+}) {
+  const [restartNonce, setRestartNonce] = useState(0);
+  const clock = useReplayClock({
+    crashPointBps: stage.crashPointBps,
+    finalizedAtSeconds: stage.finalizedAtSeconds,
+    chainTimestamp: stage.chainTimestamp,
+    reducedMotion: stage.reducedMotion,
+    restartNonce,
+  });
+
+  useTierSoundEffects({
+    crashPointBps: stage.crashPointBps,
+    progress: clock.progress,
+    isComplete: clock.isComplete,
+    enabled: !stage.reducedMotion,
+    restartNonce,
+  });
+
+  if (stage.reducedMotion) {
+    return (
+      <div data-testid="theater-finalized-static">
+        <RoundResultCard
+          crashPointBps={stage.crashPointBps}
+          displayCrashPoint={stage.displayCrashPoint}
+          finalizeTransactionUrl={stage.finalizeTransactionUrl}
+          tiers={stage.tiers}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="theater-finalized-replay">
+      <ReplayCurve
+        crashPointBps={stage.crashPointBps}
+        progress={clock.progress}
+      />
+      <TierCloseBoard
+        crashPointBps={stage.crashPointBps}
+        progress={clock.progress}
+        tiers={stage.tiers}
+      />
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          className="border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]"
+          onClick={() => setRestartNonce((n) => n + 1)}
+          type="button"
+        >
+          {theaterCopy.replayAgain}
+        </button>
+        {stage.finalizeTransactionUrl ? (
+          <a
+            className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
+            href={stage.finalizeTransactionUrl}
+            rel="noreferrer"
+            target="_blank"
+          >
+            {theaterCopy.viewFinalization}
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ExpiredStage({
+  stage,
+}: {
+  stage: Extract<TheaterStage, { kind: "expired" }>;
+}) {
+  return (
+    <div data-testid="theater-expired">
+      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+        Round status
+      </p>
+      <p className="mt-2 text-lg font-bold text-[var(--t-muted)]">
+        {theaterCopy.expired}
+      </p>
+      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
+        {theaterCopy.expiredDetail}
+      </p>
+      <TicketTape entries={stage.tape?.entries ?? []} />
+    </div>
+  );
+}
+
+function useTierSoundEffects(options: {
+  crashPointBps: bigint;
+  progress: number;
+  isComplete: boolean;
+  enabled: boolean;
+  restartNonce: number;
+}) {
+  const closedRef = useRef<Set<string>>(new Set());
+  const crashedRef = useRef(false);
+
+  useEffect(() => {
+    closedRef.current = new Set();
+    crashedRef.current = false;
+  }, [options.restartNonce, options.crashPointBps]);
+
+  useEffect(() => {
+    if (!options.enabled) return;
+    const audio = getTheaterAudio();
+    const closed = getClosedTiersAtProgress(
+      options.progress,
+      options.crashPointBps,
+      ENTRY_LEVERAGE_TIERS_BPS
+    );
+    for (const tier of closed) {
+      const key = tier.toString();
+      if (closedRef.current.has(key)) continue;
+      closedRef.current.add(key);
+      audio.playTierClose();
+    }
+    if (options.isComplete && !crashedRef.current) {
+      crashedRef.current = true;
+      audio.playCrashBell();
+      audio.playPhoneRing();
+    }
+  }, [
+    options.crashPointBps,
+    options.enabled,
+    options.isComplete,
+    options.progress,
+  ]);
+}
+
+function formatCountdown(seconds: number) {
+  const safe = Math.max(0, seconds);
+  const minutes = Math.floor(safe / 60);
+  const remainingSeconds = safe % 60;
+  return `${minutes.toString().padStart(2, "0")}:${remainingSeconds
+    .toString()
+    .padStart(2, "0")}`;
+}

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useReplayClock } from "@/hooks/use-replay-clock";
 import { useRoundTheater, type TheaterStage } from "@/hooks/use-round-theater";
-import { getClosedTiersAtProgress } from "@/lib/round-replay";
+import { getTierCloseProgress } from "@/lib/round-replay";
 import { ENTRY_LEVERAGE_TIERS_BPS } from "@/lib/margin-call-crash";
 import { getTheaterAudio } from "@/lib/theater-audio";
+import { formatCountdown, TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { delayedPhaseCopy, theaterCopy } from "./theater-copy";
+import { FinalizeLink } from "./finalize-link";
 import { ReplayCurve } from "./replay-curve";
 import { RoundResultCard } from "./round-result-card";
 import { TheaterSoundToggle } from "./theater-sound-toggle";
@@ -69,7 +71,7 @@ function TheaterBody({ stage }: { stage: TheaterStage }) {
             {stage.error}
           </p>
           <button
-            className="mt-4 border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]"
+            className={`mt-4 ${TERMINAL_ACTION_BUTTON_CLASS}`}
             onClick={() => void stage.retry()}
             type="button"
           >
@@ -98,13 +100,6 @@ function OpenStage({
   stage: Extract<TheaterStage, { kind: "open" }>;
 }) {
   const ambiance = stage.ambiance;
-  const clock = useReplayClock({
-    crashPointBps: ambiance?.round.crashPointBps ?? null,
-    finalizedAtSeconds: null,
-    chainTimestamp: null,
-    reducedMotion: stage.reducedMotion,
-    loop: true,
-  });
 
   return (
     <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
@@ -123,11 +118,7 @@ function OpenStage({
       </div>
       <div>
         {ambiance && !stage.reducedMotion ? (
-          <ReplayCurve
-            ambiance
-            crashPointBps={ambiance.round.crashPointBps}
-            progress={clock.progress}
-          />
+          <AmbianceReplay crashPointBps={ambiance.round.crashPointBps} />
         ) : ambiance && stage.reducedMotion ? (
           <div className="terminal-panel p-4">
             <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
@@ -147,12 +138,33 @@ function OpenStage({
   );
 }
 
+/**
+ * Leaf that owns the looping ambiance clock, so its ~60fps state updates
+ * re-render only the curve — not the countdown and ticket tape beside it.
+ */
+function AmbianceReplay({ crashPointBps }: { crashPointBps: bigint }) {
+  const clock = useReplayClock({
+    crashPointBps,
+    finalizedAtSeconds: null,
+    chainTimestamp: null,
+    loop: true,
+  });
+
+  return (
+    <ReplayCurve
+      ambiance
+      crashPointBps={crashPointBps}
+      progress={clock.progress}
+    />
+  );
+}
+
 function DelayedStage({
   stage,
 }: {
   stage: Extract<TheaterStage, { kind: "delayed" }>;
 }) {
-  const copy = delayedPhaseCopy(stage.phaseLabel);
+  const copy = delayedPhaseCopy[stage.phaseLabel];
   return (
     <div data-testid="theater-delayed">
       <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
@@ -218,22 +230,13 @@ function FinalizedStage({
       />
       <div className="mt-4 flex flex-wrap items-center gap-3">
         <button
-          className="border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]"
+          className={TERMINAL_ACTION_BUTTON_CLASS}
           onClick={() => setRestartNonce((n) => n + 1)}
           type="button"
         >
           {theaterCopy.replayAgain}
         </button>
-        {stage.finalizeTransactionUrl ? (
-          <a
-            className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
-            href={stage.finalizeTransactionUrl}
-            rel="noreferrer"
-            target="_blank"
-          >
-            {theaterCopy.viewFinalization}
-          </a>
-        ) : null}
+        <FinalizeLink url={stage.finalizeTransactionUrl} />
       </div>
     </div>
   );
@@ -267,46 +270,39 @@ function useTierSoundEffects(options: {
   enabled: boolean;
   restartNonce: number;
 }) {
-  const closedRef = useRef<Set<string>>(new Set());
+  // The per-frame work is two number comparisons against precomputed,
+  // ascending close thresholds; the log math runs once per Crash Point.
+  const closeThresholds = useMemo(
+    () =>
+      ENTRY_LEVERAGE_TIERS_BPS.map((tier) =>
+        getTierCloseProgress(tier, options.crashPointBps)
+      )
+        .filter((closeAt): closeAt is number => closeAt !== null)
+        .sort((a, b) => a - b),
+    [options.crashPointBps]
+  );
+  const firedCountRef = useRef(0);
   const crashedRef = useRef(false);
 
   useEffect(() => {
-    closedRef.current = new Set();
+    firedCountRef.current = 0;
     crashedRef.current = false;
   }, [options.restartNonce, options.crashPointBps]);
 
   useEffect(() => {
     if (!options.enabled) return;
-    const audio = getTheaterAudio();
-    const closed = getClosedTiersAtProgress(
-      options.progress,
-      options.crashPointBps,
-      ENTRY_LEVERAGE_TIERS_BPS
-    );
-    for (const tier of closed) {
-      const key = tier.toString();
-      if (closedRef.current.has(key)) continue;
-      closedRef.current.add(key);
-      audio.playTierClose();
+    while (
+      firedCountRef.current < closeThresholds.length &&
+      closeThresholds[firedCountRef.current] <= options.progress
+    ) {
+      firedCountRef.current += 1;
+      getTheaterAudio().playTierClose();
     }
     if (options.isComplete && !crashedRef.current) {
       crashedRef.current = true;
+      const audio = getTheaterAudio();
       audio.playCrashBell();
       audio.playPhoneRing();
     }
-  }, [
-    options.crashPointBps,
-    options.enabled,
-    options.isComplete,
-    options.progress,
-  ]);
-}
-
-function formatCountdown(seconds: number) {
-  const safe = Math.max(0, seconds);
-  const minutes = Math.floor(safe / 60);
-  const remainingSeconds = safe % 60;
-  return `${minutes.toString().padStart(2, "0")}:${remainingSeconds
-    .toString()
-    .padStart(2, "0")}`;
+  }, [closeThresholds, options.enabled, options.isComplete, options.progress]);
 }

--- a/src/components/round-theater/theater-copy.ts
+++ b/src/components/round-theater/theater-copy.ts
@@ -1,0 +1,68 @@
+/**
+ * Round-theater copy. Uses CONTEXT.md vocabulary exactly:
+ * Crash Point, Replay, Tier, Margin, Ticket, Arcade Leverage.
+ */
+
+export const theaterCopy = {
+  heading: "Round theater",
+  replayLabel: "Replay of an attested onchain result",
+  replayDetail:
+    "This climb is a dramatized rendering of the verified Crash Point. Watching, skipping, or replaying never changes settlement.",
+  awaitingAttestation: "Awaiting attestation",
+  awaitingAttestationDetail:
+    "Reveal has been requested. No Crash Point is shown and no climb plays until covalidator signatures finalize the exact stored handle.",
+  awaitingReveal: "Awaiting reveal request",
+  awaitingRevealDetail:
+    "Entry is locked. The encrypted handle stays confidential until a permissionless reveal marks it for public attestation.",
+  pastExpiry: "Past expiry",
+  pastExpiryDetail:
+    "This round can be marked expired. No Crash Point will be invented; original margin becomes refundable after expiry is recorded.",
+  expired: "Outcome unavailable",
+  expiredDetail:
+    "This round expired without a verified Crash Point. Ticket owners can pull back exactly their original margin.",
+  openCountdown: "Entry closes in",
+  openTape: "Live ticket tape",
+  openAmbiance: "Previous round replay",
+  openAmbianceEmpty: "No prior finalized round to replay yet.",
+  verifiedCrashPoint: "Verified Crash Point",
+  marginCall: "Margin call",
+  marginCallDetail:
+    "Hard stop — every Ticket still open takes the margin call.",
+  tierClosed: (tier: string) => `Closed ${tier} — paid`,
+  tierOpen: (tier: string) => `${tier} — margin call`,
+  tierIdle: (tier: string) => `${tier} — waiting`,
+  noTicketsAtTier: "No Tickets",
+  replayAgain: "Replay",
+  soundOn: "Sound on",
+  soundOff: "Sound off",
+  soundHint: "Audio is optional and muted by default.",
+  viewFinalization: "View finalization transaction",
+  loading: "Loading round theater…",
+  staticResult: "Static result card",
+} as const;
+
+export function delayedPhaseCopy(
+  phaseLabel: "locked" | "reveal-requested" | "expired-eligible"
+): { title: string; body: string } {
+  switch (phaseLabel) {
+    case "locked":
+      return {
+        title: theaterCopy.awaitingReveal,
+        body: theaterCopy.awaitingRevealDetail,
+      };
+    case "reveal-requested":
+      return {
+        title: theaterCopy.awaitingAttestation,
+        body: theaterCopy.awaitingAttestationDetail,
+      };
+    case "expired-eligible":
+      return {
+        title: theaterCopy.pastExpiry,
+        body: theaterCopy.pastExpiryDetail,
+      };
+    default: {
+      const _exhaustive: never = phaseLabel;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/components/round-theater/theater-copy.ts
+++ b/src/components/round-theater/theater-copy.ts
@@ -41,28 +41,20 @@ export const theaterCopy = {
   staticResult: "Static result card",
 } as const;
 
-export function delayedPhaseCopy(
-  phaseLabel: "locked" | "reveal-requested" | "expired-eligible"
-): { title: string; body: string } {
-  switch (phaseLabel) {
-    case "locked":
-      return {
-        title: theaterCopy.awaitingReveal,
-        body: theaterCopy.awaitingRevealDetail,
-      };
-    case "reveal-requested":
-      return {
-        title: theaterCopy.awaitingAttestation,
-        body: theaterCopy.awaitingAttestationDetail,
-      };
-    case "expired-eligible":
-      return {
-        title: theaterCopy.pastExpiry,
-        body: theaterCopy.pastExpiryDetail,
-      };
-    default: {
-      const _exhaustive: never = phaseLabel;
-      return _exhaustive;
-    }
-  }
-}
+export const delayedPhaseCopy = {
+  locked: {
+    title: theaterCopy.awaitingReveal,
+    body: theaterCopy.awaitingRevealDetail,
+  },
+  "reveal-requested": {
+    title: theaterCopy.awaitingAttestation,
+    body: theaterCopy.awaitingAttestationDetail,
+  },
+  "expired-eligible": {
+    title: theaterCopy.pastExpiry,
+    body: theaterCopy.pastExpiryDetail,
+  },
+} as const satisfies Record<
+  "locked" | "reveal-requested" | "expired-eligible",
+  { title: string; body: string }
+>;

--- a/src/components/round-theater/theater-sound-toggle.tsx
+++ b/src/components/round-theater/theater-sound-toggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import { getTheaterAudio, readTheaterSoundEnabled } from "@/lib/theater-audio";
+import { theaterCopy } from "./theater-copy";
+
+const listeners = new Set<() => void>();
+
+function subscribe(onStoreChange: () => void) {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot() {
+  return readTheaterSoundEnabled();
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+function notifySoundListeners() {
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Default-off sound toggle. Persists preference; creates AudioContext only on
+ * the enabling click (required user gesture).
+ */
+export function TheaterSoundToggle() {
+  const enabled = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+
+  const toggle = useCallback(() => {
+    const next = !readTheaterSoundEnabled();
+    getTheaterAudio().setEnabled(next);
+    notifySoundListeners();
+  }, []);
+
+  return (
+    <button
+      aria-pressed={enabled}
+      className="border border-[var(--t-border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)]"
+      onClick={toggle}
+      title={theaterCopy.soundHint}
+      type="button"
+    >
+      {enabled ? theaterCopy.soundOn : theaterCopy.soundOff}
+    </button>
+  );
+}

--- a/src/components/round-theater/theater-sound-toggle.tsx
+++ b/src/components/round-theater/theater-sound-toggle.tsx
@@ -1,29 +1,12 @@
 "use client";
 
-import { useCallback, useSyncExternalStore } from "react";
-import { getTheaterAudio, readTheaterSoundEnabled } from "@/lib/theater-audio";
+import { useSyncExternalStore } from "react";
+import {
+  getTheaterAudio,
+  readTheaterSoundEnabled,
+  subscribeTheaterSound,
+} from "@/lib/theater-audio";
 import { theaterCopy } from "./theater-copy";
-
-const listeners = new Set<() => void>();
-
-function subscribe(onStoreChange: () => void) {
-  listeners.add(onStoreChange);
-  return () => {
-    listeners.delete(onStoreChange);
-  };
-}
-
-function getSnapshot() {
-  return readTheaterSoundEnabled();
-}
-
-function getServerSnapshot() {
-  return false;
-}
-
-function notifySoundListeners() {
-  for (const listener of listeners) listener();
-}
 
 /**
  * Default-off sound toggle. Persists preference; creates AudioContext only on
@@ -31,16 +14,14 @@ function notifySoundListeners() {
  */
 export function TheaterSoundToggle() {
   const enabled = useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    getServerSnapshot
+    subscribeTheaterSound,
+    readTheaterSoundEnabled,
+    () => false
   );
 
-  const toggle = useCallback(() => {
-    const next = !readTheaterSoundEnabled();
-    getTheaterAudio().setEnabled(next);
-    notifySoundListeners();
-  }, []);
+  const toggle = () => {
+    getTheaterAudio().setEnabled(!enabled);
+  };
 
   return (
     <button

--- a/src/components/round-theater/ticket-tape.tsx
+++ b/src/components/round-theater/ticket-tape.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  formatLeverageBps,
+  type TicketTapeEntry,
+} from "@/lib/margin-call-crash";
+import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { theaterCopy } from "./theater-copy";
+
+/**
+ * Open-phase live ticket tape of public TicketEntered rows.
+ */
+export function TicketTape({
+  entries,
+}: {
+  entries: readonly TicketTapeEntry[];
+}) {
+  if (entries.length === 0) {
+    return (
+      <div className="mt-4 border border-[var(--t-divider)] bg-[var(--t-panel-strong)] px-3 py-2">
+        <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+          {theaterCopy.openTape}
+        </p>
+        <p className="mt-2 text-xs text-[var(--t-muted)]">No Tickets yet.</p>
+      </div>
+    );
+  }
+
+  const items = entries.map((entry) => (
+    <span
+      className="mc-feed-enter inline-flex shrink-0 items-center gap-2 border border-[var(--t-divider)] bg-[var(--t-surface)] px-3 py-1.5 text-xs tabular-nums text-[var(--t-text)]"
+      key={entry.ticketId.toString()}
+    >
+      <span className="text-[var(--t-green-hot)]">
+        {formatDeskDollars(entry.margin, TUSD_DECIMALS)} tUSD
+      </span>
+      <span className="text-[var(--t-amber-hot)]">
+        {formatLeverageBps(entry.leverageBps)}
+      </span>
+      <span className="font-mono text-[10px] text-[var(--t-muted)]">
+        {shortAddress(entry.player)}
+      </span>
+    </span>
+  ));
+
+  return (
+    <div
+      aria-label={theaterCopy.openTape}
+      className="mc-marquee mt-4 overflow-hidden border border-[var(--t-divider)] bg-[var(--t-panel-strong)] py-2"
+    >
+      <p className="px-3 text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+        {theaterCopy.openTape}
+      </p>
+      <div
+        className="mc-marquee-track mt-2 gap-3 px-3"
+        style={{ ["--mc-marquee-duration" as string]: "36s" }}
+      >
+        {items}
+        {items}
+      </div>
+    </div>
+  );
+}
+
+function shortAddress(address: string) {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}

--- a/src/components/round-theater/ticket-tape.tsx
+++ b/src/components/round-theater/ticket-tape.tsx
@@ -5,6 +5,7 @@ import {
   type TicketTapeEntry,
 } from "@/lib/margin-call-crash";
 import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatShortAddress } from "@/lib/utils";
 import { theaterCopy } from "./theater-copy";
 
 /**
@@ -38,7 +39,7 @@ export function TicketTape({
         {formatLeverageBps(entry.leverageBps)}
       </span>
       <span className="font-mono text-[10px] text-[var(--t-muted)]">
-        {shortAddress(entry.player)}
+        {formatShortAddress(entry.player)}
       </span>
     </span>
   ));
@@ -60,8 +61,4 @@ export function TicketTape({
       </div>
     </div>
   );
-}
-
-function shortAddress(address: string) {
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }

--- a/src/components/round-theater/tier-close-board.tsx
+++ b/src/components/round-theater/tier-close-board.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+  formatLeverageBps,
+  isWinningTicket,
+  type TierExposure,
+} from "@/lib/margin-call-crash";
+import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { getTierCloseProgress } from "@/lib/round-replay";
+import { theaterCopy } from "./theater-copy";
+
+export type TierCloseBoardProps = {
+  tiers: readonly TierExposure[];
+  crashPointBps: bigint;
+  /** Live climb progress; pass 1 for the static/reduced-motion card. */
+  progress: number;
+};
+
+/**
+ * Per-tier close board. Colour-independent text status on every row.
+ */
+export function TierCloseBoard({
+  tiers,
+  crashPointBps,
+  progress,
+}: TierCloseBoardProps) {
+  return (
+    <ul className="mt-4 space-y-1.5" aria-label="Arcade Leverage tier closes">
+      {tiers.map((tier) => {
+        const closeAt = getTierCloseProgress(tier.leverageBps, crashPointBps);
+        const wins = isWinningTicket(tier.leverageBps, crashPointBps);
+        const closed = closeAt !== null && closeAt <= progress;
+        const label = formatLeverageBps(tier.leverageBps);
+        const status = !wins
+          ? theaterCopy.tierOpen(label)
+          : closed
+            ? theaterCopy.tierClosed(label)
+            : theaterCopy.tierIdle(label);
+
+        return (
+          <li
+            className={`flex flex-wrap items-center justify-between gap-2 border px-3 py-2 text-xs ${
+              closed && wins
+                ? "mc-tier-pop border-[var(--t-green)]/50 bg-[var(--t-green)]/10 text-[var(--t-green-hot)]"
+                : !wins && progress >= 1
+                  ? "border-[var(--t-red)]/40 text-[var(--t-red-hot)]"
+                  : "border-[var(--t-divider)] text-[var(--t-muted)]"
+            }`}
+            key={tier.leverageBps.toString()}
+          >
+            <span className="font-bold uppercase tracking-[0.12em]">
+              {status}
+            </span>
+            <span className="tabular-nums">
+              {tier.ticketCount === 0
+                ? theaterCopy.noTicketsAtTier
+                : wins && closed
+                  ? `${formatDeskDollars(tier.reservedPayout, TUSD_DECIMALS)} tUSD · ${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"}`
+                  : `${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"} · ${formatDeskDollars(tier.totalMargin, TUSD_DECIMALS)} tUSD margin`}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/hooks/use-current-crash-round.ts
+++ b/src/hooks/use-current-crash-round.ts
@@ -29,7 +29,13 @@ export type CurrentCrashRoundView = { retry: () => Promise<void> } & (
       phase: CrashRoundPhase;
       countdownSeconds: number;
       crashRandom: Hex | null;
+      /** Raw verified Crash Point in basis points; null until finalized. */
+      crashPointBps: bigint | null;
       displayCrashPoint: string | null;
+      /** Unix seconds of RoundFinalized; null until finalized. */
+      finalizedAtSeconds: bigint | null;
+      /** Client-corrected chain time used for phase and countdown. */
+      chainTimestamp: bigint;
       openingTransactionUrl: string | null;
       revealTransactionUrl: string | null;
       finalizeTransactionUrl: string | null;
@@ -100,9 +106,12 @@ export function useCurrentCrashRound(): CurrentCrashRoundView {
       crashRandom: isRoundInitialized(snapshot.round)
         ? snapshot.round.crashRandom
         : null,
+      crashPointBps: published ? snapshot.round.crashPointBps : null,
       displayCrashPoint: published
         ? formatCrashPointBps(snapshot.round.crashPointBps)
         : null,
+      finalizedAtSeconds: published ? snapshot.finalizedAtSeconds : null,
+      chainTimestamp,
       openingTransactionUrl: snapshot.openingTransactionUrl,
       revealTransactionUrl: snapshot.revealTransactionUrl,
       finalizeTransactionUrl: snapshot.finalizeTransactionUrl,

--- a/src/hooks/use-reduced-motion.ts
+++ b/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribes to prefers-reduced-motion. Degrades to false when matchMedia is
+ * unavailable (jsdom / SSR) so animated clients are the default there.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return reduced;
+}

--- a/src/hooks/use-replay-clock.ts
+++ b/src/hooks/use-replay-clock.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { getReplayDurationMs, getReplayProgress } from "@/lib/round-replay";
+import { useEffect, useRef, useState } from "react";
+import {
+  getReplayDurationMs,
+  getReplayProgress,
+  isReplayComplete,
+} from "@/lib/round-replay";
 
 export type ReplayClockOptions = {
   /** Attested Crash Point in basis points. Null disables the clock. */
@@ -26,8 +30,6 @@ export type ReplayClockOptions = {
 
 export type ReplayClock = {
   progress: number;
-  elapsedMs: number;
-  durationMs: number;
   isComplete: boolean;
 };
 
@@ -67,6 +69,13 @@ export function useReplayClock(options: ReplayClockOptions): ReplayClock {
     elapsedMs: number;
   } | null>(null);
 
+  // Read the seed through a ref so a fresh chainTimestamp on each poll doesn't
+  // tear down and restart the running rAF loop; only `generation` restarts it.
+  const seedRef = useRef(seedElapsedMs);
+  useEffect(() => {
+    seedRef.current = seedElapsedMs;
+  }, [seedElapsedMs]);
+
   useEffect(() => {
     if (
       reducedMotion ||
@@ -79,7 +88,7 @@ export function useReplayClock(options: ReplayClockOptions): ReplayClock {
     let frame = 0;
     let cancelled = false;
     const start = performance.now();
-    const seed = seedElapsedMs;
+    const seed = seedRef.current;
     const activeGeneration = generation;
 
     const tick = (now: number) => {
@@ -99,14 +108,7 @@ export function useReplayClock(options: ReplayClockOptions): ReplayClock {
       cancelled = true;
       window.cancelAnimationFrame(frame);
     };
-  }, [
-    crashPointBps,
-    durationMs,
-    generation,
-    loop,
-    reducedMotion,
-    seedElapsedMs,
-  ]);
+  }, [crashPointBps, durationMs, generation, loop, reducedMotion]);
 
   const elapsedMs =
     anim !== null && anim.generation === generation
@@ -117,8 +119,6 @@ export function useReplayClock(options: ReplayClockOptions): ReplayClock {
 
   return {
     progress,
-    elapsedMs,
-    durationMs,
-    isComplete: progress >= 1,
+    isComplete: isReplayComplete(progress),
   };
 }

--- a/src/hooks/use-replay-clock.ts
+++ b/src/hooks/use-replay-clock.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getReplayDurationMs, getReplayProgress } from "@/lib/round-replay";
+
+export type ReplayClockOptions = {
+  /** Attested Crash Point in basis points. Null disables the clock. */
+  crashPointBps: bigint | null;
+  /**
+   * Unix seconds when RoundFinalized landed. Combined with chainTimestamp to
+   * seed elapsed time so mid-arrival clients seek to the correct frame.
+   */
+  finalizedAtSeconds: bigint | null;
+  /** Client-corrected chain time in Unix seconds. */
+  chainTimestamp: bigint | null;
+  /** When true, never starts a rAF loop — caller renders a static card. */
+  reducedMotion?: boolean;
+  /**
+   * Local restart nonce. Incrementing restarts the climb from 1.00x without
+   * touching settlement. Inert beyond presentation.
+   */
+  restartNonce?: number;
+  /** When true, loops the climb (Open-phase ambiance). */
+  loop?: boolean;
+};
+
+export type ReplayClock = {
+  progress: number;
+  elapsedMs: number;
+  durationMs: number;
+  isComplete: boolean;
+};
+
+/**
+ * Deterministic replay clock. Seeded from chain time for cross-client seek,
+ * then advanced with requestAnimationFrame for sub-second smoothness.
+ */
+export function useReplayClock(options: ReplayClockOptions): ReplayClock {
+  const {
+    crashPointBps,
+    finalizedAtSeconds,
+    chainTimestamp,
+    reducedMotion = false,
+    restartNonce = 0,
+    loop = false,
+  } = options;
+
+  const durationMs =
+    crashPointBps !== null ? getReplayDurationMs(crashPointBps) : 0;
+
+  const seedElapsedMs = (() => {
+    if (
+      crashPointBps === null ||
+      finalizedAtSeconds === null ||
+      chainTimestamp === null
+    ) {
+      return 0;
+    }
+    const elapsedSeconds = Number(chainTimestamp - finalizedAtSeconds);
+    return Math.max(0, elapsedSeconds * 1_000);
+  })();
+
+  const generation = `${crashPointBps?.toString() ?? "null"}:${finalizedAtSeconds?.toString() ?? "null"}:${restartNonce}:${loop}`;
+
+  const [anim, setAnim] = useState<{
+    generation: string;
+    elapsedMs: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (
+      reducedMotion ||
+      crashPointBps === null ||
+      typeof window === "undefined"
+    ) {
+      return;
+    }
+
+    let frame = 0;
+    let cancelled = false;
+    const start = performance.now();
+    const seed = seedElapsedMs;
+    const activeGeneration = generation;
+
+    const tick = (now: number) => {
+      if (cancelled) return;
+      let elapsed = seed + (now - start);
+      if (loop && durationMs > 0) {
+        elapsed = elapsed % durationMs;
+      }
+      setAnim({ generation: activeGeneration, elapsedMs: elapsed });
+      const nextProgress = getReplayProgress(elapsed, crashPointBps);
+      if (!loop && nextProgress >= 1) return;
+      frame = window.requestAnimationFrame(tick);
+    };
+
+    frame = window.requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+    };
+  }, [
+    crashPointBps,
+    durationMs,
+    generation,
+    loop,
+    reducedMotion,
+    seedElapsedMs,
+  ]);
+
+  const elapsedMs =
+    anim !== null && anim.generation === generation
+      ? anim.elapsedMs
+      : seedElapsedMs;
+  const progress =
+    crashPointBps !== null ? getReplayProgress(elapsedMs, crashPointBps) : 0;
+
+  return {
+    progress,
+    elapsedMs,
+    durationMs,
+    isComplete: progress >= 1,
+  };
+}

--- a/src/hooks/use-round-theater.ts
+++ b/src/hooks/use-round-theater.ts
@@ -8,10 +8,12 @@ import {
 import { usePolledCrashRead } from "@/hooks/use-polled-crash-read";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import {
-  ENTRY_LEVERAGE_TIERS_BPS,
+  aggregateTierExposure,
+  isPreLockPhase,
   readLatestFinalizedReplayRound,
   readRoundTicketTape,
   type FinalizedReplayRound,
+  type MarginCallCrashConfig,
   type RoundTicketTape,
   type TierExposure,
 } from "@/lib/margin-call-crash";
@@ -40,7 +42,6 @@ export type TheaterStage = TheaterBase &
         countdownSeconds: number;
         tape: RoundTicketTape | null;
         ambiance: FinalizedReplayRound | null;
-        chainTimestamp: bigint;
       }
     | {
         kind: "delayed";
@@ -66,15 +67,6 @@ export type TheaterStage = TheaterBase &
       }
   );
 
-function emptyTiers(): TierExposure[] {
-  return ENTRY_LEVERAGE_TIERS_BPS.map((leverageBps) => ({
-    leverageBps,
-    ticketCount: 0,
-    totalMargin: 0n,
-    reservedPayout: 0n,
-  }));
-}
-
 /**
  * Presentation-only theater state. Composes public round reads and ticket tape
  * — never imports settlement or entry transaction hooks.
@@ -85,25 +77,15 @@ export function useRoundTheater(): TheaterStage {
 
   const roundIdForTape = round.status === "ready" ? round.roundId : null;
 
-  const tapeRead = useCallback(
-    (config: Parameters<typeof readRoundTicketTape>[0]) => {
-      if (roundIdForTape === null) {
-        return Promise.resolve<RoundTicketTape | null>(null);
-      }
-      return readRoundTicketTape(config, roundIdForTape);
-    },
-    [roundIdForTape]
-  );
+  const tapeRead = useMemo(() => {
+    if (roundIdForTape === null) return null;
+    return (config: MarginCallCrashConfig) =>
+      readRoundTicketTape(config, roundIdForTape);
+  }, [roundIdForTape]);
 
-  const tapePoll = usePolledCrashRead(
-    roundIdForTape !== null ? tapeRead : null
-  );
+  const tapePoll = usePolledCrashRead(tapeRead);
 
-  const needsAmbiance =
-    round.status === "ready" &&
-    (round.phase === "open" ||
-      round.phase === "prelaunch" ||
-      round.phase === "uninitialized");
+  const needsAmbiance = round.status === "ready" && isPreLockPhase(round.phase);
 
   const ambianceRead = useCallback(
     (config: Parameters<typeof readLatestFinalizedReplayRound>[0]) =>
@@ -164,14 +146,13 @@ function toTheaterStage(options: {
 
   const phase = round.phase;
 
-  if (phase === "open" || phase === "prelaunch" || phase === "uninitialized") {
+  if (isPreLockPhase(phase)) {
     return {
       kind: "open",
       roundId: round.roundId,
       countdownSeconds: round.countdownSeconds,
       tape,
       ambiance,
-      chainTimestamp: round.chainTimestamp,
       reducedMotion,
       retry,
     };
@@ -212,7 +193,7 @@ function toTheaterStage(options: {
       chainTimestamp: round.chainTimestamp,
       finalizeTransactionUrl: round.finalizeTransactionUrl,
       tape,
-      tiers: tape?.tiers ?? emptyTiers(),
+      tiers: tape?.tiers ?? aggregateTierExposure([]),
       reducedMotion,
       retry,
     };

--- a/src/hooks/use-round-theater.ts
+++ b/src/hooks/use-round-theater.ts
@@ -1,0 +1,233 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import {
+  useCurrentCrashRound,
+  type CurrentCrashRoundView,
+} from "@/hooks/use-current-crash-round";
+import { usePolledCrashRead } from "@/hooks/use-polled-crash-read";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import {
+  ENTRY_LEVERAGE_TIERS_BPS,
+  readLatestFinalizedReplayRound,
+  readRoundTicketTape,
+  type FinalizedReplayRound,
+  type RoundTicketTape,
+  type TierExposure,
+} from "@/lib/margin-call-crash";
+
+export type TheaterStageKind =
+  | "loading"
+  | "error"
+  | "unavailable"
+  | "open"
+  | "delayed"
+  | "finalized"
+  | "expired";
+
+type TheaterBase = {
+  retry: () => Promise<void>;
+  reducedMotion: boolean;
+};
+
+export type TheaterStage = TheaterBase &
+  (
+    | { kind: "loading" }
+    | { kind: "error" | "unavailable"; error: string }
+    | {
+        kind: "open";
+        roundId: bigint;
+        countdownSeconds: number;
+        tape: RoundTicketTape | null;
+        ambiance: FinalizedReplayRound | null;
+        chainTimestamp: bigint;
+      }
+    | {
+        kind: "delayed";
+        roundId: bigint;
+        phaseLabel: "locked" | "reveal-requested" | "expired-eligible";
+        tape: RoundTicketTape | null;
+      }
+    | {
+        kind: "finalized";
+        roundId: bigint;
+        crashPointBps: bigint;
+        displayCrashPoint: string;
+        finalizedAtSeconds: bigint | null;
+        chainTimestamp: bigint;
+        finalizeTransactionUrl: string | null;
+        tape: RoundTicketTape | null;
+        tiers: TierExposure[];
+      }
+    | {
+        kind: "expired";
+        roundId: bigint;
+        tape: RoundTicketTape | null;
+      }
+  );
+
+function emptyTiers(): TierExposure[] {
+  return ENTRY_LEVERAGE_TIERS_BPS.map((leverageBps) => ({
+    leverageBps,
+    ticketCount: 0,
+    totalMargin: 0n,
+    reservedPayout: 0n,
+  }));
+}
+
+/**
+ * Presentation-only theater state. Composes public round reads and ticket tape
+ * — never imports settlement or entry transaction hooks.
+ */
+export function useRoundTheater(): TheaterStage {
+  const round = useCurrentCrashRound();
+  const reducedMotion = useReducedMotion();
+
+  const roundIdForTape = round.status === "ready" ? round.roundId : null;
+
+  const tapeRead = useCallback(
+    (config: Parameters<typeof readRoundTicketTape>[0]) => {
+      if (roundIdForTape === null) {
+        return Promise.resolve<RoundTicketTape | null>(null);
+      }
+      return readRoundTicketTape(config, roundIdForTape);
+    },
+    [roundIdForTape]
+  );
+
+  const tapePoll = usePolledCrashRead(
+    roundIdForTape !== null ? tapeRead : null
+  );
+
+  const needsAmbiance =
+    round.status === "ready" &&
+    (round.phase === "open" ||
+      round.phase === "prelaunch" ||
+      round.phase === "uninitialized");
+
+  const ambianceRead = useCallback(
+    (config: Parameters<typeof readLatestFinalizedReplayRound>[0]) =>
+      readLatestFinalizedReplayRound(config),
+    []
+  );
+
+  const ambiancePoll = usePolledCrashRead(needsAmbiance ? ambianceRead : null);
+
+  return useMemo(
+    () =>
+      toTheaterStage({
+        round,
+        reducedMotion,
+        tape: tapePoll.data,
+        ambiance: needsAmbiance ? ambiancePoll.data : null,
+        retryTape: tapePoll.refresh,
+        retryAmbiance: ambiancePoll.refresh,
+      }),
+    [
+      ambiancePoll.data,
+      ambiancePoll.refresh,
+      needsAmbiance,
+      reducedMotion,
+      round,
+      tapePoll.data,
+      tapePoll.refresh,
+    ]
+  );
+}
+
+function toTheaterStage(options: {
+  round: CurrentCrashRoundView;
+  reducedMotion: boolean;
+  tape: RoundTicketTape | null;
+  ambiance: FinalizedReplayRound | null;
+  retryTape: () => Promise<void>;
+  retryAmbiance: () => Promise<void>;
+}): TheaterStage {
+  const { round, reducedMotion, tape, ambiance } = options;
+  const retry = async () => {
+    await round.retry();
+    await options.retryTape();
+    await options.retryAmbiance();
+  };
+
+  if (round.status !== "ready") {
+    if (round.status === "loading") {
+      return { kind: "loading", reducedMotion, retry };
+    }
+    return {
+      kind: round.status,
+      error: round.error,
+      reducedMotion,
+      retry,
+    };
+  }
+
+  const phase = round.phase;
+
+  if (phase === "open" || phase === "prelaunch" || phase === "uninitialized") {
+    return {
+      kind: "open",
+      roundId: round.roundId,
+      countdownSeconds: round.countdownSeconds,
+      tape,
+      ambiance,
+      chainTimestamp: round.chainTimestamp,
+      reducedMotion,
+      retry,
+    };
+  }
+
+  if (
+    phase === "locked" ||
+    phase === "reveal-requested" ||
+    phase === "expired-eligible"
+  ) {
+    return {
+      kind: "delayed",
+      roundId: round.roundId,
+      phaseLabel: phase,
+      tape,
+      reducedMotion,
+      retry,
+    };
+  }
+
+  if (phase === "finalized") {
+    if (round.crashPointBps === null || round.displayCrashPoint === null) {
+      return {
+        kind: "delayed",
+        roundId: round.roundId,
+        phaseLabel: "reveal-requested",
+        tape,
+        reducedMotion,
+        retry,
+      };
+    }
+    return {
+      kind: "finalized",
+      roundId: round.roundId,
+      crashPointBps: round.crashPointBps,
+      displayCrashPoint: round.displayCrashPoint,
+      finalizedAtSeconds: round.finalizedAtSeconds,
+      chainTimestamp: round.chainTimestamp,
+      finalizeTransactionUrl: round.finalizeTransactionUrl,
+      tape,
+      tiers: tape?.tiers ?? emptyTiers(),
+      reducedMotion,
+      retry,
+    };
+  }
+
+  if (phase === "expired") {
+    return {
+      kind: "expired",
+      roundId: round.roundId,
+      tape,
+      reducedMotion,
+      retry,
+    };
+  }
+
+  const _exhaustive: never = phase;
+  return _exhaustive;
+}

--- a/src/lib/margin-call-crash.test.ts
+++ b/src/lib/margin-call-crash.test.ts
@@ -4,6 +4,7 @@ import type { CrashRound } from "./margin-call-crash";
 
 const sdk = vi.hoisted(() => ({
   getBlock: vi.fn(),
+  getBlockNumber: vi.fn(),
   getLogs: vi.fn(),
   readContract: vi.fn(),
 }));
@@ -11,6 +12,7 @@ const sdk = vi.hoisted(() => ({
 vi.mock("./base-sepolia", () => ({
   baseSepoliaPublicClient: {
     getBlock: (...args: unknown[]) => sdk.getBlock(...args),
+    getBlockNumber: (...args: unknown[]) => sdk.getBlockNumber(...args),
     getLogs: (...args: unknown[]) => sdk.getLogs(...args),
     readContract: (...args: unknown[]) => sdk.readContract(...args),
   },
@@ -33,6 +35,7 @@ describe("MarginCallCrash public reads and phase math", () => {
     vi.resetModules();
     vi.unstubAllEnvs();
     sdk.getBlock.mockReset();
+    sdk.getBlockNumber.mockReset();
     sdk.getLogs.mockReset();
     sdk.readContract.mockReset();
   });
@@ -807,7 +810,7 @@ describe("MarginCallCrash public reads and phase math", () => {
   it("reads the ticket tape and per-tier aggregates for a round", async () => {
     const playerA = "0x00000000000000000000000000000000000000aa";
     const playerB = "0x00000000000000000000000000000000000000bb";
-    sdk.getBlock.mockResolvedValue({ number: 100n, timestamp: 2_000n });
+    sdk.getBlockNumber.mockResolvedValue(100n);
     sdk.getLogs.mockResolvedValue([
       {
         args: {
@@ -853,9 +856,7 @@ describe("MarginCallCrash public reads and phase math", () => {
   });
 
   it("finds the latest finalized round for ambiance replay", async () => {
-    sdk.getBlock
-      .mockResolvedValueOnce({ number: 100n, timestamp: 2_000n })
-      .mockResolvedValueOnce({ number: 90n, timestamp: 1_800n });
+    sdk.getBlockNumber.mockResolvedValue(100n);
     sdk.readContract.mockImplementation(({ functionName, args }) => {
       if (functionName === "currentRoundId") return Promise.resolve(5n);
       if (functionName === "getRound") {
@@ -879,23 +880,6 @@ describe("MarginCallCrash public reads and phase math", () => {
       }
       return Promise.reject(new Error(`unexpected ${functionName}`));
     });
-    sdk.getLogs.mockImplementation(({ event }) => {
-      if (event.name === "RoundFinalized") {
-        return Promise.resolve([
-          {
-            transactionHash: FINALIZE_TRANSACTION_HASH,
-            blockNumber: 90n,
-          },
-        ]);
-      }
-      if (event.name === "RoundOpened") {
-        return Promise.resolve([{ transactionHash: OPENING_TRANSACTION_HASH }]);
-      }
-      if (event.name === "RevealRequested") {
-        return Promise.resolve([{ transactionHash: REVEAL_TRANSACTION_HASH }]);
-      }
-      return Promise.resolve([]);
-    });
     const { readLatestFinalizedReplayRound } =
       await import("./margin-call-crash");
 
@@ -906,7 +890,6 @@ describe("MarginCallCrash public reads and phase math", () => {
 
     expect(ambiance).toMatchObject({
       displayCrashPoint: "3.42x",
-      finalizedAtSeconds: 1_800n,
       round: { id: 3n, crashPointBps: 34_200n, status: 3 },
     });
   });

--- a/src/lib/margin-call-crash.test.ts
+++ b/src/lib/margin-call-crash.test.ts
@@ -270,7 +270,12 @@ describe("MarginCallCrash public reads and phase math", () => {
     sdk.getLogs
       .mockResolvedValueOnce([{ transactionHash: OPENING_TRANSACTION_HASH }])
       .mockResolvedValueOnce([{ transactionHash: REVEAL_TRANSACTION_HASH }])
-      .mockResolvedValueOnce([{ transactionHash: FINALIZE_TRANSACTION_HASH }]);
+      .mockResolvedValueOnce([
+        {
+          transactionHash: FINALIZE_TRANSACTION_HASH,
+          blockNumber: 95n,
+        },
+      ]);
     const { readCurrentCrashRound } = await import("./margin-call-crash");
 
     await expect(
@@ -280,6 +285,7 @@ describe("MarginCallCrash public reads and phase math", () => {
       })
     ).resolves.toMatchObject({
       round: { status: 3, crashPointBps: 34_200n },
+      finalizedAtSeconds: 1_020n,
       openingTransactionUrl: `https://sepolia.basescan.org/tx/${OPENING_TRANSACTION_HASH}`,
       revealTransactionUrl: `https://sepolia.basescan.org/tx/${REVEAL_TRANSACTION_HASH}`,
       finalizeTransactionUrl: `https://sepolia.basescan.org/tx/${FINALIZE_TRANSACTION_HASH}`,
@@ -752,6 +758,195 @@ describe("MarginCallCrash public reads and phase math", () => {
       canRefund: false,
       canExpire: false,
     });
+  });
+  it("aggregates TicketEntered rows into per-tier exposure using reservedPayout", async () => {
+    const { aggregateTierExposure, ENTRY_LEVERAGE_TIERS_BPS } =
+      await import("./margin-call-crash");
+
+    const tiers = aggregateTierExposure([
+      {
+        leverageBps: 12_500n,
+        margin: 1_000_000n,
+        reservedPayout: 1_250_000n,
+      },
+      {
+        leverageBps: 12_500n,
+        margin: 5_000_000n,
+        reservedPayout: 6_250_000n,
+      },
+      {
+        leverageBps: 20_000n,
+        margin: 10_000_000n,
+        reservedPayout: 20_000_000n,
+      },
+      // Unknown leverage is skipped (contracts reject it at entry).
+      {
+        leverageBps: 11_000n,
+        margin: 1_000_000n,
+        reservedPayout: 1_100_000n,
+      },
+    ]);
+
+    expect(tiers).toHaveLength(ENTRY_LEVERAGE_TIERS_BPS.length);
+    expect(tiers[0]).toEqual({
+      leverageBps: 12_500n,
+      ticketCount: 2,
+      totalMargin: 6_000_000n,
+      reservedPayout: 7_500_000n,
+    });
+    expect(tiers[2]).toEqual({
+      leverageBps: 20_000n,
+      ticketCount: 1,
+      totalMargin: 10_000_000n,
+      reservedPayout: 20_000_000n,
+    });
+    expect(tiers[1]?.ticketCount).toBe(0);
+    expect(tiers[5]?.ticketCount).toBe(0);
+  });
+
+  it("reads the ticket tape and per-tier aggregates for a round", async () => {
+    const playerA = "0x00000000000000000000000000000000000000aa";
+    const playerB = "0x00000000000000000000000000000000000000bb";
+    sdk.getBlock.mockResolvedValue({ number: 100n, timestamp: 2_000n });
+    sdk.getLogs.mockResolvedValue([
+      {
+        args: {
+          roundId: 3n,
+          ticketId: 10n,
+          player: playerA,
+          margin: 1_000_000n,
+          leverageBps: 12_500n,
+          reservedPayout: 1_250_000n,
+        },
+        transactionHash: OPENING_TRANSACTION_HASH,
+      },
+      {
+        args: {
+          roundId: 3n,
+          ticketId: 11n,
+          player: playerB,
+          margin: 5_000_000n,
+          leverageBps: 20_000n,
+          reservedPayout: 10_000_000n,
+        },
+        transactionHash: REVEAL_TRANSACTION_HASH,
+      },
+    ]);
+    const { readRoundTicketTape } = await import("./margin-call-crash");
+
+    const tape = await readRoundTicketTape(
+      { address: CONTRACT_ADDRESS, deploymentBlock: 50n },
+      3n
+    );
+
+    expect(tape.roundId).toBe(3n);
+    expect(tape.entries).toHaveLength(2);
+    expect(tape.entries[0]).toMatchObject({
+      ticketId: 10n,
+      player: playerA,
+      leverageBps: 12_500n,
+      reservedPayout: 1_250_000n,
+    });
+    expect(tape.tiers[0]?.ticketCount).toBe(1);
+    expect(tape.tiers[2]?.ticketCount).toBe(1);
+    expect(tape.tiers[2]?.reservedPayout).toBe(10_000_000n);
+  });
+
+  it("finds the latest finalized round for ambiance replay", async () => {
+    sdk.getBlock
+      .mockResolvedValueOnce({ number: 100n, timestamp: 2_000n })
+      .mockResolvedValueOnce({ number: 90n, timestamp: 1_800n });
+    sdk.readContract.mockImplementation(({ functionName, args }) => {
+      if (functionName === "currentRoundId") return Promise.resolve(5n);
+      if (functionName === "getRound") {
+        const roundId = args?.[0] as bigint;
+        if (roundId === 5n) {
+          return Promise.resolve(
+            makeRound({ id: 5n, status: 1, crashPointBps: 0n })
+          );
+        }
+        if (roundId === 4n) {
+          return Promise.resolve(
+            makeRound({ id: 4n, status: 2, crashPointBps: 0n })
+          );
+        }
+        if (roundId === 3n) {
+          return Promise.resolve(
+            makeRound({ id: 3n, status: 3, crashPointBps: 34_200n })
+          );
+        }
+        return Promise.resolve(makeRound({ id: roundId, status: 0 }));
+      }
+      return Promise.reject(new Error(`unexpected ${functionName}`));
+    });
+    sdk.getLogs.mockImplementation(({ event }) => {
+      if (event.name === "RoundFinalized") {
+        return Promise.resolve([
+          {
+            transactionHash: FINALIZE_TRANSACTION_HASH,
+            blockNumber: 90n,
+          },
+        ]);
+      }
+      if (event.name === "RoundOpened") {
+        return Promise.resolve([{ transactionHash: OPENING_TRANSACTION_HASH }]);
+      }
+      if (event.name === "RevealRequested") {
+        return Promise.resolve([{ transactionHash: REVEAL_TRANSACTION_HASH }]);
+      }
+      return Promise.resolve([]);
+    });
+    const { readLatestFinalizedReplayRound } =
+      await import("./margin-call-crash");
+
+    const ambiance = await readLatestFinalizedReplayRound({
+      address: CONTRACT_ADDRESS,
+      deploymentBlock: 50n,
+    });
+
+    expect(ambiance).toMatchObject({
+      displayCrashPoint: "3.42x",
+      finalizedAtSeconds: 1_800n,
+      round: { id: 3n, crashPointBps: 34_200n, status: 3 },
+    });
+  });
+
+  it("caches the finalize timestamp and returns it from current-round reads", async () => {
+    vi.stubEnv("NEXT_PUBLIC_MARGIN_CALL_CRASH_ADDRESS", CONTRACT_ADDRESS);
+    vi.stubEnv("NEXT_PUBLIC_MARGIN_CALL_CRASH_DEPLOYMENT_BLOCK", "50");
+    sdk.getBlock
+      .mockResolvedValueOnce({ number: 100n, timestamp: 2_000n })
+      .mockResolvedValueOnce({ number: 95n, timestamp: 1_950n });
+    sdk.readContract
+      .mockResolvedValueOnce(1_000n) // epochOrigin
+      .mockResolvedValueOnce(3n) // currentRoundId
+      .mockResolvedValueOnce(makeRound({ status: 3, crashPointBps: 25_000n }));
+    sdk.getLogs.mockImplementation(({ event }) => {
+      if (event.name === "RoundOpened") {
+        return Promise.resolve([{ transactionHash: OPENING_TRANSACTION_HASH }]);
+      }
+      if (event.name === "RevealRequested") {
+        return Promise.resolve([{ transactionHash: REVEAL_TRANSACTION_HASH }]);
+      }
+      if (event.name === "RoundFinalized") {
+        return Promise.resolve([
+          {
+            transactionHash: FINALIZE_TRANSACTION_HASH,
+            blockNumber: 95n,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    const { readCurrentCrashRound } = await import("./margin-call-crash");
+
+    const result = await readCurrentCrashRound({
+      address: CONTRACT_ADDRESS,
+      deploymentBlock: 50n,
+    });
+
+    expect(result.finalizedAtSeconds).toBe(1_950n);
+    expect(result.round.crashPointBps).toBe(25_000n);
   });
 });
 

--- a/src/lib/margin-call-crash.ts
+++ b/src/lib/margin-call-crash.ts
@@ -190,6 +190,42 @@ export const ROUND_STATUS = {
 /** How many prior epochs to surface in global history. */
 export const GLOBAL_HISTORY_LOOKBACK_ROUNDS = 20;
 
+/** How many prior epochs to scan for Open-phase ambiance replay. */
+export const AMBIANCE_LOOKBACK_ROUNDS = 5;
+
+/** One public TicketEntered row for the live ticket tape / tier pops. */
+export type TicketTapeEntry = {
+  ticketId: bigint;
+  player: Address;
+  margin: bigint;
+  leverageBps: bigint;
+  reservedPayout: bigint;
+  transactionHash: Hash | null;
+};
+
+/** Per-tier aggregate of committed tickets in a round. */
+export type TierExposure = {
+  leverageBps: bigint;
+  ticketCount: number;
+  totalMargin: bigint;
+  reservedPayout: bigint;
+};
+
+/** Ticket tape + tier aggregates for one round. */
+export type RoundTicketTape = {
+  roundId: bigint;
+  entries: TicketTapeEntry[];
+  tiers: TierExposure[];
+};
+
+/** A finalized round eligible for dramatized replay / ambiance. */
+export type FinalizedReplayRound = {
+  round: CrashRound;
+  displayCrashPoint: string;
+  finalizedAtSeconds: bigint;
+  finalizeTransactionUrl: string | null;
+};
+
 type RoundLifecycleEvent =
   | typeof roundOpenedEvent
   | typeof revealRequestedEvent
@@ -207,6 +243,10 @@ const lifecycleTransactionCache = new Map<
   string,
   Partial<Record<LifecycleEventKey, Hash | null>>
 >();
+/** Finalized-at timestamps are immutable once observed. */
+const finalizeTimestampCache = new Map<string, bigint>();
+/** Block number of RoundFinalized, shared with the lifecycle hash lookup. */
+const finalizeBlockNumberCache = new Map<string, bigint>();
 
 /** Public configuration only. Static env references allow Next.js client inlining. */
 export function getMarginCallCrashConfig(): MarginCallCrashConfig | null {
@@ -350,6 +390,37 @@ export function canOfferEntry(
   countdownSeconds: number
 ) {
   return phase === "open" && countdownSeconds > ENTRY_CUTOFF_SECONDS;
+}
+
+/**
+ * Groups TicketEntered rows into one TierExposure per Arcade Leverage tier.
+ * Sums the onchain reservedPayout to avoid integer-division drift vs the vault.
+ * Unknown leverage values are skipped (contracts reject them at entry).
+ */
+export function aggregateTierExposure(
+  entries: ReadonlyArray<
+    Pick<TicketTapeEntry, "leverageBps" | "margin" | "reservedPayout">
+  >
+): TierExposure[] {
+  const byTier = new Map<bigint, TierExposure>();
+  for (const tier of ENTRY_LEVERAGE_TIERS_BPS) {
+    byTier.set(tier, {
+      leverageBps: tier,
+      ticketCount: 0,
+      totalMargin: 0n,
+      reservedPayout: 0n,
+    });
+  }
+
+  for (const entry of entries) {
+    const bucket = byTier.get(entry.leverageBps);
+    if (!bucket) continue;
+    bucket.ticketCount += 1;
+    bucket.totalMargin += entry.margin;
+    bucket.reservedPayout += entry.reservedPayout;
+  }
+
+  return ENTRY_LEVERAGE_TIERS_BPS.map((tier) => byTier.get(tier)!);
 }
 
 export type CrashCallRequest = { to: Address; data: Hex };
@@ -787,6 +858,7 @@ export async function readCurrentCrashRound(config: MarginCallCrashConfig) {
       chainTimestamp: block.timestamp,
       currentRoundId: 0n,
       round: pendingRound,
+      finalizedAtSeconds: null,
       ...emptyLifecycleUrls(config.address),
     };
   }
@@ -814,14 +886,168 @@ export async function readCurrentCrashRound(config: MarginCallCrashConfig) {
     normalizedRound,
     block.number
   );
+  const finalizedAtSeconds =
+    normalizedRound.status === ROUND_STATUS.finalized
+      ? await readFinalizedAtSeconds(
+          config,
+          currentRoundId,
+          normalizedRound,
+          block.number
+        )
+      : null;
 
   return {
     blockNumber: block.number,
     chainTimestamp: block.timestamp,
     currentRoundId,
     round: normalizedRound,
+    finalizedAtSeconds,
     ...lifecycleUrls,
   };
+}
+
+/**
+ * Public TicketEntered rows for one round, plus per-tier aggregates for the
+ * theater tape and tier-close payout pops.
+ */
+export async function readRoundTicketTape(
+  config: MarginCallCrashConfig,
+  roundId: bigint
+): Promise<RoundTicketTape> {
+  const block = await baseSepoliaPublicClient.getBlock({ blockTag: "latest" });
+  const logs = await baseSepoliaPublicClient.getLogs({
+    address: config.address,
+    event: ticketEnteredEvent,
+    args: { roundId },
+    fromBlock: config.deploymentBlock,
+    toBlock: block.number,
+    strict: true,
+  });
+
+  const entries: TicketTapeEntry[] = logs.map((log) => ({
+    ticketId: log.args.ticketId,
+    player: log.args.player,
+    margin: log.args.margin,
+    leverageBps: log.args.leverageBps,
+    reservedPayout: log.args.reservedPayout,
+    transactionHash: log.transactionHash,
+  }));
+
+  return {
+    roundId,
+    entries,
+    tiers: aggregateTierExposure(entries),
+  };
+}
+
+/**
+ * Newest finalized round within the ambiance lookback, for Open-phase
+ * previous-round replay. Returns null when none exist.
+ */
+export async function readLatestFinalizedReplayRound(
+  config: MarginCallCrashConfig
+): Promise<FinalizedReplayRound | null> {
+  const block = await baseSepoliaPublicClient.getBlock({ blockTag: "latest" });
+  const currentRoundId = await baseSepoliaPublicClient.readContract({
+    address: config.address,
+    abi: marginCallCrashAbi,
+    functionName: "currentRoundId",
+    blockNumber: block.number,
+  });
+  const roundIds = lookbackRoundIds(currentRoundId, AMBIANCE_LOOKBACK_ROUNDS);
+
+  for (const roundId of roundIds) {
+    const round = await baseSepoliaPublicClient.readContract({
+      address: config.address,
+      abi: marginCallCrashAbi,
+      functionName: "getRound",
+      args: [roundId],
+      blockNumber: block.number,
+    });
+    const normalized: CrashRound = {
+      ...round,
+      status: normalizeRoundStatus(round.status),
+    };
+    if (normalized.status !== ROUND_STATUS.finalized) continue;
+
+    const finalizedAtSeconds = await readFinalizedAtSeconds(
+      config,
+      roundId,
+      normalized,
+      block.number
+    );
+    if (finalizedAtSeconds === null) continue;
+
+    const lifecycleUrls = await readLifecycleUrls(
+      config,
+      roundId,
+      normalized,
+      block.number
+    );
+
+    return {
+      round: normalized,
+      displayCrashPoint: formatCrashPointBps(normalized.crashPointBps),
+      finalizedAtSeconds,
+      finalizeTransactionUrl: lifecycleUrls.finalizeTransactionUrl,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the Unix timestamp of RoundFinalized for a finalized round.
+ * Cached forever — finalized rounds are immutable. Prefers the block number
+ * already captured by the lifecycle URL lookup to avoid a second getLogs.
+ */
+export async function readFinalizedAtSeconds(
+  config: MarginCallCrashConfig,
+  roundId: bigint,
+  round: CrashRound,
+  toBlock: bigint
+): Promise<bigint | null> {
+  if (round.status !== ROUND_STATUS.finalized) return null;
+
+  const cacheKey = lifecycleCacheKey(config.address, roundId);
+  const cached = finalizeTimestampCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  let blockNumber = finalizeBlockNumberCache.get(cacheKey);
+  if (blockNumber === undefined) {
+    const fromBlock = getEventFromBlock(config.deploymentBlock, toBlock);
+    const result = await readExactRoundEvent({
+      config,
+      roundId,
+      event: roundFinalizedEvent,
+      fromBlock,
+      toBlock,
+      required: false,
+    });
+    if (result.blockNumber === null) {
+      if (fromBlock > config.deploymentBlock) {
+        const wide = await readExactRoundEvent({
+          config,
+          roundId,
+          event: roundFinalizedEvent,
+          fromBlock: config.deploymentBlock,
+          toBlock,
+          required: false,
+        });
+        if (wide.blockNumber === null) return null;
+        blockNumber = wide.blockNumber;
+      } else {
+        return null;
+      }
+    } else {
+      blockNumber = result.blockNumber;
+    }
+    finalizeBlockNumberCache.set(cacheKey, blockNumber);
+  }
+
+  const block = await baseSepoliaPublicClient.getBlock({ blockNumber });
+  finalizeTimestampCache.set(cacheKey, block.timestamp);
+  return block.timestamp;
 }
 
 async function readEpochOrigin(
@@ -896,7 +1122,7 @@ async function readLifecycleUrls(
         hashes[key] = cached[key];
         return;
       }
-      hashes[key] = await readExactRoundEventHash({
+      const result = await readExactRoundEvent({
         config,
         roundId,
         event,
@@ -904,6 +1130,10 @@ async function readLifecycleUrls(
         toBlock,
         required,
       });
+      hashes[key] = result.hash;
+      if (key === "finalize" && result.blockNumber !== null) {
+        finalizeBlockNumberCache.set(cacheKey, result.blockNumber);
+      }
     })
   );
   lifecycleTransactionCache.set(cacheKey, hashes);
@@ -978,7 +1208,7 @@ function toTransactionUrl(hash: Hash | null | undefined): string | null {
   return hash ? getBaseSepoliaTransactionUrl(hash) : null;
 }
 
-async function readExactRoundEventHash({
+async function readExactRoundEvent({
   config,
   roundId,
   event,
@@ -992,7 +1222,7 @@ async function readExactRoundEventHash({
   fromBlock: bigint;
   toBlock: bigint;
   required: boolean;
-}): Promise<Hash | null> {
+}): Promise<{ hash: Hash | null; blockNumber: bigint | null }> {
   const logs = await baseSepoliaPublicClient.getLogs({
     address: config.address,
     event,
@@ -1002,18 +1232,21 @@ async function readExactRoundEventHash({
     strict: true,
   });
 
-  if (logs.length === 0) {
+  if (!logs || logs.length === 0) {
     if (required) {
       throw new Error(`Expected one ${event.name} event for round ${roundId}`);
     }
-    return null;
+    return { hash: null, blockNumber: null };
   }
   if (logs.length !== 1 || !logs[0].transactionHash) {
     throw new Error(
       `Expected one ${event.name} event for round ${roundId}, found ${logs.length}`
     );
   }
-  return logs[0].transactionHash;
+  return {
+    hash: logs[0].transactionHash,
+    blockNumber: logs[0].blockNumber ?? null,
+  };
 }
 
 function lifecycleCacheKey(address: Address, roundId: bigint) {

--- a/src/lib/margin-call-crash.ts
+++ b/src/lib/margin-call-crash.ts
@@ -100,8 +100,10 @@ const ticketRefundedEvent = getAbiItem({
 // window provides ample Base Sepolia reorg/block-time margin without an
 // ever-growing deployment-to-latest scan on every client poll.
 const ROUND_EVENT_LOOKBACK_BLOCKS = 512n;
-const ONE_X_BPS = 10_000n;
-const MAX_CRASH_POINT_BPS = 100_000n;
+/** 1.00x in basis points — the floor of the displayable Crash Point range. */
+export const ONE_X_BPS = 10_000n;
+/** 10.00x in basis points — the cap of the displayable Crash Point range. */
+export const MAX_CRASH_POINT_BPS = 100_000n;
 
 /** Base Sepolia Inco Lightning singleton from @inco/lightning@1.0.2. */
 export const BASE_SEPOLIA_INCO_LIGHTNING_ADDRESS =
@@ -191,7 +193,7 @@ export const ROUND_STATUS = {
 export const GLOBAL_HISTORY_LOOKBACK_ROUNDS = 20;
 
 /** How many prior epochs to scan for Open-phase ambiance replay. */
-export const AMBIANCE_LOOKBACK_ROUNDS = 5;
+const AMBIANCE_LOOKBACK_ROUNDS = 5;
 
 /** One public TicketEntered row for the live ticket tape / tier pops. */
 export type TicketTapeEntry = {
@@ -222,8 +224,6 @@ export type RoundTicketTape = {
 export type FinalizedReplayRound = {
   round: CrashRound;
   displayCrashPoint: string;
-  finalizedAtSeconds: bigint;
-  finalizeTransactionUrl: string | null;
 };
 
 type RoundLifecycleEvent =
@@ -247,6 +247,13 @@ const lifecycleTransactionCache = new Map<
 const finalizeTimestampCache = new Map<string, bigint>();
 /** Block number of RoundFinalized, shared with the lifecycle hash lookup. */
 const finalizeBlockNumberCache = new Map<string, bigint>();
+// TicketEntered rows are append-only, so each poll only scans blocks past the
+// previous watermark instead of the full deployment-to-latest range. A reorged
+// entry can linger on the decorative tape until reload; settlement never reads it.
+const ticketTapeCache = new Map<
+  string,
+  { lastScannedBlock: bigint; entries: TicketTapeEntry[] }
+>();
 
 /** Public configuration only. Static env references allow Next.js client inlining. */
 export function getMarginCallCrashConfig(): MarginCallCrashConfig | null {
@@ -279,6 +286,13 @@ export function getRoundCountdownSeconds(
 ) {
   if (deriveRoundPhase(round, chainTimestamp) !== "open") return 0;
   return Number(round.lockAt - chainTimestamp);
+}
+
+/** Phases before entry locks — the round can still accept (or start accepting) Tickets. */
+export function isPreLockPhase(
+  phase: CrashRoundPhase
+): phase is "open" | "prelaunch" | "uninitialized" {
+  return phase === "open" || phase === "prelaunch" || phase === "uninitialized";
 }
 
 export type CrashTicket = {
@@ -914,24 +928,37 @@ export async function readRoundTicketTape(
   config: MarginCallCrashConfig,
   roundId: bigint
 ): Promise<RoundTicketTape> {
-  const block = await baseSepoliaPublicClient.getBlock({ blockTag: "latest" });
-  const logs = await baseSepoliaPublicClient.getLogs({
-    address: config.address,
-    event: ticketEnteredEvent,
-    args: { roundId },
-    fromBlock: config.deploymentBlock,
-    toBlock: block.number,
-    strict: true,
-  });
+  const cacheKey = lifecycleCacheKey(config.address, roundId);
+  const cached = ticketTapeCache.get(cacheKey);
+  const latestBlock = await baseSepoliaPublicClient.getBlockNumber();
 
-  const entries: TicketTapeEntry[] = logs.map((log) => ({
-    ticketId: log.args.ticketId,
-    player: log.args.player,
-    margin: log.args.margin,
-    leverageBps: log.args.leverageBps,
-    reservedPayout: log.args.reservedPayout,
-    transactionHash: log.transactionHash,
-  }));
+  let entries = cached?.entries ?? [];
+  const fromBlock =
+    cached !== undefined
+      ? cached.lastScannedBlock + 1n
+      : config.deploymentBlock;
+  if (fromBlock <= latestBlock) {
+    const logs = await baseSepoliaPublicClient.getLogs({
+      address: config.address,
+      event: ticketEnteredEvent,
+      args: { roundId },
+      fromBlock,
+      toBlock: latestBlock,
+      strict: true,
+    });
+    entries = [
+      ...entries,
+      ...logs.map((log) => ({
+        ticketId: log.args.ticketId,
+        player: log.args.player,
+        margin: log.args.margin,
+        leverageBps: log.args.leverageBps,
+        reservedPayout: log.args.reservedPayout,
+        transactionHash: log.transactionHash,
+      })),
+    ];
+    ticketTapeCache.set(cacheKey, { lastScannedBlock: latestBlock, entries });
+  }
 
   return {
     roundId,
@@ -947,12 +974,12 @@ export async function readRoundTicketTape(
 export async function readLatestFinalizedReplayRound(
   config: MarginCallCrashConfig
 ): Promise<FinalizedReplayRound | null> {
-  const block = await baseSepoliaPublicClient.getBlock({ blockTag: "latest" });
+  const blockNumber = await baseSepoliaPublicClient.getBlockNumber();
   const currentRoundId = await baseSepoliaPublicClient.readContract({
     address: config.address,
     abi: marginCallCrashAbi,
     functionName: "currentRoundId",
-    blockNumber: block.number,
+    blockNumber,
   });
   const roundIds = lookbackRoundIds(currentRoundId, AMBIANCE_LOOKBACK_ROUNDS);
 
@@ -962,7 +989,7 @@ export async function readLatestFinalizedReplayRound(
       abi: marginCallCrashAbi,
       functionName: "getRound",
       args: [roundId],
-      blockNumber: block.number,
+      blockNumber,
     });
     const normalized: CrashRound = {
       ...round,
@@ -970,26 +997,9 @@ export async function readLatestFinalizedReplayRound(
     };
     if (normalized.status !== ROUND_STATUS.finalized) continue;
 
-    const finalizedAtSeconds = await readFinalizedAtSeconds(
-      config,
-      roundId,
-      normalized,
-      block.number
-    );
-    if (finalizedAtSeconds === null) continue;
-
-    const lifecycleUrls = await readLifecycleUrls(
-      config,
-      roundId,
-      normalized,
-      block.number
-    );
-
     return {
       round: normalized,
       displayCrashPoint: formatCrashPointBps(normalized.crashPointBps),
-      finalizedAtSeconds,
-      finalizeTransactionUrl: lifecycleUrls.finalizeTransactionUrl,
     };
   }
 
@@ -1015,33 +1025,27 @@ export async function readFinalizedAtSeconds(
 
   let blockNumber = finalizeBlockNumberCache.get(cacheKey);
   if (blockNumber === undefined) {
-    const fromBlock = getEventFromBlock(config.deploymentBlock, toBlock);
-    const result = await readExactRoundEvent({
-      config,
-      roundId,
-      event: roundFinalizedEvent,
-      fromBlock,
-      toBlock,
-      required: false,
-    });
-    if (result.blockNumber === null) {
-      if (fromBlock > config.deploymentBlock) {
-        const wide = await readExactRoundEvent({
-          config,
-          roundId,
-          event: roundFinalizedEvent,
-          fromBlock: config.deploymentBlock,
-          toBlock,
-          required: false,
-        });
-        if (wide.blockNumber === null) return null;
-        blockNumber = wide.blockNumber;
-      } else {
-        return null;
+    // Try the recent lookback window first, then the full deployment range.
+    const lookbackBlock = getEventFromBlock(config.deploymentBlock, toBlock);
+    const fromBlocks =
+      lookbackBlock > config.deploymentBlock
+        ? [lookbackBlock, config.deploymentBlock]
+        : [lookbackBlock];
+    for (const fromBlock of fromBlocks) {
+      const result = await readExactRoundEvent({
+        config,
+        roundId,
+        event: roundFinalizedEvent,
+        fromBlock,
+        toBlock,
+        required: false,
+      });
+      if (result.blockNumber !== null) {
+        blockNumber = result.blockNumber;
+        break;
       }
-    } else {
-      blockNumber = result.blockNumber;
     }
+    if (blockNumber === undefined) return null;
     finalizeBlockNumberCache.set(cacheKey, blockNumber);
   }
 

--- a/src/lib/round-replay.test.ts
+++ b/src/lib/round-replay.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampCrashPointBps,
+  getClosedTiersAtProgress,
+  getReplayDurationMs,
+  getReplayMultiplierBps,
+  getReplayPath,
+  getReplayProgress,
+  getTierCloseProgress,
+  isReplayComplete,
+  REPLAY_DURATION_MAX_MS,
+  REPLAY_DURATION_MIN_MS,
+} from "./round-replay";
+
+const ONE_X = 10_000n;
+const TIERS = [12_500n, 15_000n, 20_000n, 30_000n, 50_000n, 100_000n] as const;
+
+describe("round-replay math", () => {
+  it("clamps sub-1.00x Crash Points to 1.00x", () => {
+    expect(clampCrashPointBps(9_900n)).toBe(ONE_X);
+    expect(clampCrashPointBps(0n)).toBe(ONE_X);
+    expect(clampCrashPointBps(ONE_X)).toBe(ONE_X);
+    expect(clampCrashPointBps(100_000n)).toBe(100_000n);
+    expect(clampCrashPointBps(200_000n)).toBe(100_000n);
+  });
+
+  it("scales duration from 4s at 1.00x to 12s at 10.00x", () => {
+    expect(getReplayDurationMs(ONE_X)).toBe(REPLAY_DURATION_MIN_MS);
+    expect(getReplayDurationMs(9_900n)).toBe(REPLAY_DURATION_MIN_MS);
+    expect(getReplayDurationMs(100_000n)).toBe(REPLAY_DURATION_MAX_MS);
+    const mid = getReplayDurationMs(31_623n); // ~sqrt(10) ≈ 3.16x
+    expect(mid).toBeGreaterThan(REPLAY_DURATION_MIN_MS);
+    expect(mid).toBeLessThan(REPLAY_DURATION_MAX_MS);
+  });
+
+  it("returns exact 1.00x at p=0 and exact crash at p=1", () => {
+    expect(getReplayMultiplierBps(0, 25_000n)).toBe(ONE_X);
+    expect(getReplayMultiplierBps(1, 25_000n)).toBe(25_000n);
+    expect(getReplayMultiplierBps(1, 100_000n)).toBe(100_000n);
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const a = getReplayMultiplierBps(0.5, 40_000n);
+    const b = getReplayMultiplierBps(0.5, 40_000n);
+    expect(a).toBe(b);
+    expect(getReplayPath(40_000n, 0.5)).toBe(getReplayPath(40_000n, 0.5));
+    expect(getReplayDurationMs(40_000n)).toBe(getReplayDurationMs(40_000n));
+  });
+
+  it("pins mid-arrival seekers past the duration to the final frame", () => {
+    const crash = 50_000n;
+    const duration = getReplayDurationMs(crash);
+    expect(getReplayProgress(0, crash)).toBe(0);
+    expect(getReplayProgress(duration / 2, crash)).toBeCloseTo(0.5, 5);
+    expect(getReplayProgress(duration, crash)).toBe(1);
+    expect(getReplayProgress(duration + 60_000, crash)).toBe(1);
+    expect(isReplayComplete(1)).toBe(true);
+    expect(getReplayMultiplierBps(1, crash)).toBe(crash);
+  });
+
+  it("closes no tiers for a clamped 1.00x Crash Point (guards log(1)=0)", () => {
+    // Raw 0.99x floors to 1.00x; every Arcade Leverage tier is above 1.00x.
+    expect(getTierCloseProgress(12_500n, 9_900n)).toBeNull();
+    expect(getClosedTiersAtProgress(1, 9_900n, TIERS)).toEqual([]);
+    expect(getReplayDurationMs(9_900n)).toBe(REPLAY_DURATION_MIN_MS);
+  });
+
+  it("closes the 10.00x tier at exactly p=1 when Crash Point is capped", () => {
+    expect(getTierCloseProgress(100_000n, 100_000n)).toBe(1);
+    const closed = getClosedTiersAtProgress(1, 100_000n, TIERS);
+    expect(closed).toEqual([...TIERS]);
+  });
+
+  it("closes only tiers at or below the Crash Point (equality wins)", () => {
+    const crash = 20_000n; // 2.00x
+    expect(getTierCloseProgress(12_500n, crash)).not.toBeNull();
+    expect(getTierCloseProgress(15_000n, crash)).not.toBeNull();
+    expect(getTierCloseProgress(20_000n, crash)).toBe(1);
+    expect(getTierCloseProgress(30_000n, crash)).toBeNull();
+
+    const atHalf = getClosedTiersAtProgress(0.5, crash, TIERS);
+    for (const tier of atHalf) {
+      const closeAt = getTierCloseProgress(tier, crash);
+      expect(closeAt).not.toBeNull();
+      expect(closeAt!).toBeLessThanOrEqual(0.5);
+    }
+
+    const atEnd = getClosedTiersAtProgress(1, crash, TIERS);
+    expect(atEnd).toEqual([12_500n, 15_000n, 20_000n]);
+  });
+
+  it("builds a non-empty SVG path that starts at the origin", () => {
+    const path = getReplayPath(30_000n, 1);
+    expect(path.startsWith("M ")).toBe(true);
+    expect(path.includes(" L ")).toBe(true);
+    expect(getReplayPath(30_000n, 0).startsWith("M ")).toBe(true);
+  });
+});

--- a/src/lib/round-replay.ts
+++ b/src/lib/round-replay.ts
@@ -1,0 +1,172 @@
+/**
+ * Deterministic round-theater replay math.
+ *
+ * The climb is a pure function of the attested Crash Point and elapsed time.
+ * Mid-arrival clients seek to the correct frame; watching, skipping, or
+ * replaying never gates or changes settlement.
+ */
+
+const ONE_X_BPS = 10_000n;
+const MAX_CRASH_POINT_BPS = 100_000n;
+
+/** Minimum dramatized climb duration (at a 1.00x Crash Point). */
+export const REPLAY_DURATION_MIN_MS = 4_000;
+/** Maximum dramatized climb duration (at a 10.00x Crash Point). */
+export const REPLAY_DURATION_MAX_MS = 12_000;
+
+/** Number of polyline samples used to build the SVG path. */
+const PATH_SAMPLES = 64;
+
+/**
+ * Clamps a raw Crash Point into the displayable range [1.00x, 10.00x].
+ * Sub-1.00x values (e.g. r=0 → 0.99x) floor to 1.00x, matching formatCrashPointBps.
+ */
+export function clampCrashPointBps(crashPointBps: bigint): bigint {
+  if (crashPointBps < ONE_X_BPS) return ONE_X_BPS;
+  if (crashPointBps > MAX_CRASH_POINT_BPS) return MAX_CRASH_POINT_BPS;
+  return crashPointBps;
+}
+
+/**
+ * 4s at 1.00x to 12s at 10.00x, log-scaled so perceived growth rate is constant.
+ */
+export function getReplayDurationMs(crashPointBps: bigint): number {
+  const crash = clampCrashPointBps(crashPointBps);
+  if (crash <= ONE_X_BPS) return REPLAY_DURATION_MIN_MS;
+
+  const crashX = Number(crash) / Number(ONE_X_BPS);
+  const t = Math.log(crashX) / Math.log(10);
+  return Math.round(
+    REPLAY_DURATION_MIN_MS +
+      t * (REPLAY_DURATION_MAX_MS - REPLAY_DURATION_MIN_MS)
+  );
+}
+
+/**
+ * Progress in [0, 1] from elapsed wall time. Clamps past the duration so a
+ * mid-arrival client that joins after the climb finished lands on the final frame.
+ */
+export function getReplayProgress(
+  elapsedMs: number,
+  crashPointBps: bigint
+): number {
+  if (elapsedMs <= 0) return 0;
+  const duration = getReplayDurationMs(crashPointBps);
+  if (duration <= 0) return 1;
+  return Math.min(1, elapsedMs / duration);
+}
+
+/**
+ * Multiplier at progress p: m(p) = crash^p.
+ * Exact 1.00x at p=0 and exact crash at p=1.
+ */
+export function getReplayMultiplierBps(
+  progress: number,
+  crashPointBps: bigint
+): bigint {
+  const crash = clampCrashPointBps(crashPointBps);
+  if (progress <= 0) return ONE_X_BPS;
+  if (progress >= 1) return crash;
+
+  const crashX = Number(crash) / Number(ONE_X_BPS);
+  const multiplier = Math.pow(crashX, progress);
+  return BigInt(Math.round(multiplier * Number(ONE_X_BPS)));
+}
+
+/**
+ * Progress at which a tier closes: p = log_crash(tier).
+ * Returns null when the tier never closes (tier above the Crash Point).
+ * Equality wins: a tier exactly at the Crash Point closes at p = 1.
+ */
+export function getTierCloseProgress(
+  tierBps: bigint,
+  crashPointBps: bigint
+): number | null {
+  const crash = clampCrashPointBps(crashPointBps);
+  if (tierBps > crash) return null;
+  if (tierBps <= ONE_X_BPS) return 0;
+  if (tierBps === crash) return 1;
+  if (crash <= ONE_X_BPS) return null;
+
+  const crashX = Number(crash) / Number(ONE_X_BPS);
+  const tierX = Number(tierBps) / Number(ONE_X_BPS);
+  return Math.log(tierX) / Math.log(crashX);
+}
+
+export type ReplayPathPoint = { x: number; y: number };
+
+/**
+ * Builds an SVG path string for the climb up to `progress`.
+ * Coordinates are normalized to a 0–100 viewBox (x = time, y = multiplier
+ * inverted so higher multipliers sit higher on screen).
+ */
+export function getReplayPath(
+  crashPointBps: bigint,
+  progress: number,
+  options: { width?: number; height?: number; samples?: number } = {}
+): string {
+  const width = options.width ?? 100;
+  const height = options.height ?? 100;
+  const samples = options.samples ?? PATH_SAMPLES;
+  const points = getReplayPathPoints(crashPointBps, progress, {
+    width,
+    height,
+    samples,
+  });
+  if (points.length === 0) return "";
+
+  const [first, ...rest] = points;
+  let d = `M ${first.x.toFixed(2)} ${first.y.toFixed(2)}`;
+  for (const point of rest) {
+    d += ` L ${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
+  }
+  return d;
+}
+
+/** Sampled polyline points for the climb up to `progress`. */
+export function getReplayPathPoints(
+  crashPointBps: bigint,
+  progress: number,
+  options: { width?: number; height?: number; samples?: number } = {}
+): ReplayPathPoint[] {
+  const width = options.width ?? 100;
+  const height = options.height ?? 100;
+  const samples = Math.max(2, options.samples ?? PATH_SAMPLES);
+  const crash = clampCrashPointBps(crashPointBps);
+  const crashX = Number(crash) / Number(ONE_X_BPS);
+  const clampedProgress = Math.min(1, Math.max(0, progress));
+  const count = Math.max(
+    2,
+    Math.ceil(samples * Math.max(clampedProgress, 0.001))
+  );
+
+  const points: ReplayPathPoint[] = [];
+  for (let i = 0; i < count; i++) {
+    const p = (i / (count - 1)) * clampedProgress;
+    const multiplier = p <= 0 ? 1 : p >= 1 ? crashX : Math.pow(crashX, p);
+    const x = p * width;
+    // Invert y so 1.00x sits at the bottom and crash sits near the top,
+    // with headroom so the head never kisses the viewBox edge.
+    const yMax = crashX * 1.08;
+    const y = height - ((multiplier - 1) / (yMax - 1)) * height;
+    points.push({ x, y });
+  }
+  return points;
+}
+
+/** True when progress has reached the hard stop. */
+export function isReplayComplete(progress: number): boolean {
+  return progress >= 1;
+}
+
+/** Tiers that have closed at or before the given progress. */
+export function getClosedTiersAtProgress(
+  progress: number,
+  crashPointBps: bigint,
+  tiers: readonly bigint[]
+): bigint[] {
+  return tiers.filter((tier) => {
+    const closeAt = getTierCloseProgress(tier, crashPointBps);
+    return closeAt !== null && closeAt <= progress;
+  });
+}

--- a/src/lib/round-replay.ts
+++ b/src/lib/round-replay.ts
@@ -6,8 +6,7 @@
  * replaying never gates or changes settlement.
  */
 
-const ONE_X_BPS = 10_000n;
-const MAX_CRASH_POINT_BPS = 100_000n;
+import { MAX_CRASH_POINT_BPS, ONE_X_BPS } from "./margin-call-crash";
 
 /** Minimum dramatized climb duration (at a 1.00x Crash Point). */
 export const REPLAY_DURATION_MIN_MS = 4_000;
@@ -95,6 +94,37 @@ export function getTierCloseProgress(
 
 export type ReplayPathPoint = { x: number; y: number };
 
+// Vertical headroom above the Crash Point so the head never kisses the
+// viewBox edge. Shared by the curve and anything annotating it (tier lines).
+const Y_HEADROOM = 1.08;
+
+// Invert y so 1.00x sits at the bottom and crash sits near the top.
+function yForMultiplier(
+  multiplierX: number,
+  crashX: number,
+  height: number
+): number {
+  const yMax = crashX * Y_HEADROOM;
+  return height - ((multiplierX - 1) / (yMax - 1)) * height;
+}
+
+/**
+ * y coordinate of a multiplier on the replay viewBox — the same vertical
+ * scale the curve is plotted on, for tier gridlines and close markers.
+ */
+export function multiplierToY(
+  multiplierBps: bigint,
+  crashPointBps: bigint,
+  height: number
+): number {
+  const crashX = Number(clampCrashPointBps(crashPointBps)) / Number(ONE_X_BPS);
+  return yForMultiplier(
+    Number(multiplierBps) / Number(ONE_X_BPS),
+    crashX,
+    height
+  );
+}
+
 /**
  * Builds an SVG path string for the climb up to `progress`.
  * Coordinates are normalized to a 0–100 viewBox (x = time, y = multiplier
@@ -105,14 +135,11 @@ export function getReplayPath(
   progress: number,
   options: { width?: number; height?: number; samples?: number } = {}
 ): string {
-  const width = options.width ?? 100;
-  const height = options.height ?? 100;
-  const samples = options.samples ?? PATH_SAMPLES;
-  const points = getReplayPathPoints(crashPointBps, progress, {
-    width,
-    height,
-    samples,
-  });
+  return replayPathD(getReplayPathPoints(crashPointBps, progress, options));
+}
+
+/** Serializes sampled points to an SVG path `d` string. */
+export function replayPathD(points: readonly ReplayPathPoint[]): string {
   if (points.length === 0) return "";
 
   const [first, ...rest] = points;
@@ -144,12 +171,10 @@ export function getReplayPathPoints(
   for (let i = 0; i < count; i++) {
     const p = (i / (count - 1)) * clampedProgress;
     const multiplier = p <= 0 ? 1 : p >= 1 ? crashX : Math.pow(crashX, p);
-    const x = p * width;
-    // Invert y so 1.00x sits at the bottom and crash sits near the top,
-    // with headroom so the head never kisses the viewBox edge.
-    const yMax = crashX * 1.08;
-    const y = height - ((multiplier - 1) / (yMax - 1)) * height;
-    points.push({ x, y });
+    points.push({
+      x: p * width,
+      y: yForMultiplier(multiplier, crashX, height),
+    });
   }
   return points;
 }

--- a/src/lib/theater-audio.ts
+++ b/src/lib/theater-audio.ts
@@ -15,13 +15,26 @@ export function readTheaterSoundEnabled(): boolean {
   }
 }
 
-export function writeTheaterSoundEnabled(enabled: boolean): void {
+function writeTheaterSoundEnabled(enabled: boolean): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(SOUND_STORAGE_KEY, enabled ? "1" : "0");
   } catch {
     // Ignore quota / private-mode failures; in-memory toggle still works.
   }
+}
+
+const soundListeners = new Set<() => void>();
+
+/**
+ * Subscribe to sound-preference changes. Every `setEnabled` call notifies,
+ * so UI stays in sync no matter which surface flips the preference.
+ */
+export function subscribeTheaterSound(listener: () => void): () => void {
+  soundListeners.add(listener);
+  return () => {
+    soundListeners.delete(listener);
+  };
 }
 
 type TheaterAudioEngine = {
@@ -96,6 +109,7 @@ export function getTheaterAudio(): TheaterAudioEngine {
       enabled = next;
       writeTheaterSoundEnabled(next);
       if (next) ensureContext();
+      for (const listener of soundListeners) listener();
     },
     playTierClose() {
       tone(880, 80, { type: "triangle", gain: 0.04 });

--- a/src/lib/theater-audio.ts
+++ b/src/lib/theater-audio.ts
@@ -1,0 +1,121 @@
+/**
+ * Optional theater audio via the Web Audio API.
+ * Muted by default; AudioContext is created only after an explicit user gesture
+ * (the sound toggle), which satisfies autoplay policy.
+ */
+
+const SOUND_STORAGE_KEY = "margin-call-theater-sound";
+
+export function readTheaterSoundEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(SOUND_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeTheaterSoundEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SOUND_STORAGE_KEY, enabled ? "1" : "0");
+  } catch {
+    // Ignore quota / private-mode failures; in-memory toggle still works.
+  }
+}
+
+type TheaterAudioEngine = {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+  playTierClose: () => void;
+  playCrashBell: () => void;
+  playPhoneRing: () => void;
+  dispose: () => void;
+};
+
+let sharedEngine: TheaterAudioEngine | null = null;
+
+/**
+ * Lazily creates (or returns) the shared theater audio engine.
+ * Call only from a user-gesture handler the first time sound is enabled.
+ */
+export function getTheaterAudio(): TheaterAudioEngine {
+  if (sharedEngine) return sharedEngine;
+
+  let context: AudioContext | null = null;
+  let enabled = readTheaterSoundEnabled();
+
+  const ensureContext = (): AudioContext | null => {
+    if (typeof window === "undefined") return null;
+    if (!enabled) return null;
+    const AudioCtx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext;
+    if (!AudioCtx) return null;
+    if (!context) context = new AudioCtx();
+    if (context.state === "suspended") {
+      void context.resume();
+    }
+    return context;
+  };
+
+  const tone = (
+    frequency: number,
+    durationMs: number,
+    options: { type?: OscillatorType; gain?: number; slideTo?: number } = {}
+  ) => {
+    const ctx = ensureContext();
+    if (!ctx) return;
+    const now = ctx.currentTime;
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.type = options.type ?? "sine";
+    oscillator.frequency.setValueAtTime(frequency, now);
+    if (options.slideTo !== undefined) {
+      oscillator.frequency.exponentialRampToValueAtTime(
+        Math.max(1, options.slideTo),
+        now + durationMs / 1_000
+      );
+    }
+    const peak = options.gain ?? 0.08;
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(peak, now + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + durationMs / 1_000);
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+    oscillator.start(now);
+    oscillator.stop(now + durationMs / 1_000 + 0.02);
+  };
+
+  sharedEngine = {
+    get enabled() {
+      return enabled;
+    },
+    setEnabled(next: boolean) {
+      enabled = next;
+      writeTheaterSoundEnabled(next);
+      if (next) ensureContext();
+    },
+    playTierClose() {
+      tone(880, 80, { type: "triangle", gain: 0.04 });
+    },
+    playCrashBell() {
+      tone(660, 420, { type: "sine", gain: 0.1, slideTo: 220 });
+      tone(990, 280, { type: "sine", gain: 0.05 });
+    },
+    playPhoneRing() {
+      tone(440, 180, { type: "square", gain: 0.05 });
+      window.setTimeout(() => {
+        tone(440, 180, { type: "square", gain: 0.05 });
+      }, 220);
+    },
+    dispose() {
+      void context?.close();
+      context = null;
+      sharedEngine = null;
+    },
+  };
+
+  return sharedEngine;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,19 @@ export function dialogPopupClass(size: keyof typeof DIALOG_POPUP_SIZE_CLASS) {
   return `${DIALOG_POPUP_BASE_CLASS} ${DIALOG_POPUP_SIZE_CLASS[size]}`;
 }
 
+export const TERMINAL_ACTION_BUTTON_CLASS =
+  "border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]";
+
+/** mm:ss countdown; negative inputs clamp to 00:00. */
+export function formatCountdown(seconds: number): string {
+  const safe = Math.max(0, seconds);
+  const minutes = Math.floor(safe / 60);
+  const remainingSeconds = safe % 60;
+  return `${minutes.toString().padStart(2, "0")}:${remainingSeconds
+    .toString()
+    .padStart(2, "0")}`;
+}
+
 const USDC_FORMATTER = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",


### PR DESCRIPTION
## Summary
- Implements [#349](https://github.com/hurley87/margin-call/issues/349): deterministic 4–12s Crash Point replay with tier-close payout pops, hard margin-call stop, Open-phase ticket tape, and previous-round ambiance.
- Theater is presentation-only (no entry/settlement actions); delayed rounds show awaiting attestation without a stalled climb; reduced-motion clients get an equivalent static result card; audio is optional and muted by default.
- Extends crash reads for ticket-tape aggregation and finalize-timestamp replay anchoring; adds CRT motion CSS with reduced-motion overrides.

## Test plan
- [ ] `pnpm test` / `pnpm lint` / `pnpm typecheck`
- [ ] Open phase: countdown + live ticket tape; previous finalized round loops as ambiance (or empty copy)
- [ ] Locked / reveal-requested / expired-eligible: awaiting copy, no invented multiplier, no climb
- [ ] Finalized: climb seeks correctly on mid-arrival; Replay restarts locally; verification link works
- [ ] `prefers-reduced-motion`: static result card shows same Crash Point, tier closes, and margin-call facts
- [ ] Sound toggle starts off; enabling plays optional Web Audio cues without affecting settlement
- [ ] Confirm CurrentRound entry/settlement surfaces still work and theater offers no claim/enter buttons


Made with [Cursor](https://cursor.com)