### PR TITLE
Label ticketless rounds Empty in global history

### DIFF
--- a/src/components/history/global-history.test.tsx
+++ b/src/components/history/global-history.test.tsx
@@ -42,6 +42,23 @@ const sdk = vi.hoisted(() => {
     historyState: "delayed",
     displayCrashPoint: null,
   };
+  const empty: RoundHistoryItem = {
+    round: {
+      id: 5n,
+      openAt: 2_100n,
+      lockAt: 2_145n,
+      expiresAt: 3_045n,
+      crashRandom:
+        "0x000000000000000000000000000000000000000000000000000000000000abcd",
+      crashPointBps: 0n,
+      totalMargin: 0n,
+      reservedPayout: 0n,
+      status: 1,
+    },
+    phase: "locked",
+    historyState: "empty",
+    displayCrashPoint: null,
+  };
   const expired: RoundHistoryItem = {
     round: {
       id: 2n,
@@ -81,7 +98,7 @@ const sdk = vi.hoisted(() => {
   return {
     view: {
       status: "ready" as const,
-      rounds: [delayed, finalized, expired],
+      rounds: [empty, delayed, finalized, expired],
       selectedRoundId: null as bigint | null,
       detail: null as RoundHistoryDetail | null,
       detailStatus: "idle" as "idle" | "loading" | "ready" | "error",
@@ -110,9 +127,12 @@ describe("GlobalHistory", () => {
 
   afterEach(cleanup);
 
-  it("shows honest delayed and expired states without inventing multipliers", () => {
+  it("shows honest delayed, empty, and expired states without inventing multipliers", () => {
     render(<GlobalHistory />);
 
+    expect(screen.getByText("Round 5")).toBeTruthy();
+    expect(screen.getByText("Empty")).toBeTruthy();
+    expect(screen.getByText("No entries")).toBeTruthy();
     expect(screen.getByText("Round 4")).toBeTruthy();
     expect(screen.getByText("Delayed")).toBeTruthy();
     expect(screen.getByText("Awaiting attestation")).toBeTruthy();

--- a/src/components/history/global-history.tsx
+++ b/src/components/history/global-history.tsx
@@ -12,6 +12,7 @@ import { RoundVerificationRecord } from "./round-verification-record";
 const historyStateColors: Record<RoundHistoryState, string> = {
   open: "text-[var(--t-green-hot)] border-[var(--t-green)]/50",
   delayed: "text-[var(--t-amber-hot)] border-[var(--t-amber)]/50",
+  empty: "text-[var(--t-muted)] border-[var(--t-muted)]/40",
   finalized: "text-[var(--t-green)] border-[var(--t-green)]/40",
   expired: "text-[var(--t-muted)] border-[var(--t-muted)]/40",
 };
@@ -79,8 +80,8 @@ export function GlobalHistory() {
         Recent rounds
       </h2>
       <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        Finalized rounds show the attested Crash Point. Delayed and expired
-        rounds never invent a multiplier.
+        Finalized rounds show the attested Crash Point. Empty, delayed, and
+        expired rounds never invent a multiplier.
       </p>
 
       {history.rounds.length === 0 ? (
@@ -132,9 +133,11 @@ function HistoryRoundRow({
       ? item.displayCrashPoint
       : item.historyState === "delayed"
         ? "Awaiting attestation"
-        : item.historyState === "expired"
-          ? "Expired — no result"
-          : "—";
+        : item.historyState === "empty"
+          ? "No entries"
+          : item.historyState === "expired"
+            ? "Expired — no result"
+            : "—";
 
   return (
     <li className="py-4">

--- a/src/components/history/history-state-copy.ts
+++ b/src/components/history/history-state-copy.ts
@@ -7,6 +7,7 @@ export const historyStateCopy: Record<
 > = {
   open: { badge: "Open", detail: "Open" },
   delayed: { badge: "Delayed", detail: "Delayed — awaiting attestation" },
+  empty: { badge: "Empty", detail: "Empty — no tickets entered" },
   finalized: { badge: "Finalized", detail: "Finalized" },
   expired: { badge: "Expired", detail: "Expired — no invented multiplier" },
 };

--- a/src/lib/margin-call-crash.test.ts
+++ b/src/lib/margin-call-crash.test.ts
@@ -500,12 +500,24 @@ describe("MarginCallCrash public reads and phase math", () => {
     ).rejects.toThrow("Expected one RoundFinalized event for round 3, found 2");
   });
 
-  it("reads global history with honest crash points for delayed and expired rounds", async () => {
+  it("reads global history with honest crash points for delayed, empty, and expired rounds", async () => {
     sdk.getBlock.mockResolvedValue({ number: 100n, timestamp: 2_000n });
     sdk.readContract.mockImplementation(({ functionName, args }) => {
-      if (functionName === "currentRoundId") return Promise.resolve(5n);
+      if (functionName === "currentRoundId") return Promise.resolve(6n);
       if (functionName === "getRound") {
         const roundId = args?.[0] as bigint;
+        if (roundId === 6n) {
+          return Promise.resolve(
+            makeRound({
+              id: 6n,
+              status: 1,
+              lockAt: 1_000n,
+              expiresAt: 5_000n,
+              crashPointBps: 0n,
+              totalMargin: 0n,
+            })
+          );
+        }
         if (roundId === 5n) {
           return Promise.resolve(
             makeRound({
@@ -514,6 +526,8 @@ describe("MarginCallCrash public reads and phase math", () => {
               lockAt: 1_000n,
               expiresAt: 5_000n,
               crashPointBps: 0n,
+              totalMargin: 1_000_000n,
+              reservedPayout: 1_250_000n,
             })
           );
         }
@@ -548,21 +562,26 @@ describe("MarginCallCrash public reads and phase math", () => {
       deploymentBlock: 50n,
     });
 
-    expect(history.map((item) => item.round.id)).toEqual([5n, 4n, 3n, 1n]);
+    expect(history.map((item) => item.round.id)).toEqual([6n, 5n, 4n, 3n, 1n]);
     expect(history[0]).toMatchObject({
+      historyState: "empty",
+      displayCrashPoint: null,
+      phase: "locked",
+    });
+    expect(history[1]).toMatchObject({
       historyState: "delayed",
       displayCrashPoint: null,
       phase: "reveal-requested",
     });
-    expect(history[1]).toMatchObject({
+    expect(history[2]).toMatchObject({
       historyState: "expired",
       displayCrashPoint: null,
     });
-    expect(history[2]).toMatchObject({
+    expect(history[3]).toMatchObject({
       historyState: "finalized",
       displayCrashPoint: "3.42x",
     });
-    expect(history[3]).toMatchObject({
+    expect(history[4]).toMatchObject({
       historyState: "finalized",
       displayCrashPoint: "1.25x",
     });

--- a/src/lib/margin-call-crash.ts
+++ b/src/lib/margin-call-crash.ts
@@ -147,8 +147,9 @@ export type CrashRoundLifecycleUrls = {
   incoContractUrl: string;
 };
 
-/** Honest history labels — never invent a multiplier for delayed/expired. */
-export type RoundHistoryState = "open" | "delayed" | "finalized" | "expired";
+/** Honest history labels — never invent a multiplier for delayed/expired/empty. */
+export type RoundHistoryState =
+  "open" | "delayed" | "empty" | "finalized" | "expired";
 
 export type RoundHistoryItem = {
   round: CrashRound;
@@ -724,7 +725,7 @@ function toRoundHistoryItem(
   chainTimestamp: bigint
 ): RoundHistoryItem {
   const phase = deriveRoundPhase(round, chainTimestamp);
-  const historyState = deriveHistoryState(phase);
+  const historyState = deriveHistoryState(phase, round);
   const published = isCrashPointPublished(round);
   return {
     round,
@@ -736,7 +737,14 @@ function toRoundHistoryItem(
   };
 }
 
-function deriveHistoryState(phase: CrashRoundPhase): RoundHistoryState {
+/**
+ * Map phase → public history label. Ticketless post-lock rounds are "empty"
+ * (no attestation owed), not "delayed".
+ */
+function deriveHistoryState(
+  phase: CrashRoundPhase,
+  round: CrashRound
+): RoundHistoryState {
   switch (phase) {
     case "finalized":
       return "finalized";
@@ -749,7 +757,7 @@ function deriveHistoryState(phase: CrashRoundPhase): RoundHistoryState {
     case "locked":
     case "reveal-requested":
     case "expired-eligible":
-      return "delayed";
+      return round.totalMargin === 0n ? "empty" : "delayed";
     default: {
       const _exhaustive: never = phase;
       return _exhaustive;


### PR DESCRIPTION
## Summary
- Ticketless post-lock rounds (`locked` / `reveal-requested` / `expired-eligible` with `totalMargin == 0`) now map to history state **Empty** with copy **No entries**, instead of **Delayed / Awaiting attestation**.
- Ticketed delayed rounds and on-chain expired rounds keep their existing honest labels.
- Adds coverage in crash history + global history UI tests.

## Test plan
- [ ] `pnpm exec vitest run src/lib/margin-call-crash.test.ts src/components/history/global-history.test.tsx`
- [ ] On production/preview, open Global history and confirm ticketless past-lock rounds show **Empty / No entries** (not Delayed)
- [ ] Confirm a ticketed delayed round still shows **Awaiting attestation**
- [ ] Confirm finalized rounds still show the attested multiplier


Made with [Cursor](https://cursor.com)