### PR TITLE
Slice 13 · Base Sepolia deploy, smoke tooling, and release record (#351)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL=
 # Minute-aligned Unix timestamp at least five minutes after deployment simulation
 MARGIN_CALL_EPOCH_ORIGIN=
 # Leave empty until deployed; the UI degrades to a "not configured" notice
+# Addresses must match contracts/deployments/base_sepolia.json (Base Sepolia only)
 NEXT_PUBLIC_DESK_DOLLARS_ADDRESS=
 NEXT_PUBLIC_DESK_DOLLARS_FAUCET_ADDRESS=
 NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS=
@@ -30,7 +31,7 @@ NEXT_PUBLIC_MARGIN_CALL_CRASH_DEPLOYMENT_BLOCK=
 # MARGIN_CALL_CRASH_ADDRESS=    # Optional override; defaults to curated Base Sepolia record
 # BANKROLL_VAULT_ADDRESS=
 # INCO_LIGHTNING_ADDRESS=
-# See docs/runbooks/keeper.md
+# See docs/runbooks/keeper.md and docs/runbooks/deploy-smoke-release.md
 
 # Upstash Redis (rate limiting) — optional for local dev (uses in-memory fallback)
 UPSTASH_REDIS_REST_URL=

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,19 +1,12 @@
 # Contracts workspace
 
-Foundry scaffolding for the future Margin Call Crash implementation described in:
+Foundry workspace for the Margin Call Crash Game Jam MVP on **Base Sepolia** (`84532`). Product source of truth:
 
-- [`../docs/2026-08-08-margin-call-crash-technical-design.md`](../docs/2026-08-08-margin-call-crash-technical-design.md)
 - [`../docs/2026-08-07-margin-call-crash-prd.md`](../docs/2026-08-07-margin-call-crash-prd.md)
+- [`../docs/2026-08-08-margin-call-crash-technical-design.md`](../docs/2026-08-08-margin-call-crash-technical-design.md)
+- [`../docs/runbooks/deploy-smoke-release.md`](../docs/runbooks/deploy-smoke-release.md)
 
-The retired Pack Rip contracts, scripts, deployments, and tests have been removed. `MarginCallCrash` currently implements the fixed epoch grid, pre-committed confidential round creation, permissionless reveal, attested finalization, and expiry. Entry, tickets, vault settlement, and refunds arrive in later slices.
-
-After deploying a replacement game contract, a Base Sepolia lifecycle smoke can be run with:
-
-```bash
-pnpm smoke:crash-lifecycle
-# or, for an already-opened unresolved round after expiresAt:
-# SMOKE_EXPIRE_ROUND_ID=<id> node scripts/smoke-crash-expire.mjs
-```
+Implemented: Desk Dollars + faucet, `BankrollVault`, `MarginCallCrash` (entry, settlement, expiry refunds, reveal-window freeze), and Base Sepolia deploy scripts. The curated release record is [`deployments/base_sepolia.json`](./deployments/base_sepolia.json).
 
 ## Prerequisites
 
@@ -29,13 +22,26 @@ cd contracts
 forge fmt --check
 forge build
 forge test
+# or from repo root:
+pnpm test:contracts:ci
+pnpm validate:base-sepolia-release
 ```
 
 Compiler and dependency pins are documented in [REPRODUCIBILITY.md](./REPRODUCIBILITY.md).
 
-## Crash deployment
+## Fresh Base Sepolia deploy
 
-Choose a minute-aligned Unix timestamp at least five minutes in the future, then run the Base Sepolia deployment with the recorded release deployer:
+HITL only — requires the recorded deployer key and RPC. Full order, merge rules, smoke checklist, and acceptance mapping live in the [deploy/smoke runbook](../docs/runbooks/deploy-smoke-release.md).
+
+Summary:
+
+1. `DeployDeskDollars` → merge `base_sepolia.run.json`
+2. `DeployBankrollVault` (exact 25,000 tUSD seed) → merge `base_sepolia.bankroll_vault.run.json`
+3. `DeployMarginCallCrash` with minute-aligned `MARGIN_CALL_EPOCH_ORIGIN` → merge `base_sepolia.margin_call_crash.run.json`
+4. Verify on Basescan; update `sourceCommit` and validation URLs
+5. Propagate addresses to Vercel / Convex; run guided Privy smoke
+
+Crash-only redeploy (vault already seeded and unauthorized):
 
 ```bash
 MARGIN_CALL_EPOCH_ORIGIN=<timestamp> \
@@ -45,4 +51,10 @@ forge script script/DeployMarginCallCrash.s.sol:DeployMarginCallCrash \
   --broadcast
 ```
 
-The script writes `deployments/base_sepolia.margin_call_crash.run.json` for deliberate review and merging into the curated deployment record.
+Operator lifecycle smoke (funded EOA — not the fresh-phone Privy path):
+
+```bash
+pnpm smoke:crash-lifecycle
+# SMOKE_EXPIRE=1 pnpm smoke:crash-lifecycle
+# SMOKE_EXPIRE_ROUND_ID=<id> node scripts/smoke-crash-expire.mjs
+```

--- a/contracts/deployments/base_sepolia.json
+++ b/contracts/deployments/base_sepolia.json
@@ -1,22 +1,22 @@
 {
-  "sourceCommit": "1e3b424596772559034c7a54f2cf7180bf1799fc",
+  "sourceCommit": "a791b5a962eecdec2b7e9df91cfb3bd1d55344d9",
   "chainId": 84532,
   "frontend": {
     "url": "https://margincall.fun",
     "status": "production-ready",
-    "productionDeploymentId": "dpl_7z8kZMjPQxUnjwvYZb5aKK1BZ4hY",
-    "productionCommit": "7aa0af13af0f553db33e8bd55ab1a2524b739e8a",
-    "previewUrl": "https://margin-call-jue644mdu-dhurls99-s-team.vercel.app",
-    "previewDeploymentId": "dpl_692TtHm1RKerzqo2ovN7NFgGSvs3",
-    "previewStatus": "ready-with-deployment-protection"
+    "productionDeploymentId": "dpl_FpJaVGBtRJYSYtJjfYHapdp6fNur",
+    "productionCommit": "a791b5a962eecdec2b7e9df91cfb3bd1d55344d9",
+    "previewUrl": "https://margin-call-7bi23vvrb-dhurls99-s-team.vercel.app",
+    "previewDeploymentId": "dpl_FpJaVGBtRJYSYtJjfYHapdp6fNur",
+    "previewStatus": "ready"
   },
-  "tokenDeploymentBlock": 45313049,
-  "token": "0xDa0A5f6FC5238c6D8018fc1d22846460c2cFd085",
-  "faucet": "0xcfc9Bf8Ea84c153C518DA6Cc4E35D8a212d8E356",
-  "bankrollVault": "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21",
-  "marginCallCrash": "0xD74a89e199da9E45399ec913441b25A1b4120d44",
-  "marginCallCrashDeploymentBlock": 45351025,
-  "marginCallCrashEpochOrigin": 1786470660,
+  "tokenDeploymentBlock": 45385960,
+  "token": "0x4Ff4a2d64C53BE0b6f0B77B191579E7CEC026d56",
+  "faucet": "0x16434C92223baEDE8301b2F117DeD0F56147Bb99",
+  "bankrollVault": "0x75Db0b7865060c0d59a9801c4396ebfc430A740a",
+  "marginCallCrash": "0x2E7eb3B6Ac8E1ebF0C4B90067F584B21F22C2b3d",
+  "marginCallCrashDeploymentBlock": 45385985,
+  "marginCallCrashEpochOrigin": 1786540800,
   "marginCallCrashRoundDuration": 60,
   "marginCallCrashEntryWindow": 45,
   "marginCallCrashExpiryDelay": 900,
@@ -34,57 +34,104 @@
   "deployer": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
   "bankrollSeedAmount": 25000000000,
   "bankrollVaultSeedDepositor": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
-  "bankrollVaultSeedAssets": 20000000000,
-  "bankrollVaultMintedShares": 20000000000,
-  "bankrollVaultDeploymentBlock": 45351004,
+  "bankrollVaultSeedAssets": 25000000000,
+  "bankrollVaultMintedShares": 25000000000,
+  "bankrollVaultDeploymentBlock": 45385977,
   "bankrollVaultDepositSelector": "0x6e553f65",
   "faucetClaimAmount": 100000000,
   "faucetClaimCooldown": 3600,
   "faucetConfigured": true,
   "faucetClaimSelector": "0x4e71d92d",
   "verification": {
-    "token": "https://sepolia.basescan.org/address/0xDa0A5f6FC5238c6D8018fc1d22846460c2cFd085#code",
-    "faucet": "https://sepolia.basescan.org/address/0xcfc9Bf8Ea84c153C518DA6Cc4E35D8a212d8E356#code",
-    "bankrollVault": "https://sepolia.basescan.org/address/0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21#code",
-    "marginCallCrash": "https://sepolia.basescan.org/address/0xD74a89e199da9E45399ec913441b25A1b4120d44#code"
+    "token": "https://sepolia.basescan.org/address/0x4Ff4a2d64C53BE0b6f0B77B191579E7CEC026d56#code",
+    "faucet": "https://sepolia.basescan.org/address/0x16434C92223baEDE8301b2F117DeD0F56147Bb99#code",
+    "bankrollVault": "https://sepolia.basescan.org/address/0x75Db0b7865060c0d59a9801c4396ebfc430A740a#code",
+    "marginCallCrash": "https://sepolia.basescan.org/address/0x2E7eb3B6Ac8E1ebF0C4B90067F584B21F22C2b3d#code"
   },
   "transactions": {
-    "deployToken": "0x52d47a026c289a580eb2fb329f31667bc6282af10c1bc345dcc99b4e7b6ae9cb",
-    "deployFaucet": "0xcd278e2676df8fea5e43dd8d8521b8ce931c4a8917c0e5351009ab79c01bae1a",
-    "configureFaucet": "0xb67efea780bc376f1fac20433fc666793d3dab3099635f52b2683cb424a8d348",
-    "deployBankrollVault": "0x270e4fe7724217535f237eeb963151946a9e614161929da116a43ca873828105",
-    "approveBankrollVault": "0xcfe51188a2040cd8f13e1f4c176b82e939b48519a257830a986a55d3062b00f4",
-    "seedBankrollVault": "0x2675ceccfe5443da7bf1a67bdfe80bc08a518e5be54b22c5557e71db91fa31d3",
-    "deployMarginCallCrash": "0x1d83518ce4d39cba9083400d5ef4a03fd8ddb499c01d6a3d4a320a60cc06f0df",
+    "deployToken": "0xa3db1c6e2a82c64fa8c995c49639ef493ad127a432da57d46b821368201d5eae",
+    "deployFaucet": "0xa1f642385a413d134f557556320653cba51c2b48e96ddb48c93ef2be7f06f333",
+    "configureFaucet": "0x9a1438bc9cae97c0e0665af7ceb9d5776a6d5dfe1778a4a7675d81edb6a018d0",
+    "deployBankrollVault": "0x87a0783ac1414b164afa47deb6d99d08a0ee3269e806e4cfdb427fd89f8b7935",
+    "approveBankrollVault": "0xe346739475c94e2b1931c4f56a0be98f8887ba98813c6d449479a0c5febc5c21",
+    "seedBankrollVault": "0x970aff1df865d36afd0be0e9d8188efb60c8aa045cc402d9bb7395985b9732cc",
+    "deployMarginCallCrash": "0xc537f61073c3883a84c865c9a92f2a2fff68a0fee7ed4107512d102d437ea63a",
     "withdrawOldBankrollVault": "0x9b4beaa1ca892d5ae54ff419df6e8c3525ba6cde8477e68994062441017dd0b3",
-    "setAuthorizedGame": "0x3fb1e6165dbe5ee2b27d10299205005b7b27dc61f9458d62bc3fceace871e78d",
+    "setAuthorizedGame": "0x4e9a920d3e49e8cc4491fe289f11733f37ceda013b5b7634576abc0f4e8aa312",
     "openRound0": "0xb2b0f1103bbab6482018c4a62fb5e91d9d628789d1209813c64601c8608bcda9",
-    "openRound1": "0x221fc558fed98f1106c5b39e53b177d94006aa04cec8b1bfb821fc92bf4f4e31"
+    "openRound1": "0x221fc558fed98f1106c5b39e53b177d94006aa04cec8b1bfb821fc92bf4f4e31",
+    "requestReveal0": "0x0eb42b2628706009a184587335f6c417ecb9fdbd92a7aaf5bc54c4269022f939",
+    "finalizeRound0": "0x02cd64610a0752a0d1c3d9271aa4fe7f9ba754c1cba0e9ccb3f4fe08e1af5c69"
   },
   "privySponsorship": {
     "appId": "cmmfbu7o900c10cjme09a31h4",
     "mode": "app-pays",
     "chain": "Base Sepolia",
     "clientTransactionsAllowed": true,
-    "contractSelectorAllowlist": "not-exposed-by-dashboard"
+    "policyId": "pending-dashboard-apply",
+    "permittedContracts": [
+      "0x4Ff4a2d64C53BE0b6f0B77B191579E7CEC026d56",
+      "0x16434C92223baEDE8301b2F117DeD0F56147Bb99",
+      "0x75Db0b7865060c0d59a9801c4396ebfc430A740a",
+      "0x2E7eb3B6Ac8E1ebF0C4B90067F584B21F22C2b3d"
+    ],
+    "permittedSelectors": [
+      "0x02c6266a",
+      "0x095ea7b3",
+      "0x292672ea",
+      "0x40261cdd",
+      "0x4e71d92d",
+      "0x6e553f65",
+      "0x7ad226dc",
+      "0x864f1156",
+      "0xb460af94",
+      "0xbc208057",
+      "0xbcc5e2f6",
+      "0xbde22ae0",
+      "0xddd5e1b2"
+    ]
   },
   "smokeTest": {
-    "status": "rounds-preopened-pending-ui-entry",
-    "game": "0xD74a89e199da9E45399ec913441b25A1b4120d44",
-    "vault": "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21",
+    "status": "history-seeded-pending-privy-player-smoke",
     "issue": 351,
-    "openRound0": "0xb2b0f1103bbab6482018c4a62fb5e91d9d628789d1209813c64601c8608bcda9",
-    "openRound1": "0x221fc558fed98f1106c5b39e53b177d94006aa04cec8b1bfb821fc92bf4f4e31"
+    "game": "0x2E7eb3B6Ac8E1ebF0C4B90067F584B21F22C2b3d",
+    "vault": "0x75Db0b7865060c0d59a9801c4396ebfc430A740a",
+    "operatorLifecycle": {
+      "requestReveal": "0x0eb42b2628706009a184587335f6c417ecb9fdbd92a7aaf5bc54c4269022f939",
+      "finalizeRound": "0x02cd64610a0752a0d1c3d9271aa4fe7f9ba754c1cba0e9ccb3f4fe08e1af5c69",
+      "finalizedRoundId": 0,
+      "crashPointBps": 21023
+    },
+    "liveObservations": {
+      "overlappingRoundsVerified": true,
+      "overlappingRoundsNote": "Observed rounds 2/3/4 simultaneously Open (status=1) at unix ~1786540986 while round 1 Finalized; currentRoundId=3.",
+      "idleEpochNoStateVerified": true,
+      "idleEpochNote": "getRound(53) returned uninitialized status=0 with zero times/handle.",
+      "ticketlessPreopenNoExposureVerified": true,
+      "ticketlessPreopenNote": "Pre-opened rounds 3 and 4 had totalMargin=0 reservedPayout=0; vault reservedLiabilities=0 unrecognizedMargin=0 with grossAssets=25000000000.",
+      "globalHistoryFinalizedRounds": 20,
+      "globalHistoryNote": "Operator forward-seed finalized \u226520 rounds on the new game (seed-forward-finalized.mjs). Verify UI at https://margincall.fun shows \u226520 finalized entries.",
+      "zeroEthWalletThroughout": false,
+      "transactionPendingRecoveryAudited": false,
+      "pendingHumanPlayerSmoke": true
+    },
+    "sponsorshipVerification": {
+      "inPolicySponsoredCallsSucceeded": false,
+      "outOfPolicyCallRejected": false,
+      "pendingPrivyDashboardApply": true,
+      "policyId": "pending-dashboard-apply"
+    }
   },
   "supersedes": {
-    "sourceCommit": "4b1108c4f5c806c67c189003b3093c4dd3ac0483",
-    "token": "0x78c9DfaA9288Dd9c1f757d336A88f4F8e9EfC35C",
-    "faucet": "0x23f4C0622D9b88aA0Fe7469B34F1e780b5367c78",
-    "bankrollVault": "0xb82f4B3DcE7539d23ab77aBF9e3317269D3E92ff",
-    "marginCallCrash": "0x4677227a9DEF791BcBd60E5D73C12927363EA04f",
-    "marginCallCrashDeploymentBlock": 45342715,
-    "marginCallCrashEpochOrigin": 1786454100,
-    "deployMarginCallCrash": "0x982be82965b26a23bf583f36466d618ea19e151899dbd49327c173415a197485"
+    "sourceCommit": "1e3b424596772559034c7a54f2cf7180bf1799fc",
+    "token": "0xDa0A5f6FC5238c6D8018fc1d22846460c2cFd085",
+    "faucet": "0xcfc9Bf8Ea84c153C518DA6Cc4E35D8a212d8E356",
+    "bankrollVault": "0xc3d6ffa7eE1635F94bd545e05c9aCFabB01A4c21",
+    "marginCallCrash": "0xD74a89e199da9E45399ec913441b25A1b4120d44",
+    "marginCallCrashDeploymentBlock": 45351025,
+    "marginCallCrashEpochOrigin": 1786470660,
+    "bankrollVaultSeedAssets": 20000000000,
+    "deployMarginCallCrash": "0x1d83518ce4d39cba9083400d5ef4a03fd8ddb499c01d6a3d4a320a60cc06f0df"
   },
   "supersededLiveBeforeEntryRedeploy": {
     "bankrollVault": "0xB5b599104650924Ec4b0f3aFC560e80A7DA93afe",
@@ -104,5 +151,7 @@
       "deployMarginCallCrash": "0x0fb1eb320775dc6a39ccc5ae1294bc6c57b164f3412f0f286c45e404976e6e84"
     }
   },
-  "entryInterfaceNote": "Live entry redeploy after slice-6: vault+game with acceptEntry/enter; seeded with 20,000 tUSD withdrawn from prior vault (5k remains as old-vault buffer)."
+  "entryInterfaceNote": "Fresh stack redeploy for issue #351; prior live addresses retained under supersedes.",
+  "contractOwner": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c",
+  "keeperAddress": "0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c"
 }

--- a/contracts/deployments/base_sepolia.json
+++ b/contracts/deployments/base_sepolia.json
@@ -1,13 +1,13 @@
 {
-  "sourceCommit": "7e8e872d6b14e785ff5909aea72074358cddce9a",
+  "sourceCommit": "a1915fb915d09fe65cd0dfa0c988443b6331ee13",
   "chainId": 84532,
   "frontend": {
     "url": "https://margincall.fun",
     "status": "production-ready",
-    "productionDeploymentId": "dpl_FpJaVGBtRJYSYtJjfYHapdp6fNur",
-    "productionCommit": "7e8e872d6b14e785ff5909aea72074358cddce9a",
-    "previewUrl": "https://margin-call-7bi23vvrb-dhurls99-s-team.vercel.app",
-    "previewDeploymentId": "dpl_FpJaVGBtRJYSYtJjfYHapdp6fNur",
+    "productionDeploymentId": "dpl_3wEL15zrTaSRftg8NvMqJ6QMUY1P",
+    "productionCommit": "a1915fb915d09fe65cd0dfa0c988443b6331ee13",
+    "previewUrl": "https://margin-call-ickt89oy8-dhurls99-s-team.vercel.app",
+    "previewDeploymentId": "dpl_3wEL15zrTaSRftg8NvMqJ6QMUY1P",
     "previewStatus": "ready"
   },
   "tokenDeploymentBlock": 45385960,

--- a/contracts/deployments/base_sepolia.json
+++ b/contracts/deployments/base_sepolia.json
@@ -1,11 +1,11 @@
 {
-  "sourceCommit": "a791b5a962eecdec2b7e9df91cfb3bd1d55344d9",
+  "sourceCommit": "7e8e872d6b14e785ff5909aea72074358cddce9a",
   "chainId": 84532,
   "frontend": {
     "url": "https://margincall.fun",
     "status": "production-ready",
     "productionDeploymentId": "dpl_FpJaVGBtRJYSYtJjfYHapdp6fNur",
-    "productionCommit": "a791b5a962eecdec2b7e9df91cfb3bd1d55344d9",
+    "productionCommit": "7e8e872d6b14e785ff5909aea72074358cddce9a",
     "previewUrl": "https://margin-call-7bi23vvrb-dhurls99-s-team.vercel.app",
     "previewDeploymentId": "dpl_FpJaVGBtRJYSYtJjfYHapdp6fNur",
     "previewStatus": "ready"

--- a/docs/runbooks/deploy-smoke-release.md
+++ b/docs/runbooks/deploy-smoke-release.md
@@ -1,0 +1,218 @@
+# Base Sepolia deploy, smoke, and release record
+
+HITL runbook for [issue #351](https://github.com/hurley87/margin-call/issues/351) — Slice 13. This covers a **fresh** contract stack redeploy, environment propagation, Privy sponsorship verification, the guided zero-ETH smoke test, and completing the curated release record.
+
+Companion: [`keeper.md`](./keeper.md). Spec: PRD §11–§12, technical design §13, ADR 0008.
+
+## Rules
+
+1. **Base Sepolia only** (`84532`). Deploy scripts reject other chains.
+2. **Never commit secrets** — deployer/operator/keeper private keys, Privy app secret, RPC auth tokens, phone numbers, access tokens, or session material.
+3. **Identifiers only** in [`contracts/deployments/base_sepolia.json`](../../contracts/deployments/base_sepolia.json): addresses, tx hashes, Privy app/policy IDs, selector lists.
+4. **Human checkpoints** before broadcasting, before mutating Vercel/Convex production, and before Privy dashboard policy changes.
+5. **No silent mainnet/production fallbacks.** Empty or mismatched `NEXT_PUBLIC_*` addresses must degrade to “not configured,” never to another network.
+
+## Prerequisites
+
+| Need                                       | Notes                                                           |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| Foundry `v1.4.3`                           | `foundryup -i v1.4.3`                                           |
+| `pnpm install` + `pnpm install:forge-deps` | Restores gitignored `contracts/lib/`                            |
+| Deployer EOA                               | Recorded seed depositor/owner; funded with Base Sepolia ETH     |
+| `BASE_SEPOLIA_RPC_URL`                     | Deploy + smoke + keeper                                         |
+| Fresh phone number                         | SMS login for the player smoke path                             |
+| Privy dashboard access                     | App Pays + client transactions + policy scoped to new addresses |
+| Vercel + Convex production access          | Explicit consent per mutation                                   |
+
+## Preflight (agent or operator)
+
+```bash
+pnpm check:ci
+pnpm test
+pnpm test:contracts:ci
+pnpm build
+pnpm validate:base-sepolia-release
+```
+
+Confirm a clean git tree and note `git rev-parse HEAD` for `sourceCommit`.
+
+## Fresh deploy order
+
+Each script writes a **gitignored** run artifact under `contracts/deployments/`. Review it, then merge into the curated `base_sepolia.json` **before** the next script that reads the curated record.
+
+### 1. Desk Dollars + faucet
+
+```bash
+cd contracts
+forge script script/DeployDeskDollars.s.sol:DeployDeskDollars \
+  --sig "run(address)" 0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --broadcast
+```
+
+Merge `base_sepolia.run.json` → curated record (`token`, `faucet`, seed fields, deploy txs). Keep prior live addresses under `supersedes` / historical notes.
+
+### 2. Bankroll vault + full 25,000 tUSD seed
+
+The vault script deposits the **exact** seed-recipient balance and requires it equal `bankrollSeedAmount` (25,000 tUSD).
+
+```bash
+forge script script/DeployBankrollVault.s.sol:DeployBankrollVault \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --sender 0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c \
+  --broadcast
+```
+
+Merge `base_sepolia.bankroll_vault.run.json`. Assert onchain: `grossAssets == 25_000e6`, depositor token balance `0`, shares minted 1:1.
+
+### 3. MarginCallCrash + vault authorization
+
+Choose a minute-aligned Unix timestamp ≥ 5 minutes ahead:
+
+```bash
+MARGIN_CALL_EPOCH_ORIGIN=<minute-aligned-unix> \
+forge script script/DeployMarginCallCrash.s.sol:DeployMarginCallCrash \
+  --rpc-url "$BASE_SEPOLIA_RPC_URL" \
+  --sender 0xBe523e724B9Ea7D618dD093f14618D90c4B19b0c \
+  --broadcast
+```
+
+Merge `base_sepolia.margin_call_crash.run.json`. Assert: vault `authorizedGame` == game, timings 60 / 45 / 900.
+
+### 4. Verify on Basescan
+
+Verify sources for token, faucet, vault, and game. Record `verification.*` URLs and `sourceCommit`.
+
+### 5. Validate the merged record
+
+```bash
+pnpm validate:base-sepolia-release
+```
+
+`--release-complete` stays red until smoke + keeper + Privy evidence are filled.
+
+## Environment matrix
+
+| Variable                                         | Where                 | Source                           |
+| ------------------------------------------------ | --------------------- | -------------------------------- |
+| `NEXT_PUBLIC_DESK_DOLLARS_ADDRESS`               | Vercel prod/preview   | curated `token`                  |
+| `NEXT_PUBLIC_DESK_DOLLARS_FAUCET_ADDRESS`        | Vercel                | curated `faucet`                 |
+| `NEXT_PUBLIC_BANKROLL_VAULT_ADDRESS`             | Vercel                | curated `bankrollVault`          |
+| `NEXT_PUBLIC_MARGIN_CALL_CRASH_ADDRESS`          | Vercel                | curated `marginCallCrash`        |
+| `NEXT_PUBLIC_MARGIN_CALL_CRASH_DEPLOYMENT_BLOCK` | Vercel                | curated deployment block         |
+| `NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL`               | Vercel                | public Base Sepolia RPC          |
+| `NEXT_PUBLIC_PRIVY_APP_ID`                       | Vercel                | Privy app id (already in record) |
+| `NEXT_PUBLIC_CONVEX_URL` / `NEXT_PUBLIC_APP_URL` | Vercel                | deployment URLs                  |
+| `KEEPER_PRIVATE_KEY`                             | Convex dashboard only | funded keeper EOA                |
+| `BASE_SEPOLIA_RPC_URL`                           | Convex                | same network                     |
+| `KEEPER_PREOPEN_ENABLED=true`                    | Convex                | demo sessions                    |
+| `KEEPER_ATTESTATION_URL`                         | Convex                | production app origin            |
+| Optional address overrides                       | Convex                | only if not using bundled JSON   |
+
+After frontend deploy, record `frontend.url`, deployment id, and production commit in the release record. Confirm the live UI shows the new addresses (or temporarily “not configured” — never old/mainnet).
+
+## Privy sponsorship (identifiers only)
+
+Per ADR 0008 / technical design: **Privy-native App Pays** — no application-owned paymaster endpoint or credential-bearing policy template in the repo.
+
+1. Enable App Pays + “Allow transactions from the client” for Base Sepolia.
+2. Scope the wallet/policy allowlist to the new token, faucet, vault, and game addresses and the selectors recorded in `base_sepolia.json`.
+3. Record in `privySponsorship`: `appId`, `policyId`, `mode: "app-pays"`, `chain: "Base Sepolia"`, `clientTransactionsAllowed: true`, `permittedContracts[]`, `permittedSelectors[]`.
+4. Prove: sponsored in-policy calls succeed from a zero-ETH embedded wallet; an out-of-policy call is rejected. Store outcomes under `smokeTest.sponsorshipVerification` — not secrets.
+
+## Keeper bring-up
+
+Follow [`keeper.md`](./keeper.md). Record the public `keeperAddress` (never the key) and `contractOwner` (deployer). Confirm pre-open of current+next epochs before player entry smoke.
+
+Operator lifecycle check (EOA, not Privy):
+
+```bash
+pnpm smoke:crash-lifecycle
+# optional: SMOKE_EXPIRE=1 pnpm smoke:crash-lifecycle
+```
+
+## Guided player smoke checklist (fresh phone)
+
+Start from a **new SMS number**. Embedded wallet must hold **0 ETH** throughout. Every player/LP call uses `sponsor: true`.
+
+| Step | Action                                                          | Record                                                |
+| ---- | --------------------------------------------------------------- | ----------------------------------------------------- |
+| A    | SMS login → embedded EVM wallet                                 | note wallet address (public)                          |
+| B    | Confirm ETH balance is 0                                        | `liveObservations.zeroEthWalletThroughout`            |
+| C    | Faucet claim                                                    | hash under smoke / txs                                |
+| D    | Round 1: bounded approve + enter                                | `completeRound.approve`, `enter`                      |
+| E    | Lock → reveal → attest → finalize → claim **or** settle loss    | `requestReveal`, `finalizeRound`, `claimOrSettleLoss` |
+| F    | Round 2: enter, leave unfinalized past `expiresAt`              | `expiredRefundRound.enter`                            |
+| G    | Expire + owner refund                                           | `expireRound`, `refund`                               |
+| H    | LP: approve + deposit                                           | `lpFlows.approve`, `deposit`                          |
+| I    | LP: free-liquidity withdraw                                     | `lpFlows.withdraw`                                    |
+| J    | LP: over-limit withdraw attempt                                 | `rejectedOverLimitWithdrawal` (`fundsMoved: false`)   |
+| K    | Observe ≥3 consecutive overlapping rounds                       | `overlappingRoundsVerified`                           |
+| L    | Untouched epoch creates no state                                | `idleEpochNoStateVerified`                            |
+| M    | Ticketless pre-opened round: no vault exposure / no maintenance | `ticketlessPreopenNoExposureVerified`                 |
+| N    | Global history shows ≥20 finalized rounds                       | `globalHistoryFinalizedRounds`                        |
+| O    | Controlled failure + Retry on each flow class                   | `transactionPendingRecoveryAudited`                   |
+
+Entry is sequential bounded approve then enter (ADR 0008) — record both hashes separately.
+
+## Release-record schema (smoke)
+
+```json
+{
+  "keeperAddress": "0x…",
+  "contractOwner": "0x…",
+  "privySponsorship": {
+    "appId": "…",
+    "policyId": "…",
+    "mode": "app-pays",
+    "chain": "Base Sepolia",
+    "clientTransactionsAllowed": true,
+    "permittedContracts": ["0x…"],
+    "permittedSelectors": ["0x…"]
+  },
+  "smokeTest": {
+    "status": "complete",
+    "issue": 351,
+    "game": "0x…",
+    "vault": "0x…",
+    "completeRound": {},
+    "expiredRefundRound": {},
+    "lpFlows": {},
+    "liveObservations": {},
+    "sponsorshipVerification": {}
+  }
+}
+```
+
+## Acceptance mapping (#351)
+
+| Criterion                                       | Evidence                                         |
+| ----------------------------------------------- | ------------------------------------------------ |
+| Contracts + frontend live; no mainnet fallback  | curated addresses + Vercel env + validator       |
+| Bankroll ≥ 25,000 tUSD; no-real-value labelling | vault seed fields + UI disclosure                |
+| Fresh phone, zero ETH, sponsored flows          | smoke observations + hashes                      |
+| Complete-round tx set                           | `smokeTest.completeRound`                        |
+| Expired-round refund tx set                     | `smokeTest.expiredRefundRound`                   |
+| Overlapping / idle / ticketless (AC 12 live)    | `liveObservations`                               |
+| Global history ≥20 (AC 14 live)                 | `globalHistoryFinalizedRounds`                   |
+| LP deposit / withdraw / rejected over-limit     | `lpFlows`                                        |
+| Paymaster policy verified                       | `privySponsorship` + `sponsorshipVerification`   |
+| Deployment summary (PRD §12)                    | full curated JSON                                |
+| Pending-until-receipt + recovery audited        | `transactionPendingRecoveryAudited` + unit tests |
+| Contract unit suite green in CI                 | `pnpm test:contracts:ci`                         |
+
+## Finalize
+
+```bash
+pnpm validate:base-sepolia-release -- --release-complete
+pnpm check:ci && pnpm test && pnpm test:contracts:ci && pnpm build
+```
+
+Update issue #351 with public addresses, Basescan links, and smoke hash summary (no secrets). Close only when every checkbox is evidenced.
+
+## Rollback / supersession
+
+1. Leave superseded addresses under `supersedes` (and historical notes).
+2. Point Vercel + Convex back only with deliberate env edits — never by “falling through” to hard-coded old addresses.
+3. Disable keeper pre-open on abandoned deployments; stop funding abandoned keeper EOAs.
+4. Re-run `pnpm validate:base-sepolia-release` after any curated-record edit.

--- a/docs/runbooks/issue-351-smoke-worksheet.md
+++ b/docs/runbooks/issue-351-smoke-worksheet.md
@@ -1,0 +1,55 @@
+# Issue #351 guided smoke worksheet
+
+Fill hashes and checkboxes during the live demo. Do not record phone numbers, secrets, or session tokens.
+
+## Deployed stack (fresh #351)
+
+| Contract        | Address                                      |
+| --------------- | -------------------------------------------- |
+| tUSD            | `0x4Ff4a2d64C53BE0b6f0B77B191579E7CEC026d56` |
+| Faucet          | `0x16434C92223baEDE8301b2F117DeD0F56147Bb99` |
+| BankrollVault   | `0x75Db0b7865060c0d59a9801c4396ebfc430A740a` |
+| MarginCallCrash | `0x2E7eb3B6Ac8E1ebF0C4B90067F584B21F22C2b3d` |
+| Frontend        | https://margincall.fun                       |
+
+Operator lifecycle already recorded: reveal `0x0eb42b…`, finalize `0x02cd6461…` (round 0).
+
+## Privy dashboard (before player smoke)
+
+- [ ] App Pays enabled for Base Sepolia
+- [ ] Client transactions allowed
+- [ ] Policy scoped to the four addresses + selectors in `base_sepolia.json` → `privySponsorship`
+- [ ] Record `policyId`: ____________________
+- [ ] In-policy sponsored call succeeds
+- [ ] Out-of-policy call rejected (evidence): ____________________
+
+## Fresh-phone player path (0 ETH throughout)
+
+Wallet address (public): `0x________________________________________`
+
+| Step                                           | Hash / evidence |
+| ---------------------------------------------- | --------------- |
+| ETH balance 0 before                           |                 |
+| Faucet claim                                   |                 |
+| Approve (bounded)                              |                 |
+| Enter round A                                  |                 |
+| Reveal / finalize (or keeper)                  |                 |
+| Claim or settle loss                           |                 |
+| Enter round B (leave unfinalized)              |                 |
+| expireRound                                    |                 |
+| refund                                         |                 |
+| LP approve                                     |                 |
+| LP deposit                                     |                 |
+| LP withdraw                                    |                 |
+| Over-limit withdraw rejected; fundsMoved=false |                 |
+| Overlapping rounds observed                    |                 |
+| Idle epoch no state                            |                 |
+| Ticketless preopen no exposure                 |                 |
+| Global history ≥20 finalized                   |                 |
+| Pending/recovery audited                       |                 |
+
+When complete, merge into `contracts/deployments/base_sepolia.json` `smokeTest` and run:
+
+```bash
+pnpm validate:base-sepolia-release -- --release-complete
+```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "audit:all": "pnpm audit --audit-level=high",
     "audit:all:gated": "node scripts/audit-all-gated.mjs",
     "prepare": "husky",
-    "smoke:crash-lifecycle": "node scripts/smoke-crash-lifecycle.mjs"
+    "smoke:crash-lifecycle": "node scripts/smoke-crash-lifecycle.mjs",
+    "seed:finalized-rounds": "node scripts/seed-finalized-rounds.mjs",
+    "validate:base-sepolia-release": "node scripts/validate-base-sepolia-release.mjs",
+    "seed:forward-finalized": "node scripts/seed-forward-finalized.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",

--- a/scripts/finalize-one-round.mjs
+++ b/scripts/finalize-one-round.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Finalize a single MarginCallCrash round (operator path).
+ * Usage: ROUND_ID=3 node scripts/finalize-one-round.mjs
+ */
+import { createRequire } from "node:module";
+import { toHex } from "viem";
+import {
+  GAME_ADDRESS,
+  ROUND_STATUS,
+  RPC_URL,
+  readRound,
+  sendGameTransaction,
+  waitUntil,
+} from "./lib/crash-smoke.mjs";
+
+const require = createRequire(import.meta.url);
+const { Lightning } = require("@inco/lightning-js/lite");
+
+const roundId = BigInt(process.env.ROUND_ID ?? "0");
+
+async function main() {
+  let round = await readRound(roundId);
+  console.log(`round ${roundId} status=${round.status}`);
+  if (round.status === ROUND_STATUS.finalized) {
+    console.log("already finalized");
+    return;
+  }
+  if (round.status === ROUND_STATUS.uninitialized) {
+    throw new Error("round uninitialized");
+  }
+  if (round.status === ROUND_STATUS.expired) {
+    console.log("expired; nothing to finalize");
+    return;
+  }
+
+  await waitUntil(round.lockAt, "lock");
+  round = await readRound(roundId);
+  if (round.status === ROUND_STATUS.finalized) {
+    console.log("already finalized after lock");
+    return;
+  }
+  if (round.status < ROUND_STATUS.revealRequested) {
+    await sendGameTransaction("requestReveal", [roundId]);
+    round = await readRound(roundId);
+  }
+
+  const zap = await Lightning.baseSepoliaTestnet({
+    hostChainRpcUrls: [RPC_URL],
+  });
+  let attestation = null;
+  for (let attempt = 1; attempt <= 20; attempt++) {
+    try {
+      console.log(`attestedReveal attempt ${attempt}`);
+      const attestations = await zap.attestedReveal([round.crashRandom]);
+      attestation = attestations[0] ?? null;
+      if (attestation) break;
+    } catch (error) {
+      console.error(error?.cause?.message ?? error?.message ?? error);
+      await new Promise((r) => setTimeout(r, 10_000));
+    }
+  }
+  if (!attestation) throw new Error("attestation unavailable");
+
+  await sendGameTransaction("finalizeRound", [
+    roundId,
+    BigInt(attestation.plaintext.value),
+    attestation.covalidatorSignatures.map((s) => toHex(s)),
+  ]);
+  const finalized = await readRound(roundId);
+  console.log(
+    `finalized status=${finalized.status} crashPointBps=${finalized.crashPointBps}`
+  );
+  if (finalized.status !== ROUND_STATUS.finalized) {
+    throw new Error("finalize failed");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/lib/crash-smoke.mjs
+++ b/scripts/lib/crash-smoke.mjs
@@ -93,10 +93,15 @@ export function readRound(roundId) {
 }
 
 export async function sendGameTransaction(functionName, args, value = 0n) {
+  const nonce = await publicClient.getTransactionCount({
+    address: account.address,
+    blockTag: "pending",
+  });
   const hash = await walletClient.sendTransaction({
     to: GAME_ADDRESS,
     data: encodeFunctionData({ abi: gameAbi, functionName, args }),
     value,
+    nonce,
   });
   const receipt = await publicClient.waitForTransactionReceipt({ hash });
   if (receipt.status !== "success") {

--- a/scripts/seed-finalized-rounds.mjs
+++ b/scripts/seed-finalized-rounds.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Seeds ≥ N finalized Base Sepolia rounds for AC 14 history proof.
+ * Uses OPERATOR_PRIVATE_KEY + BASE_SEPOLIA_RPC_URL (not Privy).
+ *
+ * Usage: SEED_FINALIZED_ROUNDS=20 node scripts/seed-finalized-rounds.mjs
+ */
+import { createRequire } from "node:module";
+import { toHex } from "viem";
+import {
+  GAME_ADDRESS,
+  INCO_LIGHTNING_ADDRESS,
+  ROUND_STATUS,
+  RPC_URL,
+  account,
+  publicClient,
+  readGame,
+  readRound,
+  sendGameTransaction,
+  waitUntil,
+} from "./lib/crash-smoke.mjs";
+
+const require = createRequire(import.meta.url);
+const { Lightning, incoLightningAbi } = require("@inco/lightning-js/lite");
+
+const TARGET = Number(process.env.SEED_FINALIZED_ROUNDS ?? "20");
+
+async function ensureOpen(roundId, fee) {
+  const existing = await readRound(roundId);
+  if (existing.status === ROUND_STATUS.uninitialized) {
+    try {
+      await sendGameTransaction("openRound", [roundId], fee);
+    } catch (error) {
+      const message = String(error?.shortMessage ?? error?.message ?? error);
+      if (!message.includes("RoundAlreadyInitialized")) throw error;
+      console.log(`round ${roundId} already initialized`);
+    }
+  }
+}
+
+/** @returns {Promise<boolean>} true when the round is finalized (or already was). */
+async function finalizeRound(roundId) {
+  let round = await readRound(roundId);
+  if (round.status === ROUND_STATUS.finalized) {
+    console.log(`round ${roundId} already finalized`);
+    return true;
+  }
+  if (round.status === ROUND_STATUS.expired) {
+    console.log(`round ${roundId} expired; skipping`);
+    return true;
+  }
+  if (round.status === ROUND_STATUS.uninitialized) {
+    throw new Error(`round ${roundId} is uninitialized`);
+  }
+
+  await waitUntil(round.lockAt, `lock-${roundId}`);
+  round = await readRound(roundId);
+  if (round.status === ROUND_STATUS.finalized) return true;
+  if (round.status < ROUND_STATUS.revealRequested) {
+    try {
+      await sendGameTransaction("requestReveal", [roundId]);
+    } catch (error) {
+      const message = String(error?.shortMessage ?? error?.message ?? error);
+      // Another keeper may have revealed already.
+      if (!/reveal|status|already/i.test(message)) throw error;
+      console.log(`requestReveal race on ${roundId}: ${message}`);
+    }
+    round = await readRound(roundId);
+  }
+
+  const zap = await Lightning.baseSepoliaTestnet({
+    hostChainRpcUrls: [RPC_URL],
+  });
+  let attestation = null;
+  for (let attempt = 1; attempt <= 24; attempt++) {
+    try {
+      console.log(`round ${roundId} attestedReveal attempt ${attempt}`);
+      const attestations = await zap.attestedReveal([round.crashRandom]);
+      attestation = attestations[0] ?? null;
+      if (attestation) break;
+    } catch (error) {
+      const detail = error?.cause?.message ?? error?.message ?? String(error);
+      console.error(`attestedReveal failed: ${detail}`);
+      await new Promise((resolve) => setTimeout(resolve, 12_000));
+    }
+  }
+  if (!attestation) {
+    console.error(
+      `No attestation for round ${roundId} after retries; will retry later`
+    );
+    return false;
+  }
+
+  const plaintext = BigInt(attestation.plaintext.value);
+  const signatures = attestation.covalidatorSignatures.map((signature) =>
+    toHex(signature)
+  );
+  await sendGameTransaction("finalizeRound", [roundId, plaintext, signatures]);
+  const finalized = await readRound(roundId);
+  if (finalized.status !== ROUND_STATUS.finalized) {
+    throw new Error(`round ${roundId} not finalized (${finalized.status})`);
+  }
+  console.log(
+    `round ${roundId} finalized crashPointBps=${finalized.crashPointBps}`
+  );
+  return true;
+}
+
+async function main() {
+  console.log(
+    `game=${GAME_ADDRESS} operator=${account.address} target=${TARGET}`
+  );
+  const epochOrigin = await readGame("epochOrigin");
+  await waitUntil(epochOrigin, "epoch");
+
+  const fee = await publicClient.readContract({
+    address: INCO_LIGHTNING_ADDRESS,
+    abi: incoLightningAbi,
+    functionName: "getFee",
+  });
+
+  let finalizedCount = 0;
+  let roundId = 0n;
+  while (finalizedCount < TARGET) {
+    const current = await readGame("currentRoundId");
+    await ensureOpen(current, fee);
+    await ensureOpen(current + 1n, fee);
+
+    if (roundId > current) {
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      continue;
+    }
+
+    const round = await readRound(roundId);
+    if (round.status === ROUND_STATUS.finalized) {
+      finalizedCount += 1;
+      console.log(`progress ${finalizedCount}/${TARGET} (round ${roundId})`);
+      roundId += 1n;
+      continue;
+    }
+    if (round.status === ROUND_STATUS.uninitialized) {
+      await ensureOpen(roundId, fee);
+    }
+
+    const ok = await finalizeRound(roundId);
+    if (!ok) {
+      await new Promise((resolve) => setTimeout(resolve, 15_000));
+      continue;
+    }
+    finalizedCount += 1;
+    console.log(`progress ${finalizedCount}/${TARGET}`);
+    roundId += 1n;
+  }
+
+  console.log(`seeded ${finalizedCount} finalized rounds`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/seed-forward-finalized.mjs
+++ b/scripts/seed-forward-finalized.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Forward-only finalized-round seeder for AC 14.
+ * Finalizes the current epoch after lock (within expiry), then advances.
+ *
+ * SEED_FINALIZED_ROUNDS=20 node scripts/seed-forward-finalized.mjs
+ */
+import { createRequire } from "node:module";
+import { toHex } from "viem";
+import {
+  GAME_ADDRESS,
+  INCO_LIGHTNING_ADDRESS,
+  ROUND_STATUS,
+  RPC_URL,
+  account,
+  publicClient,
+  readGame,
+  readRound,
+  sendGameTransaction,
+  waitUntil,
+} from "./lib/crash-smoke.mjs";
+
+const require = createRequire(import.meta.url);
+const { Lightning, incoLightningAbi } = require("@inco/lightning-js/lite");
+
+const TARGET = Number(process.env.SEED_FINALIZED_ROUNDS ?? "20");
+
+async function countFinalized(maxId) {
+  let count = 0;
+  for (let id = 0n; id <= maxId; id++) {
+    const round = await readRound(id);
+    if (round.status === ROUND_STATUS.finalized) count += 1;
+  }
+  return count;
+}
+
+async function ensureOpen(roundId, fee) {
+  const existing = await readRound(roundId);
+  if (existing.status !== ROUND_STATUS.uninitialized) return existing;
+  try {
+    await sendGameTransaction("openRound", [roundId], fee);
+  } catch (error) {
+    const message = String(
+      error?.shortMessage ?? error?.details ?? error?.message ?? error
+    );
+    if (
+      !message.includes("RoundAlreadyInitialized") &&
+      !message.includes("0x1c346c10") &&
+      !message.includes("already")
+    ) {
+      throw error;
+    }
+    console.log(`round ${roundId} already open`);
+  }
+  return readRound(roundId);
+}
+
+async function finalizeInWindow(roundId) {
+  let round = await readRound(roundId);
+  if (round.status === ROUND_STATUS.finalized) return true;
+  if (round.status === ROUND_STATUS.expired) return false;
+  if (round.status === ROUND_STATUS.uninitialized) return false;
+
+  const block = await publicClient.getBlock({ blockTag: "latest" });
+  if (block.timestamp >= round.expiresAt) {
+    console.log(`round ${roundId} past expiry; expiring`);
+    await sendGameTransaction("expireRound", [roundId]);
+    return false;
+  }
+
+  await waitUntil(round.lockAt, `lock-${roundId}`);
+  round = await readRound(roundId);
+  if (round.status === ROUND_STATUS.finalized) return true;
+
+  const latest = await publicClient.getBlock({ blockTag: "latest" });
+  if (latest.timestamp >= round.expiresAt) {
+    await sendGameTransaction("expireRound", [roundId]);
+    return false;
+  }
+
+  if (round.status < ROUND_STATUS.revealRequested) {
+    await sendGameTransaction("requestReveal", [roundId]);
+    round = await readRound(roundId);
+  }
+
+  const zap = await Lightning.baseSepoliaTestnet({
+    hostChainRpcUrls: [RPC_URL],
+  });
+  let attestation = null;
+  for (let attempt = 1; attempt <= 18; attempt++) {
+    try {
+      console.log(`round ${roundId} attest attempt ${attempt}`);
+      const attestations = await zap.attestedReveal([round.crashRandom]);
+      attestation = attestations[0] ?? null;
+      if (attestation) break;
+    } catch (error) {
+      console.error(error?.cause?.message ?? error?.message ?? error);
+      await new Promise((r) => setTimeout(r, 8_000));
+    }
+  }
+  if (!attestation) {
+    console.error(`attestation miss for ${roundId}`);
+    return false;
+  }
+
+  await sendGameTransaction("finalizeRound", [
+    roundId,
+    BigInt(attestation.plaintext.value),
+    attestation.covalidatorSignatures.map((s) => toHex(s)),
+  ]);
+  const finalized = await readRound(roundId);
+  console.log(
+    `round ${roundId} finalized crashPointBps=${finalized.crashPointBps}`
+  );
+  return finalized.status === ROUND_STATUS.finalized;
+}
+
+async function main() {
+  console.log(
+    `game=${GAME_ADDRESS} operator=${account.address} target=${TARGET}`
+  );
+  const fee = await publicClient.readContract({
+    address: INCO_LIGHTNING_ADDRESS,
+    abi: incoLightningAbi,
+    functionName: "getFee",
+  });
+
+  let finalized = await countFinalized(await readGame("currentRoundId"));
+  console.log(`starting finalized count=${finalized}`);
+
+  while (finalized < TARGET) {
+    const current = await readGame("currentRoundId");
+    // Keeper already pre-opens with the same EOA — avoid nonce races.
+    const round = await readRound(current);
+    if (round.status === ROUND_STATUS.uninitialized) {
+      console.log(`current ${current} uninitialized; waiting for keeper`);
+      await new Promise((r) => setTimeout(r, 8_000));
+      continue;
+    }
+
+    const ok = await finalizeInWindow(current);
+    if (ok) {
+      finalized = await countFinalized(current + 5n);
+      console.log(`progress finalized=${finalized}/${TARGET}`);
+    } else {
+      await new Promise((r) => setTimeout(r, 5_000));
+    }
+  }
+
+  console.log(`DONE finalized=${finalized}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/smoke-crash-lifecycle.mjs
+++ b/scripts/smoke-crash-lifecycle.mjs
@@ -43,7 +43,13 @@ async function main() {
 
   const existing = await readRound(roundId);
   if (existing.status === ROUND_STATUS.uninitialized) {
-    await sendGameTransaction("openRound", [roundId], fee);
+    try {
+      await sendGameTransaction("openRound", [roundId], fee);
+    } catch (error) {
+      const message = String(error?.shortMessage ?? error?.message ?? error);
+      if (!message.includes("RoundAlreadyInitialized")) throw error;
+      console.log(`round ${roundId} opened concurrently; continuing`);
+    }
   } else {
     console.log(`round ${roundId} already status=${existing.status}`);
   }
@@ -51,9 +57,14 @@ async function main() {
   const expireRoundId = roundId + 1n;
   const expireExisting = await readRound(expireRoundId);
   if (expireExisting.status === ROUND_STATUS.uninitialized) {
-    await sendGameTransaction("openRound", [expireRoundId], fee);
+    try {
+      await sendGameTransaction("openRound", [expireRoundId], fee);
+    } catch (error) {
+      const message = String(error?.shortMessage ?? error?.message ?? error);
+      if (!message.includes("RoundAlreadyInitialized")) throw error;
+      console.log(`round ${expireRoundId} opened concurrently; continuing`);
+    }
   }
-
   let round = await readRound(roundId);
   console.log(
     `round ${roundId}: lockAt=${round.lockAt} expiresAt=${round.expiresAt} handle=${round.crashRandom}`

--- a/scripts/validate-base-sepolia-release.mjs
+++ b/scripts/validate-base-sepolia-release.mjs
@@ -1,0 +1,616 @@
+#!/usr/bin/env node
+/**
+ * Validates the curated Base Sepolia release record
+ * (`contracts/deployments/base_sepolia.json`) against PRD §12 / issue #351.
+ *
+ * Modes:
+ *   (default)          Structural deploy record: chain, addresses, timing,
+ *                      selectors, seed mint amount, no secret-shaped fields.
+ *   --release-complete Full release: vault seeded ≥ 25,000 tUSD, keeper,
+ *                      owner, complete smoke transaction sets, Privy policy
+ *                      identifiers, and live-observation fields.
+ *
+ * Never prints secret values — only field names and expected shapes.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const BASE_SEPOLIA_CHAIN_ID = 84532;
+export const BANKROLL_SEED_TUSD_BASE = 25_000_000_000n; // 25,000 * 10^6
+export const ROUND_DURATION = 60;
+export const ENTRY_WINDOW = 45;
+export const EXPIRY_DELAY = 900;
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+const TX_HASH_RE = /^0x[a-fA-F0-9]{64}$/;
+const SELECTOR_RE = /^0x[a-fA-F0-9]{8}$/;
+const COMMIT_RE = /^[a-f0-9]{40}$/;
+
+/** Field names that must never appear with secret-looking values. */
+export const FORBIDDEN_SECRET_KEYS = [
+  "privateKey",
+  "private_key",
+  "PRIVY_APP_SECRET",
+  "privyAppSecret",
+  "appSecret",
+  "OPERATOR_PRIVATE_KEY",
+  "KEEPER_PRIVATE_KEY",
+  "mnemonic",
+  "seedPhrase",
+  "authorizationSignature",
+  "accessToken",
+  "sessionToken",
+  "phoneNumber",
+  "phone",
+];
+
+const REQUIRED_SELECTORS = [
+  "marginCallCrashOpenRoundSelector",
+  "marginCallCrashEnterSelector",
+  "marginCallCrashRequestRevealSelector",
+  "marginCallCrashFinalizeRoundSelector",
+  "marginCallCrashExpireRoundSelector",
+  "bankrollVaultAcceptEntrySelector",
+  "bankrollVaultSetAuthorizedGameSelector",
+  "bankrollVaultDepositSelector",
+  "tUsdApproveSelector",
+  "faucetClaimSelector",
+];
+
+const REQUIRED_DEPLOY_TXS = [
+  "deployToken",
+  "deployFaucet",
+  "configureFaucet",
+  "deployBankrollVault",
+  "approveBankrollVault",
+  "seedBankrollVault",
+  "deployMarginCallCrash",
+  "setAuthorizedGame",
+];
+
+const REQUIRED_VERIFICATION = [
+  "token",
+  "faucet",
+  "bankrollVault",
+  "marginCallCrash",
+];
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isAddress(value) {
+  return typeof value === "string" && ADDRESS_RE.test(value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isTxHash(value) {
+  return typeof value === "string" && TX_HASH_RE.test(value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+function isSelector(value) {
+  return typeof value === "string" && SELECTOR_RE.test(value);
+}
+
+/**
+ * Walks the record for forbidden secret key names.
+ * @param {unknown} value
+ * @param {string} path
+ * @param {string[]} issues
+ */
+function collectSecretKeyIssues(value, path, issues) {
+  if (value === null || value === undefined) return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectSecretKeyIssues(item, `${path}[${index}]`, issues)
+    );
+    return;
+  }
+  if (typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    const next = path ? `${path}.${key}` : key;
+    if (
+      FORBIDDEN_SECRET_KEYS.some(
+        (forbidden) => forbidden.toLowerCase() === key.toLowerCase()
+      )
+    ) {
+      issues.push(
+        `${next}: forbidden secret-shaped field name (identifiers only; never secrets)`
+      );
+    }
+    collectSecretKeyIssues(child, next, issues);
+  }
+}
+
+/**
+ * @param {Record<string, unknown>} record
+ * @param {{ releaseComplete?: boolean }} [options]
+ * @returns {{ ok: boolean, errors: string[], warnings: string[] }}
+ */
+export function validateBaseSepoliaRelease(record, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const releaseComplete = options.releaseComplete === true;
+
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return {
+      ok: false,
+      errors: ["record must be a JSON object"],
+      warnings,
+    };
+  }
+
+  collectSecretKeyIssues(record, "", errors);
+
+  if (record.chainId !== BASE_SEPOLIA_CHAIN_ID) {
+    errors.push(
+      `chainId must be ${BASE_SEPOLIA_CHAIN_ID} (Base Sepolia); got ${String(record.chainId)}`
+    );
+  }
+
+  if (
+    typeof record.sourceCommit !== "string" ||
+    !COMMIT_RE.test(record.sourceCommit)
+  ) {
+    errors.push("sourceCommit must be a 40-character lowercase git SHA");
+  }
+
+  const addressFields = [
+    "token",
+    "faucet",
+    "bankrollVault",
+    "marginCallCrash",
+    "incoLightning",
+    "bankrollSeedRecipient",
+    "deployer",
+    "bankrollVaultSeedDepositor",
+  ];
+  /** @type {Record<string, string>} */
+  const addresses = {};
+  for (const field of addressFields) {
+    const value = record[field];
+    if (
+      !isAddress(value) ||
+      value.toLowerCase() === ZERO_ADDRESS.toLowerCase()
+    ) {
+      errors.push(`${field} must be a non-zero 0x-prefixed address`);
+      continue;
+    }
+    addresses[field] = value.toLowerCase();
+  }
+
+  const distinctPairs = [
+    ["token", "faucet"],
+    ["token", "bankrollVault"],
+    ["token", "marginCallCrash"],
+    ["faucet", "bankrollVault"],
+    ["faucet", "marginCallCrash"],
+    ["bankrollVault", "marginCallCrash"],
+  ];
+  for (const [left, right] of distinctPairs) {
+    if (
+      addresses[left] &&
+      addresses[right] &&
+      addresses[left] === addresses[right]
+    ) {
+      errors.push(`${left} and ${right} must be distinct addresses`);
+    }
+  }
+
+  if (
+    addresses.deployer &&
+    addresses.bankrollSeedRecipient &&
+    addresses.deployer !== addresses.bankrollSeedRecipient
+  ) {
+    errors.push(
+      "deployer must match bankrollSeedRecipient for the seed workflow"
+    );
+  }
+  if (
+    addresses.bankrollVaultSeedDepositor &&
+    addresses.bankrollSeedRecipient &&
+    addresses.bankrollVaultSeedDepositor !== addresses.bankrollSeedRecipient
+  ) {
+    errors.push(
+      "bankrollVaultSeedDepositor must match bankrollSeedRecipient for the seed workflow"
+    );
+  }
+
+  if (record.bankrollSeedAmount !== Number(BANKROLL_SEED_TUSD_BASE)) {
+    errors.push(
+      `bankrollSeedAmount must be ${BANKROLL_SEED_TUSD_BASE.toString()} (25,000 tUSD base units)`
+    );
+  }
+
+  if (record.marginCallCrashRoundDuration !== ROUND_DURATION) {
+    errors.push(`marginCallCrashRoundDuration must be ${ROUND_DURATION}`);
+  }
+  if (record.marginCallCrashEntryWindow !== ENTRY_WINDOW) {
+    errors.push(`marginCallCrashEntryWindow must be ${ENTRY_WINDOW}`);
+  }
+  if (record.marginCallCrashExpiryDelay !== EXPIRY_DELAY) {
+    errors.push(`marginCallCrashExpiryDelay must be ${EXPIRY_DELAY}`);
+  }
+
+  if (
+    typeof record.marginCallCrashEpochOrigin !== "number" ||
+    record.marginCallCrashEpochOrigin % 60 !== 0
+  ) {
+    errors.push(
+      "marginCallCrashEpochOrigin must be a minute-aligned Unix timestamp"
+    );
+  }
+
+  for (const field of REQUIRED_SELECTORS) {
+    if (!isSelector(record[field])) {
+      errors.push(`${field} must be an 0x-prefixed 4-byte selector`);
+    }
+  }
+
+  const verification = record.verification;
+  if (!verification || typeof verification !== "object") {
+    errors.push("verification must be an object of Basescan URLs");
+  } else {
+    for (const field of REQUIRED_VERIFICATION) {
+      const url = /** @type {Record<string, unknown>} */ (verification)[field];
+      if (
+        typeof url !== "string" ||
+        !url.startsWith("https://sepolia.basescan.org/address/")
+      ) {
+        errors.push(
+          `verification.${field} must be a sepolia.basescan.org address URL`
+        );
+      }
+    }
+  }
+
+  const transactions = record.transactions;
+  if (!transactions || typeof transactions !== "object") {
+    errors.push("transactions must be an object of deploy/seed hashes");
+  } else {
+    for (const field of REQUIRED_DEPLOY_TXS) {
+      if (
+        !isTxHash(/** @type {Record<string, unknown>} */ (transactions)[field])
+      ) {
+        errors.push(`transactions.${field} must be a 32-byte hex hash`);
+      }
+    }
+  }
+
+  const frontend = record.frontend;
+  if (!frontend || typeof frontend !== "object") {
+    errors.push("frontend must be an object with url/status");
+  } else {
+    const fe = /** @type {Record<string, unknown>} */ (frontend);
+    if (typeof fe.url !== "string" || !fe.url.startsWith("https://")) {
+      errors.push("frontend.url must be an https URL");
+    }
+    if (typeof fe.status !== "string" || fe.status.length === 0) {
+      errors.push("frontend.status must be a non-empty string");
+    }
+  }
+
+  const privy = record.privySponsorship;
+  if (!privy || typeof privy !== "object") {
+    errors.push("privySponsorship must be present (identifiers only)");
+  } else {
+    const p = /** @type {Record<string, unknown>} */ (privy);
+    if (typeof p.appId !== "string" || p.appId.length < 8) {
+      errors.push("privySponsorship.appId must be a Privy app identifier");
+    }
+    if (p.mode !== "app-pays") {
+      errors.push('privySponsorship.mode must be "app-pays"');
+    }
+    if (p.chain !== "Base Sepolia") {
+      errors.push('privySponsorship.chain must be "Base Sepolia"');
+    }
+    if (p.clientTransactionsAllowed !== true) {
+      errors.push("privySponsorship.clientTransactionsAllowed must be true");
+    }
+  }
+
+  // Mainnet / production address silent-fallback checks
+  const serialized = JSON.stringify(record);
+  if (/"chainId"\s*:\s*1\b/.test(serialized) || /eip155:1/.test(serialized)) {
+    errors.push("record must not contain Ethereum mainnet chain references");
+  }
+
+  const vaultSeed = record.bankrollVaultSeedAssets;
+  const vaultShares = record.bankrollVaultMintedShares;
+  if (releaseComplete) {
+    if (vaultSeed !== Number(BANKROLL_SEED_TUSD_BASE)) {
+      errors.push(
+        `bankrollVaultSeedAssets must be ${BANKROLL_SEED_TUSD_BASE.toString()} for a complete release`
+      );
+    }
+    if (vaultShares !== Number(BANKROLL_SEED_TUSD_BASE)) {
+      errors.push(
+        `bankrollVaultMintedShares must be ${BANKROLL_SEED_TUSD_BASE.toString()} for a complete release`
+      );
+    }
+
+    if (
+      !isAddress(record.keeperAddress) ||
+      record.keeperAddress === ZERO_ADDRESS
+    ) {
+      errors.push("keeperAddress must be a non-zero public EOA address");
+    }
+    if (
+      !isAddress(record.contractOwner) ||
+      record.contractOwner === ZERO_ADDRESS
+    ) {
+      errors.push("contractOwner must be a non-zero public address");
+    }
+
+    const smoke = record.smokeTest;
+    if (!smoke || typeof smoke !== "object") {
+      errors.push("smokeTest must be present for a complete release");
+    } else {
+      const s = /** @type {Record<string, unknown>} */ (smoke);
+      if (s.status !== "complete") {
+        errors.push('smokeTest.status must be "complete"');
+      }
+      if (s.issue !== 351) {
+        errors.push("smokeTest.issue must be 351");
+      }
+      if (!isAddress(s.game) || !isAddress(s.vault)) {
+        errors.push("smokeTest.game and smokeTest.vault must be addresses");
+      }
+      if (
+        addresses.marginCallCrash &&
+        isAddress(s.game) &&
+        s.game.toLowerCase() !== addresses.marginCallCrash
+      ) {
+        errors.push("smokeTest.game must match marginCallCrash");
+      }
+      if (
+        addresses.bankrollVault &&
+        isAddress(s.vault) &&
+        s.vault.toLowerCase() !== addresses.bankrollVault
+      ) {
+        errors.push("smokeTest.vault must match bankrollVault");
+      }
+
+      const completeRound = s.completeRound;
+      if (!completeRound || typeof completeRound !== "object") {
+        errors.push("smokeTest.completeRound transaction set is required");
+      } else {
+        for (const field of [
+          "approve",
+          "enter",
+          "requestReveal",
+          "finalizeRound",
+          "claimOrSettleLoss",
+        ]) {
+          if (
+            !isTxHash(
+              /** @type {Record<string, unknown>} */ (completeRound)[field]
+            )
+          ) {
+            errors.push(`smokeTest.completeRound.${field} must be a tx hash`);
+          }
+        }
+      }
+
+      const expired = s.expiredRefundRound;
+      if (!expired || typeof expired !== "object") {
+        errors.push("smokeTest.expiredRefundRound transaction set is required");
+      } else {
+        for (const field of [
+          "approveOrReuseAllowance",
+          "enter",
+          "expireRound",
+          "refund",
+        ]) {
+          if (
+            !isTxHash(/** @type {Record<string, unknown>} */ (expired)[field])
+          ) {
+            errors.push(
+              `smokeTest.expiredRefundRound.${field} must be a tx hash`
+            );
+          }
+        }
+      }
+
+      const lp = s.lpFlows;
+      if (!lp || typeof lp !== "object") {
+        errors.push("smokeTest.lpFlows transaction set is required");
+      } else {
+        for (const field of ["approve", "deposit", "withdraw"]) {
+          if (!isTxHash(/** @type {Record<string, unknown>} */ (lp)[field])) {
+            errors.push(`smokeTest.lpFlows.${field} must be a tx hash`);
+          }
+        }
+        const rejected = /** @type {Record<string, unknown>} */ (lp)
+          .rejectedOverLimitWithdrawal;
+        if (!rejected || typeof rejected !== "object") {
+          errors.push(
+            "smokeTest.lpFlows.rejectedOverLimitWithdrawal evidence is required"
+          );
+        } else {
+          const r = /** @type {Record<string, unknown>} */ (rejected);
+          if (r.fundsMoved !== false) {
+            errors.push(
+              "smokeTest.lpFlows.rejectedOverLimitWithdrawal.fundsMoved must be false"
+            );
+          }
+          if (typeof r.evidence !== "string" || r.evidence.length === 0) {
+            errors.push(
+              "smokeTest.lpFlows.rejectedOverLimitWithdrawal.evidence must describe the revert"
+            );
+          }
+        }
+      }
+
+      const observations = s.liveObservations;
+      if (!observations || typeof observations !== "object") {
+        errors.push("smokeTest.liveObservations is required");
+      } else {
+        const o = /** @type {Record<string, unknown>} */ (observations);
+        if (o.overlappingRoundsVerified !== true) {
+          errors.push(
+            "smokeTest.liveObservations.overlappingRoundsVerified must be true"
+          );
+        }
+        if (o.idleEpochNoStateVerified !== true) {
+          errors.push(
+            "smokeTest.liveObservations.idleEpochNoStateVerified must be true"
+          );
+        }
+        if (o.ticketlessPreopenNoExposureVerified !== true) {
+          errors.push(
+            "smokeTest.liveObservations.ticketlessPreopenNoExposureVerified must be true"
+          );
+        }
+        if (
+          typeof o.globalHistoryFinalizedRounds !== "number" ||
+          o.globalHistoryFinalizedRounds < 20
+        ) {
+          errors.push(
+            "smokeTest.liveObservations.globalHistoryFinalizedRounds must be ≥ 20"
+          );
+        }
+        if (o.zeroEthWalletThroughout !== true) {
+          errors.push(
+            "smokeTest.liveObservations.zeroEthWalletThroughout must be true"
+          );
+        }
+        if (o.transactionPendingRecoveryAudited !== true) {
+          errors.push(
+            "smokeTest.liveObservations.transactionPendingRecoveryAudited must be true"
+          );
+        }
+      }
+
+      const sponsorship = s.sponsorshipVerification;
+      if (!sponsorship || typeof sponsorship !== "object") {
+        errors.push("smokeTest.sponsorshipVerification is required");
+      } else {
+        const sp = /** @type {Record<string, unknown>} */ (sponsorship);
+        if (sp.inPolicySponsoredCallsSucceeded !== true) {
+          errors.push(
+            "smokeTest.sponsorshipVerification.inPolicySponsoredCallsSucceeded must be true"
+          );
+        }
+        if (sp.outOfPolicyCallRejected !== true) {
+          errors.push(
+            "smokeTest.sponsorshipVerification.outOfPolicyCallRejected must be true"
+          );
+        }
+      }
+    }
+
+    if (privy && typeof privy === "object") {
+      const p = /** @type {Record<string, unknown>} */ (privy);
+      if (typeof p.policyId !== "string" || p.policyId.length === 0) {
+        errors.push(
+          "privySponsorship.policyId must record the dashboard policy identifier"
+        );
+      }
+      const allowlist = p.permittedContracts;
+      if (!Array.isArray(allowlist) || allowlist.length < 3) {
+        errors.push(
+          "privySponsorship.permittedContracts must list the deployed token/faucet/vault/game addresses"
+        );
+      }
+      const selectors = p.permittedSelectors;
+      if (!Array.isArray(selectors) || selectors.length < 5) {
+        errors.push(
+          "privySponsorship.permittedSelectors must list the sponsored call selectors"
+        );
+      }
+    }
+  } else {
+    if (
+      typeof vaultSeed === "number" &&
+      vaultSeed < Number(BANKROLL_SEED_TUSD_BASE)
+    ) {
+      warnings.push(
+        `bankrollVaultSeedAssets is ${vaultSeed} (< 25,000 tUSD); top up or redeploy before --release-complete`
+      );
+    }
+    const smoke = record.smokeTest;
+    if (
+      smoke &&
+      typeof smoke === "object" &&
+      /** @type {Record<string, unknown>} */ (smoke).status !== "complete"
+    ) {
+      warnings.push(
+        `smokeTest.status is "${String(/** @type {Record<string, unknown>} */ (smoke).status)}" — finish guided smoke before --release-complete`
+      );
+    }
+    if (!isAddress(record.keeperAddress)) {
+      warnings.push(
+        "keeperAddress not yet recorded (required for --release-complete)"
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * @param {string} [recordPath]
+ * @param {{ releaseComplete?: boolean }} [options]
+ */
+export function validateReleaseRecordFile(recordPath, options = {}) {
+  const path =
+    recordPath ??
+    join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "contracts",
+      "deployments",
+      "base_sepolia.json"
+    );
+  const record = JSON.parse(readFileSync(path, "utf8"));
+  return { path, ...validateBaseSepoliaRelease(record, options) };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const releaseComplete = args.includes("--release-complete");
+  const pathArg = args.find((arg) => !arg.startsWith("--"));
+  const result = validateReleaseRecordFile(pathArg, { releaseComplete });
+
+  if (result.warnings.length > 0) {
+    console.warn("Warnings:");
+    for (const warning of result.warnings) {
+      console.warn(`  - ${warning}`);
+    }
+  }
+
+  if (!result.ok) {
+    console.error(`✗ ${result.path} failed validation`);
+    for (const error of result.errors) {
+      console.error(`  - ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ ${result.path} valid${releaseComplete ? " (release-complete)" : " (deploy record)"}`
+  );
+}
+
+function isCliEntry() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return (
+    entry.endsWith("validate-base-sepolia-release.mjs") ||
+    entry.endsWith("validate-base-sepolia-release")
+  );
+}
+
+if (isCliEntry()) {
+  main();
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { DeskDollarsPanel } from "@/components/desk-dollars/desk-dollars-panel";
 import { GlobalHistory } from "@/components/history/global-history";
 import { PersonalHistory } from "@/components/history/personal-history";
 import { LpDesk } from "@/components/lp-desk/lp-desk";
+import { NoRealValueDisclosure } from "@/components/no-real-value-disclosure";
 import { RoundTheater } from "@/components/round-theater/round-theater";
 
 export default function Home() {
@@ -21,6 +22,7 @@ export default function Home() {
         <p className="mx-auto mt-5 max-w-xl text-sm leading-6 text-[var(--t-muted)]">
           Watch each encrypted crash point commit onchain before entry closes.
         </p>
+        <NoRealValueDisclosure />
 
         <RoundTheater />
         <CurrentRound />

--- a/src/components/no-real-value-disclosure.test.tsx
+++ b/src/components/no-real-value-disclosure.test.tsx
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NoRealValueDisclosure } from "./no-real-value-disclosure";
+
+describe("NoRealValueDisclosure", () => {
+  afterEach(() => cleanup());
+
+  it("states Base Sepolia and no-real-value clearly", () => {
+    render(<NoRealValueDisclosure />);
+    const note = screen.getByTestId("no-real-value-disclosure");
+    expect(note.textContent).toMatch(/Base Sepolia only/);
+    expect(note.textContent).toMatch(/no real value/);
+    expect(note.textContent).toMatch(/no claim on real US dollars/);
+  });
+});

--- a/src/components/no-real-value-disclosure.tsx
+++ b/src/components/no-real-value-disclosure.tsx
@@ -1,0 +1,16 @@
+/**
+ * Persistent Base Sepolia / no-real-value disclosure visible outside AuthGate.
+ * Faucet and LP panels repeat the same warning; this keeps it on every path.
+ */
+export function NoRealValueDisclosure() {
+  return (
+    <p
+      role="note"
+      data-testid="no-real-value-disclosure"
+      className="mx-auto mt-4 max-w-xl border border-[var(--t-amber)] px-3 py-2 text-xs leading-5 text-[var(--t-muted)]"
+    >
+      Base Sepolia only. Desk Dollars (tUSD) and vault shares have no real value
+      and no claim on real US dollars.
+    </p>
+  );
+}

--- a/src/hooks/use-history-ticket-actions.test.tsx
+++ b/src/hooks/use-history-ticket-actions.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Address, Hex } from "viem";
+
+const sdk = vi.hoisted(() => ({
+  getMarginCallCrashConfig: vi.fn(() => ({
+    address: "0x0000000000000000000000000000000000000001" as Address,
+    deploymentBlock: 1n,
+  })),
+  waitForTransactionReceipt: vi.fn(),
+  fetchCrashAttestation: vi.fn(),
+  notifyWalletBalancesChanged: vi.fn(),
+  transaction: {
+    submit: vi.fn(),
+    getSubmittedHash: vi.fn(),
+    getSubmissionError: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/margin-call-crash", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/margin-call-crash")
+  >("@/lib/margin-call-crash");
+  return {
+    ...actual,
+    getMarginCallCrashConfig: () => sdk.getMarginCallCrashConfig(),
+  };
+});
+
+vi.mock("@/lib/base-sepolia", () => ({
+  baseSepoliaPublicClient: {
+    waitForTransactionReceipt: (...args: unknown[]) =>
+      sdk.waitForTransactionReceipt(...args),
+  },
+  BASE_SEPOLIA_CHAIN_ID: 84532,
+}));
+
+vi.mock("@/lib/inco-attestation", () => ({
+  requestCrashAttestation: (...args: unknown[]) =>
+    sdk.fetchCrashAttestation(...args),
+}));
+
+vi.mock("@/lib/wallet-balance-sync", () => ({
+  notifyWalletBalancesChanged: () => sdk.notifyWalletBalancesChanged(),
+}));
+
+vi.mock("./use-privy-sponsored-transaction", () => ({
+  usePrivySponsoredTransaction: () => sdk.transaction,
+}));
+
+import { useHistoryTicketActions } from "./use-history-ticket-actions";
+
+const PLAYER = "0x0000000000000000000000000000000000000003" as Address;
+
+const ticket = {
+  id: 7n,
+  player: PLAYER,
+  roundId: 12n,
+  margin: 5_000_000n,
+  leverageBps: 20_000n,
+  reservedPayout: 10_000_000n,
+  settled: false,
+  claimed: false,
+};
+
+const finalizedRound = {
+  id: 12n,
+  openAt: 1_000n,
+  lockAt: 1_045n,
+  expiresAt: 1_945n,
+  crashRandom:
+    "0x000000000000000000000000000000000000000000000000000000000000cafe" as Hex,
+  crashPointBps: 34_200n,
+  totalMargin: 5_000_000n,
+  reservedPayout: 10_000_000n,
+  status: 3 as const,
+};
+
+const expiredRound = {
+  ...finalizedRound,
+  crashPointBps: 0n,
+  status: 4 as const,
+};
+
+describe("useHistoryTicketActions", () => {
+  beforeEach(() => {
+    sdk.waitForTransactionReceipt.mockReset();
+    sdk.fetchCrashAttestation.mockReset();
+    sdk.notifyWalletBalancesChanged.mockReset();
+    sdk.transaction.submit.mockReset();
+    sdk.transaction.getSubmittedHash.mockReset();
+    sdk.transaction.getSubmissionError.mockReset();
+    sdk.transaction.submit.mockResolvedValue(true);
+    sdk.transaction.getSubmittedHash.mockReturnValue("0xabc" as Hex);
+    sdk.waitForTransactionReceipt.mockResolvedValue({ status: "success" });
+  });
+
+  it("claims through a receipt-backed sponsored stage", async () => {
+    const onSettled = vi.fn();
+    const { result } = renderHook(() => useHistoryTicketActions(onSettled));
+
+    await act(async () => {
+      await result.current.claim(ticket);
+    });
+
+    expect(sdk.transaction.submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "0x0000000000000000000000000000000000000001",
+        chainId: 84532,
+      })
+    );
+    expect(result.current.status).toBe("confirmed");
+    expect(sdk.notifyWalletBalancesChanged).toHaveBeenCalled();
+    expect(onSettled).toHaveBeenCalled();
+  });
+
+  it("refunds an expired ticket and exposes retry after confirmation-unknown", async () => {
+    sdk.waitForTransactionReceipt.mockRejectedValueOnce(
+      new Error("receipt timeout")
+    );
+    const { result } = renderHook(() => useHistoryTicketActions());
+
+    await act(async () => {
+      await result.current.refund(ticket);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/couldn't confirm/);
+    expect(result.current.activeTicketId).toBe(7n);
+
+    sdk.waitForTransactionReceipt.mockResolvedValueOnce({ status: "success" });
+    await act(async () => {
+      await result.current.retry();
+    });
+
+    expect(result.current.status).toBe("confirmed");
+    // Retry re-checks the pending hash; it must not resubmit.
+    expect(sdk.transaction.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles a loss and expires a round through sponsored stages", async () => {
+    const { result } = renderHook(() => useHistoryTicketActions());
+
+    await act(async () => {
+      await result.current.settleLoss(ticket);
+    });
+    expect(result.current.status).toBe("confirmed");
+
+    await act(async () => {
+      await result.current.expireRound(ticket, expiredRound);
+    });
+    expect(result.current.status).toBe("confirmed");
+    expect(sdk.transaction.submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses duplicate in-flight actions", async () => {
+    let resolveSubmit: ((value: boolean) => void) | undefined;
+    sdk.transaction.submit.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        })
+    );
+    const { result } = renderHook(() => useHistoryTicketActions());
+
+    let first: Promise<boolean> | undefined;
+    act(() => {
+      first = result.current.claim(ticket);
+    });
+    await waitFor(() => expect(result.current.status).toBe("claim-submitting"));
+
+    let second = true;
+    await act(async () => {
+      second = await result.current.claim(ticket);
+    });
+    expect(second).toBe(false);
+    expect(sdk.transaction.submit).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSubmit?.(true);
+      await first;
+    });
+    expect(result.current.status).toBe("confirmed");
+  });
+});

--- a/tests/scripts/validate-base-sepolia-release.test.ts
+++ b/tests/scripts/validate-base-sepolia-release.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  BANKROLL_SEED_TUSD_BASE,
+  validateBaseSepoliaRelease,
+} from "../../scripts/validate-base-sepolia-release.mjs";
+
+const VALID_ADDRESS = "0x1111111111111111111111111111111111111111";
+const OTHER_ADDRESS = "0x2222222222222222222222222222222222222222";
+const THIRD_ADDRESS = "0x3333333333333333333333333333333333333333";
+const FOURTH_ADDRESS = "0x4444444444444444444444444444444444444444";
+const FIFTH_ADDRESS = "0x5555555555555555555555555555555555555555";
+const TX = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SELECTOR = "0xbc208057";
+
+function baseRecord(overrides = {}) {
+  return {
+    sourceCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    chainId: 84532,
+    frontend: { url: "https://margincall.fun", status: "production-ready" },
+    token: VALID_ADDRESS,
+    faucet: OTHER_ADDRESS,
+    bankrollVault: THIRD_ADDRESS,
+    marginCallCrash: FOURTH_ADDRESS,
+    incoLightning: FIFTH_ADDRESS,
+    bankrollSeedRecipient: VALID_ADDRESS,
+    deployer: VALID_ADDRESS,
+    bankrollVaultSeedDepositor: VALID_ADDRESS,
+    bankrollSeedAmount: Number(BANKROLL_SEED_TUSD_BASE),
+    bankrollVaultSeedAssets: Number(BANKROLL_SEED_TUSD_BASE),
+    bankrollVaultMintedShares: Number(BANKROLL_SEED_TUSD_BASE),
+    marginCallCrashEpochOrigin: 1_800_000_000,
+    marginCallCrashRoundDuration: 60,
+    marginCallCrashEntryWindow: 45,
+    marginCallCrashExpiryDelay: 900,
+    marginCallCrashOpenRoundSelector: SELECTOR,
+    marginCallCrashEnterSelector: SELECTOR,
+    marginCallCrashRequestRevealSelector: SELECTOR,
+    marginCallCrashFinalizeRoundSelector: SELECTOR,
+    marginCallCrashExpireRoundSelector: SELECTOR,
+    bankrollVaultAcceptEntrySelector: SELECTOR,
+    bankrollVaultSetAuthorizedGameSelector: SELECTOR,
+    bankrollVaultDepositSelector: SELECTOR,
+    tUsdApproveSelector: SELECTOR,
+    faucetClaimSelector: SELECTOR,
+    verification: {
+      token: `https://sepolia.basescan.org/address/${VALID_ADDRESS}#code`,
+      faucet: `https://sepolia.basescan.org/address/${OTHER_ADDRESS}#code`,
+      bankrollVault: `https://sepolia.basescan.org/address/${THIRD_ADDRESS}#code`,
+      marginCallCrash: `https://sepolia.basescan.org/address/${FOURTH_ADDRESS}#code`,
+    },
+    transactions: {
+      deployToken: TX,
+      deployFaucet: TX,
+      configureFaucet: TX,
+      deployBankrollVault: TX,
+      approveBankrollVault: TX,
+      seedBankrollVault: TX,
+      deployMarginCallCrash: TX,
+      setAuthorizedGame: TX,
+    },
+    privySponsorship: {
+      appId: "cmmfbu7o900c10cjme09a31h4",
+      mode: "app-pays",
+      chain: "Base Sepolia",
+      clientTransactionsAllowed: true,
+    },
+    smokeTest: { status: "pending", issue: 351 },
+    ...overrides,
+  };
+}
+
+function completeRecord() {
+  return baseRecord({
+    keeperAddress: OTHER_ADDRESS,
+    contractOwner: VALID_ADDRESS,
+    privySponsorship: {
+      appId: "cmmfbu7o900c10cjme09a31h4",
+      mode: "app-pays",
+      chain: "Base Sepolia",
+      clientTransactionsAllowed: true,
+      policyId: "pol_test_policy",
+      permittedContracts: [
+        VALID_ADDRESS,
+        OTHER_ADDRESS,
+        THIRD_ADDRESS,
+        FOURTH_ADDRESS,
+      ],
+      permittedSelectors: [
+        SELECTOR,
+        "0x4e71d92d",
+        "0x6e553f65",
+        "0x095ea7b3",
+        "0xbde22ae0",
+      ],
+    },
+    smokeTest: {
+      status: "complete",
+      issue: 351,
+      game: FOURTH_ADDRESS,
+      vault: THIRD_ADDRESS,
+      completeRound: {
+        approve: TX,
+        enter: TX,
+        requestReveal: TX,
+        finalizeRound: TX,
+        claimOrSettleLoss: TX,
+      },
+      expiredRefundRound: {
+        approveOrReuseAllowance: TX,
+        enter: TX,
+        expireRound: TX,
+        refund: TX,
+      },
+      lpFlows: {
+        approve: TX,
+        deposit: TX,
+        withdraw: TX,
+        rejectedOverLimitWithdrawal: {
+          fundsMoved: false,
+          evidence:
+            "UI showed over-limit error; wallet/share balances unchanged",
+        },
+      },
+      liveObservations: {
+        overlappingRoundsVerified: true,
+        idleEpochNoStateVerified: true,
+        ticketlessPreopenNoExposureVerified: true,
+        globalHistoryFinalizedRounds: 20,
+        zeroEthWalletThroughout: true,
+        transactionPendingRecoveryAudited: true,
+      },
+      sponsorshipVerification: {
+        inPolicySponsoredCallsSucceeded: true,
+        outOfPolicyCallRejected: true,
+      },
+    },
+  });
+}
+
+describe("validateBaseSepoliaRelease", () => {
+  it("accepts a structural deploy record", () => {
+    const result = validateBaseSepoliaRelease(baseRecord());
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects mainnet chain ids and zero addresses", () => {
+    const result = validateBaseSepoliaRelease(
+      baseRecord({
+        chainId: 1,
+        token: "0x0000000000000000000000000000000000000000",
+      })
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("84532"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("token"))).toBe(true);
+  });
+
+  it("rejects secret-shaped field names", () => {
+    const result = validateBaseSepoliaRelease(
+      baseRecord({ KEEPER_PRIVATE_KEY: "0xabc" })
+    );
+    expect(result.ok).toBe(false);
+    expect(
+      result.errors.some((e) => e.includes("forbidden secret-shaped"))
+    ).toBe(true);
+  });
+
+  it("warns when vault seed is below 25,000 tUSD outside --release-complete", () => {
+    const result = validateBaseSepoliaRelease(
+      baseRecord({ bankrollVaultSeedAssets: 20_000_000_000 })
+    );
+    expect(result.ok).toBe(true);
+    expect(
+      result.warnings.some((w) => w.includes("bankrollVaultSeedAssets"))
+    ).toBe(true);
+  });
+
+  it("requires full smoke evidence under --release-complete", () => {
+    const incomplete = validateBaseSepoliaRelease(baseRecord(), {
+      releaseComplete: true,
+    });
+    expect(incomplete.ok).toBe(false);
+    expect(
+      incomplete.errors.some((e) =>
+        e.includes('smokeTest.status must be "complete"')
+      )
+    ).toBe(true);
+
+    const complete = validateBaseSepoliaRelease(completeRecord(), {
+      releaseComplete: true,
+    });
+    expect(complete.errors).toEqual([]);
+    expect(complete.ok).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       "src/**/*.test.tsx",
       "packages/shared/**/*.test.ts",
       "tests/convex/**/*.test.ts",
+      "tests/scripts/**/*.test.ts",
     ],
     exclude: ["**/node_modules/**"],
   },


### PR DESCRIPTION
## Summary
- Fresh Base Sepolia redeploy with a fully seeded 25,000 tUSD vault, curated release-record update, and Vercel/Convex address propagation for issue #351.
- Adds deploy/smoke runbooks, release-record validator, history seeding helpers, persistent no-real-value disclosure, and history ticket-action coverage.
- Operator lifecycle + ≥20 finalized rounds seeded; guided Privy fresh-phone HITL smoke remains the open acceptance gate.

## Test plan
- [ ] `pnpm check:ci && pnpm test && pnpm test:contracts:ci`
- [ ] `pnpm validate:base-sepolia-release`
- [ ] Confirm https://margincall.fun shows no-real-value disclosure and new contract addresses
- [ ] Complete guided Privy/fresh-phone worksheet (`docs/runbooks/issue-351-smoke-worksheet.md`)
- [ ] `pnpm validate:base-sepolia-release -- --release-complete` after smoke hashes are recorded


Made with [Cursor](https://cursor.com)