### PR TITLE
Add Crash keeper + monitoring (#350)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,17 @@ NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS=
 NEXT_PUBLIC_MARGIN_CALL_CRASH_ADDRESS=
 NEXT_PUBLIC_MARGIN_CALL_CRASH_DEPLOYMENT_BLOCK=
 
+# Crash keeper (Convex dashboard secrets — never commit values)
+# KEEPER_PRIVATE_KEY=           # Funded EOA; pays gas + Inco round-creation fee
+# KEEPER_PREOPEN_ENABLED=true   # Keep current+next epochs initialized during active sessions
+# KEEPER_ATTESTATION_URL=       # App origin for POST /api/crash-attestation
+# KEEPER_ALERT_WEBHOOK_URL=     # Optional alert webhook
+# KEEPER_PAYMASTER_SPEND_BUDGET_WEI=  # Optional sponsorship spend budget (wei string)
+# MARGIN_CALL_CRASH_ADDRESS=    # Optional override; defaults to curated Base Sepolia record
+# BANKROLL_VAULT_ADDRESS=
+# INCO_LIGHTNING_ADDRESS=
+# See docs/runbooks/keeper.md
+
 # Upstash Redis (rate limiting) — optional for local dev (uses in-memory fallback)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,9 @@
 
 import type * as crons from "../crons.js";
 import type * as http from "../http.js";
+import type * as keeperAlerts from "../keeperAlerts.js";
+import type * as keeperSponsorship from "../keeperSponsorship.js";
+import type * as keeperTick from "../keeperTick.js";
 import type * as me from "../me.js";
 
 import type {
@@ -21,11 +24,14 @@ import type {
 declare const fullApi: ApiFromModules<{
   crons: typeof crons;
   http: typeof http;
+  keeperAlerts: typeof keeperAlerts;
+  keeperSponsorship: typeof keeperSponsorship;
+  keeperTick: typeof keeperTick;
   me: typeof me;
 }>;
 
 /**
- * A utility for referencing Convex functions in your app's public API.
+ * A utility for referencing Convex functions in your app's API.
  *
  * Usage:
  * ```js

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,5 +1,12 @@
 import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
 
 const crons = cronJobs();
+
+/**
+ * Crash keeper: expire → reveal → attest/finalize → pre-open.
+ * No-ops when credentials are missing or there is no work.
+ */
+crons.interval("crash-keeper", { seconds: 20 }, internal.keeperTick.run, {});
 
 export default crons;

--- a/convex/keeperAlerts.ts
+++ b/convex/keeperAlerts.ts
@@ -1,0 +1,104 @@
+import { v } from "convex/values";
+import { internalMutation, internalQuery } from "./_generated/server";
+
+/** Suppress duplicate fingerprints within this window (ms). */
+const ALERT_DEDUPE_MS = 5 * 60 * 1000;
+
+export const recordAlerts = internalMutation({
+  args: {
+    alerts: v.array(
+      v.object({
+        kind: v.string(),
+        severity: v.string(),
+        message: v.string(),
+        roundId: v.optional(v.string()),
+        fingerprint: v.string(),
+        meta: v.optional(v.string()),
+      })
+    ),
+    observedAt: v.number(),
+  },
+  returns: v.number(),
+  handler: async (ctx, args) => {
+    let inserted = 0;
+    const windowStart = args.observedAt - ALERT_DEDUPE_MS;
+
+    for (const alert of args.alerts) {
+      const recent = await ctx.db
+        .query("keeperAlerts")
+        .withIndex("by_fingerprint_observedAt", (q) =>
+          q.eq("fingerprint", alert.fingerprint).gte("observedAt", windowStart)
+        )
+        .take(1);
+
+      if (recent.length > 0) continue;
+
+      await ctx.db.insert("keeperAlerts", {
+        kind: alert.kind,
+        severity: alert.severity,
+        message: alert.message,
+        roundId: alert.roundId,
+        observedAt: args.observedAt,
+        fingerprint: alert.fingerprint,
+        meta: alert.meta,
+      });
+      inserted += 1;
+      console.error(`[keeper-alert] ${alert.kind}: ${alert.message}`);
+    }
+
+    return inserted;
+  },
+});
+
+export const recordRun = internalMutation({
+  args: {
+    startedAt: v.number(),
+    finishedAt: v.number(),
+    actionCount: v.number(),
+    alertCount: v.number(),
+    txHashes: v.array(v.string()),
+    skippedReason: v.optional(v.string()),
+    sessionActive: v.boolean(),
+  },
+  returns: v.id("keeperRuns"),
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("keeperRuns", args);
+  },
+});
+
+export const listRecentAlerts = internalQuery({
+  args: {
+    since: v.number(),
+    limit: v.optional(v.number()),
+  },
+  returns: v.array(
+    v.object({
+      _id: v.id("keeperAlerts"),
+      kind: v.string(),
+      severity: v.string(),
+      message: v.string(),
+      roundId: v.optional(v.string()),
+      observedAt: v.number(),
+      fingerprint: v.string(),
+      meta: v.optional(v.string()),
+    })
+  ),
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 100;
+    const rows = await ctx.db
+      .query("keeperAlerts")
+      .withIndex("by_observedAt", (q) => q.gte("observedAt", args.since))
+      .order("desc")
+      .take(limit);
+    return rows.map((row) => ({
+      _id: row._id,
+      kind: row.kind,
+      severity: row.severity,
+      message: row.message,
+      roundId: row.roundId,
+      observedAt: row.observedAt,
+      fingerprint: row.fingerprint,
+      meta: row.meta,
+    }));
+  },
+});

--- a/convex/keeperAlerts.ts
+++ b/convex/keeperAlerts.ts
@@ -34,13 +34,8 @@ export const recordAlerts = internalMutation({
       if (recent.length > 0) continue;
 
       await ctx.db.insert("keeperAlerts", {
-        kind: alert.kind,
-        severity: alert.severity,
-        message: alert.message,
-        roundId: alert.roundId,
+        ...alert,
         observedAt: args.observedAt,
-        fingerprint: alert.fingerprint,
-        meta: alert.meta,
       });
       inserted += 1;
       console.error(`[keeper-alert] ${alert.kind}: ${alert.message}`);
@@ -74,6 +69,7 @@ export const listRecentAlerts = internalQuery({
   returns: v.array(
     v.object({
       _id: v.id("keeperAlerts"),
+      _creationTime: v.number(),
       kind: v.string(),
       severity: v.string(),
       message: v.string(),
@@ -85,20 +81,10 @@ export const listRecentAlerts = internalQuery({
   ),
   handler: async (ctx, args) => {
     const limit = args.limit ?? 100;
-    const rows = await ctx.db
+    return await ctx.db
       .query("keeperAlerts")
       .withIndex("by_observedAt", (q) => q.gte("observedAt", args.since))
       .order("desc")
       .take(limit);
-    return rows.map((row) => ({
-      _id: row._id,
-      kind: row.kind,
-      severity: row.severity,
-      message: row.message,
-      roundId: row.roundId,
-      observedAt: row.observedAt,
-      fingerprint: row.fingerprint,
-      meta: row.meta,
-    }));
   },
 });

--- a/convex/keeperSponsorship.ts
+++ b/convex/keeperSponsorship.ts
@@ -1,0 +1,68 @@
+import { v } from "convex/values";
+import { internalMutation, internalQuery } from "./_generated/server";
+
+/** Rolling window used for paymaster failure/spend alerts (ms). */
+export const SPONSORSHIP_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Record a Privy sponsorship failure or spend sample.
+ * Alerts never gate settlement — the keeper only monitors.
+ */
+export const reportSponsorshipEvent = internalMutation({
+  args: {
+    kind: v.union(v.literal("failure"), v.literal("spend")),
+    observedAt: v.number(),
+    amountWei: v.optional(v.string()),
+    detail: v.optional(v.string()),
+  },
+  returns: v.id("keeperSponsorshipEvents"),
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("keeperSponsorshipEvents", {
+      kind: args.kind,
+      observedAt: args.observedAt,
+      amountWei: args.amountWei,
+      detail: args.detail,
+    });
+  },
+});
+
+export const getSponsorshipWindowSample = internalQuery({
+  args: {
+    now: v.number(),
+    windowMs: v.optional(v.number()),
+    spendBudgetWei: v.optional(v.string()),
+  },
+  returns: v.object({
+    failuresInWindow: v.number(),
+    spendWeiInWindow: v.string(),
+    spendBudgetWei: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx, args) => {
+    const windowMs = args.windowMs ?? SPONSORSHIP_WINDOW_MS;
+    const since = args.now - windowMs;
+    const events = await ctx.db
+      .query("keeperSponsorshipEvents")
+      .withIndex("by_observedAt", (q) => q.gte("observedAt", since))
+      .take(500);
+
+    let failuresInWindow = 0;
+    let spendWei = 0n;
+    for (const event of events) {
+      if (event.kind === "failure") {
+        failuresInWindow += 1;
+      } else if (event.kind === "spend" && event.amountWei) {
+        try {
+          spendWei += BigInt(event.amountWei);
+        } catch {
+          // ignore malformed samples
+        }
+      }
+    }
+
+    return {
+      failuresInWindow,
+      spendWeiInWindow: spendWei.toString(),
+      spendBudgetWei: args.spendBudgetWei ?? null,
+    };
+  },
+});

--- a/convex/keeperSponsorship.ts
+++ b/convex/keeperSponsorship.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 import { internalMutation, internalQuery } from "./_generated/server";
 
 /** Rolling window used for paymaster failure/spend alerts (ms). */
-export const SPONSORSHIP_WINDOW_MS = 60 * 60 * 1000;
+const SPONSORSHIP_WINDOW_MS = 60 * 60 * 1000;
 
 /**
  * Record a Privy sponsorship failure or spend sample.
@@ -29,17 +29,13 @@ export const reportSponsorshipEvent = internalMutation({
 export const getSponsorshipWindowSample = internalQuery({
   args: {
     now: v.number(),
-    windowMs: v.optional(v.number()),
-    spendBudgetWei: v.optional(v.string()),
   },
   returns: v.object({
     failuresInWindow: v.number(),
     spendWeiInWindow: v.string(),
-    spendBudgetWei: v.union(v.string(), v.null()),
   }),
   handler: async (ctx, args) => {
-    const windowMs = args.windowMs ?? SPONSORSHIP_WINDOW_MS;
-    const since = args.now - windowMs;
+    const since = args.now - SPONSORSHIP_WINDOW_MS;
     const events = await ctx.db
       .query("keeperSponsorshipEvents")
       .withIndex("by_observedAt", (q) => q.gte("observedAt", since))
@@ -62,7 +58,6 @@ export const getSponsorshipWindowSample = internalQuery({
     return {
       failuresInWindow,
       spendWeiInWindow: spendWei.toString(),
-      spendBudgetWei: args.spendBudgetWei ?? null,
     };
   },
 });

--- a/convex/keeperTick.ts
+++ b/convex/keeperTick.ts
@@ -2,18 +2,22 @@
 
 import {
   KEEPER_ROUND_STATUS,
+  failedAttestationAlert,
   missingCredentialsAlert,
   planKeeperTick,
   type KeeperAction,
   type KeeperAlert,
   type KeeperRoundSnapshot,
+  type KeeperRoundStatus,
   type KeeperSnapshot,
   type KeeperVaultSnapshot,
 } from "@margin-call/shared/crash-keeper";
+import { parseAddress } from "@margin-call/shared/address";
+import { parsePrivateKey } from "@margin-call/shared/parse-private-key";
 import {
   createPublicClient,
   createWalletClient,
-  encodeFunctionData,
+  getContract,
   http,
   parseAbi,
   type Address,
@@ -22,16 +26,14 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 import { v } from "convex/values";
+import deployments from "../contracts/deployments/base_sepolia.json";
 import { internal } from "./_generated/api";
 import { internalAction } from "./_generated/server";
 
-/** Defaults from contracts/deployments/base_sepolia.json — override via Convex env. */
-const DEFAULT_GAME =
-  "0xD74a89e199da9E45399ec913441b25A1b4120d44" as const satisfies Address;
-const DEFAULT_VAULT =
-  "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21" as const satisfies Address;
-const DEFAULT_INCO =
-  "0x4b9911b0191B0b6a6eA8F2Ed562e20Cff5AC8624" as const satisfies Address;
+/** Defaults from the curated Base Sepolia record — override via Convex env. */
+const DEFAULT_GAME = deployments.marginCallCrash as Address;
+const DEFAULT_VAULT = deployments.bankrollVault as Address;
+const DEFAULT_INCO = deployments.incoLightning as Address;
 
 /** Scan this many prior epochs for overdue expiry / delayed reveal work. */
 const WORK_LOOKBACK = 20n;
@@ -60,9 +62,11 @@ const vaultAbi = parseAbi([
 const incoAbi = parseAbi(["function getFee() view returns (uint256)"]);
 
 function envAddress(name: string, fallback: Address): Address {
-  const value = process.env[name];
-  if (!value) return fallback;
-  return value as Address;
+  try {
+    return parseAddress(process.env[name]) ?? fallback;
+  } catch {
+    throw new Error(`${name} format`);
+  }
 }
 
 function readCredentials():
@@ -85,26 +89,21 @@ function readCredentials():
   if (!rpcUrl) {
     return { ok: false, detail: "BASE_SEPOLIA_RPC_URL" };
   }
-  let normalized: Hex;
   try {
-    normalized = (
-      privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`
-    ) as Hex;
-    if (!/^0x[0-9a-fA-F]{64}$/.test(normalized)) {
-      return { ok: false, detail: "KEEPER_PRIVATE_KEY format" };
-    }
-  } catch {
-    return { ok: false, detail: "KEEPER_PRIVATE_KEY format" };
+    return {
+      ok: true,
+      privateKey: parsePrivateKey(privateKey),
+      rpcUrl,
+      game: envAddress("MARGIN_CALL_CRASH_ADDRESS", DEFAULT_GAME),
+      vault: envAddress("BANKROLL_VAULT_ADDRESS", DEFAULT_VAULT),
+      inco: envAddress("INCO_LIGHTNING_ADDRESS", DEFAULT_INCO),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      detail: error instanceof Error ? error.message : "invalid keeper env",
+    };
   }
-
-  return {
-    ok: true,
-    privateKey: normalized,
-    rpcUrl,
-    game: envAddress("MARGIN_CALL_CRASH_ADDRESS", DEFAULT_GAME),
-    vault: envAddress("BANKROLL_VAULT_ADDRESS", DEFAULT_VAULT),
-    inco: envAddress("INCO_LIGHTNING_ADDRESS", DEFAULT_INCO),
-  };
 }
 
 function stubRound(id: bigint): KeeperRoundSnapshot {
@@ -118,6 +117,16 @@ function stubRound(id: bigint): KeeperRoundSnapshot {
   };
 }
 
+function toStoredAlert(alert: KeeperAlert) {
+  return {
+    kind: alert.kind,
+    severity: alert.severity,
+    message: alert.message,
+    roundId: alert.roundId?.toString(),
+    fingerprint: alert.fingerprint,
+  };
+}
+
 async function postWebhook(alerts: KeeperAlert[]): Promise<void> {
   const url = process.env.KEEPER_ALERT_WEBHOOK_URL;
   if (!url || alerts.length === 0) return;
@@ -127,10 +136,7 @@ async function postWebhook(alerts: KeeperAlert[]): Promise<void> {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         source: "margin-call-keeper",
-        alerts: alerts.map((alert) => ({
-          ...alert,
-          roundId: alert.roundId?.toString(),
-        })),
+        alerts: alerts.map(toStoredAlert),
       }),
     });
   } catch (error) {
@@ -138,6 +144,7 @@ async function postWebhook(alerts: KeeperAlert[]): Promise<void> {
   }
 }
 
+/** Single attempt per tick — the cron re-plans finalize from chain state 20s later. */
 async function fetchAttestation(
   crashRandom: Hex
 ): Promise<{ plaintext: bigint; signatures: Hex[] }> {
@@ -146,40 +153,26 @@ async function fetchAttestation(
   if (!base) {
     throw new Error("KEEPER_ATTESTATION_URL (or NEXT_PUBLIC_APP_URL) unset");
   }
-  const attempts = 3;
-  let lastError: unknown = null;
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    try {
-      const response = await fetch(
-        new URL("/api/crash-attestation", base).toString(),
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ crashRandom }),
-        }
-      );
-      const body = (await response.json()) as {
-        plaintext?: string;
-        signatures?: Hex[];
-        error?: string;
-      };
-      if (!response.ok || !body.plaintext || !body.signatures) {
-        throw new Error(body.error ?? "Attestation request failed");
-      }
-      return {
-        plaintext: BigInt(body.plaintext),
-        signatures: body.signatures,
-      };
-    } catch (error) {
-      lastError = error;
-      if (attempt < attempts) {
-        await new Promise((resolve) => setTimeout(resolve, 5_000));
-      }
+  const response = await fetch(
+    new URL("/api/crash-attestation", base).toString(),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ crashRandom }),
     }
+  );
+  const body = (await response.json()) as {
+    plaintext?: string;
+    signatures?: Hex[];
+    error?: string;
+  };
+  if (!response.ok || !body.plaintext || !body.signatures) {
+    throw new Error(body.error ?? "Attestation request failed");
   }
-  throw lastError instanceof Error
-    ? lastError
-    : new Error("Attestation request failed");
+  return {
+    plaintext: BigInt(body.plaintext),
+    signatures: body.signatures,
+  };
 }
 
 function isBenignRevert(error: unknown): boolean {
@@ -200,32 +193,28 @@ export const run = internalAction({
     const startedAt = Date.now();
     const credentials = readCredentials();
     if (!credentials.ok) {
-      const alert = missingCredentialsAlert(credentials.detail);
-      await ctx.runMutation(internal.keeperAlerts.recordAlerts, {
-        observedAt: startedAt,
-        alerts: [
-          {
-            kind: alert.kind,
-            severity: alert.severity,
-            message: alert.message,
-            fingerprint: alert.fingerprint,
-          },
-        ],
-      });
-      await ctx.runMutation(internal.keeperAlerts.recordRun, {
-        startedAt,
-        finishedAt: Date.now(),
-        actionCount: 0,
-        alertCount: 1,
-        txHashes: [],
-        skippedReason: `missing_credentials:${credentials.detail}`,
-        sessionActive: false,
-      });
-      return {
-        actionCount: 0,
-        alertCount: 1,
-        skippedReason: `missing_credentials:${credentials.detail}`,
-      };
+      const skippedReason = `missing_credentials:${credentials.detail}`;
+      const inserted = await ctx.runMutation(
+        internal.keeperAlerts.recordAlerts,
+        {
+          observedAt: startedAt,
+          alerts: [toStoredAlert(missingCredentialsAlert(credentials.detail))],
+        }
+      );
+      // Only record a run when the alert was fresh — a permanently
+      // unconfigured deployment must not grow keeperRuns every 20s.
+      if (inserted > 0) {
+        await ctx.runMutation(internal.keeperAlerts.recordRun, {
+          startedAt,
+          finishedAt: Date.now(),
+          actionCount: 0,
+          alertCount: 1,
+          txHashes: [],
+          skippedReason,
+          sessionActive: false,
+        });
+      }
+      return { actionCount: 0, alertCount: 1, skippedReason };
     }
 
     const account = privateKeyToAccount(credentials.privateKey);
@@ -238,22 +227,18 @@ export const run = internalAction({
       chain: baseSepolia,
       transport: http(credentials.rpcUrl),
     });
+    const game = getContract({
+      address: credentials.game,
+      abi: gameAbi,
+      client: { public: publicClient, wallet: walletClient },
+    });
+    const vaultContract = getContract({
+      address: credentials.vault,
+      abi: vaultAbi,
+      client: publicClient,
+    });
 
-    const sendGameTx = async (
-      functionName:
-        "openRound" | "requestReveal" | "finalizeRound" | "expireRound",
-      args: readonly unknown[],
-      value = 0n
-    ): Promise<Hex> => {
-      const hash = await walletClient.sendTransaction({
-        to: credentials.game,
-        data: encodeFunctionData({
-          abi: gameAbi,
-          functionName,
-          args: args as never,
-        }),
-        value,
-      });
+    const confirmTx = async (hash: Hex): Promise<Hex> => {
       const receipt = await publicClient.waitForTransactionReceipt({ hash });
       if (receipt.status !== "success") {
         throw new Error(`Keeper tx failed: ${hash}`);
@@ -261,23 +246,9 @@ export const run = internalAction({
       return hash;
     };
 
-    const currentRoundId = await publicClient.readContract({
-      address: credentials.game,
-      abi: gameAbi,
-      functionName: "currentRoundId",
-    });
-
-    const block = await publicClient.getBlock({ blockTag: "latest" });
-    const now = block.timestamp;
-
-    const roundIds = new Set<bigint>();
-    const startId =
-      currentRoundId > WORK_LOOKBACK ? currentRoundId - WORK_LOOKBACK : 1n;
-    for (let id = startId; id <= currentRoundId + 1n; id++) {
-      roundIds.add(id);
-    }
-
     const [
+      currentRoundId,
+      block,
       grossAssets,
       freeLiquidity,
       shareOperationsFrozen,
@@ -285,93 +256,70 @@ export const run = internalAction({
       frozenRoundCount,
       keeperEthWei,
     ] = await Promise.all([
-      publicClient.readContract({
-        address: credentials.vault,
-        abi: vaultAbi,
-        functionName: "grossAssets",
-      }),
-      publicClient.readContract({
-        address: credentials.vault,
-        abi: vaultAbi,
-        functionName: "freeLiquidity",
-      }),
-      publicClient.readContract({
-        address: credentials.vault,
-        abi: vaultAbi,
-        functionName: "shareOperationsFrozen",
-      }),
-      publicClient.readContract({
-        address: credentials.vault,
-        abi: vaultAbi,
-        functionName: "oldestBlockingRound",
-      }),
-      publicClient.readContract({
-        address: credentials.vault,
-        abi: vaultAbi,
-        functionName: "frozenRoundCount",
-      }),
+      game.read.currentRoundId(),
+      publicClient.getBlock({ blockTag: "latest" }),
+      vaultContract.read.grossAssets(),
+      vaultContract.read.freeLiquidity(),
+      vaultContract.read.shareOperationsFrozen(),
+      vaultContract.read.oldestBlockingRound(),
+      vaultContract.read.frozenRoundCount(),
       publicClient.getBalance({ address: account.address }),
     ]);
+    const now = block.timestamp;
+
+    // Current + next always present so pre-open planning sees them.
+    const roundIds = new Set<bigint>([currentRoundId, currentRoundId + 1n]);
+    const startId =
+      currentRoundId > WORK_LOOKBACK ? currentRoundId - WORK_LOOKBACK : 1n;
+    for (let id = startId; id <= currentRoundId; id++) {
+      roundIds.add(id);
+    }
 
     let oldestBlockingExpiresAt: bigint | null = null;
     if (oldestBlockingRound !== NO_BLOCKING_ROUND) {
       roundIds.add(oldestBlockingRound);
-      const blocking = await publicClient.readContract({
-        address: credentials.vault,
-        abi: vaultAbi,
-        functionName: "getBlockingRound",
-        args: [oldestBlockingRound],
-      });
+      const blocking = await vaultContract.read.getBlockingRound([
+        oldestBlockingRound,
+      ]);
       if (blocking[0]) {
         oldestBlockingExpiresAt = BigInt(blocking[1]);
         let next = blocking[3];
         let guard = 0;
         while (next !== NO_BLOCKING_ROUND && guard < 32) {
           roundIds.add(next);
-          const row = await publicClient.readContract({
-            address: credentials.vault,
-            abi: vaultAbi,
-            functionName: "getBlockingRound",
-            args: [next],
-          });
+          const row = await vaultContract.read.getBlockingRound([next]);
           next = row[3];
           guard += 1;
         }
       }
     }
 
+    const sortedIds = [...roundIds].sort((a, b) =>
+      a < b ? -1 : a > b ? 1 : 0
+    );
+    const roundReads = await Promise.all(
+      sortedIds.map(async (id) => ({
+        id,
+        raw: await game.read.getRound([id]).catch(() => null),
+      }))
+    );
+
     const rounds: KeeperRoundSnapshot[] = [];
     const crashRandomByRound = new Map<bigint, Hex>();
-    for (const id of [...roundIds].sort((a, b) =>
-      a < b ? -1 : a > b ? 1 : 0
-    )) {
-      try {
-        const raw = await publicClient.readContract({
-          address: credentials.game,
-          abi: gameAbi,
-          functionName: "getRound",
-          args: [id],
-        });
-        rounds.push({
-          id: raw.id,
-          status: Number(raw.status) as KeeperRoundSnapshot["status"],
-          openAt: BigInt(raw.openAt),
-          lockAt: BigInt(raw.lockAt),
-          expiresAt: BigInt(raw.expiresAt),
-          totalMargin: raw.totalMargin,
-        });
-        crashRandomByRound.set(id, raw.crashRandom);
-      } catch {
+    for (const { id, raw } of roundReads) {
+      if (!raw) {
         rounds.push(stubRound(id));
+        continue;
       }
-    }
-
-    // Ensure current + next exist for pre-open planning.
-    if (!rounds.some((r) => r.id === currentRoundId)) {
-      rounds.push(stubRound(currentRoundId));
-    }
-    if (!rounds.some((r) => r.id === currentRoundId + 1n)) {
-      rounds.push(stubRound(currentRoundId + 1n));
+      rounds.push({
+        id: raw.id,
+        status: Number(raw.status) as KeeperRoundStatus,
+        openAt: BigInt(raw.openAt),
+        lockAt: BigInt(raw.lockAt),
+        expiresAt: BigInt(raw.expiresAt),
+        totalMargin: raw.totalMargin,
+      });
+      crashRandomByRound.set(id, raw.crashRandom);
     }
 
     const vault: KeeperVaultSnapshot = {
@@ -383,13 +331,20 @@ export const run = internalAction({
       oldestBlockingExpiresAt,
     };
 
-    const spendBudgetWei = process.env.KEEPER_PAYMASTER_SPEND_BUDGET_WEI;
+    const spendBudgetEnv = process.env.KEEPER_PAYMASTER_SPEND_BUDGET_WEI;
+    let spendBudgetWei: bigint | null = null;
+    if (spendBudgetEnv) {
+      try {
+        spendBudgetWei = BigInt(spendBudgetEnv);
+      } catch {
+        console.error(
+          "[keeper] KEEPER_PAYMASTER_SPEND_BUDGET_WEI is not a wei integer; spend alerts disabled"
+        );
+      }
+    }
     const sponsorshipSample = await ctx.runQuery(
       internal.keeperSponsorship.getSponsorshipWindowSample,
-      {
-        now: startedAt,
-        spendBudgetWei: spendBudgetWei ?? undefined,
-      }
+      { now: startedAt }
     );
 
     const snapshot: KeeperSnapshot = {
@@ -402,31 +357,26 @@ export const run = internalAction({
       sponsorship: {
         failuresInWindow: sponsorshipSample.failuresInWindow,
         spendWeiInWindow: BigInt(sponsorshipSample.spendWeiInWindow),
-        spendBudgetWei:
-          sponsorshipSample.spendBudgetWei === null
-            ? null
-            : BigInt(sponsorshipSample.spendBudgetWei),
+        spendBudgetWei,
       },
     };
 
     const plan = planKeeperTick(snapshot);
     const txHashes: string[] = [];
-    const attestationFailures: bigint[] = [];
+    const alerts: KeeperAlert[] = [...plan.alerts];
     let incoFee: bigint | null = null;
 
-    const execute = async (action: KeeperAction): Promise<void> => {
+    const execute = async (action: KeeperAction): Promise<Hex | null> => {
       try {
         switch (action.type) {
-          case "expire": {
-            const hash = await sendGameTx("expireRound", [action.roundId]);
-            txHashes.push(hash);
-            return;
-          }
-          case "requestReveal": {
-            const hash = await sendGameTx("requestReveal", [action.roundId]);
-            txHashes.push(hash);
-            return;
-          }
+          case "expire":
+            return await confirmTx(
+              await game.write.expireRound([action.roundId])
+            );
+          case "requestReveal":
+            return await confirmTx(
+              await game.write.requestReveal([action.roundId])
+            );
           case "finalize": {
             const crashRandom = crashRandomByRound.get(action.roundId);
             if (!crashRandom) {
@@ -434,35 +384,30 @@ export const run = internalAction({
                 `Missing crashRandom for round ${action.roundId}`
               );
             }
+            let attestation;
             try {
-              const attestation = await fetchAttestation(crashRandom);
-              const hash = await sendGameTx("finalizeRound", [
+              attestation = await fetchAttestation(crashRandom);
+            } catch (error) {
+              alerts.push(failedAttestationAlert(action.roundId));
+              throw error;
+            }
+            return await confirmTx(
+              await game.write.finalizeRound([
                 action.roundId,
                 attestation.plaintext,
                 attestation.signatures,
-              ]);
-              txHashes.push(hash);
-            } catch (error) {
-              attestationFailures.push(action.roundId);
-              throw error;
-            }
-            return;
+              ])
+            );
           }
           case "openRound": {
-            if (incoFee === null) {
-              incoFee = await publicClient.readContract({
-                address: credentials.inco,
-                abi: incoAbi,
-                functionName: "getFee",
-              });
-            }
-            const hash = await sendGameTx(
-              "openRound",
-              [action.roundId],
-              incoFee
+            incoFee ??= await publicClient.readContract({
+              address: credentials.inco,
+              abi: incoAbi,
+              functionName: "getFee",
+            });
+            return await confirmTx(
+              await game.write.openRound([action.roundId], { value: incoFee })
             );
-            txHashes.push(hash);
-            return;
           }
           default: {
             const _exhaustive: never = action;
@@ -472,56 +417,46 @@ export const run = internalAction({
       } catch (error) {
         if (isBenignRevert(error)) {
           console.error(
-            `[keeper] benign revert on ${action.type} ${"roundId" in action ? action.roundId : ""}`,
+            `[keeper] benign revert on ${action.type} ${action.roundId}`,
             error
           );
-          return;
+        } else {
+          console.error(
+            `[keeper] action failed: ${action.type}`,
+            error instanceof Error ? error.message : error
+          );
         }
-        console.error(
-          `[keeper] action failed: ${action.type}`,
-          error instanceof Error ? error.message : error
-        );
+        return null;
       }
     };
 
     for (const action of plan.actions) {
-      await execute(action);
-    }
-
-    const alerts: KeeperAlert[] = [...plan.alerts];
-    if (attestationFailures.length > 0) {
-      const retrySnapshot: KeeperSnapshot = {
-        ...snapshot,
-        attestationFailures,
-      };
-      alerts.push(
-        ...planKeeperTick(retrySnapshot).alerts.filter(
-          (alert) => alert.kind === "failed_attestation"
-        )
-      );
+      const hash = await execute(action);
+      if (hash) txHashes.push(hash);
     }
 
     await postWebhook(alerts);
 
-    await ctx.runMutation(internal.keeperAlerts.recordAlerts, {
-      observedAt: Date.now(),
-      alerts: alerts.map((alert) => ({
-        kind: alert.kind,
-        severity: alert.severity,
-        message: alert.message,
-        roundId: alert.roundId?.toString(),
-        fingerprint: alert.fingerprint,
-      })),
-    });
+    const insertedAlerts =
+      alerts.length === 0
+        ? 0
+        : await ctx.runMutation(internal.keeperAlerts.recordAlerts, {
+            observedAt: Date.now(),
+            alerts: alerts.map(toStoredAlert),
+          });
 
-    await ctx.runMutation(internal.keeperAlerts.recordRun, {
-      startedAt,
-      finishedAt: Date.now(),
-      actionCount: plan.actions.length,
-      alertCount: alerts.length,
-      txHashes,
-      sessionActive: plan.sessionActive,
-    });
+    // Idle ticks (no actions, nothing newly alerted) leave no keeperRuns row —
+    // a 20s cron would otherwise grow the table without bound.
+    if (plan.actions.length > 0 || insertedAlerts > 0) {
+      await ctx.runMutation(internal.keeperAlerts.recordRun, {
+        startedAt,
+        finishedAt: Date.now(),
+        actionCount: plan.actions.length,
+        alertCount: alerts.length,
+        txHashes,
+        sessionActive: plan.sessionActive,
+      });
+    }
 
     return {
       actionCount: plan.actions.length,

--- a/convex/keeperTick.ts
+++ b/convex/keeperTick.ts
@@ -1,0 +1,532 @@
+"use node";
+
+import {
+  KEEPER_ROUND_STATUS,
+  missingCredentialsAlert,
+  planKeeperTick,
+  type KeeperAction,
+  type KeeperAlert,
+  type KeeperRoundSnapshot,
+  type KeeperSnapshot,
+  type KeeperVaultSnapshot,
+} from "@margin-call/shared/crash-keeper";
+import {
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  http,
+  parseAbi,
+  type Address,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
+
+/** Defaults from contracts/deployments/base_sepolia.json — override via Convex env. */
+const DEFAULT_GAME =
+  "0xD74a89e199da9E45399ec913441b25A1b4120d44" as const satisfies Address;
+const DEFAULT_VAULT =
+  "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21" as const satisfies Address;
+const DEFAULT_INCO =
+  "0x4b9911b0191B0b6a6eA8F2Ed562e20Cff5AC8624" as const satisfies Address;
+
+/** Scan this many prior epochs for overdue expiry / delayed reveal work. */
+const WORK_LOOKBACK = 20n;
+
+const NO_BLOCKING_ROUND =
+  0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn;
+
+const gameAbi = parseAbi([
+  "function currentRoundId() view returns (uint256)",
+  "function getRound(uint256 roundId) view returns ((uint256 id, uint64 openAt, uint64 lockAt, uint64 expiresAt, bytes32 crashRandom, uint256 crashPointBps, uint256 totalMargin, uint256 reservedPayout, uint8 status))",
+  "function openRound(uint256 roundId) payable",
+  "function requestReveal(uint256 roundId)",
+  "function finalizeRound(uint256 roundId, uint256 plaintext, bytes[] signatures)",
+  "function expireRound(uint256 roundId)",
+]);
+
+const vaultAbi = parseAbi([
+  "function grossAssets() view returns (uint256)",
+  "function freeLiquidity() view returns (uint256)",
+  "function shareOperationsFrozen() view returns (bool)",
+  "function oldestBlockingRound() view returns (uint256)",
+  "function frozenRoundCount() view returns (uint256)",
+  "function getBlockingRound(uint256 roundId) view returns (bool present, uint64 expiresAt, bool revealFrozen, uint256 nextRoundId)",
+]);
+
+const incoAbi = parseAbi(["function getFee() view returns (uint256)"]);
+
+function envAddress(name: string, fallback: Address): Address {
+  const value = process.env[name];
+  if (!value) return fallback;
+  return value as Address;
+}
+
+function readCredentials():
+  | {
+      ok: true;
+      privateKey: Hex;
+      rpcUrl: string;
+      game: Address;
+      vault: Address;
+      inco: Address;
+    }
+  | { ok: false; detail: string } {
+  const privateKey = process.env.KEEPER_PRIVATE_KEY;
+  const rpcUrl =
+    process.env.BASE_SEPOLIA_RPC_URL ??
+    process.env.NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL;
+  if (!privateKey) {
+    return { ok: false, detail: "KEEPER_PRIVATE_KEY" };
+  }
+  if (!rpcUrl) {
+    return { ok: false, detail: "BASE_SEPOLIA_RPC_URL" };
+  }
+  let normalized: Hex;
+  try {
+    normalized = (
+      privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`
+    ) as Hex;
+    if (!/^0x[0-9a-fA-F]{64}$/.test(normalized)) {
+      return { ok: false, detail: "KEEPER_PRIVATE_KEY format" };
+    }
+  } catch {
+    return { ok: false, detail: "KEEPER_PRIVATE_KEY format" };
+  }
+
+  return {
+    ok: true,
+    privateKey: normalized,
+    rpcUrl,
+    game: envAddress("MARGIN_CALL_CRASH_ADDRESS", DEFAULT_GAME),
+    vault: envAddress("BANKROLL_VAULT_ADDRESS", DEFAULT_VAULT),
+    inco: envAddress("INCO_LIGHTNING_ADDRESS", DEFAULT_INCO),
+  };
+}
+
+function stubRound(id: bigint): KeeperRoundSnapshot {
+  return {
+    id,
+    status: KEEPER_ROUND_STATUS.uninitialized,
+    openAt: 0n,
+    lockAt: 0n,
+    expiresAt: 0n,
+    totalMargin: 0n,
+  };
+}
+
+async function postWebhook(alerts: KeeperAlert[]): Promise<void> {
+  const url = process.env.KEEPER_ALERT_WEBHOOK_URL;
+  if (!url || alerts.length === 0) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source: "margin-call-keeper",
+        alerts: alerts.map((alert) => ({
+          ...alert,
+          roundId: alert.roundId?.toString(),
+        })),
+      }),
+    });
+  } catch (error) {
+    console.error("[keeper] webhook post failed", error);
+  }
+}
+
+async function fetchAttestation(
+  crashRandom: Hex
+): Promise<{ plaintext: bigint; signatures: Hex[] }> {
+  const base =
+    process.env.KEEPER_ATTESTATION_URL ?? process.env.NEXT_PUBLIC_APP_URL;
+  if (!base) {
+    throw new Error("KEEPER_ATTESTATION_URL (or NEXT_PUBLIC_APP_URL) unset");
+  }
+  const attempts = 3;
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetch(
+        new URL("/api/crash-attestation", base).toString(),
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ crashRandom }),
+        }
+      );
+      const body = (await response.json()) as {
+        plaintext?: string;
+        signatures?: Hex[];
+        error?: string;
+      };
+      if (!response.ok || !body.plaintext || !body.signatures) {
+        throw new Error(body.error ?? "Attestation request failed");
+      }
+      return {
+        plaintext: BigInt(body.plaintext),
+        signatures: body.signatures,
+      };
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+      }
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Attestation request failed");
+}
+
+function isBenignRevert(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /InvalidRoundStatus|RoundAlready|already|execution reverted/i.test(
+    message
+  );
+}
+
+export const run = internalAction({
+  args: {},
+  returns: v.object({
+    actionCount: v.number(),
+    alertCount: v.number(),
+    skippedReason: v.union(v.string(), v.null()),
+  }),
+  handler: async (ctx) => {
+    const startedAt = Date.now();
+    const credentials = readCredentials();
+    if (!credentials.ok) {
+      const alert = missingCredentialsAlert(credentials.detail);
+      await ctx.runMutation(internal.keeperAlerts.recordAlerts, {
+        observedAt: startedAt,
+        alerts: [
+          {
+            kind: alert.kind,
+            severity: alert.severity,
+            message: alert.message,
+            fingerprint: alert.fingerprint,
+          },
+        ],
+      });
+      await ctx.runMutation(internal.keeperAlerts.recordRun, {
+        startedAt,
+        finishedAt: Date.now(),
+        actionCount: 0,
+        alertCount: 1,
+        txHashes: [],
+        skippedReason: `missing_credentials:${credentials.detail}`,
+        sessionActive: false,
+      });
+      return {
+        actionCount: 0,
+        alertCount: 1,
+        skippedReason: `missing_credentials:${credentials.detail}`,
+      };
+    }
+
+    const account = privateKeyToAccount(credentials.privateKey);
+    const publicClient = createPublicClient({
+      chain: baseSepolia,
+      transport: http(credentials.rpcUrl),
+    });
+    const walletClient = createWalletClient({
+      account,
+      chain: baseSepolia,
+      transport: http(credentials.rpcUrl),
+    });
+
+    const sendGameTx = async (
+      functionName:
+        "openRound" | "requestReveal" | "finalizeRound" | "expireRound",
+      args: readonly unknown[],
+      value = 0n
+    ): Promise<Hex> => {
+      const hash = await walletClient.sendTransaction({
+        to: credentials.game,
+        data: encodeFunctionData({
+          abi: gameAbi,
+          functionName,
+          args: args as never,
+        }),
+        value,
+      });
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== "success") {
+        throw new Error(`Keeper tx failed: ${hash}`);
+      }
+      return hash;
+    };
+
+    const currentRoundId = await publicClient.readContract({
+      address: credentials.game,
+      abi: gameAbi,
+      functionName: "currentRoundId",
+    });
+
+    const block = await publicClient.getBlock({ blockTag: "latest" });
+    const now = block.timestamp;
+
+    const roundIds = new Set<bigint>();
+    const startId =
+      currentRoundId > WORK_LOOKBACK ? currentRoundId - WORK_LOOKBACK : 1n;
+    for (let id = startId; id <= currentRoundId + 1n; id++) {
+      roundIds.add(id);
+    }
+
+    const [
+      grossAssets,
+      freeLiquidity,
+      shareOperationsFrozen,
+      oldestBlockingRound,
+      frozenRoundCount,
+      keeperEthWei,
+    ] = await Promise.all([
+      publicClient.readContract({
+        address: credentials.vault,
+        abi: vaultAbi,
+        functionName: "grossAssets",
+      }),
+      publicClient.readContract({
+        address: credentials.vault,
+        abi: vaultAbi,
+        functionName: "freeLiquidity",
+      }),
+      publicClient.readContract({
+        address: credentials.vault,
+        abi: vaultAbi,
+        functionName: "shareOperationsFrozen",
+      }),
+      publicClient.readContract({
+        address: credentials.vault,
+        abi: vaultAbi,
+        functionName: "oldestBlockingRound",
+      }),
+      publicClient.readContract({
+        address: credentials.vault,
+        abi: vaultAbi,
+        functionName: "frozenRoundCount",
+      }),
+      publicClient.getBalance({ address: account.address }),
+    ]);
+
+    let oldestBlockingExpiresAt: bigint | null = null;
+    if (oldestBlockingRound !== NO_BLOCKING_ROUND) {
+      roundIds.add(oldestBlockingRound);
+      const blocking = await publicClient.readContract({
+        address: credentials.vault,
+        abi: vaultAbi,
+        functionName: "getBlockingRound",
+        args: [oldestBlockingRound],
+      });
+      if (blocking[0]) {
+        oldestBlockingExpiresAt = BigInt(blocking[1]);
+        let next = blocking[3];
+        let guard = 0;
+        while (next !== NO_BLOCKING_ROUND && guard < 32) {
+          roundIds.add(next);
+          const row = await publicClient.readContract({
+            address: credentials.vault,
+            abi: vaultAbi,
+            functionName: "getBlockingRound",
+            args: [next],
+          });
+          next = row[3];
+          guard += 1;
+        }
+      }
+    }
+
+    const rounds: KeeperRoundSnapshot[] = [];
+    const crashRandomByRound = new Map<bigint, Hex>();
+    for (const id of [...roundIds].sort((a, b) =>
+      a < b ? -1 : a > b ? 1 : 0
+    )) {
+      try {
+        const raw = await publicClient.readContract({
+          address: credentials.game,
+          abi: gameAbi,
+          functionName: "getRound",
+          args: [id],
+        });
+        rounds.push({
+          id: raw.id,
+          status: Number(raw.status) as KeeperRoundSnapshot["status"],
+          openAt: BigInt(raw.openAt),
+          lockAt: BigInt(raw.lockAt),
+          expiresAt: BigInt(raw.expiresAt),
+          totalMargin: raw.totalMargin,
+        });
+        crashRandomByRound.set(id, raw.crashRandom);
+      } catch {
+        rounds.push(stubRound(id));
+      }
+    }
+
+    // Ensure current + next exist for pre-open planning.
+    if (!rounds.some((r) => r.id === currentRoundId)) {
+      rounds.push(stubRound(currentRoundId));
+    }
+    if (!rounds.some((r) => r.id === currentRoundId + 1n)) {
+      rounds.push(stubRound(currentRoundId + 1n));
+    }
+
+    const vault: KeeperVaultSnapshot = {
+      shareOperationsFrozen,
+      oldestBlockingRound,
+      frozenRoundCount,
+      freeLiquidity,
+      grossAssets,
+      oldestBlockingExpiresAt,
+    };
+
+    const spendBudgetWei = process.env.KEEPER_PAYMASTER_SPEND_BUDGET_WEI;
+    const sponsorshipSample = await ctx.runQuery(
+      internal.keeperSponsorship.getSponsorshipWindowSample,
+      {
+        now: startedAt,
+        spendBudgetWei: spendBudgetWei ?? undefined,
+      }
+    );
+
+    const snapshot: KeeperSnapshot = {
+      now,
+      currentRoundId,
+      rounds,
+      vault,
+      keeperEthWei,
+      preopenEnabled: process.env.KEEPER_PREOPEN_ENABLED === "true",
+      sponsorship: {
+        failuresInWindow: sponsorshipSample.failuresInWindow,
+        spendWeiInWindow: BigInt(sponsorshipSample.spendWeiInWindow),
+        spendBudgetWei:
+          sponsorshipSample.spendBudgetWei === null
+            ? null
+            : BigInt(sponsorshipSample.spendBudgetWei),
+      },
+    };
+
+    const plan = planKeeperTick(snapshot);
+    const txHashes: string[] = [];
+    const attestationFailures: bigint[] = [];
+    let incoFee: bigint | null = null;
+
+    const execute = async (action: KeeperAction): Promise<void> => {
+      try {
+        switch (action.type) {
+          case "expire": {
+            const hash = await sendGameTx("expireRound", [action.roundId]);
+            txHashes.push(hash);
+            return;
+          }
+          case "requestReveal": {
+            const hash = await sendGameTx("requestReveal", [action.roundId]);
+            txHashes.push(hash);
+            return;
+          }
+          case "finalize": {
+            const crashRandom = crashRandomByRound.get(action.roundId);
+            if (!crashRandom) {
+              throw new Error(
+                `Missing crashRandom for round ${action.roundId}`
+              );
+            }
+            try {
+              const attestation = await fetchAttestation(crashRandom);
+              const hash = await sendGameTx("finalizeRound", [
+                action.roundId,
+                attestation.plaintext,
+                attestation.signatures,
+              ]);
+              txHashes.push(hash);
+            } catch (error) {
+              attestationFailures.push(action.roundId);
+              throw error;
+            }
+            return;
+          }
+          case "openRound": {
+            if (incoFee === null) {
+              incoFee = await publicClient.readContract({
+                address: credentials.inco,
+                abi: incoAbi,
+                functionName: "getFee",
+              });
+            }
+            const hash = await sendGameTx(
+              "openRound",
+              [action.roundId],
+              incoFee
+            );
+            txHashes.push(hash);
+            return;
+          }
+          default: {
+            const _exhaustive: never = action;
+            return _exhaustive;
+          }
+        }
+      } catch (error) {
+        if (isBenignRevert(error)) {
+          console.error(
+            `[keeper] benign revert on ${action.type} ${"roundId" in action ? action.roundId : ""}`,
+            error
+          );
+          return;
+        }
+        console.error(
+          `[keeper] action failed: ${action.type}`,
+          error instanceof Error ? error.message : error
+        );
+      }
+    };
+
+    for (const action of plan.actions) {
+      await execute(action);
+    }
+
+    const alerts: KeeperAlert[] = [...plan.alerts];
+    if (attestationFailures.length > 0) {
+      const retrySnapshot: KeeperSnapshot = {
+        ...snapshot,
+        attestationFailures,
+      };
+      alerts.push(
+        ...planKeeperTick(retrySnapshot).alerts.filter(
+          (alert) => alert.kind === "failed_attestation"
+        )
+      );
+    }
+
+    await postWebhook(alerts);
+
+    await ctx.runMutation(internal.keeperAlerts.recordAlerts, {
+      observedAt: Date.now(),
+      alerts: alerts.map((alert) => ({
+        kind: alert.kind,
+        severity: alert.severity,
+        message: alert.message,
+        roundId: alert.roundId?.toString(),
+        fingerprint: alert.fingerprint,
+      })),
+    });
+
+    await ctx.runMutation(internal.keeperAlerts.recordRun, {
+      startedAt,
+      finishedAt: Date.now(),
+      actionCount: plan.actions.length,
+      alertCount: alerts.length,
+      txHashes,
+      sessionActive: plan.sessionActive,
+    });
+
+    return {
+      actionCount: plan.actions.length,
+      alertCount: alerts.length,
+      skippedReason: null,
+    };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -16,7 +16,6 @@ export default defineSchema({
     meta: v.optional(v.string()),
   })
     .index("by_fingerprint_observedAt", ["fingerprint", "observedAt"])
-    .index("by_kind_observedAt", ["kind", "observedAt"])
     .index("by_observedAt", ["observedAt"]),
 
   keeperRuns: defineTable({
@@ -27,14 +26,12 @@ export default defineSchema({
     txHashes: v.array(v.string()),
     skippedReason: v.optional(v.string()),
     sessionActive: v.boolean(),
-  }).index("by_startedAt", ["startedAt"]),
+  }),
 
   keeperSponsorshipEvents: defineTable({
     kind: v.union(v.literal("failure"), v.literal("spend")),
     observedAt: v.number(),
     amountWei: v.optional(v.string()),
     detail: v.optional(v.string()),
-  })
-    .index("by_observedAt", ["observedAt"])
-    .index("by_kind_observedAt", ["kind", "observedAt"]),
+  }).index("by_observedAt", ["observedAt"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,3 +1,40 @@
-import { defineSchema } from "convex/server";
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
 
-export default defineSchema({});
+/**
+ * Keeper ops tables only — round/ticket truth stays onchain.
+ * Alerts never become settlement authority.
+ */
+export default defineSchema({
+  keeperAlerts: defineTable({
+    kind: v.string(),
+    severity: v.string(),
+    message: v.string(),
+    roundId: v.optional(v.string()),
+    observedAt: v.number(),
+    fingerprint: v.string(),
+    meta: v.optional(v.string()),
+  })
+    .index("by_fingerprint_observedAt", ["fingerprint", "observedAt"])
+    .index("by_kind_observedAt", ["kind", "observedAt"])
+    .index("by_observedAt", ["observedAt"]),
+
+  keeperRuns: defineTable({
+    startedAt: v.number(),
+    finishedAt: v.number(),
+    actionCount: v.number(),
+    alertCount: v.number(),
+    txHashes: v.array(v.string()),
+    skippedReason: v.optional(v.string()),
+    sessionActive: v.boolean(),
+  }).index("by_startedAt", ["startedAt"]),
+
+  keeperSponsorshipEvents: defineTable({
+    kind: v.union(v.literal("failure"), v.literal("spend")),
+    observedAt: v.number(),
+    amountWei: v.optional(v.string()),
+    detail: v.optional(v.string()),
+  })
+    .index("by_observedAt", ["observedAt"])
+    .index("by_kind_observedAt", ["kind", "observedAt"]),
+});

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ESNext"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
     "strict": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,

--- a/docs/runbooks/keeper.md
+++ b/docs/runbooks/keeper.md
@@ -1,0 +1,85 @@
+# Keeper + monitoring runbook
+
+The Crash keeper is a Convex scheduled action (`crash-keeper`, every 20s) that drives **permissionless** round transitions from onchain state. It chooses no outcome, receives no early decryption access, and never becomes settlement authority.
+
+## Why the keeper exists
+
+Under phone-only login (ADR 0008), players use Privy embedded wallets with sponsored gas. A paymaster sponsors gas but **cannot supply `msg.value`**, so embedded wallets cannot call payable `openRound` / create rounds (ADR 0006).
+
+**The keeper is required for entry availability and optional for settlement.**
+
+- Phone-login players can only enter rounds some ETH-holding wallet has already opened.
+- Settlement, claim, refund, expiry, and LP operations remain fully permissionless with the keeper stopped.
+- If pre-opening stalls while players are active, the UI shows an honest waiting state (no fake countdown); the stale-pre-open alert fires.
+
+## Duties (priority order)
+
+1. **Expire** eligible exposed rounds (`Open` | `RevealRequested` past `expiresAt`) — highest priority; clears reveal-window freeze.
+2. **`requestReveal`** for locked rounds that have tickets.
+3. **Fetch attestation** + **`finalizeRound`** (plaintext comes only from Inco covalidators).
+4. **Pre-open** current and next epochs while a session is active (`KEEPER_PREOPEN_ENABLED=true` or recent onchain demand).
+5. Emit **monitoring alerts** (never gate transactions).
+
+Idle deployments emit **zero transactions**.
+
+## Credentials (Convex dashboard only)
+
+Set these on the Convex deployment — never in client code or the repo:
+
+| Variable                                                                          | Purpose                                                                            |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `KEEPER_PRIVATE_KEY`                                                              | Funded EOA that pays gas + Inco fees                                               |
+| `BASE_SEPOLIA_RPC_URL`                                                            | Base Sepolia RPC                                                                   |
+| `KEEPER_PREOPEN_ENABLED`                                                          | `true` to keep current+next initialized during demo/judged sessions                |
+| `KEEPER_ATTESTATION_URL`                                                          | App origin for `POST /api/crash-attestation` (falls back to `NEXT_PUBLIC_APP_URL`) |
+| `KEEPER_ALERT_WEBHOOK_URL`                                                        | Optional webhook for alert fan-out                                                 |
+| `KEEPER_PAYMASTER_SPEND_BUDGET_WEI`                                               | Optional spend budget for paymaster alerts                                         |
+| `MARGIN_CALL_CRASH_ADDRESS` / `BANKROLL_VAULT_ADDRESS` / `INCO_LIGHTNING_ADDRESS` | Optional overrides (defaults from the curated Base Sepolia deployment record)      |
+
+Missing credentials → keeper no-ops and records a `missing_credentials` alert (cron does not crash).
+
+## Manual failover (pre-open)
+
+Any ETH-holding wallet can restore entry availability:
+
+```bash
+# Funded key with Base Sepolia ETH; addresses default from deployments/base_sepolia.json
+export BASE_SEPOLIA_RPC_URL=…
+export OPERATOR_PRIVATE_KEY=0x…
+
+# Open current (+ next) via the lifecycle smoke helper, or call openRound directly:
+cast send "$MARGIN_CALL_CRASH_ADDRESS" "openRound(uint256)" "$ROUND_ID" \
+  --value "$(cast call "$INCO_LIGHTNING_ADDRESS" "getFee()(uint256)")" \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --private-key "$OPERATOR_PRIVATE_KEY"
+```
+
+Redundant keeper: run a second Convex deployment (or operator bot) with the same permissionless calls — first successful receipt wins; transitions are idempotent / safely retryable.
+
+## Settlement with the keeper stopped (drill)
+
+1. Stop the Convex cron / unset `KEEPER_PRIVATE_KEY` so the keeper no-ops.
+2. Drive reveal → attest → finalize (or expire) from any wallet — the product UI already offers these permissionless paths for tickets and LP freeze recovery.
+3. Confirm claims/refunds still complete.
+4. Confirm phone-login **entry** stays blocked until some ETH wallet opens the current epoch (expected).
+
+## Alerts
+
+Alerts append to the `keeperAlerts` table and `console.error`; they **do not** authorize or block settlement.
+
+| Kind                                    | Trigger                                                            |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| `delayed_reveal`                        | Ticketed `Open` still past `lockAt + 90s`                          |
+| `failed_attestation`                    | Attestation fetch failed for a finalize attempt                    |
+| `expiry_eligibility`                    | Exposed round past `expiresAt` not yet expired                     |
+| `freeze_outliving_expiry`               | Share freeze still on after oldest blocking round's `expiresAt`    |
+| `low_free_liquidity`                    | `freeLiquidity < 5,000 tUSD`                                       |
+| `entry_floor_approach`                  | `grossAssets < 12,500 tUSD` (entry floor is 10,000)                |
+| `low_keeper_eth`                        | Keeper balance `< 0.005 ETH`                                       |
+| `stale_preopen`                         | Active session + current epoch uninitialized                       |
+| `paymaster_failure` / `paymaster_spend` | Sponsorship samples via `keeperSponsorship.reportSponsorshipEvent` |
+| `missing_credentials`                   | Required env unset                                                 |
+
+## Active session heuristic
+
+Session is active when `KEEPER_PREOPEN_ENABLED=true` **or** any of the current / prior-1 / prior-2 rounds has `totalMargin > 0`. Pre-open runs only while active; settlement work always runs when onchain state requires it.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./address": "./src/address.ts",
+    "./crash-keeper": "./src/crash-keeper.ts",
     "./parse-private-key": "./src/parse-private-key.ts"
   },
   "dependencies": {

--- a/packages/shared/src/crash-keeper.test.ts
+++ b/packages/shared/src/crash-keeper.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  KEEPER_ROUND_STATUS,
+  KEEPER_THRESHOLDS,
+  classifyKeeperAlerts,
+  isExpireEligible,
+  isFinalizeEligible,
+  isKeeperSessionActive,
+  isRevealEligible,
+  missingCredentialsAlert,
+  planKeeperTick,
+  type KeeperRoundSnapshot,
+  type KeeperSnapshot,
+  type KeeperVaultSnapshot,
+} from "./crash-keeper";
+
+const ONE_TUSD = 1_000_000n;
+
+function vault(
+  overrides: Partial<KeeperVaultSnapshot> = {}
+): KeeperVaultSnapshot {
+  return {
+    shareOperationsFrozen: false,
+    oldestBlockingRound: 0n,
+    frozenRoundCount: 0n,
+    freeLiquidity: 50_000n * ONE_TUSD,
+    grossAssets: 50_000n * ONE_TUSD,
+    oldestBlockingExpiresAt: null,
+    ...overrides,
+  };
+}
+
+function round(
+  overrides: Partial<KeeperRoundSnapshot> & Pick<KeeperRoundSnapshot, "id">
+): KeeperRoundSnapshot {
+  return {
+    status: KEEPER_ROUND_STATUS.uninitialized,
+    openAt: 0n,
+    lockAt: 0n,
+    expiresAt: 0n,
+    totalMargin: 0n,
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<KeeperSnapshot> = {}): KeeperSnapshot {
+  return {
+    now: 1_000n,
+    currentRoundId: 10n,
+    rounds: [
+      round({ id: 10n, status: KEEPER_ROUND_STATUS.uninitialized }),
+      round({ id: 11n, status: KEEPER_ROUND_STATUS.uninitialized }),
+    ],
+    vault: vault(),
+    keeperEthWei: 1n * 10n ** 18n,
+    preopenEnabled: false,
+    sponsorship: null,
+    ...overrides,
+  };
+}
+
+describe("crash-keeper planner", () => {
+  it("emits zero actions when idle (inactive session, no work)", () => {
+    const plan = planKeeperTick(snapshot());
+    expect(plan.sessionActive).toBe(false);
+    expect(plan.actions).toEqual([]);
+  });
+
+  it("detects active session from preopen flag or recent demand", () => {
+    expect(isKeeperSessionActive(snapshot({ preopenEnabled: true }))).toBe(
+      true
+    );
+    expect(
+      isKeeperSessionActive(
+        snapshot({
+          rounds: [
+            round({
+              id: 10n,
+              status: KEEPER_ROUND_STATUS.open,
+              totalMargin: ONE_TUSD,
+              openAt: 900n,
+              lockAt: 945n,
+              expiresAt: 1845n,
+            }),
+          ],
+        })
+      )
+    ).toBe(true);
+    // Margin only on current-3 is outside the lookback window.
+    expect(
+      isKeeperSessionActive(
+        snapshot({
+          rounds: [
+            round({
+              id: 7n,
+              status: KEEPER_ROUND_STATUS.finalized,
+              totalMargin: ONE_TUSD,
+            }),
+            round({ id: 10n }),
+          ],
+        })
+      )
+    ).toBe(false);
+    // Prior-2 (current-2) with margin counts as recent demand.
+    expect(
+      isKeeperSessionActive(
+        snapshot({
+          currentRoundId: 10n,
+          rounds: [
+            round({
+              id: 8n,
+              status: KEEPER_ROUND_STATUS.expired,
+              totalMargin: ONE_TUSD,
+            }),
+            round({ id: 10n }),
+          ],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("prioritizes expiry before reveal and finalize", () => {
+    const plan = planKeeperTick(
+      snapshot({
+        now: 2_000n,
+        preopenEnabled: false,
+        rounds: [
+          round({
+            id: 9n,
+            status: KEEPER_ROUND_STATUS.revealRequested,
+            totalMargin: ONE_TUSD,
+            openAt: 800n,
+            lockAt: 845n,
+            expiresAt: 1_745n,
+          }),
+          round({
+            id: 10n,
+            status: KEEPER_ROUND_STATUS.open,
+            totalMargin: ONE_TUSD,
+            openAt: 900n,
+            lockAt: 945n,
+            expiresAt: 1_845n,
+          }),
+          round({
+            id: 11n,
+            status: KEEPER_ROUND_STATUS.revealRequested,
+            totalMargin: ONE_TUSD,
+            openAt: 1_000n,
+            lockAt: 1_045n,
+            expiresAt: 2_045n,
+          }),
+          // Ticketless past expiry is not keeper work (no vault exposure).
+          round({
+            id: 8n,
+            status: KEEPER_ROUND_STATUS.open,
+            totalMargin: 0n,
+            openAt: 700n,
+            lockAt: 745n,
+            expiresAt: 1_645n,
+          }),
+        ],
+      })
+    );
+
+    expect(plan.actions.map((a) => a.type)).toEqual([
+      "expire",
+      "expire",
+      "finalize",
+    ]);
+    expect(plan.actions[0]).toEqual({ type: "expire", roundId: 9n });
+    expect(plan.actions[1]).toEqual({ type: "expire", roundId: 10n });
+    expect(plan.actions[2]).toEqual({ type: "finalize", roundId: 11n });
+  });
+
+  it("skips reveal for ticketless locked rounds", () => {
+    expect(
+      isRevealEligible(
+        round({
+          id: 10n,
+          status: KEEPER_ROUND_STATUS.open,
+          totalMargin: 0n,
+          lockAt: 900n,
+          expiresAt: 1_800n,
+        }),
+        1_000n
+      )
+    ).toBe(false);
+
+    const plan = planKeeperTick(
+      snapshot({
+        now: 1_000n,
+        rounds: [
+          round({
+            id: 10n,
+            status: KEEPER_ROUND_STATUS.open,
+            totalMargin: 0n,
+            openAt: 900n,
+            lockAt: 945n,
+            expiresAt: 1_845n,
+          }),
+        ],
+      })
+    );
+    expect(plan.actions).toEqual([]);
+  });
+
+  it("requests reveal for ticketed locked rounds before expiry", () => {
+    const locked = round({
+      id: 10n,
+      status: KEEPER_ROUND_STATUS.open,
+      totalMargin: ONE_TUSD,
+      openAt: 900n,
+      lockAt: 945n,
+      expiresAt: 1_845n,
+    });
+    expect(isRevealEligible(locked, 950n)).toBe(true);
+    expect(isRevealEligible(locked, 1_845n)).toBe(false);
+
+    const plan = planKeeperTick(
+      snapshot({
+        now: 950n,
+        rounds: [
+          locked,
+          round({
+            id: 11n,
+            status: KEEPER_ROUND_STATUS.open,
+            openAt: 960n,
+            lockAt: 1_005n,
+            expiresAt: 1_905n,
+          }),
+        ],
+      })
+    );
+    expect(plan.actions).toEqual([{ type: "requestReveal", roundId: 10n }]);
+  });
+
+  it("plans finalize without inventing plaintext", () => {
+    const revealing = round({
+      id: 10n,
+      status: KEEPER_ROUND_STATUS.revealRequested,
+      totalMargin: ONE_TUSD,
+      openAt: 900n,
+      lockAt: 945n,
+      expiresAt: 1_845n,
+    });
+    expect(isFinalizeEligible(revealing, 1_000n)).toBe(true);
+    expect(isFinalizeEligible(revealing, 1_845n)).toBe(false);
+
+    const plan = planKeeperTick(
+      snapshot({
+        now: 1_000n,
+        rounds: [
+          revealing,
+          round({
+            id: 11n,
+            status: KEEPER_ROUND_STATUS.open,
+            openAt: 960n,
+            lockAt: 1_005n,
+            expiresAt: 1_905n,
+          }),
+        ],
+      })
+    );
+    expect(plan.actions).toEqual([{ type: "finalize", roundId: 10n }]);
+    expect(plan.actions[0]).not.toHaveProperty("plaintext");
+  });
+
+  it("pre-opens current and next only during active sessions", () => {
+    const inactive = planKeeperTick(snapshot({ preopenEnabled: false }));
+    expect(inactive.actions).toEqual([]);
+
+    const active = planKeeperTick(snapshot({ preopenEnabled: true }));
+    expect(active.sessionActive).toBe(true);
+    expect(active.actions).toEqual([
+      { type: "openRound", roundId: 10n },
+      { type: "openRound", roundId: 11n },
+    ]);
+
+    const alreadyOpen = planKeeperTick(
+      snapshot({
+        preopenEnabled: true,
+        rounds: [
+          round({
+            id: 10n,
+            status: KEEPER_ROUND_STATUS.open,
+            openAt: 900n,
+            lockAt: 945n,
+            expiresAt: 1_845n,
+          }),
+          round({
+            id: 11n,
+            status: KEEPER_ROUND_STATUS.open,
+            openAt: 960n,
+            lockAt: 1_005n,
+            expiresAt: 1_905n,
+          }),
+        ],
+      })
+    );
+    expect(alreadyOpen.actions).toEqual([]);
+  });
+
+  it("marks exposed rounds expire-eligible after expiresAt", () => {
+    const exposed = round({
+      id: 10n,
+      status: KEEPER_ROUND_STATUS.open,
+      totalMargin: ONE_TUSD,
+      expiresAt: 1_000n,
+    });
+    expect(isExpireEligible(exposed, 999n)).toBe(false);
+    expect(isExpireEligible(exposed, 1_000n)).toBe(true);
+  });
+});
+
+describe("crash-keeper alerts", () => {
+  it("fires every listed alert kind in a synthetic scenario", () => {
+    const alerts = classifyKeeperAlerts(
+      snapshot({
+        now: 2_000n,
+        preopenEnabled: true,
+        currentRoundId: 10n,
+        keeperEthWei: 1n,
+        attestationFailures: [9n],
+        sponsorship: {
+          failuresInWindow: 2,
+          spendWeiInWindow: 100n,
+          spendBudgetWei: 50n,
+        },
+        vault: vault({
+          shareOperationsFrozen: true,
+          oldestBlockingRound: 8n,
+          frozenRoundCount: 1n,
+          oldestBlockingExpiresAt: 1_500n,
+          freeLiquidity: 1n * ONE_TUSD,
+          grossAssets: 11_000n * ONE_TUSD,
+        }),
+        rounds: [
+          round({
+            id: 8n,
+            status: KEEPER_ROUND_STATUS.revealRequested,
+            totalMargin: ONE_TUSD,
+            openAt: 500n,
+            lockAt: 545n,
+            expiresAt: 1_445n,
+          }),
+          round({
+            id: 9n,
+            status: KEEPER_ROUND_STATUS.open,
+            totalMargin: ONE_TUSD,
+            openAt: 800n,
+            lockAt: 845n,
+            expiresAt: 1_745n,
+          }),
+          round({ id: 10n, status: KEEPER_ROUND_STATUS.uninitialized }),
+        ],
+      })
+    );
+
+    const kinds = new Set(alerts.map((a) => a.kind));
+    expect(kinds.has("delayed_reveal")).toBe(true);
+    expect(kinds.has("failed_attestation")).toBe(true);
+    expect(kinds.has("expiry_eligibility")).toBe(true);
+    expect(kinds.has("freeze_outliving_expiry")).toBe(true);
+    expect(kinds.has("low_free_liquidity")).toBe(true);
+    expect(kinds.has("entry_floor_approach")).toBe(true);
+    expect(kinds.has("low_keeper_eth")).toBe(true);
+    expect(kinds.has("stale_preopen")).toBe(true);
+    expect(kinds.has("paymaster_failure")).toBe(true);
+    expect(kinds.has("paymaster_spend")).toBe(true);
+  });
+
+  it("alerts stale pre-open when active players have no open round", () => {
+    const alerts = classifyKeeperAlerts(
+      snapshot({
+        preopenEnabled: true,
+        rounds: [round({ id: 10n }), round({ id: 11n })],
+      })
+    );
+    expect(alerts.some((a) => a.kind === "stale_preopen")).toBe(true);
+  });
+
+  it("alerts delayed reveal after lockAt + SLA", () => {
+    const lockAt = 900n;
+    const alerts = classifyKeeperAlerts(
+      snapshot({
+        now: lockAt + KEEPER_THRESHOLDS.delayedRevealSeconds + 1n,
+        rounds: [
+          round({
+            id: 10n,
+            status: KEEPER_ROUND_STATUS.open,
+            totalMargin: ONE_TUSD,
+            lockAt,
+            expiresAt: lockAt + 900n,
+          }),
+        ],
+      })
+    );
+    expect(alerts.some((a) => a.kind === "delayed_reveal")).toBe(true);
+  });
+
+  it("alerts entry floor at 12,500 tUSD", () => {
+    const alerts = classifyKeeperAlerts(
+      snapshot({
+        vault: vault({
+          grossAssets: KEEPER_THRESHOLDS.entryFloorAlertAssets - 1n,
+        }),
+      })
+    );
+    expect(alerts.some((a) => a.kind === "entry_floor_approach")).toBe(true);
+  });
+
+  it("builds a missing-credentials alert for the executor", () => {
+    const a = missingCredentialsAlert("KEEPER_PRIVATE_KEY");
+    expect(a.kind).toBe("missing_credentials");
+    expect(a.severity).toBe("critical");
+  });
+
+  it("never treats alerts as settlement actions", () => {
+    const plan = planKeeperTick(
+      snapshot({
+        vault: vault({
+          grossAssets: 1n,
+          freeLiquidity: 1n,
+        }),
+        keeperEthWei: 1n,
+      })
+    );
+    expect(plan.actions).toEqual([]);
+    expect(plan.alerts.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/shared/src/crash-keeper.test.ts
+++ b/packages/shared/src/crash-keeper.test.ts
@@ -8,6 +8,7 @@ import {
   isFinalizeEligible,
   isKeeperSessionActive,
   isRevealEligible,
+  failedAttestationAlert,
   missingCredentialsAlert,
   planKeeperTick,
   type KeeperRoundSnapshot,
@@ -321,7 +322,6 @@ describe("crash-keeper alerts", () => {
         preopenEnabled: true,
         currentRoundId: 10n,
         keeperEthWei: 1n,
-        attestationFailures: [9n],
         sponsorship: {
           failuresInWindow: 2,
           spendWeiInWindow: 100n,
@@ -359,7 +359,6 @@ describe("crash-keeper alerts", () => {
 
     const kinds = new Set(alerts.map((a) => a.kind));
     expect(kinds.has("delayed_reveal")).toBe(true);
-    expect(kinds.has("failed_attestation")).toBe(true);
     expect(kinds.has("expiry_eligibility")).toBe(true);
     expect(kinds.has("freeze_outliving_expiry")).toBe(true);
     expect(kinds.has("low_free_liquidity")).toBe(true);
@@ -414,6 +413,13 @@ describe("crash-keeper alerts", () => {
     const a = missingCredentialsAlert("KEEPER_PRIVATE_KEY");
     expect(a.kind).toBe("missing_credentials");
     expect(a.severity).toBe("critical");
+  });
+
+  it("builds a failed-attestation alert for the executor", () => {
+    const a = failedAttestationAlert(9n);
+    expect(a.kind).toBe("failed_attestation");
+    expect(a.roundId).toBe(9n);
+    expect(a.fingerprint).toBe("failed_attestation:9");
   });
 
   it("never treats alerts as settlement actions", () => {

--- a/packages/shared/src/crash-keeper.ts
+++ b/packages/shared/src/crash-keeper.ts
@@ -31,7 +31,7 @@ export const KEEPER_THRESHOLDS = {
 
 export type KeeperRoundSnapshot = {
   id: bigint;
-  status: number;
+  status: KeeperRoundStatus;
   openAt: bigint;
   lockAt: bigint;
   expiresAt: bigint;
@@ -65,8 +65,6 @@ export type KeeperSnapshot = {
   /** Operator flag: keep current+next pre-opened during demo/judged sessions. */
   preopenEnabled: boolean;
   sponsorship: KeeperSponsorshipSample | null;
-  /** Rounds whose attestation fetch failed on a prior attempt this window. */
-  attestationFailures?: readonly bigint[];
 };
 
 export type KeeperAction =
@@ -215,17 +213,6 @@ export function classifyKeeperAlerts(snapshot: KeeperSnapshot): KeeperAlert[] {
     }
   }
 
-  for (const roundId of snapshot.attestationFailures ?? []) {
-    alerts.push(
-      alert(
-        "failed_attestation",
-        "warning",
-        `Attestation failed for round ${roundId}; finalize will retry`,
-        roundId
-      )
-    );
-  }
-
   if (
     vault.shareOperationsFrozen &&
     vault.oldestBlockingExpiresAt !== null &&
@@ -324,33 +311,22 @@ export function planKeeperTick(snapshot: KeeperSnapshot): KeeperPlan {
   const actions: KeeperAction[] = [];
   const { now, currentRoundId, rounds } = snapshot;
 
-  const expireCandidates = rounds
-    .filter((round) => isExpireEligible(round, now) && isExposed(round))
-    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-
-  for (const round of expireCandidates) {
-    actions.push({ type: "expire", roundId: round.id });
-  }
-
-  const remaining = rounds.filter(
-    (round) => !(isExpireEligible(round, now) && isExposed(round))
+  const sorted = [...rounds].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0
   );
 
-  for (const round of [...remaining].sort((a, b) =>
-    a.id < b.id ? -1 : a.id > b.id ? 1 : 0
-  )) {
-    if (isRevealEligible(round, now)) {
-      actions.push({ type: "requestReveal", roundId: round.id });
+  const reveals: KeeperAction[] = [];
+  const finalizes: KeeperAction[] = [];
+  for (const round of sorted) {
+    if (isExpireEligible(round, now) && isExposed(round)) {
+      actions.push({ type: "expire", roundId: round.id });
+    } else if (isRevealEligible(round, now)) {
+      reveals.push({ type: "requestReveal", roundId: round.id });
+    } else if (isFinalizeEligible(round, now)) {
+      finalizes.push({ type: "finalize", roundId: round.id });
     }
   }
-
-  for (const round of [...remaining].sort((a, b) =>
-    a.id < b.id ? -1 : a.id > b.id ? 1 : 0
-  )) {
-    if (isFinalizeEligible(round, now)) {
-      actions.push({ type: "finalize", roundId: round.id });
-    }
-  }
+  actions.push(...reveals, ...finalizes);
 
   if (sessionActive) {
     const current = roundById(rounds, currentRoundId);
@@ -378,5 +354,15 @@ export function missingCredentialsAlert(detail: string): KeeperAlert {
     "missing_credentials",
     "critical",
     `Keeper credentials missing or invalid: ${detail}`
+  );
+}
+
+/** Build a failed-attestation alert for a finalize attempt whose fetch failed. */
+export function failedAttestationAlert(roundId: bigint): KeeperAlert {
+  return alert(
+    "failed_attestation",
+    "warning",
+    `Attestation failed for round ${roundId}; finalize will retry`,
+    roundId
   );
 }

--- a/packages/shared/src/crash-keeper.ts
+++ b/packages/shared/src/crash-keeper.ts
@@ -1,0 +1,382 @@
+/**
+ * Pure Crash keeper planner: ordered permissionless actions + monitoring alerts.
+ * No outcome privilege — finalize never invents plaintext; the executor attests.
+ */
+
+/** Mirrors MarginCallCrash.RoundStatus. */
+export const KEEPER_ROUND_STATUS = {
+  uninitialized: 0,
+  open: 1,
+  revealRequested: 2,
+  finalized: 3,
+  expired: 4,
+} as const;
+
+export type KeeperRoundStatus =
+  (typeof KEEPER_ROUND_STATUS)[keyof typeof KEEPER_ROUND_STATUS];
+
+/** Operational thresholds (tech design §11 + issue #350 defaults). */
+export const KEEPER_THRESHOLDS = {
+  /** Seconds after lockAt before a ticketed Open round is "delayed reveal". */
+  delayedRevealSeconds: 90n,
+  /** Alert when vault gross assets fall below this (tUSD 6 decimals). Floor is 10_000. */
+  entryFloorAlertAssets: 12_500n * 1_000_000n,
+  /** Alert when freeLiquidity falls below this (tUSD 6 decimals). */
+  lowFreeLiquidityAssets: 5_000n * 1_000_000n,
+  /** Alert when keeper wallet ETH is below this (wei). */
+  lowKeeperEthWei: 5_000_000_000_000_000n, // 0.005 ETH
+  /** How many prior epochs count as recent demand for session detection. */
+  recentDemandLookback: 2n,
+} as const;
+
+export type KeeperRoundSnapshot = {
+  id: bigint;
+  status: number;
+  openAt: bigint;
+  lockAt: bigint;
+  expiresAt: bigint;
+  totalMargin: bigint;
+};
+
+export type KeeperVaultSnapshot = {
+  shareOperationsFrozen: boolean;
+  oldestBlockingRound: bigint;
+  frozenRoundCount: bigint;
+  freeLiquidity: bigint;
+  grossAssets: bigint;
+  /** expiresAt of the oldest blocking round when known; null if none/unknown. */
+  oldestBlockingExpiresAt: bigint | null;
+};
+
+export type KeeperSponsorshipSample = {
+  failuresInWindow: number;
+  spendWeiInWindow: bigint;
+  /** When null, spend alerts are skipped. */
+  spendBudgetWei: bigint | null;
+};
+
+export type KeeperSnapshot = {
+  /** Chain time in unix seconds. */
+  now: bigint;
+  currentRoundId: bigint;
+  rounds: readonly KeeperRoundSnapshot[];
+  vault: KeeperVaultSnapshot;
+  keeperEthWei: bigint;
+  /** Operator flag: keep current+next pre-opened during demo/judged sessions. */
+  preopenEnabled: boolean;
+  sponsorship: KeeperSponsorshipSample | null;
+  /** Rounds whose attestation fetch failed on a prior attempt this window. */
+  attestationFailures?: readonly bigint[];
+};
+
+export type KeeperAction =
+  | { type: "expire"; roundId: bigint }
+  | { type: "requestReveal"; roundId: bigint }
+  | { type: "finalize"; roundId: bigint }
+  | { type: "openRound"; roundId: bigint };
+
+export type KeeperAlertKind =
+  | "delayed_reveal"
+  | "failed_attestation"
+  | "expiry_eligibility"
+  | "freeze_outliving_expiry"
+  | "low_free_liquidity"
+  | "entry_floor_approach"
+  | "low_keeper_eth"
+  | "stale_preopen"
+  | "paymaster_failure"
+  | "paymaster_spend"
+  | "missing_credentials";
+
+export type KeeperAlertSeverity = "info" | "warning" | "critical";
+
+export type KeeperAlert = {
+  kind: KeeperAlertKind;
+  severity: KeeperAlertSeverity;
+  message: string;
+  roundId?: bigint;
+  fingerprint: string;
+};
+
+export type KeeperPlan = {
+  actions: KeeperAction[];
+  alerts: KeeperAlert[];
+  sessionActive: boolean;
+};
+
+function roundById(
+  rounds: readonly KeeperRoundSnapshot[],
+  id: bigint
+): KeeperRoundSnapshot | undefined {
+  return rounds.find((round) => round.id === id);
+}
+
+function isExposed(round: KeeperRoundSnapshot): boolean {
+  return round.totalMargin > 0n;
+}
+
+/**
+ * Active when the operator enables pre-open, or recent onchain demand exists
+ * (margin on current or either of the prior two epochs).
+ */
+export function isKeeperSessionActive(snapshot: KeeperSnapshot): boolean {
+  if (snapshot.preopenEnabled) return true;
+
+  const { currentRoundId, rounds } = snapshot;
+  const lookback = KEEPER_THRESHOLDS.recentDemandLookback;
+  for (let delta = 0n; delta <= lookback; delta++) {
+    if (currentRoundId < delta) continue;
+    const round = roundById(rounds, currentRoundId - delta);
+    if (round && isExposed(round)) return true;
+  }
+  return false;
+}
+
+function alert(
+  kind: KeeperAlertKind,
+  severity: KeeperAlertSeverity,
+  message: string,
+  roundId?: bigint
+): KeeperAlert {
+  const fingerprint =
+    roundId === undefined ? kind : `${kind}:${roundId.toString()}`;
+  return { kind, severity, message, roundId, fingerprint };
+}
+
+/** True when a round can be expired onchain (Open | RevealRequested past expiresAt). */
+export function isExpireEligible(
+  round: KeeperRoundSnapshot,
+  now: bigint
+): boolean {
+  if (
+    round.status !== KEEPER_ROUND_STATUS.open &&
+    round.status !== KEEPER_ROUND_STATUS.revealRequested
+  ) {
+    return false;
+  }
+  return now >= round.expiresAt;
+}
+
+/** True when a ticketed Open round is past lock and before expiry. */
+export function isRevealEligible(
+  round: KeeperRoundSnapshot,
+  now: bigint
+): boolean {
+  if (round.status !== KEEPER_ROUND_STATUS.open) return false;
+  if (!isExposed(round)) return false;
+  if (now < round.lockAt) return false;
+  if (now >= round.expiresAt) return false;
+  return true;
+}
+
+/** True when RevealRequested and still before expiry. */
+export function isFinalizeEligible(
+  round: KeeperRoundSnapshot,
+  now: bigint
+): boolean {
+  if (round.status !== KEEPER_ROUND_STATUS.revealRequested) return false;
+  return now < round.expiresAt;
+}
+
+/**
+ * Classify monitoring alerts from a chain snapshot.
+ * Alerts never become settlement authority — callers must not gate txs on them.
+ */
+export function classifyKeeperAlerts(snapshot: KeeperSnapshot): KeeperAlert[] {
+  const alerts: KeeperAlert[] = [];
+  const sessionActive = isKeeperSessionActive(snapshot);
+  const { now, vault, rounds, currentRoundId } = snapshot;
+
+  for (const round of rounds) {
+    if (
+      round.status === KEEPER_ROUND_STATUS.open &&
+      isExposed(round) &&
+      now > round.lockAt + KEEPER_THRESHOLDS.delayedRevealSeconds
+    ) {
+      alerts.push(
+        alert(
+          "delayed_reveal",
+          "warning",
+          `Round ${round.id} still Open ${now - round.lockAt}s after lock`,
+          round.id
+        )
+      );
+    }
+
+    if (isExpireEligible(round, now) && isExposed(round)) {
+      alerts.push(
+        alert(
+          "expiry_eligibility",
+          "critical",
+          `Exposed round ${round.id} is expiry-eligible and should be expired promptly`,
+          round.id
+        )
+      );
+    }
+  }
+
+  for (const roundId of snapshot.attestationFailures ?? []) {
+    alerts.push(
+      alert(
+        "failed_attestation",
+        "warning",
+        `Attestation failed for round ${roundId}; finalize will retry`,
+        roundId
+      )
+    );
+  }
+
+  if (
+    vault.shareOperationsFrozen &&
+    vault.oldestBlockingExpiresAt !== null &&
+    now > vault.oldestBlockingExpiresAt
+  ) {
+    alerts.push(
+      alert(
+        "freeze_outliving_expiry",
+        "critical",
+        `Share freeze still active after blocking round ${vault.oldestBlockingRound} expiry`,
+        vault.oldestBlockingRound
+      )
+    );
+  }
+
+  if (vault.freeLiquidity < KEEPER_THRESHOLDS.lowFreeLiquidityAssets) {
+    alerts.push(
+      alert(
+        "low_free_liquidity",
+        "warning",
+        `Free liquidity ${vault.freeLiquidity} below ${KEEPER_THRESHOLDS.lowFreeLiquidityAssets}`
+      )
+    );
+  }
+
+  if (vault.grossAssets < KEEPER_THRESHOLDS.entryFloorAlertAssets) {
+    alerts.push(
+      alert(
+        "entry_floor_approach",
+        "warning",
+        `Gross assets ${vault.grossAssets} approaching 10,000 tUSD entry floor (alert at 12,500)`
+      )
+    );
+  }
+
+  if (snapshot.keeperEthWei < KEEPER_THRESHOLDS.lowKeeperEthWei) {
+    alerts.push(
+      alert(
+        "low_keeper_eth",
+        "critical",
+        `Keeper wallet ETH ${snapshot.keeperEthWei} below ${KEEPER_THRESHOLDS.lowKeeperEthWei} wei`
+      )
+    );
+  }
+
+  const current = roundById(rounds, currentRoundId);
+  if (
+    sessionActive &&
+    (!current || current.status === KEEPER_ROUND_STATUS.uninitialized)
+  ) {
+    alerts.push(
+      alert(
+        "stale_preopen",
+        "critical",
+        `Active session but epoch ${currentRoundId} is uninitialized — phone-login entry blocked`,
+        currentRoundId
+      )
+    );
+  }
+
+  const sponsorship = snapshot.sponsorship;
+  if (sponsorship) {
+    if (sponsorship.failuresInWindow > 0) {
+      alerts.push(
+        alert(
+          "paymaster_failure",
+          "warning",
+          `${sponsorship.failuresInWindow} sponsorship failure(s) in monitoring window`
+        )
+      );
+    }
+    if (
+      sponsorship.spendBudgetWei !== null &&
+      sponsorship.spendWeiInWindow > sponsorship.spendBudgetWei
+    ) {
+      alerts.push(
+        alert(
+          "paymaster_spend",
+          "warning",
+          `Sponsorship spend ${sponsorship.spendWeiInWindow} exceeds budget ${sponsorship.spendBudgetWei}`
+        )
+      );
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Plan one keeper tick from onchain state.
+ * Priority: expire → requestReveal → finalize → pre-open (when session active).
+ * Idle (no work, inactive session) yields zero actions.
+ */
+export function planKeeperTick(snapshot: KeeperSnapshot): KeeperPlan {
+  const sessionActive = isKeeperSessionActive(snapshot);
+  const actions: KeeperAction[] = [];
+  const { now, currentRoundId, rounds } = snapshot;
+
+  const expireCandidates = rounds
+    .filter((round) => isExpireEligible(round, now) && isExposed(round))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  for (const round of expireCandidates) {
+    actions.push({ type: "expire", roundId: round.id });
+  }
+
+  const remaining = rounds.filter(
+    (round) => !(isExpireEligible(round, now) && isExposed(round))
+  );
+
+  for (const round of [...remaining].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  )) {
+    if (isRevealEligible(round, now)) {
+      actions.push({ type: "requestReveal", roundId: round.id });
+    }
+  }
+
+  for (const round of [...remaining].sort((a, b) =>
+    a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  )) {
+    if (isFinalizeEligible(round, now)) {
+      actions.push({ type: "finalize", roundId: round.id });
+    }
+  }
+
+  if (sessionActive) {
+    const current = roundById(rounds, currentRoundId);
+    const nextId = currentRoundId + 1n;
+    const next = roundById(rounds, nextId);
+
+    if (!current || current.status === KEEPER_ROUND_STATUS.uninitialized) {
+      actions.push({ type: "openRound", roundId: currentRoundId });
+    }
+    if (!next || next.status === KEEPER_ROUND_STATUS.uninitialized) {
+      actions.push({ type: "openRound", roundId: nextId });
+    }
+  }
+
+  return {
+    actions,
+    alerts: classifyKeeperAlerts(snapshot),
+    sessionActive,
+  };
+}
+
+/** Build a missing-credentials alert for the executor when env is incomplete. */
+export function missingCredentialsAlert(detail: string): KeeperAlert {
+  return alert(
+    "missing_credentials",
+    "critical",
+    `Keeper credentials missing or invalid: ${detail}`
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./address";
+export * from "./crash-keeper";
 export * from "./parse-private-key";

--- a/tests/convex/keeper.test.ts
+++ b/tests/convex/keeper.test.ts
@@ -1,0 +1,96 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { internal } from "../../convex/_generated/api";
+import schema from "../../convex/schema";
+
+const modules = import.meta.glob("../../convex/**/*.ts");
+
+describe("keeper alerts + sponsorship", () => {
+  it("records alerts and dedupes fingerprints within the window", async () => {
+    const t = convexTest(schema, modules);
+    const observedAt = 1_700_000_000_000;
+
+    const first = await t.mutation(internal.keeperAlerts.recordAlerts, {
+      observedAt,
+      alerts: [
+        {
+          kind: "stale_preopen",
+          severity: "critical",
+          message: "Active session but epoch uninitialized",
+          roundId: "10",
+          fingerprint: "stale_preopen:10",
+        },
+      ],
+    });
+    expect(first).toBe(1);
+
+    const dup = await t.mutation(internal.keeperAlerts.recordAlerts, {
+      observedAt: observedAt + 60_000,
+      alerts: [
+        {
+          kind: "stale_preopen",
+          severity: "critical",
+          message: "Active session but epoch uninitialized",
+          roundId: "10",
+          fingerprint: "stale_preopen:10",
+        },
+      ],
+    });
+    expect(dup).toBe(0);
+
+    const listed = await t.query(internal.keeperAlerts.listRecentAlerts, {
+      since: observedAt - 1,
+    });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.kind).toBe("stale_preopen");
+  });
+
+  it("aggregates paymaster failure and spend samples for alerts", async () => {
+    const t = convexTest(schema, modules);
+    const now = 1_700_000_000_000;
+
+    await t.mutation(internal.keeperSponsorship.reportSponsorshipEvent, {
+      kind: "failure",
+      observedAt: now - 1_000,
+      detail: "policy rejected",
+    });
+    await t.mutation(internal.keeperSponsorship.reportSponsorshipEvent, {
+      kind: "spend",
+      observedAt: now - 500,
+      amountWei: "1000",
+    });
+    await t.mutation(internal.keeperSponsorship.reportSponsorshipEvent, {
+      kind: "spend",
+      observedAt: now - 100,
+      amountWei: "500",
+    });
+
+    const sample = await t.query(
+      internal.keeperSponsorship.getSponsorshipWindowSample,
+      {
+        now,
+        spendBudgetWei: "1200",
+      }
+    );
+
+    expect(sample.failuresInWindow).toBe(1);
+    expect(sample.spendWeiInWindow).toBe("1500");
+    expect(sample.spendBudgetWei).toBe("1200");
+  });
+
+  it("records keeper runs without becoming settlement authority", async () => {
+    const t = convexTest(schema, modules);
+    const id = await t.mutation(internal.keeperAlerts.recordRun, {
+      startedAt: 1,
+      finishedAt: 2,
+      actionCount: 0,
+      alertCount: 2,
+      txHashes: [],
+      skippedReason: "missing_credentials:KEEPER_PRIVATE_KEY",
+      sessionActive: false,
+    });
+    expect(id).toBeTruthy();
+  });
+});

--- a/tests/convex/keeper.test.ts
+++ b/tests/convex/keeper.test.ts
@@ -69,15 +69,11 @@ describe("keeper alerts + sponsorship", () => {
 
     const sample = await t.query(
       internal.keeperSponsorship.getSponsorshipWindowSample,
-      {
-        now,
-        spendBudgetWei: "1200",
-      }
+      { now }
     );
 
     expect(sample.failuresInWindow).toBe(1);
     expect(sample.spendWeiInWindow).toBe("1500");
-    expect(sample.spendBudgetWei).toBe("1200");
   });
 
   it("records keeper runs without becoming settlement authority", async () => {


### PR DESCRIPTION
## Summary
- Implements Slice 12 (#350): Convex scheduled keeper that expires exposed rounds first, then reveal/attest/finalize, then pre-opens current+next during active sessions
- Pure planner in `@margin-call/shared` with unit coverage for idle/no-op, priority order, stale pre-open, and all alert kinds including paymaster samples
- Runbook documents phone-login pre-open dependency, manual `openRound` failover, and settlement-without-keeper drill

## Test plan
- [x] `pnpm exec vitest run packages/shared/src/crash-keeper.test.ts tests/convex/keeper.test.ts`
- [x] `pnpm typecheck`
- [x] `node scripts/check-convex-codegen.mjs`
- [ ] Set Convex env (`KEEPER_PRIVATE_KEY`, `BASE_SEPOLIA_RPC_URL`, optional `KEEPER_PREOPEN_ENABLED`) and deploy functions
- [ ] Confirm idle deployment emits no txs; with preopen enabled, current+next initialize
- [ ] Confirm expiry clears reveal-window freeze when keeper drives `expireRound`


Made with [Cursor](https://cursor.com)