### PR TITLE
Make the Floor chart-first and move LP Desk to /lp

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, IBM_Plex_Sans_Condensed } from "next/font/google";
+import { AppShell } from "@/components/app-shell/app-shell";
 import { MarginCallPrivyProvider } from "@/components/providers/privy-provider";
 import "./globals.css";
 
@@ -44,7 +45,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${plexMono.variable} ${plexSans.variable} antialiased`}>
-        <MarginCallPrivyProvider>{children}</MarginCallPrivyProvider>
+        <MarginCallPrivyProvider>
+          <AppShell>{children}</AppShell>
+        </MarginCallPrivyProvider>
       </body>
     </html>
   );

--- a/src/app/lp/page.tsx
+++ b/src/app/lp/page.tsx
@@ -1,0 +1,26 @@
+import { AuthGate } from "@/components/auth/auth-gate";
+import { LpDesk } from "@/components/lp-desk/lp-desk";
+
+/**
+ * Liquidity desk — vault metrics, deposit, and withdraw. Sign-in required for
+ * share operations; unsigned visitors see the auth prompt in the shell.
+ */
+export default function LpPage() {
+  return (
+    <div className="mx-auto max-w-3xl">
+      <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
+        Base Sepolia · Liquidity
+      </p>
+      <h1 className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl">
+        LP Desk
+      </h1>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--t-muted)]">
+        Provide Desk Dollars (tUSD) to receive vault shares. Sign in to deposit
+        or withdraw.
+      </p>
+      <AuthGate>
+        <LpDesk />
+      </AuthGate>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,39 +5,28 @@ import { CrashTicketSettlement } from "@/components/current-round/crash-ticket-s
 import { DeskDollarsPanel } from "@/components/desk-dollars/desk-dollars-panel";
 import { GlobalHistory } from "@/components/history/global-history";
 import { PersonalHistory } from "@/components/history/personal-history";
-import { LpDesk } from "@/components/lp-desk/lp-desk";
-import { NoRealValueDisclosure } from "@/components/no-real-value-disclosure";
 import { RoundTheater } from "@/components/round-theater/round-theater";
 
+/**
+ * Chart-first play floor: hero replay + entry rail, then player actions and
+ * recent rounds. LP Desk lives on /lp.
+ */
 export default function Home() {
   return (
-    <main className="min-h-screen bg-[var(--t-bg)] px-4 py-10 font-mono text-[var(--t-text)] sm:px-6 sm:py-14">
-      <div className="mx-auto w-full max-w-5xl text-center">
-        <p className="text-xs font-bold uppercase tracking-[0.28em] text-[var(--t-green)]">
-          Shared-round Crash · Base Sepolia
-        </p>
-        <h1 className="mt-4 font-[family-name:var(--font-plex-sans)] text-5xl font-black uppercase tracking-tight text-[var(--t-accent)] sm:text-7xl">
-          Margin Call
-        </h1>
-        <p className="mx-auto mt-5 max-w-xl text-sm leading-6 text-[var(--t-muted)]">
-          Watch each encrypted crash point commit onchain before entry closes.
-        </p>
-        <NoRealValueDisclosure />
-
+    <div className="space-y-8">
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.65fr)_minmax(18rem,1fr)] lg:items-start">
         <RoundTheater />
-        <CurrentRound />
-        <GlobalHistory />
-
-        <div className="mx-auto max-w-xl">
+        <div className="space-y-6">
+          <CurrentRound />
           <AuthGate>
             <CrashTicketSettlement />
             <CrashTicketRefund />
-            <PersonalHistory />
             <DeskDollarsPanel />
-            <LpDesk />
+            <PersonalHistory />
           </AuthGate>
         </div>
       </div>
-    </main>
+      <GlobalHistory />
+    </div>
   );
 }

--- a/src/components/app-shell/app-shell.test.tsx
+++ b/src/components/app-shell/app-shell.test.tsx
@@ -25,11 +25,10 @@ vi.mock("@privy-io/react-auth", () => ({
   useWallets: () => sdk.wallets,
 }));
 
-vi.mock("@/hooks/use-desk-dollars-faucet", () => ({
-  useDeskDollarsFaucet: () => ({
+vi.mock("@/hooks/use-desk-dollars-balance", () => ({
+  useDeskDollarsBalance: () => ({
     balance: null,
     decimals: null,
-    status: "loading",
   }),
 }));
 

--- a/src/components/app-shell/app-shell.test.tsx
+++ b/src/components/app-shell/app-shell.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  pathname: "/",
+  privy: {
+    ready: true,
+    authenticated: false,
+    user: null as unknown,
+  },
+  wallets: {
+    ready: false,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => sdk.pathname,
+}));
+
+vi.mock("@privy-io/react-auth", () => ({
+  useLogin: () => ({ login: vi.fn() }),
+  usePrivy: () => ({ ...sdk.privy, logout: vi.fn() }),
+  useWallets: () => sdk.wallets,
+}));
+
+vi.mock("@/hooks/use-desk-dollars-faucet", () => ({
+  useDeskDollarsFaucet: () => ({
+    balance: null,
+    decimals: null,
+    status: "loading",
+  }),
+}));
+
+import { AppShell } from "./app-shell";
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    sdk.pathname = "/";
+    sdk.privy = { ready: true, authenticated: false, user: null };
+    sdk.wallets = { ready: false };
+  });
+
+  afterEach(cleanup);
+
+  it("renders Floor and LP Desk navigation links", () => {
+    render(
+      <AppShell>
+        <p>Floor content</p>
+      </AppShell>
+    );
+
+    const nav = screen.getByTestId("app-shell-nav");
+    expect(nav).toBeTruthy();
+    const floor = screen.getByRole("link", { name: "Floor" });
+    const lp = screen.getByRole("link", { name: "LP Desk" });
+    expect(floor.getAttribute("href")).toBe("/");
+    expect(lp.getAttribute("href")).toBe("/lp");
+    expect(floor.getAttribute("aria-current")).toBe("page");
+    expect(lp.getAttribute("aria-current")).toBeNull();
+    expect(screen.getByTestId("no-real-value-disclosure")).toBeTruthy();
+    expect(screen.getByText("Floor content")).toBeTruthy();
+  });
+
+  it("marks LP Desk as current on /lp", () => {
+    sdk.pathname = "/lp";
+    render(
+      <AppShell>
+        <p>LP content</p>
+      </AppShell>
+    );
+
+    expect(
+      screen.getByRole("link", { name: "LP Desk" }).getAttribute("aria-current")
+    ).toBe("page");
+    expect(
+      screen.getByRole("link", { name: "Floor" }).getAttribute("aria-current")
+    ).toBeNull();
+  });
+});

--- a/src/components/app-shell/app-shell.tsx
+++ b/src/components/app-shell/app-shell.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { AuthControls } from "@/components/auth/auth-controls";
+import { NoRealValueDisclosure } from "@/components/no-real-value-disclosure";
+
+const NAV = [
+  { href: "/", label: "Floor" },
+  { href: "/lp", label: "LP Desk" },
+] as const;
+
+/**
+ * Shared chrome: brand, Floor / LP Desk nav, compact auth, disclosure.
+ * Leaves page content as the primary workspace.
+ */
+export function AppShell({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const pathname = usePathname();
+
+  return (
+    <div className="min-h-screen bg-[var(--t-bg)] font-mono text-[var(--t-text)]">
+      <header className="border-b border-[var(--t-border)] bg-[var(--t-panel-strong)]">
+        <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-4 sm:px-6">
+          <div className="flex flex-wrap items-center gap-6">
+            <Link
+              className="font-[family-name:var(--font-plex-sans)] text-xl font-black uppercase tracking-tight text-[var(--t-accent)] sm:text-2xl"
+              href="/"
+            >
+              Margin Call
+            </Link>
+            <nav
+              aria-label="Primary"
+              className="flex items-center gap-1"
+              data-testid="app-shell-nav"
+            >
+              {NAV.map((item) => {
+                const isActive =
+                  item.href === "/"
+                    ? pathname === "/"
+                    : pathname.startsWith(item.href);
+                return (
+                  <Link
+                    aria-current={isActive ? "page" : undefined}
+                    className={`px-3 py-1.5 text-xs font-bold uppercase tracking-[0.16em] transition-colors duration-[var(--mc-dur-fast)] ${
+                      isActive
+                        ? "border-b-2 border-[var(--t-accent)] text-[var(--t-accent)]"
+                        : "text-[var(--t-muted)] hover:text-[var(--t-text)]"
+                    }`}
+                    href={item.href}
+                    key={item.href}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+          <AuthControls />
+        </div>
+        <div className="mx-auto w-full max-w-7xl px-4 pb-3 sm:px-6">
+          <NoRealValueDisclosure />
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-7xl px-4 py-6 text-left sm:px-6 sm:py-8">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/components/auth/auth-boundary.ts
+++ b/src/components/auth/auth-boundary.ts
@@ -3,9 +3,11 @@ export type AuthBoundaryInput = {
   authenticated: boolean;
   walletsReady: boolean;
   walletAddress: `0x${string}` | null;
-  loginError: boolean;
-  logoutPending: boolean;
-  logoutError: boolean;
+  // Only surfaces that own login/logout actions (AuthControls) have these;
+  // read-only consumers like AuthGate omit them.
+  loginError?: boolean;
+  logoutPending?: boolean;
+  logoutError?: boolean;
 };
 
 export type AuthBoundaryState = {

--- a/src/components/auth/auth-controls.test.tsx
+++ b/src/components/auth/auth-controls.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type LoginCallbacks = {
+  onError?: (error: unknown) => void;
+};
+
+const sdk = vi.hoisted(() => ({
+  login: vi.fn(),
+  loginCallbacks: null as LoginCallbacks | null,
+  logout: vi.fn<() => Promise<void>>(),
+  privy: {
+    ready: false,
+    authenticated: false,
+    user: null as unknown,
+  },
+  wallets: {
+    ready: false,
+  },
+  balance: {
+    balance: 100_000_000n as bigint | null,
+    decimals: 6 as number | null,
+  },
+}));
+
+vi.mock("@privy-io/react-auth", () => ({
+  useLogin: (callbacks: LoginCallbacks) => {
+    sdk.loginCallbacks = callbacks;
+    return { login: sdk.login };
+  },
+  usePrivy: () => ({ ...sdk.privy, logout: sdk.logout }),
+  useWallets: () => sdk.wallets,
+}));
+
+vi.mock("@/hooks/use-desk-dollars-balance", () => ({
+  useDeskDollarsBalance: () => sdk.balance,
+}));
+
+import { AuthControls } from "@/components/auth/auth-controls";
+
+function embeddedUser() {
+  return {
+    wallet: {
+      address: "0x1234",
+      chainType: "ethereum",
+      walletClientType: "privy",
+    },
+    linkedAccounts: [],
+    phone: "+15555550123",
+    email: "private@example.com",
+  };
+}
+
+function renderSignedInControls() {
+  sdk.privy = { ready: true, authenticated: true, user: embeddedUser() };
+  sdk.wallets = { ready: true };
+  render(<AuthControls />);
+}
+
+describe("AuthControls", () => {
+  beforeEach(() => {
+    sdk.privy = { ready: false, authenticated: false, user: null };
+    sdk.wallets = { ready: false };
+    sdk.login.mockReset();
+    sdk.loginCallbacks = null;
+    sdk.logout.mockReset();
+    sdk.balance = {
+      balance: 100_000_000n,
+      decimals: 6,
+    };
+  });
+
+  afterEach(() => cleanup());
+
+  it("waits for session restoration without an authentication action", () => {
+    render(<AuthControls />);
+
+    expect(screen.getByText("Restoring your session…")).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Continue with phone" })
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
+  });
+
+  it("keeps an external-only wallet in setup, never displays it, and lets the user leave", () => {
+    sdk.privy = {
+      ready: true,
+      authenticated: true,
+      user: {
+        wallet: {
+          address: "0xexternal",
+          chainType: "ethereum",
+          walletClientType: "metamask",
+        },
+        linkedAccounts: [],
+      },
+    };
+    sdk.wallets = { ready: true };
+
+    render(<AuthControls />);
+
+    expect(screen.getByText("Setting up your wallet…")).not.toBeNull();
+    expect(screen.queryByText(/0xexternal/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+    expect(sdk.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a cancelled login to a retryable phone sign-in action", () => {
+    sdk.privy = { ready: true, authenticated: false, user: null };
+    render(<AuthControls />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with phone" })
+    );
+    expect(sdk.login).toHaveBeenCalledTimes(1);
+
+    act(() => sdk.loginCallbacks?.onError?.(new Error("cancelled")));
+    expect(
+      screen.getByText("Sign-in was cancelled or unavailable. Try again.")
+    ).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with phone" })
+    );
+    expect(sdk.login).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows truncated wallet and tUSD balance when signed in", () => {
+    renderSignedInControls();
+    expect(screen.getByText("0x1234")).not.toBeNull();
+    expect(screen.getByText("100 tUSD")).not.toBeNull();
+    expect(screen.queryByText("+15555550123")).toBeNull();
+  });
+
+  it("shows logout pending and ignores rapid duplicate submissions", () => {
+    let resolveLogout: () => void;
+    sdk.logout.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = resolve;
+        })
+    );
+    renderSignedInControls();
+
+    const logoutButton = screen.getByRole("button", { name: "Log out" });
+    act(() => {
+      fireEvent.click(logoutButton);
+      fireEvent.click(logoutButton);
+    });
+
+    expect(sdk.logout).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Signing out…")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
+
+    act(() => resolveLogout());
+  });
+
+  it("keeps the session retryable after logout fails", async () => {
+    sdk.logout
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce();
+    renderSignedInControls();
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+
+    await screen.findByText("We couldn't sign you out. Please try again.");
+    expect(screen.getByText("0x1234")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Log out" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+    await waitFor(() => expect(sdk.logout).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useLogin, usePrivy, useWallets } from "@privy-io/react-auth";
+import { useCallback, useRef, useState } from "react";
+import { formatDeskDollars } from "@/lib/desk-dollars";
+import { getEvmWalletAddress } from "@/lib/privy/wallet";
+import { formatShortAddress } from "@/lib/utils";
+import { useDeskDollarsFaucet } from "@/hooks/use-desk-dollars-faucet";
+import { getAuthBoundaryState } from "./auth-boundary";
+
+/**
+ * Compact shell auth: login/logout, truncated wallet, and live tUSD balance.
+ * Does not gate children — use AuthGate for signed-in-only surfaces.
+ */
+export function AuthControls() {
+  const { ready: privyReady, authenticated, logout, user } = usePrivy();
+  const { ready: walletsReady } = useWallets();
+  const [loginError, setLoginError] = useState(false);
+  const [logoutPending, setLogoutPending] = useState(false);
+  const [logoutError, setLogoutError] = useState(false);
+  const logoutInFlight = useRef(false);
+  const { login } = useLogin({
+    onError: () => setLoginError(true),
+  });
+  const walletAddress = getEvmWalletAddress(user);
+  const faucet = useDeskDollarsFaucet(
+    authenticated && walletAddress ? walletAddress : null
+  );
+  const state = getAuthBoundaryState({
+    privyReady,
+    authenticated,
+    walletsReady,
+    walletAddress,
+    loginError,
+    logoutPending,
+    logoutError,
+  });
+
+  const handleLogin = useCallback(() => {
+    setLoginError(false);
+    login();
+  }, [login]);
+
+  const handleLogout = useCallback(async () => {
+    if (logoutInFlight.current) return;
+
+    logoutInFlight.current = true;
+    setLogoutError(false);
+    setLogoutPending(true);
+
+    try {
+      await logout();
+    } catch {
+      setLogoutError(true);
+    } finally {
+      logoutInFlight.current = false;
+      setLogoutPending(false);
+    }
+  }, [logout]);
+
+  const balanceLabel =
+    faucet.balance !== null && faucet.decimals !== null
+      ? `${formatDeskDollars(faucet.balance, faucet.decimals)} tUSD`
+      : null;
+
+  return (
+    <div
+      className="flex flex-wrap items-center justify-end gap-3"
+      data-testid="auth-controls"
+    >
+      <p aria-live="polite" className="text-xs text-[var(--t-muted)]">
+        {state.message}
+      </p>
+      {walletAddress &&
+      (state.status === "signed-in" || state.status === "logout-error") ? (
+        <div className="flex flex-wrap items-center gap-2 text-xs tabular-nums">
+          <span className="text-[var(--t-text)]">
+            {formatShortAddress(walletAddress)}
+          </span>
+          {balanceLabel ? (
+            <span className="text-[var(--t-green-hot)]">{balanceLabel}</span>
+          ) : null}
+        </div>
+      ) : null}
+      {state.action === "login" ? (
+        <button
+          className="rounded-sm bg-[var(--t-accent)] px-3 py-1.5 text-xs font-bold uppercase tracking-wide text-[var(--t-bg)]"
+          onClick={handleLogin}
+          type="button"
+        >
+          Continue with phone
+        </button>
+      ) : null}
+      {state.action === "logout" ? (
+        <button
+          className="rounded-sm border border-[var(--t-muted)] px-3 py-1.5 text-xs font-bold uppercase tracking-wide text-[var(--t-text)]"
+          onClick={handleLogout}
+          type="button"
+        >
+          Log out
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -2,10 +2,10 @@
 
 import { useLogin, usePrivy, useWallets } from "@privy-io/react-auth";
 import { useCallback, useRef, useState } from "react";
-import { formatDeskDollars } from "@/lib/desk-dollars";
+import { formatDeskDollarsBalanceLabel } from "@/lib/desk-dollars";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 import { formatShortAddress } from "@/lib/utils";
-import { useDeskDollarsFaucet } from "@/hooks/use-desk-dollars-faucet";
+import { useDeskDollarsBalance } from "@/hooks/use-desk-dollars-balance";
 import { getAuthBoundaryState } from "./auth-boundary";
 
 /**
@@ -23,7 +23,7 @@ export function AuthControls() {
     onError: () => setLoginError(true),
   });
   const walletAddress = getEvmWalletAddress(user);
-  const faucet = useDeskDollarsFaucet(
+  const { balance, decimals } = useDeskDollarsBalance(
     authenticated && walletAddress ? walletAddress : null
   );
   const state = getAuthBoundaryState({
@@ -58,10 +58,7 @@ export function AuthControls() {
     }
   }, [logout]);
 
-  const balanceLabel =
-    faucet.balance !== null && faucet.decimals !== null
-      ? `${formatDeskDollars(faucet.balance, faucet.decimals)} tUSD`
-      : null;
+  const balanceLabel = formatDeskDollarsBalanceLabel(balance, decimals);
 
   return (
     <div

--- a/src/components/auth/auth-gate.test.tsx
+++ b/src/components/auth/auth-gate.test.tsx
@@ -1,23 +1,9 @@
 // @vitest-environment jsdom
 
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type LoginCallbacks = {
-  onError?: (error: unknown) => void;
-};
-
 const sdk = vi.hoisted(() => ({
-  login: vi.fn(),
-  loginCallbacks: null as LoginCallbacks | null,
-  logout: vi.fn<() => Promise<void>>(),
   privy: {
     ready: false,
     authenticated: false,
@@ -26,27 +12,13 @@ const sdk = vi.hoisted(() => ({
   wallets: {
     ready: false,
   },
-  faucet: {
-    balance: 100_000_000n as bigint | null,
-    decimals: 6 as number | null,
-    status: "ready",
-  },
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
-  useLogin: (callbacks: LoginCallbacks) => {
-    sdk.loginCallbacks = callbacks;
-    return { login: sdk.login };
-  },
-  usePrivy: () => ({ ...sdk.privy, logout: sdk.logout }),
+  usePrivy: () => sdk.privy,
   useWallets: () => sdk.wallets,
 }));
 
-vi.mock("@/hooks/use-desk-dollars-faucet", () => ({
-  useDeskDollarsFaucet: () => sdk.faucet,
-}));
-
-import { AuthControls } from "@/components/auth/auth-controls";
 import { AuthGate } from "@/components/auth/auth-gate";
 
 function embeddedUser() {
@@ -61,129 +33,6 @@ function embeddedUser() {
     email: "private@example.com",
   };
 }
-
-function renderSignedInControls() {
-  sdk.privy = { ready: true, authenticated: true, user: embeddedUser() };
-  sdk.wallets = { ready: true };
-  render(<AuthControls />);
-}
-
-describe("AuthControls", () => {
-  beforeEach(() => {
-    sdk.privy = { ready: false, authenticated: false, user: null };
-    sdk.wallets = { ready: false };
-    sdk.login.mockReset();
-    sdk.loginCallbacks = null;
-    sdk.logout.mockReset();
-    sdk.faucet = {
-      balance: 100_000_000n,
-      decimals: 6,
-      status: "ready",
-    };
-  });
-
-  afterEach(() => cleanup());
-
-  it("waits for session restoration without an authentication action", () => {
-    render(<AuthControls />);
-
-    expect(screen.getByText("Restoring your session…")).not.toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Continue with phone" })
-    ).toBeNull();
-    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
-  });
-
-  it("keeps an external-only wallet in setup, never displays it, and lets the user leave", () => {
-    sdk.privy = {
-      ready: true,
-      authenticated: true,
-      user: {
-        wallet: {
-          address: "0xexternal",
-          chainType: "ethereum",
-          walletClientType: "metamask",
-        },
-        linkedAccounts: [],
-      },
-    };
-    sdk.wallets = { ready: true };
-
-    render(<AuthControls />);
-
-    expect(screen.getByText("Setting up your wallet…")).not.toBeNull();
-    expect(screen.queryByText(/0xexternal/)).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
-    expect(sdk.logout).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns a cancelled login to a retryable phone sign-in action", () => {
-    sdk.privy = { ready: true, authenticated: false, user: null };
-    render(<AuthControls />);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Continue with phone" })
-    );
-    expect(sdk.login).toHaveBeenCalledTimes(1);
-
-    act(() => sdk.loginCallbacks?.onError?.(new Error("cancelled")));
-    expect(
-      screen.getByText("Sign-in was cancelled or unavailable. Try again.")
-    ).not.toBeNull();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Continue with phone" })
-    );
-    expect(sdk.login).toHaveBeenCalledTimes(2);
-  });
-
-  it("shows truncated wallet and tUSD balance when signed in", () => {
-    renderSignedInControls();
-    expect(screen.getByText("0x1234")).not.toBeNull();
-    expect(screen.getByText("100 tUSD")).not.toBeNull();
-    expect(screen.queryByText("+15555550123")).toBeNull();
-  });
-
-  it("shows logout pending and ignores rapid duplicate submissions", () => {
-    let resolveLogout: () => void;
-    sdk.logout.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveLogout = resolve;
-        })
-    );
-    renderSignedInControls();
-
-    const logoutButton = screen.getByRole("button", { name: "Log out" });
-    act(() => {
-      fireEvent.click(logoutButton);
-      fireEvent.click(logoutButton);
-    });
-
-    expect(sdk.logout).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Signing out…")).not.toBeNull();
-    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
-
-    act(() => resolveLogout());
-  });
-
-  it("keeps the session retryable after logout fails", async () => {
-    sdk.logout
-      .mockRejectedValueOnce(new Error("network unavailable"))
-      .mockResolvedValueOnce();
-    renderSignedInControls();
-
-    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
-
-    await screen.findByText("We couldn't sign you out. Please try again.");
-    expect(screen.getByText("0x1234")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Log out" })).not.toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
-    await waitFor(() => expect(sdk.logout).toHaveBeenCalledTimes(2));
-  });
-});
 
 describe("AuthGate", () => {
   beforeEach(() => {

--- a/src/components/auth/auth-gate.test.tsx
+++ b/src/components/auth/auth-gate.test.tsx
@@ -26,6 +26,11 @@ const sdk = vi.hoisted(() => ({
   wallets: {
     ready: false,
   },
+  faucet: {
+    balance: 100_000_000n as bigint | null,
+    decimals: 6 as number | null,
+    status: "ready",
+  },
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
@@ -37,6 +42,11 @@ vi.mock("@privy-io/react-auth", () => ({
   useWallets: () => sdk.wallets,
 }));
 
+vi.mock("@/hooks/use-desk-dollars-faucet", () => ({
+  useDeskDollarsFaucet: () => sdk.faucet,
+}));
+
+import { AuthControls } from "@/components/auth/auth-controls";
 import { AuthGate } from "@/components/auth/auth-gate";
 
 function embeddedUser() {
@@ -52,25 +62,30 @@ function embeddedUser() {
   };
 }
 
-function renderSignedInGate() {
+function renderSignedInControls() {
   sdk.privy = { ready: true, authenticated: true, user: embeddedUser() };
   sdk.wallets = { ready: true };
-  render(<AuthGate />);
+  render(<AuthControls />);
 }
 
-describe("AuthGate", () => {
+describe("AuthControls", () => {
   beforeEach(() => {
     sdk.privy = { ready: false, authenticated: false, user: null };
     sdk.wallets = { ready: false };
     sdk.login.mockReset();
     sdk.loginCallbacks = null;
     sdk.logout.mockReset();
+    sdk.faucet = {
+      balance: 100_000_000n,
+      decimals: 6,
+      status: "ready",
+    };
   });
 
   afterEach(() => cleanup());
 
   it("waits for session restoration without an authentication action", () => {
-    render(<AuthGate />);
+    render(<AuthControls />);
 
     expect(screen.getByText("Restoring your session…")).not.toBeNull();
     expect(
@@ -94,14 +109,89 @@ describe("AuthGate", () => {
     };
     sdk.wallets = { ready: true };
 
-    render(<AuthGate />);
+    render(<AuthControls />);
 
     expect(screen.getByText("Setting up your wallet…")).not.toBeNull();
-    expect(screen.queryByText("Wallet: 0xexternal")).toBeNull();
+    expect(screen.queryByText(/0xexternal/)).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
     expect(sdk.logout).toHaveBeenCalledTimes(1);
   });
+
+  it("returns a cancelled login to a retryable phone sign-in action", () => {
+    sdk.privy = { ready: true, authenticated: false, user: null };
+    render(<AuthControls />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with phone" })
+    );
+    expect(sdk.login).toHaveBeenCalledTimes(1);
+
+    act(() => sdk.loginCallbacks?.onError?.(new Error("cancelled")));
+    expect(
+      screen.getByText("Sign-in was cancelled or unavailable. Try again.")
+    ).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue with phone" })
+    );
+    expect(sdk.login).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows truncated wallet and tUSD balance when signed in", () => {
+    renderSignedInControls();
+    expect(screen.getByText("0x1234")).not.toBeNull();
+    expect(screen.getByText("100 tUSD")).not.toBeNull();
+    expect(screen.queryByText("+15555550123")).toBeNull();
+  });
+
+  it("shows logout pending and ignores rapid duplicate submissions", () => {
+    let resolveLogout: () => void;
+    sdk.logout.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = resolve;
+        })
+    );
+    renderSignedInControls();
+
+    const logoutButton = screen.getByRole("button", { name: "Log out" });
+    act(() => {
+      fireEvent.click(logoutButton);
+      fireEvent.click(logoutButton);
+    });
+
+    expect(sdk.logout).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Signing out…")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
+
+    act(() => resolveLogout());
+  });
+
+  it("keeps the session retryable after logout fails", async () => {
+    sdk.logout
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce();
+    renderSignedInControls();
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+
+    await screen.findByText("We couldn't sign you out. Please try again.");
+    expect(screen.getByText("0x1234")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Log out" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
+    await waitFor(() => expect(sdk.logout).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("AuthGate", () => {
+  beforeEach(() => {
+    sdk.privy = { ready: false, authenticated: false, user: null };
+    sdk.wallets = { ready: false };
+  });
+
+  afterEach(() => cleanup());
 
   it("renders gated children only once the user is signed in", () => {
     sdk.privy = { ready: true, authenticated: false, user: null };
@@ -123,67 +213,5 @@ describe("AuthGate", () => {
     );
 
     expect(screen.getByText("Gated content")).not.toBeNull();
-  });
-
-  it("returns a cancelled login to a retryable phone sign-in action", () => {
-    sdk.privy = { ready: true, authenticated: false, user: null };
-    render(<AuthGate />);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Continue with phone" })
-    );
-    expect(sdk.login).toHaveBeenCalledTimes(1);
-
-    act(() => sdk.loginCallbacks?.onError?.(new Error("cancelled")));
-    expect(
-      screen.getByText("Sign-in was cancelled or unavailable. Try again.")
-    ).not.toBeNull();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Continue with phone" })
-    );
-    expect(sdk.login).toHaveBeenCalledTimes(2);
-  });
-
-  it("shows logout pending and ignores rapid duplicate submissions", () => {
-    let resolveLogout: () => void;
-    sdk.logout.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveLogout = resolve;
-        })
-    );
-    renderSignedInGate();
-
-    expect(screen.queryByText("+15555550123")).toBeNull();
-    expect(screen.queryByText("private@example.com")).toBeNull();
-
-    const logoutButton = screen.getByRole("button", { name: "Log out" });
-    act(() => {
-      fireEvent.click(logoutButton);
-      fireEvent.click(logoutButton);
-    });
-
-    expect(sdk.logout).toHaveBeenCalledTimes(1);
-    expect(screen.getByText("Signing out…")).not.toBeNull();
-    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
-
-    act(() => resolveLogout());
-  });
-
-  it("keeps the session retryable after logout fails", async () => {
-    sdk.logout
-      .mockRejectedValueOnce(new Error("network unavailable"))
-      .mockResolvedValueOnce();
-    renderSignedInGate();
-
-    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
-
-    await screen.findByText("We couldn't sign you out. Please try again.");
-    expect(screen.getByText("Wallet: 0x1234")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Log out" })).not.toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Log out" }));
-    await waitFor(() => expect(sdk.logout).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/components/auth/auth-gate.tsx
+++ b/src/components/auth/auth-gate.tsx
@@ -1,87 +1,31 @@
 "use client";
 
-import { useLogin, usePrivy, useWallets } from "@privy-io/react-auth";
-import { useCallback, useRef, useState } from "react";
+import { usePrivy, useWallets } from "@privy-io/react-auth";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 import { getAuthBoundaryState } from "./auth-boundary";
 
+/**
+ * Renders children only when the player is fully signed in with an embedded
+ * wallet. Login / logout chrome lives in AuthControls (AppShell).
+ */
 export function AuthGate({
   children,
 }: Readonly<{
   children?: React.ReactNode;
 }>) {
-  const { ready: privyReady, authenticated, logout, user } = usePrivy();
+  const { ready: privyReady, authenticated, user } = usePrivy();
   const { ready: walletsReady } = useWallets();
-  const [loginError, setLoginError] = useState(false);
-  const [logoutPending, setLogoutPending] = useState(false);
-  const [logoutError, setLogoutError] = useState(false);
-  const logoutInFlight = useRef(false);
-  const { login } = useLogin({
-    onError: () => setLoginError(true),
-  });
   const walletAddress = getEvmWalletAddress(user);
   const state = getAuthBoundaryState({
     privyReady,
     authenticated,
     walletsReady,
     walletAddress,
-    loginError,
-    logoutPending,
-    logoutError,
+    loginError: false,
+    logoutPending: false,
+    logoutError: false,
   });
 
-  const handleLogin = useCallback(() => {
-    setLoginError(false);
-    login();
-  }, [login]);
-
-  const handleLogout = useCallback(async () => {
-    if (logoutInFlight.current) return;
-
-    logoutInFlight.current = true;
-    setLogoutError(false);
-    setLogoutPending(true);
-
-    try {
-      await logout();
-    } catch {
-      setLogoutError(true);
-    } finally {
-      logoutInFlight.current = false;
-      setLogoutPending(false);
-    }
-  }, [logout]);
-
-  return (
-    <>
-      <p aria-live="polite" className="mt-8 text-sm text-[var(--t-text)]">
-        {state.message}
-      </p>
-      {walletAddress &&
-      (state.status === "signed-in" || state.status === "logout-error") ? (
-        <p className="mt-2 break-all text-xs text-[var(--t-muted)]">
-          Wallet: {walletAddress}
-        </p>
-      ) : null}
-      {state.status === "signed-in" ? children : null}
-      {state.action === "login" ? (
-        <button
-          className="mt-6 rounded-sm bg-[var(--t-accent)] px-5 py-3 text-sm font-bold uppercase tracking-wide text-[var(--t-bg)]"
-          onClick={handleLogin}
-          type="button"
-        >
-          Continue with phone
-        </button>
-      ) : null}
-      {state.action === "logout" ? (
-        <button
-          className="mt-6 rounded-sm border border-[var(--t-muted)] px-5 py-3 text-sm font-bold uppercase tracking-wide text-[var(--t-text)]"
-          onClick={handleLogout}
-          type="button"
-        >
-          Log out
-        </button>
-      ) : null}
-    </>
-  );
+  if (state.status !== "signed-in") return null;
+  return <>{children}</>;
 }

--- a/src/components/auth/auth-gate.tsx
+++ b/src/components/auth/auth-gate.tsx
@@ -21,9 +21,6 @@ export function AuthGate({
     authenticated,
     walletsReady,
     walletAddress,
-    loginError: false,
-    logoutPending: false,
-    logoutError: false,
   });
 
   if (state.status !== "signed-in") return null;

--- a/src/components/current-round/current-round.test.tsx
+++ b/src/components/current-round/current-round.test.tsx
@@ -65,24 +65,21 @@ describe("CurrentRound", () => {
 
     expect(screen.getByText("Round 12")).toBeTruthy();
     expect(screen.getByText("Entry open")).toBeTruthy();
-    expect(screen.getByText("00:18")).toBeTruthy();
+    // Countdown and Crash Point live on the theater chart, not this rail.
+    expect(screen.queryByText("00:18")).toBeNull();
     expect(screen.getByText(ready.crashRandom as string)).toBeTruthy();
     expect(
-      screen
-        .getByRole("link", { name: "View opening transaction" })
-        .getAttribute("href")
+      screen.getByRole("link", { name: "Opening tx" }).getAttribute("href")
     ).toBe(ready.openingTransactionUrl);
     expect(
-      screen
-        .getByRole("link", { name: "Verified game contract" })
-        .getAttribute("href")
+      screen.getByRole("link", { name: "Game contract" }).getAttribute("href")
     ).toBe(ready.gameContractUrl);
     expect(screen.getByTestId("crash-round-entry").textContent).toBe(
       "entry:open:18"
     );
   });
 
-  it("renders finalized Crash Point and attestation verification links", () => {
+  it("renders finalized status without duplicating the Crash Point", () => {
     const ready = sdk.makeReadyRound();
     sdk.round = {
       ...ready,
@@ -96,21 +93,16 @@ describe("CurrentRound", () => {
     };
     render(<CurrentRound />);
 
-    expect(screen.getByText("Finalized")).toBeTruthy();
-    expect(screen.getByText("Verified Crash Point")).toBeTruthy();
-    expect(screen.getByLabelText("Verified crash point 3.42x")).toBeTruthy();
-    expect(screen.queryByText("Awaiting attestation")).toBeNull();
+    expect(screen.getAllByText("Finalized").length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText("Verified crash point 3.42x")).toBeNull();
+    expect(screen.queryByText("Verified Crash Point")).toBeNull();
     expect(
-      screen
-        .getByRole("link", { name: "View finalization transaction" })
-        .getAttribute("href")
+      screen.getByRole("link", { name: "Finalization tx" }).getAttribute("href")
     ).toBe(
       "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     );
     expect(
-      screen
-        .getByRole("link", { name: "Verified Inco Lightning" })
-        .getAttribute("href")
+      screen.getByRole("link", { name: "Inco Lightning" }).getAttribute("href")
     ).toBe(ready.incoContractUrl);
   });
 
@@ -158,9 +150,7 @@ describe("CurrentRound", () => {
     expect(screen.getByText("Outcome unavailable")).toBeTruthy();
     expect(screen.queryByText("Verified Crash Point")).toBeNull();
     expect(
-      screen
-        .getByRole("link", { name: "View expiry transaction" })
-        .getAttribute("href")
+      screen.getByRole("link", { name: "Expiry tx" }).getAttribute("href")
     ).toBe(
       "https://sepolia.basescan.org/tx/0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
     );

--- a/src/components/current-round/current-round.tsx
+++ b/src/components/current-round/current-round.tsx
@@ -5,7 +5,7 @@ import {
   type CurrentCrashRoundView,
 } from "@/hooks/use-current-crash-round";
 import type { CrashRoundPhase } from "@/lib/margin-call-crash";
-import { formatCountdown, TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
+import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { CrashRoundEntry } from "./crash-round-entry";
 
 type ReadyRound = Extract<CurrentCrashRoundView, { status: "ready" }>;
@@ -32,6 +32,10 @@ const phaseColors: Record<CrashRoundPhase, string> = {
   expired: "text-[var(--t-muted)] border-[var(--t-muted)]/40",
 };
 
+/**
+ * Action rail for the current round: phase, entry, compact verification.
+ * Countdown and Crash Point live on the Round Theater chart.
+ */
 export function CurrentRound() {
   const round = useCurrentCrashRound();
 
@@ -42,64 +46,45 @@ export function CurrentRound() {
   return (
     <section
       aria-labelledby="current-round-heading"
-      className="mt-10 border-y border-[var(--t-border)] bg-[var(--t-panel)] text-left"
+      className="border border-[var(--t-border)] bg-[var(--t-panel)] text-left"
+      data-testid="current-round"
     >
-      <div className="grid gap-8 px-5 py-6 sm:px-8 lg:grid-cols-[1fr_auto] lg:items-start lg:py-8">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-3">
-            <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
-              Base Sepolia · Current round
-            </p>
-            <span
-              className={`inline-flex border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.18em] ${phaseColors[phase]}`}
-            >
-              {phaseLabels[phase]}
-            </span>
-          </div>
-          <h2
-            id="current-round-heading"
-            className="mt-4 font-[family-name:var(--font-plex-sans)] text-4xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-6xl"
+      <div className="px-4 py-5 sm:px-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
+            Current round
+          </p>
+          <span
+            className={`inline-flex border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.18em] ${phaseColors[phase]}`}
           >
-            Round {round.roundId.toString()}
-          </h2>
-
-          <PhasePrimaryContent round={round} />
-          <EncryptedHandle round={round} />
-          <CrashRoundEntry
-            countdownSeconds={round.countdownSeconds}
-            phase={phase}
-            roundId={round.roundId}
-          />
+            {phaseLabels[phase]}
+          </span>
         </div>
+        <h2
+          id="current-round-heading"
+          className="mt-3 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl"
+        >
+          Round {round.roundId.toString()}
+        </h2>
 
-        <div className="min-w-44 border-l border-[var(--t-divider)] pl-5 lg:text-right">
-          <PhaseSidebar round={round} />
-        </div>
+        <PhaseStatusCopy phase={phase} />
+        <CrashRoundEntry
+          countdownSeconds={round.countdownSeconds}
+          phase={phase}
+          roundId={round.roundId}
+        />
+        <EncryptedHandle round={round} />
+        <VerificationLinks round={round} />
+        <p className="mt-4 text-[10px] text-[var(--t-muted)]">
+          Read at block {round.blockNumber.toString()}
+        </p>
       </div>
     </section>
   );
 }
 
-function PhasePrimaryContent({ round }: { round: ReadyRound }) {
-  switch (round.phase) {
-    case "finalized":
-      return (
-        <div className="mt-6">
-          <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-            Verified Crash Point
-          </p>
-          <p
-            aria-label={`Verified crash point ${round.displayCrashPoint}`}
-            className="mc-live-value mt-2 font-[family-name:var(--font-plex-sans)] text-5xl font-bold tabular-nums text-[var(--t-green-hot)] sm:text-6xl"
-          >
-            {round.displayCrashPoint}
-          </p>
-          <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-            Attested onchain against the exact stored encrypted handle. The
-            finalization transaction is the public attestation record.
-          </p>
-        </div>
-      );
+function PhaseStatusCopy({ phase }: { phase: CrashRoundPhase }) {
+  switch (phase) {
     case "locked":
       return (
         <StatusCopy
@@ -128,12 +113,19 @@ function PhasePrimaryContent({ round }: { round: ReadyRound }) {
           body="This round expired without a verified Crash Point. Ticket owners can pull back exactly their original margin."
         />
       );
+    case "finalized":
+      return (
+        <StatusCopy
+          title="Finalized"
+          body="The attested Crash Point is on the floor chart. Claim or settle from your ticket below."
+        />
+      );
     case "prelaunch":
     case "uninitialized":
     case "open":
       return null;
     default: {
-      const _exhaustive: never = round.phase;
+      const _exhaustive: never = phase;
       return _exhaustive;
     }
   }
@@ -141,85 +133,53 @@ function PhasePrimaryContent({ round }: { round: ReadyRound }) {
 
 function EncryptedHandle({ round }: { round: ReadyRound }) {
   return (
-    <div className="mt-6">
+    <div className="mt-5 border-t border-[var(--t-divider)] pt-4">
       <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        Public encrypted crash handle
+        Encrypted crash handle
       </p>
       {round.crashRandom ? (
-        <code className="mt-2 block break-all text-xs leading-5 text-[var(--t-accent)] sm:text-sm">
+        <code className="mt-2 block break-all text-[10px] leading-4 text-[var(--t-accent)] sm:text-xs">
           {round.crashRandom}
         </code>
       ) : (
-        <p className="mt-2 text-sm text-[var(--t-muted)]">
+        <p className="mt-2 text-xs text-[var(--t-muted)]">
           No handle has been pre-committed for this epoch yet.
         </p>
       )}
-      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        The ciphertext is public and auditable. Its plaintext remains
-        confidential until attested finalization.
-      </p>
     </div>
-  );
-}
-
-function PhaseSidebar({ round }: { round: ReadyRound }) {
-  const phase = round.phase;
-  return (
-    <>
-      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        {phase === "open" ? "Entry closes in" : "Entry window"}
-      </p>
-      <p
-        aria-label={
-          phase === "open"
-            ? `${round.countdownSeconds} seconds until entry locks`
-            : "Entry is not open"
-        }
-        className="mc-live-value mt-2 text-4xl font-bold tabular-nums text-[var(--t-green-hot)]"
-      >
-        {phase === "open" ? formatCountdown(round.countdownSeconds) : "—:—"}
-      </p>
-      <p className="mt-5 text-xs text-[var(--t-muted)]">
-        Read at block {round.blockNumber.toString()}
-      </p>
-      <VerificationLinks round={round} />
-    </>
   );
 }
 
 function VerificationLinks({ round }: { round: ReadyRound }) {
   const links = [
     round.openingTransactionUrl
-      ? { href: round.openingTransactionUrl, label: "View opening transaction" }
+      ? { href: round.openingTransactionUrl, label: "Opening tx" }
       : null,
     round.revealTransactionUrl
-      ? { href: round.revealTransactionUrl, label: "View reveal transaction" }
+      ? { href: round.revealTransactionUrl, label: "Reveal tx" }
       : null,
     round.finalizeTransactionUrl
-      ? {
-          href: round.finalizeTransactionUrl,
-          label: "View finalization transaction",
-        }
+      ? { href: round.finalizeTransactionUrl, label: "Finalization tx" }
       : null,
     round.expireTransactionUrl
-      ? { href: round.expireTransactionUrl, label: "View expiry transaction" }
+      ? { href: round.expireTransactionUrl, label: "Expiry tx" }
       : null,
-    { href: round.gameContractUrl, label: "Verified game contract" },
-    { href: round.incoContractUrl, label: "Verified Inco Lightning" },
+    { href: round.gameContractUrl, label: "Game contract" },
+    { href: round.incoContractUrl, label: "Inco Lightning" },
   ].filter((link): link is { href: string; label: string } => link !== null);
 
   return (
-    <ul className="mt-3 space-y-2">
+    <ul className="mt-4 flex flex-wrap gap-x-4 gap-y-2">
       {links.map((link) => (
         <li key={link.label}>
           <a
-            className="group inline-flex items-center gap-2 text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
+            className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
             href={link.href}
             rel="noreferrer"
             target="_blank"
           >
             {link.label}
-            <span aria-hidden="true" className="wire-cta-bounce">
+            <span aria-hidden="true" className="ml-1">
               ↗
             </span>
           </a>
@@ -231,14 +191,9 @@ function VerificationLinks({ round }: { round: ReadyRound }) {
 
 function StatusCopy({ title, body }: { title: string; body: string }) {
   return (
-    <div className="mt-6">
-      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        Round status
-      </p>
-      <p className="mt-2 text-lg font-bold text-[var(--t-text)]">{title}</p>
-      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        {body}
-      </p>
+    <div className="mt-4">
+      <p className="text-sm font-bold text-[var(--t-text)]">{title}</p>
+      <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">{body}</p>
     </div>
   );
 }
@@ -248,7 +203,8 @@ function CurrentRoundLoading() {
     <section
       aria-busy="true"
       aria-labelledby="current-round-loading"
-      className="mt-10 border-y border-[var(--t-border)] px-5 py-10 text-left sm:px-8"
+      className="border border-[var(--t-border)] px-4 py-8 text-left sm:px-5"
+      data-testid="current-round"
     >
       <p
         id="current-round-loading"
@@ -268,11 +224,12 @@ function CurrentRoundFailure({
   return (
     <section
       aria-labelledby="current-round-failure"
-      className="mt-10 border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
+      className="border border-[var(--t-border)] px-4 py-6 text-left sm:px-5"
+      data-testid="current-round"
     >
       <h2
         id="current-round-failure"
-        className="font-[family-name:var(--font-plex-sans)] text-2xl font-bold uppercase text-[var(--t-text)]"
+        className="font-[family-name:var(--font-plex-sans)] text-xl font-bold uppercase text-[var(--t-text)]"
       >
         Current round
       </h2>

--- a/src/components/desk-dollars/desk-dollars-panel.tsx
+++ b/src/components/desk-dollars/desk-dollars-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePrivy } from "@privy-io/react-auth";
-import { formatDeskDollars } from "@/lib/desk-dollars";
+import { formatDeskDollarsBalanceLabel } from "@/lib/desk-dollars";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 import { useDeskDollarsFaucet } from "@/hooks/use-desk-dollars-faucet";
 
@@ -15,9 +15,7 @@ export function DeskDollarsPanel() {
   const walletAddress = getEvmWalletAddress(user);
   const faucet = useDeskDollarsFaucet(walletAddress);
   const balance =
-    faucet.balance !== null && faucet.decimals !== null
-      ? `${formatDeskDollars(faucet.balance, faucet.decimals)} tUSD`
-      : "— tUSD";
+    formatDeskDollarsBalanceLabel(faucet.balance, faucet.decimals) ?? "— tUSD";
 
   return (
     <section

--- a/src/components/history/global-history.test.tsx
+++ b/src/components/history/global-history.test.tsx
@@ -139,6 +139,8 @@ describe("GlobalHistory", () => {
     expect(screen.getByText("3.42x")).toBeTruthy();
     expect(screen.getByText("Expired — no result")).toBeTruthy();
     expect(screen.queryByText("0.00x")).toBeNull();
+    // Finalized rows get a static curve thumb; delayed/empty/expired do not.
+    expect(screen.getAllByTestId("replay-curve-thumb")).toHaveLength(1);
   });
 
   it("expands a verification record with BaseScan lifecycle links", () => {

--- a/src/components/history/global-history.tsx
+++ b/src/components/history/global-history.tsx
@@ -6,7 +6,7 @@ import type {
   RoundHistoryItem,
   RoundHistoryState,
 } from "@/lib/margin-call-crash";
-import { ReplayCurve } from "@/components/round-theater/replay-curve";
+import { ReplayCurveThumb } from "@/components/round-theater/replay-curve";
 import { historyStateCopy } from "./history-state-copy";
 import { RoundVerificationRecord } from "./round-verification-record";
 
@@ -152,11 +152,7 @@ function HistoryRoundRow({
       >
         <div className="flex min-w-0 flex-wrap items-center gap-3">
           {showThumb ? (
-            <ReplayCurve
-              crashPointBps={item.round.crashPointBps}
-              progress={1}
-              size="thumb"
-            />
+            <ReplayCurveThumb crashPointBps={item.round.crashPointBps} />
           ) : null}
           <span className="font-[family-name:var(--font-plex-sans)] text-lg font-bold tabular-nums text-[var(--t-text)]">
             Round {item.round.id.toString()}

--- a/src/components/history/global-history.tsx
+++ b/src/components/history/global-history.tsx
@@ -6,6 +6,7 @@ import type {
   RoundHistoryItem,
   RoundHistoryState,
 } from "@/lib/margin-call-crash";
+import { ReplayCurve } from "@/components/round-theater/replay-curve";
 import { historyStateCopy } from "./history-state-copy";
 import { RoundVerificationRecord } from "./round-verification-record";
 
@@ -29,7 +30,7 @@ export function GlobalHistory() {
       <section
         aria-busy="true"
         aria-labelledby="global-history-loading"
-        className="mt-10 border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
+        className="border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
       >
         <p
           id="global-history-loading"
@@ -45,7 +46,7 @@ export function GlobalHistory() {
     return (
       <section
         aria-labelledby="global-history-error"
-        className="mt-10 border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
+        className="border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
       >
         <p
           id="global-history-error"
@@ -68,7 +69,7 @@ export function GlobalHistory() {
   return (
     <section
       aria-labelledby="global-history-heading"
-      className="mt-10 border-y border-[var(--t-border)] bg-[var(--t-panel)] px-5 py-6 text-left sm:px-8 sm:py-8"
+      className="border-y border-[var(--t-border)] bg-[var(--t-panel)] px-5 py-6 text-left sm:px-8 sm:py-8"
     >
       <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
         Base Sepolia · Global history
@@ -138,6 +139,8 @@ function HistoryRoundRow({
           : item.historyState === "expired"
             ? "Expired — no result"
             : "—";
+  const showThumb =
+    item.historyState === "finalized" && item.round.crashPointBps > 0n;
 
   return (
     <li className="py-4">
@@ -147,7 +150,14 @@ function HistoryRoundRow({
         onClick={onSelect}
         type="button"
       >
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-3">
+          {showThumb ? (
+            <ReplayCurve
+              crashPointBps={item.round.crashPointBps}
+              progress={1}
+              size="thumb"
+            />
+          ) : null}
           <span className="font-[family-name:var(--font-plex-sans)] text-lg font-bold tabular-nums text-[var(--t-text)]">
             Round {item.round.id.toString()}
           </span>

--- a/src/components/no-real-value-disclosure.tsx
+++ b/src/components/no-real-value-disclosure.tsx
@@ -7,7 +7,7 @@ export function NoRealValueDisclosure() {
     <p
       role="note"
       data-testid="no-real-value-disclosure"
-      className="mx-auto mt-4 max-w-xl border border-[var(--t-amber)] px-3 py-2 text-xs leading-5 text-[var(--t-muted)]"
+      className="border border-[var(--t-amber)] px-3 py-2 text-xs leading-5 text-[var(--t-muted)]"
     >
       Base Sepolia only. Desk Dollars (tUSD) and vault shares have no real value
       and no claim on real US dollars.

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -20,25 +20,18 @@ import { theaterCopy } from "./theater-copy";
 const VIEW_W = 100;
 const VIEW_H = 56;
 
-export type ReplayCurveSize = "hero" | "thumb";
-
 export type ReplayCurveProps = {
   crashPointBps: bigint;
   progress: number;
   /** Open-phase previous-round ambiance (same hero size, different label). */
   ambiance?: boolean;
-  size?: ReplayCurveSize;
 };
 
-const sizeClass: Record<ReplayCurveSize, string> = {
-  hero: "min-h-[22rem] lg:min-h-[28rem]",
-  thumb: "h-14 w-28",
-};
-
-const svgClass: Record<ReplayCurveSize, string> = {
-  hero: "mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]",
-  thumb: "h-full w-full",
-};
+/**
+ * Every chart-slot state (live curve, empty, reduced-motion panel) shares this
+ * footprint so the floor layout never jumps between phases.
+ */
+export const REPLAY_HERO_MIN_H = "min-h-[22rem] lg:min-h-[28rem]";
 
 /**
  * SVG multiplier climb. Axes rescale with the live multiplier; hard stop at
@@ -48,7 +41,6 @@ export function ReplayCurve({
   crashPointBps,
   progress,
   ambiance = false,
-  size = "hero",
 }: ReplayCurveProps) {
   // `progress` moves every animation frame, so memoizing on it buys nothing.
   const points = getReplayPathPoints(crashPointBps, progress, {
@@ -61,7 +53,6 @@ export function ReplayCurve({
   const displayMultiplier = formatCrashPointBps(multiplierBps);
   const isComplete = isReplayComplete(progress);
   const crashLabel = formatCrashPointBps(crashPointBps);
-  const isThumb = size === "thumb";
 
   const tierLines = useMemo(
     () =>
@@ -75,35 +66,9 @@ export function ReplayCurve({
     [crashPointBps]
   );
 
-  if (isThumb) {
-    return (
-      <div
-        aria-hidden="true"
-        className={`terminal-panel relative overflow-hidden p-1 ${sizeClass.thumb}`}
-        data-testid="replay-curve-thumb"
-      >
-        <svg
-          className={svgClass.thumb}
-          preserveAspectRatio="none"
-          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-        >
-          <path
-            d={path}
-            fill="none"
-            stroke="var(--t-green-hot)"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.4"
-          />
-          <circle cx={head.x} cy={head.y} fill="var(--t-red-hot)" r="1.6" />
-        </svg>
-      </div>
-    );
-  }
-
   return (
     <div
-      className={`terminal-panel relative overflow-hidden p-3 sm:p-5 ${sizeClass.hero}`}
+      className={`terminal-panel relative overflow-hidden p-3 sm:p-5 ${REPLAY_HERO_MIN_H}`}
       data-testid={ambiance ? "replay-curve-ambiance" : "replay-curve"}
     >
       <div className="flex flex-wrap items-end justify-between gap-3">
@@ -141,7 +106,7 @@ export function ReplayCurve({
 
       <svg
         aria-hidden="true"
-        className={svgClass.hero}
+        className="mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]"
         preserveAspectRatio="none"
         viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
       >
@@ -209,6 +174,47 @@ export function ReplayCurve({
 }
 
 /**
+ * Static history sparkline: the full curve at its final frame. Kept separate
+ * from ReplayCurve so list rows skip the hero's multiplier/tier work.
+ */
+export function ReplayCurveThumb({ crashPointBps }: { crashPointBps: bigint }) {
+  const { path, head } = useMemo(() => {
+    const points = getReplayPathPoints(crashPointBps, 1, {
+      width: VIEW_W,
+      height: VIEW_H,
+    });
+    return {
+      path: replayPathD(points),
+      head: points[points.length - 1] ?? { x: 0, y: VIEW_H },
+    };
+  }, [crashPointBps]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="terminal-panel relative h-14 w-28 overflow-hidden p-1"
+      data-testid="replay-curve-thumb"
+    >
+      <svg
+        className="h-full w-full"
+        preserveAspectRatio="none"
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      >
+        <path
+          d={path}
+          fill="none"
+          stroke="var(--t-green-hot)"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.4"
+        />
+        <circle cx={head.x} cy={head.y} fill="var(--t-red-hot)" r="1.6" />
+      </svg>
+    </div>
+  );
+}
+
+/**
  * Empty chart workspace while the round has no climb to show (delayed /
  * expired / loading). Keeps the floor from collapsing into a text block.
  */
@@ -218,12 +224,12 @@ export function ReplayCurveEmpty({
   testId,
 }: {
   title: string;
-  body: string;
+  body?: string;
   testId?: string;
 }) {
   return (
     <div
-      className="terminal-panel relative flex min-h-[22rem] flex-col justify-center overflow-hidden p-5 sm:p-8 lg:min-h-[28rem]"
+      className={`terminal-panel relative flex flex-col justify-center overflow-hidden p-5 sm:p-8 ${REPLAY_HERO_MIN_H}`}
       data-testid={testId}
     >
       <svg
@@ -252,7 +258,9 @@ export function ReplayCurveEmpty({
         <p className="mt-3 font-[family-name:var(--font-plex-sans)] text-2xl font-bold text-[var(--t-amber-hot)] sm:text-3xl">
           {title}
         </p>
-        <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">{body}</p>
+        {body ? (
+          <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">{body}</p>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -20,11 +20,24 @@ import { theaterCopy } from "./theater-copy";
 const VIEW_W = 100;
 const VIEW_H = 56;
 
+export type ReplayCurveSize = "hero" | "thumb";
+
 export type ReplayCurveProps = {
   crashPointBps: bigint;
   progress: number;
-  /** Dimmed looping ambiance mode (Open phase). */
+  /** Open-phase previous-round ambiance (same hero size, different label). */
   ambiance?: boolean;
+  size?: ReplayCurveSize;
+};
+
+const sizeClass: Record<ReplayCurveSize, string> = {
+  hero: "min-h-[22rem] lg:min-h-[28rem]",
+  thumb: "h-14 w-28",
+};
+
+const svgClass: Record<ReplayCurveSize, string> = {
+  hero: "mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]",
+  thumb: "h-full w-full",
 };
 
 /**
@@ -35,6 +48,7 @@ export function ReplayCurve({
   crashPointBps,
   progress,
   ambiance = false,
+  size = "hero",
 }: ReplayCurveProps) {
   // `progress` moves every animation frame, so memoizing on it buys nothing.
   const points = getReplayPathPoints(crashPointBps, progress, {
@@ -47,6 +61,7 @@ export function ReplayCurve({
   const displayMultiplier = formatCrashPointBps(multiplierBps);
   const isComplete = isReplayComplete(progress);
   const crashLabel = formatCrashPointBps(crashPointBps);
+  const isThumb = size === "thumb";
 
   const tierLines = useMemo(
     () =>
@@ -60,9 +75,36 @@ export function ReplayCurve({
     [crashPointBps]
   );
 
+  if (isThumb) {
+    return (
+      <div
+        aria-hidden="true"
+        className={`terminal-panel relative overflow-hidden p-1 ${sizeClass.thumb}`}
+        data-testid="replay-curve-thumb"
+      >
+        <svg
+          className={svgClass.thumb}
+          preserveAspectRatio="none"
+          viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        >
+          <path
+            d={path}
+            fill="none"
+            stroke="var(--t-green-hot)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.4"
+          />
+          <circle cx={head.x} cy={head.y} fill="var(--t-red-hot)" r="1.6" />
+        </svg>
+      </div>
+    );
+  }
+
   return (
     <div
-      className={`terminal-panel relative overflow-hidden p-3 sm:p-4 ${ambiance ? "opacity-70" : ""}`}
+      className={`terminal-panel relative overflow-hidden p-3 sm:p-5 ${sizeClass.hero}`}
+      data-testid={ambiance ? "replay-curve-ambiance" : "replay-curve"}
     >
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
@@ -73,7 +115,7 @@ export function ReplayCurve({
           </p>
           <p
             aria-live="polite"
-            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-4xl font-bold tabular-nums sm:text-5xl ${
+            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-5xl font-bold tabular-nums sm:text-6xl lg:text-7xl ${
               isComplete
                 ? "text-[var(--t-red-hot)]"
                 : "text-[var(--t-green-hot)]"
@@ -99,7 +141,7 @@ export function ReplayCurve({
 
       <svg
         aria-hidden="true"
-        className="mt-4 h-40 w-full sm:h-52"
+        className={svgClass.hero}
         preserveAspectRatio="none"
         viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
       >
@@ -162,6 +204,56 @@ export function ReplayCurve({
           {theaterCopy.replayLabel}. {theaterCopy.replayDetail}
         </p>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * Empty chart workspace while the round has no climb to show (delayed /
+ * expired / loading). Keeps the floor from collapsing into a text block.
+ */
+export function ReplayCurveEmpty({
+  title,
+  body,
+  testId,
+}: {
+  title: string;
+  body: string;
+  testId?: string;
+}) {
+  return (
+    <div
+      className="terminal-panel relative flex min-h-[22rem] flex-col justify-center overflow-hidden p-5 sm:p-8 lg:min-h-[28rem]"
+      data-testid={testId}
+    >
+      <svg
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full opacity-40"
+        preserveAspectRatio="none"
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      >
+        {[0.2, 0.4, 0.6, 0.8].map((t) => (
+          <line
+            key={t}
+            stroke="var(--t-divider)"
+            strokeDasharray="1 2"
+            strokeWidth="0.25"
+            x1="0"
+            x2={VIEW_W}
+            y1={VIEW_H * t}
+            y2={VIEW_H * t}
+          />
+        ))}
+      </svg>
+      <div className="relative max-w-xl">
+        <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+          Round status
+        </p>
+        <p className="mt-3 font-[family-name:var(--font-plex-sans)] text-2xl font-bold text-[var(--t-amber-hot)] sm:text-3xl">
+          {title}
+        </p>
+        <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">{body}</p>
+      </div>
     </div>
   );
 }

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -33,7 +33,21 @@ const sdk = vi.hoisted(() => {
       ],
       tiers: emptyTiers(),
     },
-    ambiance: null,
+    ambiance: {
+      round: {
+        id: 11n,
+        openAt: 900n,
+        lockAt: 945n,
+        expiresAt: 1_845n,
+        crashRandom:
+          "0x000000000000000000000000000000000000000000000000000000000000bbbb",
+        crashPointBps: 25_000n,
+        totalMargin: 1_000_000n,
+        reservedPayout: 1_250_000n,
+        status: 3,
+      },
+      displayCrashPoint: "2.50x",
+    },
     reducedMotion: false,
     retry: vi.fn(),
   });
@@ -92,12 +106,14 @@ describe("RoundTheater", () => {
 
   afterEach(cleanup);
 
-  it("shows the Open stage with contract-derived countdown and ticket tape", () => {
+  it("shows the Open stage with hero previous-round chart, countdown, and ticket tape", () => {
     render(<RoundTheater />);
 
     expect(screen.getByTestId("round-theater")).toBeTruthy();
     expect(screen.getByTestId("theater-countdown").textContent).toBe("00:22");
     expect(screen.getByText("Live ticket tape")).toBeTruthy();
+    expect(screen.getByTestId("replay-curve-ambiance")).toBeTruthy();
+    expect(screen.getByText("Previous round replay")).toBeTruthy();
     expect(
       screen.getAllByText((_, el) => el?.textContent === "1 tUSD").length
     ).toBeGreaterThan(0);

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -9,7 +9,7 @@ import { getTheaterAudio } from "@/lib/theater-audio";
 import { formatCountdown, TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { delayedPhaseCopy, theaterCopy } from "./theater-copy";
 import { FinalizeLink } from "./finalize-link";
-import { ReplayCurve } from "./replay-curve";
+import { ReplayCurve, ReplayCurveEmpty } from "./replay-curve";
 import { RoundResultCard } from "./round-result-card";
 import { TheaterSoundToggle } from "./theater-sound-toggle";
 import { TicketTape } from "./ticket-tape";
@@ -25,10 +25,10 @@ export function RoundTheater() {
   return (
     <section
       aria-labelledby="round-theater-heading"
-      className="mt-10 border-y border-[var(--t-border)] bg-[var(--t-panel)] text-left"
+      className="border-y border-[var(--t-border)] bg-[var(--t-panel)] text-left"
       data-testid="round-theater"
     >
-      <div className="px-5 py-6 sm:px-8 sm:py-8">
+      <div className="px-4 py-5 sm:px-6 sm:py-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
@@ -36,7 +36,7 @@ export function RoundTheater() {
             </p>
             <h2
               id="round-theater-heading"
-              className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl"
+              className="mt-2 font-[family-name:var(--font-plex-sans)] text-2xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-3xl"
             >
               {theaterCopy.heading}
             </h2>
@@ -44,7 +44,7 @@ export function RoundTheater() {
           <TheaterSoundToggle />
         </div>
 
-        <div className="mt-6">
+        <div className="mt-5">
           <TheaterBody stage={stage} />
         </div>
       </div>
@@ -56,20 +56,21 @@ function TheaterBody({ stage }: { stage: TheaterStage }) {
   switch (stage.kind) {
     case "loading":
       return (
-        <p
-          aria-busy="true"
-          className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]"
-        >
-          {theaterCopy.loading}
-        </p>
+        <ReplayCurveEmpty
+          body={theaterCopy.loading}
+          testId="theater-loading"
+          title={theaterCopy.loading}
+        />
       );
     case "error":
     case "unavailable":
       return (
         <div>
-          <p className="text-sm text-[var(--t-red)]" role="alert">
-            {stage.error}
-          </p>
+          <ReplayCurveEmpty
+            body={stage.error}
+            testId="theater-error"
+            title="Theater unavailable"
+          />
           <button
             className={`mt-4 ${TERMINAL_ACTION_BUTTON_CLASS}`}
             onClick={() => void stage.retry()}
@@ -102,37 +103,42 @@ function OpenStage({
   const ambiance = stage.ambiance;
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
-      <div>
-        <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-          {theaterCopy.openCountdown}
-        </p>
-        <p
-          aria-label={`${stage.countdownSeconds} seconds until entry locks`}
-          className="mc-live-value mt-2 text-5xl font-bold tabular-nums text-[var(--t-green-hot)]"
-          data-testid="theater-countdown"
-        >
-          {formatCountdown(stage.countdownSeconds)}
-        </p>
-        <TicketTape entries={stage.tape?.entries ?? []} />
-      </div>
-      <div>
-        {ambiance && !stage.reducedMotion ? (
-          <AmbianceReplay crashPointBps={ambiance.round.crashPointBps} />
-        ) : ambiance && stage.reducedMotion ? (
-          <div className="terminal-panel p-4">
-            <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-              {theaterCopy.openAmbiance}
-            </p>
-            <p className="mc-live-value mt-2 text-3xl font-bold text-[var(--t-green-hot)]">
-              {ambiance.displayCrashPoint}
-            </p>
-          </div>
-        ) : (
-          <div className="terminal-panel p-4 text-xs text-[var(--t-muted)]">
-            {theaterCopy.openAmbianceEmpty}
-          </div>
-        )}
+    <div className="space-y-4">
+      {ambiance && !stage.reducedMotion ? (
+        <AmbianceReplay crashPointBps={ambiance.round.crashPointBps} />
+      ) : ambiance && stage.reducedMotion ? (
+        <div className="terminal-panel min-h-[22rem] p-5 lg:min-h-[28rem]">
+          <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+            {theaterCopy.openAmbiance}
+          </p>
+          <p className="mc-live-value mt-2 font-[family-name:var(--font-plex-sans)] text-5xl font-bold text-[var(--t-green-hot)] sm:text-6xl">
+            {ambiance.displayCrashPoint}
+          </p>
+        </div>
+      ) : (
+        <ReplayCurveEmpty
+          body={theaterCopy.openAmbianceEmpty}
+          testId="theater-ambiance-empty"
+          title={theaterCopy.openAmbiance}
+        />
+      )}
+
+      <div className="flex flex-wrap items-end justify-between gap-4 border-t border-[var(--t-divider)] pt-4">
+        <div>
+          <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
+            {theaterCopy.openCountdown}
+          </p>
+          <p
+            aria-label={`${stage.countdownSeconds} seconds until entry locks`}
+            className="mc-live-value mt-1 text-4xl font-bold tabular-nums text-[var(--t-green-hot)] sm:text-5xl"
+            data-testid="theater-countdown"
+          >
+            {formatCountdown(stage.countdownSeconds)}
+          </p>
+        </div>
+        <div className="min-w-0 flex-1">
+          <TicketTape entries={stage.tape?.entries ?? []} />
+        </div>
       </div>
     </div>
   );
@@ -155,6 +161,7 @@ function AmbianceReplay({ crashPointBps }: { crashPointBps: bigint }) {
       ambiance
       crashPointBps={crashPointBps}
       progress={clock.progress}
+      size="hero"
     />
   );
 }
@@ -166,17 +173,9 @@ function DelayedStage({
 }) {
   const copy = delayedPhaseCopy[stage.phaseLabel];
   return (
-    <div data-testid="theater-delayed">
-      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        Round status
-      </p>
-      <p className="mt-2 text-lg font-bold text-[var(--t-amber-hot)]">
-        {copy.title}
-      </p>
-      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        {copy.body}
-      </p>
+    <div className="space-y-4" data-testid="theater-delayed">
       {/* Never invent a multiplier or start a climb while delayed. */}
+      <ReplayCurveEmpty body={copy.body} title={copy.title} />
       <TicketTape entries={stage.tape?.entries ?? []} />
     </div>
   );
@@ -218,17 +217,18 @@ function FinalizedStage({
   }
 
   return (
-    <div data-testid="theater-finalized-replay">
+    <div className="space-y-4" data-testid="theater-finalized-replay">
       <ReplayCurve
         crashPointBps={stage.crashPointBps}
         progress={clock.progress}
+        size="hero"
       />
       <TierCloseBoard
         crashPointBps={stage.crashPointBps}
         progress={clock.progress}
         tiers={stage.tiers}
       />
-      <div className="mt-4 flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <button
           className={TERMINAL_ACTION_BUTTON_CLASS}
           onClick={() => setRestartNonce((n) => n + 1)}
@@ -248,16 +248,11 @@ function ExpiredStage({
   stage: Extract<TheaterStage, { kind: "expired" }>;
 }) {
   return (
-    <div data-testid="theater-expired">
-      <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        Round status
-      </p>
-      <p className="mt-2 text-lg font-bold text-[var(--t-muted)]">
-        {theaterCopy.expired}
-      </p>
-      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        {theaterCopy.expiredDetail}
-      </p>
+    <div className="space-y-4" data-testid="theater-expired">
+      <ReplayCurveEmpty
+        body={theaterCopy.expiredDetail}
+        title={theaterCopy.expired}
+      />
       <TicketTape entries={stage.tape?.entries ?? []} />
     </div>
   );

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -9,7 +9,11 @@ import { getTheaterAudio } from "@/lib/theater-audio";
 import { formatCountdown, TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { delayedPhaseCopy, theaterCopy } from "./theater-copy";
 import { FinalizeLink } from "./finalize-link";
-import { ReplayCurve, ReplayCurveEmpty } from "./replay-curve";
+import {
+  REPLAY_HERO_MIN_H,
+  ReplayCurve,
+  ReplayCurveEmpty,
+} from "./replay-curve";
 import { RoundResultCard } from "./round-result-card";
 import { TheaterSoundToggle } from "./theater-sound-toggle";
 import { TicketTape } from "./ticket-tape";
@@ -57,7 +61,6 @@ function TheaterBody({ stage }: { stage: TheaterStage }) {
     case "loading":
       return (
         <ReplayCurveEmpty
-          body={theaterCopy.loading}
           testId="theater-loading"
           title={theaterCopy.loading}
         />
@@ -107,7 +110,7 @@ function OpenStage({
       {ambiance && !stage.reducedMotion ? (
         <AmbianceReplay crashPointBps={ambiance.round.crashPointBps} />
       ) : ambiance && stage.reducedMotion ? (
-        <div className="terminal-panel min-h-[22rem] p-5 lg:min-h-[28rem]">
+        <div className={`terminal-panel p-5 ${REPLAY_HERO_MIN_H}`}>
           <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
             {theaterCopy.openAmbiance}
           </p>
@@ -161,7 +164,6 @@ function AmbianceReplay({ crashPointBps }: { crashPointBps: bigint }) {
       ambiance
       crashPointBps={crashPointBps}
       progress={clock.progress}
-      size="hero"
     />
   );
 }
@@ -221,7 +223,6 @@ function FinalizedStage({
       <ReplayCurve
         crashPointBps={stage.crashPointBps}
         progress={clock.progress}
-        size="hero"
       />
       <TierCloseBoard
         crashPointBps={stage.crashPointBps}

--- a/src/hooks/use-desk-dollars-balance.ts
+++ b/src/hooks/use-desk-dollars-balance.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Address } from "viem";
+import {
+  getDeskDollarsTokenAddress,
+  readDeskDollarsBalance,
+} from "@/lib/desk-dollars";
+import { subscribeToWalletBalanceChanges } from "@/lib/wallet-balance-sync";
+
+type BalanceState = {
+  wallet: Address;
+  balance: bigint;
+  decimals: number;
+};
+
+/**
+ * Display-only tUSD balance for always-mounted chrome (AppShell header).
+ * Unlike useDeskDollarsFaucet, it carries no claim plumbing and no cooldown
+ * ticker, so consumers never re-render on the faucet's one-second interval.
+ */
+export function useDeskDollarsBalance(walletAddress: Address | null) {
+  const tokenAddress = useMemo(() => getDeskDollarsTokenAddress(), []);
+  const [state, setState] = useState<BalanceState | null>(null);
+
+  useEffect(() => {
+    if (!tokenAddress || !walletAddress) return;
+    let cancelled = false;
+    const read = () => {
+      readDeskDollarsBalance(tokenAddress, walletAddress)
+        .then(({ balance, decimals }) => {
+          if (!cancelled)
+            setState({ wallet: walletAddress, balance, decimals });
+        })
+        // Display-only: the label just stays hidden until a read lands.
+        .catch(() => undefined);
+    };
+    read();
+    const unsubscribe = subscribeToWalletBalanceChanges(read);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [tokenAddress, walletAddress]);
+
+  // Keying the result by wallet (instead of resetting state in the effect)
+  // also keeps a previous wallet's balance from flashing after a switch.
+  return state && state.wallet === walletAddress
+    ? { balance: state.balance, decimals: state.decimals }
+    : { balance: null, decimals: null };
+}

--- a/src/lib/desk-dollars.ts
+++ b/src/lib/desk-dollars.ts
@@ -74,6 +74,28 @@ export async function readDeskDollarsState(
   return { balance, decimals, nextClaimAt };
 }
 
+/** Balance-only read for display surfaces that don't need faucet state. */
+export async function readDeskDollarsBalance(
+  tokenAddress: Address,
+  walletAddress: Address
+) {
+  const [balance, decimals] = await Promise.all([
+    baseSepoliaPublicClient.readContract({
+      address: tokenAddress,
+      abi: deskDollarsAbi,
+      functionName: "balanceOf",
+      args: [walletAddress],
+    }),
+    baseSepoliaPublicClient.readContract({
+      address: tokenAddress,
+      abi: deskDollarsAbi,
+      functionName: "decimals",
+    }),
+  ]);
+
+  return { balance, decimals };
+}
+
 export function formatDeskDollars(value: bigint, decimals: number) {
   const scale = 10n ** BigInt(decimals);
   const whole = value / scale;
@@ -82,6 +104,16 @@ export function formatDeskDollars(value: bigint, decimals: number) {
     .padStart(decimals, "0")
     .replace(/0+$/, "");
   return fraction ? `${whole}.${fraction}` : whole.toString();
+}
+
+/** "100 tUSD" once both reads have landed, null while either is pending. */
+export function formatDeskDollarsBalanceLabel(
+  balance: bigint | null,
+  decimals: number | null
+): string | null {
+  return balance !== null && decimals !== null
+    ? `${formatDeskDollars(balance, decimals)} tUSD`
+    : null;
 }
 
 const TUSD_SCALE = 10n ** BigInt(TUSD_DECIMALS);


### PR DESCRIPTION
## Summary
- Rebuild `/` as a chart-first play floor: hero replay curve, entry/ticket rail beside it, faucet and settlement next to the ticket
- Move LP Desk to `/lp` with shared AppShell nav (Floor / LP Desk), compact auth, and no-real-value disclosure
- Enlarge the replay chart, stop dimming Open-phase ambiance, keep empty chart frames for delayed/expired, and add static curve thumbs on finalized history rows

## Test plan
- [ ] Open `/` — chart is the first viewport; no LP Desk on the Floor
- [ ] Enter an open round from the right rail; countdown lives under the chart
- [ ] After finalization, this round’s climb plays at hero size (no duplicate Crash Point in the rail)
- [ ] Navigate to `/lp` — vault deposit/withdraw still work when signed in
- [ ] Signed-out: shell shows Continue with phone; entry rail prompts sign-in
- [ ] Global history: finalized rows show curve thumbs; delayed/empty/expired do not invent multipliers
- [ ] `pnpm test` and `pnpm typecheck` pass


Made with [Cursor](https://cursor.com)