### PR TITLE
Freeze theater chart on Won / Margin called

### DIFF
--- a/src/components/round-theater/landing-frame.test.ts
+++ b/src/components/round-theater/landing-frame.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  presentLanding,
+  ticketLanding,
+  type TicketLanding,
+} from "./landing-frame";
+import { theaterCopy } from "./theater-copy";
+
+const CRASH = "2.50x";
+
+describe("ticketLanding", () => {
+  it("returns spectator when there is no ticket", () => {
+    expect(ticketLanding(null, 25_000n)).toEqual({ kind: "spectator" });
+  });
+
+  it("returns won when Arcade Leverage is at or below the Crash Point", () => {
+    expect(
+      ticketLanding(
+        {
+          id: 1n,
+          player: "0x00000000000000000000000000000000000000aa",
+          roundId: 12n,
+          margin: 5_000_000n,
+          leverageBps: 20_000n,
+          reservedPayout: 10_000_000n,
+          settled: false,
+          claimed: false,
+        },
+        25_000n
+      )
+    ).toEqual({ kind: "won" });
+  });
+
+  it("returns margin-called when Arcade Leverage is above the Crash Point", () => {
+    expect(
+      ticketLanding(
+        {
+          id: 1n,
+          player: "0x00000000000000000000000000000000000000aa",
+          roundId: 12n,
+          margin: 5_000_000n,
+          leverageBps: 50_000n,
+          reservedPayout: 25_000_000n,
+          settled: false,
+          claimed: false,
+        },
+        25_000n
+      )
+    ).toEqual({ kind: "margin-called" });
+  });
+});
+
+describe("presentLanding", () => {
+  it("freezes won without a margin-call stamp", () => {
+    const frame = presentLanding({ kind: "won" }, CRASH);
+    expect(frame.heroValue).toBe(theaterCopy.playerWon);
+    expect(frame.supportingCrashPoint).toBe(`Crash Point ${CRASH}`);
+    expect(frame.outcomeDetail).toBe(theaterCopy.playerWonDetail);
+    expect(frame.showMarginCallStamp).toBe(false);
+    expect(frame.stampDetail).toBeNull();
+    expect(frame.heroColorClass).toContain("green");
+  });
+
+  it("freezes margin-called with personal detail once and market stamp copy", () => {
+    const frame = presentLanding({ kind: "margin-called" }, CRASH);
+    expect(frame.heroValue).toBe(theaterCopy.playerMarginCalled);
+    expect(frame.outcomeDetail).toBe(theaterCopy.playerMarginCalledDetail);
+    expect(frame.showMarginCallStamp).toBe(true);
+    // Stamp must not re-print the personal detail.
+    expect(frame.stampDetail).toBe(theaterCopy.marginCallDetail);
+    expect(frame.stampDetail).not.toBe(frame.outcomeDetail);
+  });
+
+  it("freezes spectator on Crash Point in red with the market stamp", () => {
+    const frame = presentLanding({ kind: "spectator" }, CRASH);
+    expect(frame.heroLabel).toBe(theaterCopy.verifiedCrashPoint);
+    expect(frame.heroValue).toBe(CRASH);
+    expect(frame.heroIsMultiplier).toBe(true);
+    expect(frame.heroColorClass).toContain("red");
+    expect(frame.supportingCrashPoint).toBeNull();
+    expect(frame.showMarginCallStamp).toBe(true);
+    expect(frame.stampDetail).toBe(theaterCopy.marginCallDetail);
+  });
+
+  it("covers every TicketLanding kind", () => {
+    const kinds: TicketLanding["kind"][] = [
+      "spectator",
+      "won",
+      "margin-called",
+    ];
+    for (const kind of kinds) {
+      expect(presentLanding({ kind }, CRASH).heroValue.length).toBeGreaterThan(
+        0
+      );
+    }
+  });
+});

--- a/src/components/round-theater/landing-frame.ts
+++ b/src/components/round-theater/landing-frame.ts
@@ -1,0 +1,94 @@
+/**
+ * Shared post-climb landing frame for the round theater.
+ *
+ * Climb surfaces decide *when* the freeze applies; this module decides *what*
+ * Won / Margin called / spectator Crash Point looks like so ReplayCurve and
+ * RoundResultCard cannot drift.
+ */
+
+import { isWinningTicket, type CrashTicket } from "@/lib/margin-call-crash";
+import { theaterCopy } from "./theater-copy";
+
+export type TicketLanding =
+  { kind: "spectator" } | { kind: "won" } | { kind: "margin-called" };
+
+export type LandingPresentation = {
+  heroLabel: string;
+  heroValue: string;
+  /** Tailwind text color class for the hero value. */
+  heroColorClass: string;
+  /** True when heroValue is a multiplier (tabular nums). */
+  heroIsMultiplier: boolean;
+  supportingCrashPoint: string | null;
+  outcomeDetail: string | null;
+  showMarginCallStamp: boolean;
+  /** Body under the Margin call stamp; never duplicates outcomeDetail. */
+  stampDetail: string | null;
+  /** Crash-moment edge flash color (curve juice only). */
+  momentColor: string;
+};
+
+/** Domain boundary: ticket + Crash Point → personal or spectator landing. */
+export function ticketLanding(
+  ticket: CrashTicket | null,
+  crashPointBps: bigint
+): TicketLanding {
+  if (ticket === null) return { kind: "spectator" };
+  return isWinningTicket(ticket.leverageBps, crashPointBps)
+    ? { kind: "won" }
+    : { kind: "margin-called" };
+}
+
+/**
+ * Pure presentation of a finalized freeze. Both animated and reduced-motion
+ * surfaces render these fields; they do not re-derive policy.
+ */
+export function presentLanding(
+  landing: TicketLanding,
+  crashPointLabel: string
+): LandingPresentation {
+  switch (landing.kind) {
+    case "won":
+      return {
+        heroLabel: theaterCopy.yourTicket,
+        heroValue: theaterCopy.playerWon,
+        heroColorClass: "text-[var(--t-green-hot)]",
+        heroIsMultiplier: false,
+        supportingCrashPoint: theaterCopy.crashPointSupporting(crashPointLabel),
+        outcomeDetail: theaterCopy.playerWonDetail,
+        showMarginCallStamp: false,
+        stampDetail: null,
+        momentColor: "var(--t-safe)",
+      };
+    case "margin-called":
+      return {
+        heroLabel: theaterCopy.yourTicket,
+        heroValue: theaterCopy.playerMarginCalled,
+        heroColorClass: "text-[var(--t-red-hot)]",
+        heroIsMultiplier: false,
+        supportingCrashPoint: theaterCopy.crashPointSupporting(crashPointLabel),
+        // Personal why sits under the hero; stamp keeps the market-die copy.
+        outcomeDetail: theaterCopy.playerMarginCalledDetail,
+        showMarginCallStamp: true,
+        stampDetail: theaterCopy.marginCallDetail,
+        momentColor: "var(--t-threat)",
+      };
+    case "spectator":
+      return {
+        heroLabel: theaterCopy.verifiedCrashPoint,
+        heroValue: crashPointLabel,
+        // Match the climb freeze: Crash Point lands red with the margin call.
+        heroColorClass: "text-[var(--t-red-hot)]",
+        heroIsMultiplier: true,
+        supportingCrashPoint: null,
+        outcomeDetail: null,
+        showMarginCallStamp: true,
+        stampDetail: theaterCopy.marginCallDetail,
+        momentColor: "var(--t-amber-hot)",
+      };
+    default: {
+      const _exhaustive: never = landing;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -15,6 +15,7 @@ import {
   replayPathD,
 } from "@/lib/round-replay";
 import { MarginCallPhone } from "./margin-call-phone";
+import { presentLanding, type TicketLanding } from "./landing-frame";
 import { theaterCopy } from "./theater-copy";
 
 const VIEW_W = 100;
@@ -27,11 +28,8 @@ export type ReplayCurveProps = {
   ambiance?: { roundId: bigint } | null;
   /** Signed-in player's Arcade Leverage tier, highlighted on the chart. */
   playerTierBps?: bigint | null;
-  /**
-   * Personal landing frame after the climb finishes.
-   * `true` → Won, `false` → Margin called, `null` → spectator (Crash Point).
-   */
-  playerWon?: boolean | null;
+  /** Personal vs spectator freeze once the climb completes. */
+  landing?: TicketLanding;
 };
 
 /**
@@ -50,7 +48,7 @@ export function ReplayCurve({
   progress,
   ambiance = null,
   playerTierBps = null,
-  playerWon = null,
+  landing = { kind: "spectator" },
 }: ReplayCurveProps) {
   // `progress` moves every animation frame, so memoizing on it buys nothing.
   const points = getReplayPathPoints(crashPointBps, progress, {
@@ -76,42 +74,17 @@ export function ReplayCurve({
     [crashPointBps]
   );
 
-  // Crash-moment juice: shake the panel and flash its edge once, colored by
-  // the player's outcome (green closed-in-time, red margin-called, amber none).
+  // Crash-moment: climb finished and this is the result hero (not ambiance).
+  // *When* freeze applies lives here; *what* it shows comes from presentLanding.
   const crashMoment = isComplete && !ambiance;
-  const momentColor =
-    playerWon === null
-      ? "var(--t-amber-hot)"
-      : playerWon
-        ? "var(--t-safe)"
-        : "var(--t-threat)";
+  const freeze = crashMoment ? presentLanding(landing, crashLabel) : null;
 
-  // Landing frame: personal outcome for ticket holders, Crash Point for everyone else.
-  const showPlayerOutcome = crashMoment && playerWon !== null;
-  const showPhoneStamp = crashMoment && playerWon !== true;
   const heroLabel = ambiance
     ? theaterCopy.openAmbiance(ambiance.roundId.toString())
-    : showPlayerOutcome
-      ? theaterCopy.yourTicket
-      : theaterCopy.verifiedCrashPoint;
-  const heroValue = showPlayerOutcome
-    ? playerWon
-      ? theaterCopy.playerWon
-      : theaterCopy.playerMarginCalled
-    : isComplete
-      ? crashLabel
-      : displayMultiplier;
-  const heroColor = !isComplete
-    ? "text-[var(--t-green-hot)]"
-    : showPlayerOutcome && playerWon
-      ? "text-[var(--t-green-hot)]"
-      : "text-[var(--t-red-hot)]";
-  const outcomeDetail =
-    showPlayerOutcome && playerWon
-      ? theaterCopy.playerWonDetail
-      : showPlayerOutcome
-        ? theaterCopy.playerMarginCalledDetail
-        : null;
+    : (freeze?.heroLabel ?? theaterCopy.verifiedCrashPoint);
+  const heroValue = freeze?.heroValue ?? displayMultiplier;
+  const heroColor = freeze?.heroColorClass ?? "text-[var(--t-green-hot)]";
+  const heroIsMultiplier = freeze?.heroIsMultiplier ?? true;
 
   return (
     <div
@@ -120,11 +93,13 @@ export function ReplayCurve({
       }`}
       data-testid={ambiance ? "replay-curve-ambiance" : "replay-curve"}
     >
-      {crashMoment ? (
+      {freeze ? (
         <div
           aria-hidden="true"
           className="mc-moment-edge pointer-events-none absolute inset-0"
-          style={{ "--mc-moment-color": momentColor } as React.CSSProperties}
+          style={
+            { "--mc-moment-color": freeze.momentColor } as React.CSSProperties
+          }
         />
       ) : null}
       <div className="flex flex-wrap items-end justify-between gap-3">
@@ -135,44 +110,44 @@ export function ReplayCurve({
           <p
             aria-live="polite"
             className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-5xl font-bold sm:text-6xl lg:text-7xl ${
-              showPlayerOutcome ? "" : "tabular-nums"
+              heroIsMultiplier ? "tabular-nums" : ""
             } ${heroColor}`}
             data-testid={
-              showPlayerOutcome
-                ? "replay-curve-outcome"
-                : isComplete && !ambiance
+              freeze
+                ? landing.kind === "spectator"
                   ? "replay-curve-crash-point"
-                  : undefined
+                  : "replay-curve-outcome"
+                : undefined
             }
           >
             {heroValue}
           </p>
-          {showPlayerOutcome ? (
+          {freeze?.supportingCrashPoint ? (
             <p
               className="mt-1 text-sm font-bold tabular-nums text-[var(--t-muted)]"
               data-testid="replay-curve-crash-point-supporting"
             >
-              {theaterCopy.crashPointSupporting(crashLabel)}
+              {freeze.supportingCrashPoint}
             </p>
           ) : null}
-          {outcomeDetail ? (
+          {freeze?.outcomeDetail ? (
             <p className="mt-1 max-w-[20rem] text-[10px] leading-4 text-[var(--t-muted)]">
-              {outcomeDetail}
+              {freeze.outcomeDetail}
             </p>
           ) : null}
         </div>
-        {showPhoneStamp ? (
+        {freeze?.showMarginCallStamp ? (
           <div className="flex items-center gap-3">
             <MarginCallPhone ringing />
             <div>
               <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-red-hot)]">
                 {theaterCopy.marginCall}
               </p>
-              <p className="mt-1 max-w-[14rem] text-[10px] leading-4 text-[var(--t-muted)]">
-                {playerWon === false
-                  ? theaterCopy.playerMarginCalledDetail
-                  : theaterCopy.marginCallDetail}
-              </p>
+              {freeze.stampDetail ? (
+                <p className="mt-1 max-w-[14rem] text-[10px] leading-4 text-[var(--t-muted)]">
+                  {freeze.stampDetail}
+                </p>
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -27,6 +27,11 @@ export type ReplayCurveProps = {
   ambiance?: { roundId: bigint } | null;
   /** Signed-in player's Arcade Leverage tier, highlighted on the chart. */
   playerTierBps?: bigint | null;
+  /**
+   * Personal landing frame after the climb finishes.
+   * `true` → Won, `false` → Margin called, `null` → spectator (Crash Point).
+   */
+  playerWon?: boolean | null;
 };
 
 /**
@@ -37,13 +42,15 @@ export const REPLAY_HERO_MIN_H = "min-h-[22rem] lg:min-h-[28rem]";
 
 /**
  * SVG multiplier climb. Axes rescale with the live multiplier; hard stop at
- * the Crash Point with a margin-call phone stamp.
+ * the Crash Point. Signed-in players freeze on Won / Margin called; spectators
+ * keep the Crash Point number and margin-call phone.
  */
 export function ReplayCurve({
   crashPointBps,
   progress,
   ambiance = null,
   playerTierBps = null,
+  playerWon = null,
 }: ReplayCurveProps) {
   // `progress` moves every animation frame, so memoizing on it buys nothing.
   const points = getReplayPathPoints(crashPointBps, progress, {
@@ -73,11 +80,38 @@ export function ReplayCurve({
   // the player's outcome (green closed-in-time, red margin-called, amber none).
   const crashMoment = isComplete && !ambiance;
   const momentColor =
-    playerTierBps === null
+    playerWon === null
       ? "var(--t-amber-hot)"
-      : playerTierBps <= crashPointBps
+      : playerWon
         ? "var(--t-safe)"
         : "var(--t-threat)";
+
+  // Landing frame: personal outcome for ticket holders, Crash Point for everyone else.
+  const showPlayerOutcome = crashMoment && playerWon !== null;
+  const showPhoneStamp = crashMoment && playerWon !== true;
+  const heroLabel = ambiance
+    ? theaterCopy.openAmbiance(ambiance.roundId.toString())
+    : showPlayerOutcome
+      ? theaterCopy.yourTicket
+      : theaterCopy.verifiedCrashPoint;
+  const heroValue = showPlayerOutcome
+    ? playerWon
+      ? theaterCopy.playerWon
+      : theaterCopy.playerMarginCalled
+    : isComplete
+      ? crashLabel
+      : displayMultiplier;
+  const heroColor = !isComplete
+    ? "text-[var(--t-green-hot)]"
+    : showPlayerOutcome && playerWon
+      ? "text-[var(--t-green-hot)]"
+      : "text-[var(--t-red-hot)]";
+  const outcomeDetail =
+    showPlayerOutcome && playerWon
+      ? theaterCopy.playerWonDetail
+      : showPlayerOutcome
+        ? theaterCopy.playerMarginCalledDetail
+        : null;
 
   return (
     <div
@@ -96,22 +130,38 @@ export function ReplayCurve({
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-            {ambiance
-              ? theaterCopy.openAmbiance(ambiance.roundId.toString())
-              : theaterCopy.verifiedCrashPoint}
+            {heroLabel}
           </p>
           <p
             aria-live="polite"
-            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-5xl font-bold tabular-nums sm:text-6xl lg:text-7xl ${
-              isComplete
-                ? "text-[var(--t-red-hot)]"
-                : "text-[var(--t-green-hot)]"
-            }`}
+            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-5xl font-bold sm:text-6xl lg:text-7xl ${
+              showPlayerOutcome ? "" : "tabular-nums"
+            } ${heroColor}`}
+            data-testid={
+              showPlayerOutcome
+                ? "replay-curve-outcome"
+                : isComplete && !ambiance
+                  ? "replay-curve-crash-point"
+                  : undefined
+            }
           >
-            {isComplete ? crashLabel : displayMultiplier}
+            {heroValue}
           </p>
+          {showPlayerOutcome ? (
+            <p
+              className="mt-1 text-sm font-bold tabular-nums text-[var(--t-muted)]"
+              data-testid="replay-curve-crash-point-supporting"
+            >
+              {theaterCopy.crashPointSupporting(crashLabel)}
+            </p>
+          ) : null}
+          {outcomeDetail ? (
+            <p className="mt-1 max-w-[20rem] text-[10px] leading-4 text-[var(--t-muted)]">
+              {outcomeDetail}
+            </p>
+          ) : null}
         </div>
-        {isComplete && !ambiance ? (
+        {showPhoneStamp ? (
           <div className="flex items-center gap-3">
             <MarginCallPhone ringing />
             <div>
@@ -119,7 +169,9 @@ export function ReplayCurve({
                 {theaterCopy.marginCall}
               </p>
               <p className="mt-1 max-w-[14rem] text-[10px] leading-4 text-[var(--t-muted)]">
-                {theaterCopy.marginCallDetail}
+                {playerWon === false
+                  ? theaterCopy.playerMarginCalledDetail
+                  : theaterCopy.marginCallDetail}
               </p>
             </div>
           </div>

--- a/src/components/round-theater/round-result-card.tsx
+++ b/src/components/round-theater/round-result-card.tsx
@@ -10,49 +10,106 @@ export type RoundResultCardProps = {
   crashPointBps: bigint;
   tiers: readonly TierExposure[];
   finalizeTransactionUrl: string | null;
+  /**
+   * Personal landing frame matching the animated climb's freeze.
+   * `true` → Won, `false` → Margin called, `null` → spectator (Crash Point).
+   */
+  playerWon?: boolean | null;
+  /** Signed-in player's Arcade Leverage — marks their row on the tier board. */
+  playerTierBps?: bigint | null;
 };
 
 /**
  * Reduced-motion equivalent of the climb. Carries identical facts: verified
- * Crash Point, each tier's close-or-margin-call state and payout, and the
- * verification link. Colour- and sound-independent.
+ * Crash Point (or personal Won / Margin called freeze), each tier's
+ * close-or-margin-call state and payout, and the verification link.
+ * Colour- and sound-independent.
  */
 export function RoundResultCard({
   displayCrashPoint,
   crashPointBps,
   tiers,
   finalizeTransactionUrl,
+  playerWon = null,
+  playerTierBps = null,
 }: RoundResultCardProps) {
+  const showPlayerOutcome = playerWon !== null;
+  const heroValue = showPlayerOutcome
+    ? playerWon
+      ? theaterCopy.playerWon
+      : theaterCopy.playerMarginCalled
+    : displayCrashPoint;
+  const heroColor =
+    showPlayerOutcome && playerWon
+      ? "text-[var(--t-green-hot)]"
+      : showPlayerOutcome
+        ? "text-[var(--t-red-hot)]"
+        : "text-[var(--t-green-hot)]";
+  const outcomeDetail =
+    playerWon === true
+      ? theaterCopy.playerWonDetail
+      : playerWon === false
+        ? theaterCopy.playerMarginCalledDetail
+        : null;
+  // Phone / market-die stamp: spectators and losers only — not winners.
+  const showMarginCallStamp = playerWon !== true;
+
   return (
     <div
       aria-label={theaterCopy.staticResult}
       className="terminal-panel p-4 sm:p-5"
     >
       <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        {theaterCopy.verifiedCrashPoint}
+        {showPlayerOutcome
+          ? theaterCopy.yourTicket
+          : theaterCopy.verifiedCrashPoint}
       </p>
       <p
-        className="mc-live-value mt-2 font-[family-name:var(--font-plex-sans)] text-5xl font-bold tabular-nums text-[var(--t-green-hot)] sm:text-6xl"
-        data-testid="static-crash-point"
+        className={`mc-live-value mt-2 font-[family-name:var(--font-plex-sans)] text-5xl font-bold sm:text-6xl ${
+          showPlayerOutcome ? "" : "tabular-nums"
+        } ${heroColor}`}
+        data-testid={
+          showPlayerOutcome ? "static-outcome" : "static-crash-point"
+        }
       >
-        {displayCrashPoint}
+        {heroValue}
       </p>
+      {showPlayerOutcome ? (
+        <p
+          className="mt-1 text-sm font-bold tabular-nums text-[var(--t-muted)]"
+          data-testid="static-crash-point-supporting"
+        >
+          {theaterCopy.crashPointSupporting(displayCrashPoint)}
+        </p>
+      ) : null}
+      {outcomeDetail ? (
+        <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">
+          {outcomeDetail}
+        </p>
+      ) : null}
       <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">
         {theaterCopy.replayLabel}. {theaterCopy.replayDetail}
       </p>
 
       <TierCloseBoard
         crashPointBps={crashPointBps}
+        playerTierBps={playerTierBps}
         progress={1}
         tiers={tiers}
       />
 
-      <p className="mt-4 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-red-hot)]">
-        {theaterCopy.marginCall}
-      </p>
-      <p className="mt-1 text-xs text-[var(--t-muted)]">
-        {theaterCopy.marginCallDetail}
-      </p>
+      {showMarginCallStamp ? (
+        <>
+          <p className="mt-4 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-red-hot)]">
+            {theaterCopy.marginCall}
+          </p>
+          <p className="mt-1 text-xs text-[var(--t-muted)]">
+            {playerWon === false
+              ? theaterCopy.playerMarginCalledDetail
+              : theaterCopy.marginCallDetail}
+          </p>
+        </>
+      ) : null}
 
       <FinalizeLink className="mt-4 inline-flex" url={finalizeTransactionUrl} />
     </div>

--- a/src/components/round-theater/round-result-card.tsx
+++ b/src/components/round-theater/round-result-card.tsx
@@ -2,6 +2,7 @@
 
 import type { TierExposure } from "@/lib/margin-call-crash";
 import { FinalizeLink } from "./finalize-link";
+import { presentLanding, type TicketLanding } from "./landing-frame";
 import { TierCloseBoard } from "./tier-close-board";
 import { theaterCopy } from "./theater-copy";
 
@@ -10,49 +11,25 @@ export type RoundResultCardProps = {
   crashPointBps: bigint;
   tiers: readonly TierExposure[];
   finalizeTransactionUrl: string | null;
-  /**
-   * Personal landing frame matching the animated climb's freeze.
-   * `true` → Won, `false` → Margin called, `null` → spectator (Crash Point).
-   */
-  playerWon?: boolean | null;
+  /** Personal vs spectator freeze — same model as the animated climb. */
+  landing?: TicketLanding;
   /** Signed-in player's Arcade Leverage — marks their row on the tier board. */
   playerTierBps?: bigint | null;
 };
 
 /**
- * Reduced-motion equivalent of the climb. Carries identical facts: verified
- * Crash Point (or personal Won / Margin called freeze), each tier's
- * close-or-margin-call state and payout, and the verification link.
- * Colour- and sound-independent.
+ * Reduced-motion equivalent of the climb. Renders the shared landing frame
+ * plus tier closes and the verification link. Colour- and sound-independent.
  */
 export function RoundResultCard({
   displayCrashPoint,
   crashPointBps,
   tiers,
   finalizeTransactionUrl,
-  playerWon = null,
+  landing = { kind: "spectator" },
   playerTierBps = null,
 }: RoundResultCardProps) {
-  const showPlayerOutcome = playerWon !== null;
-  const heroValue = showPlayerOutcome
-    ? playerWon
-      ? theaterCopy.playerWon
-      : theaterCopy.playerMarginCalled
-    : displayCrashPoint;
-  const heroColor =
-    showPlayerOutcome && playerWon
-      ? "text-[var(--t-green-hot)]"
-      : showPlayerOutcome
-        ? "text-[var(--t-red-hot)]"
-        : "text-[var(--t-green-hot)]";
-  const outcomeDetail =
-    playerWon === true
-      ? theaterCopy.playerWonDetail
-      : playerWon === false
-        ? theaterCopy.playerMarginCalledDetail
-        : null;
-  // Phone / market-die stamp: spectators and losers only — not winners.
-  const showMarginCallStamp = playerWon !== true;
+  const freeze = presentLanding(landing, displayCrashPoint);
 
   return (
     <div
@@ -60,31 +37,29 @@ export function RoundResultCard({
       className="terminal-panel p-4 sm:p-5"
     >
       <p className="text-[var(--t-type-label)] uppercase tracking-[0.18em] text-[var(--t-muted)]">
-        {showPlayerOutcome
-          ? theaterCopy.yourTicket
-          : theaterCopy.verifiedCrashPoint}
+        {freeze.heroLabel}
       </p>
       <p
         className={`mc-live-value mt-2 font-[family-name:var(--font-plex-sans)] text-5xl font-bold sm:text-6xl ${
-          showPlayerOutcome ? "" : "tabular-nums"
-        } ${heroColor}`}
+          freeze.heroIsMultiplier ? "tabular-nums" : ""
+        } ${freeze.heroColorClass}`}
         data-testid={
-          showPlayerOutcome ? "static-outcome" : "static-crash-point"
+          landing.kind === "spectator" ? "static-crash-point" : "static-outcome"
         }
       >
-        {heroValue}
+        {freeze.heroValue}
       </p>
-      {showPlayerOutcome ? (
+      {freeze.supportingCrashPoint ? (
         <p
           className="mt-1 text-sm font-bold tabular-nums text-[var(--t-muted)]"
           data-testid="static-crash-point-supporting"
         >
-          {theaterCopy.crashPointSupporting(displayCrashPoint)}
+          {freeze.supportingCrashPoint}
         </p>
       ) : null}
-      {outcomeDetail ? (
+      {freeze.outcomeDetail ? (
         <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">
-          {outcomeDetail}
+          {freeze.outcomeDetail}
         </p>
       ) : null}
       <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">
@@ -98,16 +73,16 @@ export function RoundResultCard({
         tiers={tiers}
       />
 
-      {showMarginCallStamp ? (
+      {freeze.showMarginCallStamp ? (
         <>
           <p className="mt-4 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-red-hot)]">
             {theaterCopy.marginCall}
           </p>
-          <p className="mt-1 text-xs text-[var(--t-muted)]">
-            {playerWon === false
-              ? theaterCopy.playerMarginCalledDetail
-              : theaterCopy.marginCallDetail}
-          </p>
+          {freeze.stampDetail ? (
+            <p className="mt-1 text-xs text-[var(--t-muted)]">
+              {freeze.stampDetail}
+            </p>
+          ) : null}
         </>
       ) : null}
 

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -67,22 +67,67 @@ const sdk = vi.hoisted(() => {
     retry: vi.fn(),
   });
 
+  const FINALIZE_URL =
+    "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+  const makeFinalized = ({
+    reducedMotion = false,
+    finalizeUrl = FINALIZE_URL as string | null,
+  }: {
+    reducedMotion?: boolean;
+    finalizeUrl?: string | null;
+  } = {}): TheaterView => ({
+    live: {
+      kind: "finalized",
+      roundId: 12n,
+      crashPointBps: 25_000n,
+      displayCrashPoint: "2.50x",
+      finalizedAtSeconds: 900n,
+      chainTimestamp: 910n,
+      finalizeTransactionUrl: finalizeUrl,
+      tape: null,
+      tiers: emptyTiers(),
+      timeline: makeTimeline("finalized", {
+        kind: "next-opens",
+        seconds: 5,
+      }),
+    },
+    hero: {
+      type: "replay",
+      roundId: 12n,
+      crashPointBps: 25_000n,
+      displayCrashPoint: "2.50x",
+      finalizedAtSeconds: 900n,
+      chainTimestamp: 910n,
+      finalizeTransactionUrl: finalizeUrl,
+      tape: null,
+      tiers: emptyTiers(),
+    },
+    reducedMotion,
+    retry: vi.fn(),
+  });
+
+  const makeTicket = (leverageBps: bigint) => ({
+    id: 7n,
+    player: "0x00000000000000000000000000000000000000aa",
+    roundId: 12n,
+    margin: 5_000_000n,
+    leverageBps,
+    reservedPayout: (5_000_000n * leverageBps) / 10_000n,
+    settled: false,
+    claimed: false,
+  });
+
   return {
     emptyTiers,
     makeTimeline,
     makeOpen,
+    makeFinalized,
+    makeTicket,
+    FINALIZE_URL,
     view: makeOpen() as TheaterView,
     ticketRoundId: null as bigint | null,
-    playerTicket: null as {
-      id: bigint;
-      player: string;
-      roundId: bigint;
-      margin: bigint;
-      leverageBps: bigint;
-      reservedPayout: bigint;
-      settled: boolean;
-      claimed: boolean;
-    } | null,
+    playerTicket: null as ReturnType<typeof makeTicket> | null,
   };
 });
 
@@ -248,38 +293,7 @@ describe("RoundTheater", () => {
   });
 
   it("renders the animated replay for finalized rounds with tier closes", () => {
-    sdk.view = {
-      live: {
-        kind: "finalized",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl:
-          "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        tape: null,
-        tiers: sdk.emptyTiers(),
-        timeline: sdk.makeTimeline("finalized", {
-          kind: "next-opens",
-          seconds: 5,
-        }),
-      },
-      hero: {
-        type: "replay",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl:
-          "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        tape: null,
-        tiers: sdk.emptyTiers(),
-      },
-      reducedMotion: false,
-      retry: vi.fn(),
-    };
+    sdk.view = sdk.makeFinalized();
     render(<RoundTheater />);
 
     expect(screen.getByTestId("theater-finalized-replay")).toBeTruthy();
@@ -305,46 +319,8 @@ describe("RoundTheater", () => {
   });
 
   it("freezes the climb on Won when the signed-in player's tier closed", () => {
-    sdk.view = {
-      live: {
-        kind: "finalized",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl: null,
-        tape: null,
-        tiers: sdk.emptyTiers(),
-        timeline: sdk.makeTimeline("finalized", {
-          kind: "next-opens",
-          seconds: 5,
-        }),
-      },
-      hero: {
-        type: "replay",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl: null,
-        tape: null,
-        tiers: sdk.emptyTiers(),
-      },
-      reducedMotion: false,
-      retry: vi.fn(),
-    };
-    sdk.playerTicket = {
-      id: 7n,
-      player: "0x00000000000000000000000000000000000000aa",
-      roundId: 12n,
-      margin: 5_000_000n,
-      leverageBps: 20_000n, // 2.00x ≤ 2.50x → won
-      reservedPayout: 10_000_000n,
-      settled: false,
-      claimed: false,
-    };
+    sdk.view = sdk.makeFinalized({ finalizeUrl: null });
+    sdk.playerTicket = sdk.makeTicket(20_000n); // 2.00x ≤ 2.50x → won
     render(<RoundTheater />);
 
     expect(screen.getByTestId("replay-curve-outcome").textContent).toBe("Won");
@@ -358,46 +334,8 @@ describe("RoundTheater", () => {
   });
 
   it("freezes the climb on Margin called when the signed-in player's tier stayed open", () => {
-    sdk.view = {
-      live: {
-        kind: "finalized",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl: null,
-        tape: null,
-        tiers: sdk.emptyTiers(),
-        timeline: sdk.makeTimeline("finalized", {
-          kind: "next-opens",
-          seconds: 5,
-        }),
-      },
-      hero: {
-        type: "replay",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl: null,
-        tape: null,
-        tiers: sdk.emptyTiers(),
-      },
-      reducedMotion: false,
-      retry: vi.fn(),
-    };
-    sdk.playerTicket = {
-      id: 8n,
-      player: "0x00000000000000000000000000000000000000aa",
-      roundId: 12n,
-      margin: 5_000_000n,
-      leverageBps: 50_000n, // 5.00x > 2.50x → margin called
-      reservedPayout: 25_000_000n,
-      settled: false,
-      claimed: false,
-    };
+    sdk.view = sdk.makeFinalized({ finalizeUrl: null });
+    sdk.playerTicket = sdk.makeTicket(50_000n); // 5.00x > 2.50x → margin called
     render(<RoundTheater />);
 
     expect(screen.getByTestId("replay-curve-outcome").textContent).toBe(
@@ -407,6 +345,16 @@ describe("RoundTheater", () => {
       screen.getByTestId("replay-curve-crash-point-supporting").textContent
     ).toBe("Crash Point 2.50x");
     expect(screen.getByText("Margin call")).toBeTruthy();
+    // Personal why once under the hero; stamp keeps market-die copy.
+    expect(
+      screen.getAllByText("The Crash Point died below your Arcade Leverage.")
+        .length
+    ).toBe(1);
+    expect(
+      screen.getByText(
+        "Hard stop — every Ticket still open takes the margin call."
+      )
+    ).toBeTruthy();
     expect(screen.queryByRole("button", { name: /settle/i })).toBeNull();
   });
 
@@ -451,38 +399,7 @@ describe("RoundTheater", () => {
   });
 
   it("renders the static result card under reduced motion with identical facts", () => {
-    sdk.view = {
-      live: {
-        kind: "finalized",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl:
-          "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        tape: null,
-        tiers: sdk.emptyTiers(),
-        timeline: sdk.makeTimeline("finalized", {
-          kind: "next-opens",
-          seconds: 5,
-        }),
-      },
-      hero: {
-        type: "replay",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl:
-          "https://sepolia.basescan.org/tx/0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        tape: null,
-        tiers: sdk.emptyTiers(),
-      },
-      reducedMotion: true,
-      retry: vi.fn(),
-    };
+    sdk.view = sdk.makeFinalized({ reducedMotion: true });
     render(<RoundTheater />);
 
     expect(screen.getByTestId("theater-finalized-static")).toBeTruthy();
@@ -495,46 +412,8 @@ describe("RoundTheater", () => {
   });
 
   it("shows Won on the reduced-motion card when the signed-in player won", () => {
-    sdk.view = {
-      live: {
-        kind: "finalized",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl: null,
-        tape: null,
-        tiers: sdk.emptyTiers(),
-        timeline: sdk.makeTimeline("finalized", {
-          kind: "next-opens",
-          seconds: 5,
-        }),
-      },
-      hero: {
-        type: "replay",
-        roundId: 12n,
-        crashPointBps: 25_000n,
-        displayCrashPoint: "2.50x",
-        finalizedAtSeconds: 900n,
-        chainTimestamp: 910n,
-        finalizeTransactionUrl: null,
-        tape: null,
-        tiers: sdk.emptyTiers(),
-      },
-      reducedMotion: true,
-      retry: vi.fn(),
-    };
-    sdk.playerTicket = {
-      id: 7n,
-      player: "0x00000000000000000000000000000000000000aa",
-      roundId: 12n,
-      margin: 5_000_000n,
-      leverageBps: 12_500n,
-      reservedPayout: 6_250_000n,
-      settled: false,
-      claimed: false,
-    };
+    sdk.view = sdk.makeFinalized({ reducedMotion: true, finalizeUrl: null });
+    sdk.playerTicket = sdk.makeTicket(12_500n);
     render(<RoundTheater />);
 
     expect(screen.getByTestId("static-outcome").textContent).toBe("Won");
@@ -543,6 +422,24 @@ describe("RoundTheater", () => {
     ).toBe("Crash Point 2.50x");
     expect(screen.queryByTestId("static-crash-point")).toBeNull();
     expect(screen.queryByText("Margin call")).toBeNull();
+  });
+
+  it("shows Margin called on the reduced-motion card when the signed-in player lost", () => {
+    sdk.view = sdk.makeFinalized({ reducedMotion: true, finalizeUrl: null });
+    sdk.playerTicket = sdk.makeTicket(50_000n);
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("static-outcome").textContent).toBe(
+      "Margin called"
+    );
+    expect(
+      screen.getByTestId("static-crash-point-supporting").textContent
+    ).toBe("Crash Point 2.50x");
+    expect(screen.getByText("Margin call")).toBeTruthy();
+    expect(
+      screen.getAllByText("The Crash Point died below your Arcade Leverage.")
+        .length
+    ).toBe(1);
   });
 
   it("defaults the sound toggle to off and can enable it", () => {

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -286,7 +286,12 @@ describe("RoundTheater", () => {
     expect(screen.getByTestId("theater-next-round").textContent).toBe(
       "Next round 13 opens in 00:05"
     );
-    expect(screen.getByText("2.50x")).toBeTruthy();
+    // Spectator freeze: Crash Point stays the hero; no personal outcome stamp.
+    expect(screen.getByTestId("replay-curve-crash-point").textContent).toBe(
+      "2.50x"
+    );
+    expect(screen.queryByTestId("replay-curve-outcome")).toBeNull();
+    expect(screen.getByText("Margin call")).toBeTruthy();
     expect(screen.getByText("Closed 2.00x — paid")).toBeTruthy();
     expect(screen.getByText("Closed 1.25x — paid")).toBeTruthy();
     expect(screen.getByText("3.00x — margin call")).toBeTruthy();
@@ -297,6 +302,112 @@ describe("RoundTheater", () => {
         .getAttribute("href")
     ).toContain("0xcccccccccccccccc");
     expect(screen.queryByRole("button", { name: /claim/i })).toBeNull();
+  });
+
+  it("freezes the climb on Won when the signed-in player's tier closed", () => {
+    sdk.view = {
+      live: {
+        kind: "finalized",
+        roundId: 12n,
+        crashPointBps: 25_000n,
+        displayCrashPoint: "2.50x",
+        finalizedAtSeconds: 900n,
+        chainTimestamp: 910n,
+        finalizeTransactionUrl: null,
+        tape: null,
+        tiers: sdk.emptyTiers(),
+        timeline: sdk.makeTimeline("finalized", {
+          kind: "next-opens",
+          seconds: 5,
+        }),
+      },
+      hero: {
+        type: "replay",
+        roundId: 12n,
+        crashPointBps: 25_000n,
+        displayCrashPoint: "2.50x",
+        finalizedAtSeconds: 900n,
+        chainTimestamp: 910n,
+        finalizeTransactionUrl: null,
+        tape: null,
+        tiers: sdk.emptyTiers(),
+      },
+      reducedMotion: false,
+      retry: vi.fn(),
+    };
+    sdk.playerTicket = {
+      id: 7n,
+      player: "0x00000000000000000000000000000000000000aa",
+      roundId: 12n,
+      margin: 5_000_000n,
+      leverageBps: 20_000n, // 2.00x ≤ 2.50x → won
+      reservedPayout: 10_000_000n,
+      settled: false,
+      claimed: false,
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("replay-curve-outcome").textContent).toBe("Won");
+    expect(
+      screen.getByTestId("replay-curve-crash-point-supporting").textContent
+    ).toBe("Crash Point 2.50x");
+    expect(screen.queryByTestId("replay-curve-crash-point")).toBeNull();
+    expect(screen.queryByText("Margin call")).toBeNull();
+    expect(screen.getByRole("button", { name: "Replay" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /claim/i })).toBeNull();
+  });
+
+  it("freezes the climb on Margin called when the signed-in player's tier stayed open", () => {
+    sdk.view = {
+      live: {
+        kind: "finalized",
+        roundId: 12n,
+        crashPointBps: 25_000n,
+        displayCrashPoint: "2.50x",
+        finalizedAtSeconds: 900n,
+        chainTimestamp: 910n,
+        finalizeTransactionUrl: null,
+        tape: null,
+        tiers: sdk.emptyTiers(),
+        timeline: sdk.makeTimeline("finalized", {
+          kind: "next-opens",
+          seconds: 5,
+        }),
+      },
+      hero: {
+        type: "replay",
+        roundId: 12n,
+        crashPointBps: 25_000n,
+        displayCrashPoint: "2.50x",
+        finalizedAtSeconds: 900n,
+        chainTimestamp: 910n,
+        finalizeTransactionUrl: null,
+        tape: null,
+        tiers: sdk.emptyTiers(),
+      },
+      reducedMotion: false,
+      retry: vi.fn(),
+    };
+    sdk.playerTicket = {
+      id: 8n,
+      player: "0x00000000000000000000000000000000000000aa",
+      roundId: 12n,
+      margin: 5_000_000n,
+      leverageBps: 50_000n, // 5.00x > 2.50x → margin called
+      reservedPayout: 25_000_000n,
+      settled: false,
+      claimed: false,
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("replay-curve-outcome").textContent).toBe(
+      "Margin called"
+    );
+    expect(
+      screen.getByTestId("replay-curve-crash-point-supporting").textContent
+    ).toBe("Crash Point 2.50x");
+    expect(screen.getByText("Margin call")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /settle/i })).toBeNull();
   });
 
   it("renders a held previous replay while live stays the open round", () => {
@@ -381,6 +492,57 @@ describe("RoundTheater", () => {
     expect(screen.getByText("3.00x — margin call")).toBeTruthy();
     expect(screen.getByText("Margin call")).toBeTruthy();
     expect(screen.queryByTestId("theater-finalized-replay")).toBeNull();
+  });
+
+  it("shows Won on the reduced-motion card when the signed-in player won", () => {
+    sdk.view = {
+      live: {
+        kind: "finalized",
+        roundId: 12n,
+        crashPointBps: 25_000n,
+        displayCrashPoint: "2.50x",
+        finalizedAtSeconds: 900n,
+        chainTimestamp: 910n,
+        finalizeTransactionUrl: null,
+        tape: null,
+        tiers: sdk.emptyTiers(),
+        timeline: sdk.makeTimeline("finalized", {
+          kind: "next-opens",
+          seconds: 5,
+        }),
+      },
+      hero: {
+        type: "replay",
+        roundId: 12n,
+        crashPointBps: 25_000n,
+        displayCrashPoint: "2.50x",
+        finalizedAtSeconds: 900n,
+        chainTimestamp: 910n,
+        finalizeTransactionUrl: null,
+        tape: null,
+        tiers: sdk.emptyTiers(),
+      },
+      reducedMotion: true,
+      retry: vi.fn(),
+    };
+    sdk.playerTicket = {
+      id: 7n,
+      player: "0x00000000000000000000000000000000000000aa",
+      roundId: 12n,
+      margin: 5_000_000n,
+      leverageBps: 12_500n,
+      reservedPayout: 6_250_000n,
+      settled: false,
+      claimed: false,
+    };
+    render(<RoundTheater />);
+
+    expect(screen.getByTestId("static-outcome").textContent).toBe("Won");
+    expect(
+      screen.getByTestId("static-crash-point-supporting").textContent
+    ).toBe("Crash Point 2.50x");
+    expect(screen.queryByTestId("static-crash-point")).toBeNull();
+    expect(screen.queryByText("Margin call")).toBeNull();
   });
 
   it("defaults the sound toggle to off and can enable it", () => {

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -15,6 +15,7 @@ import { getTierCloseProgress } from "@/lib/round-replay";
 import {
   ENTRY_LEVERAGE_TIERS_BPS,
   formatLeverageBps,
+  isWinningTicket,
   type CrashTicket,
 } from "@/lib/margin-call-crash";
 import {
@@ -408,6 +409,10 @@ function ReplayStage({
 }) {
   const [restartNonce, setRestartNonce] = useState(0);
   const playerTierBps = playerTicket?.leverageBps ?? null;
+  const playerWon =
+    playerTicket === null
+      ? null
+      : isWinningTicket(playerTicket.leverageBps, hero.crashPointBps);
   const clock = useReplayClock({
     crashPointBps: hero.crashPointBps,
     finalizedAtSeconds: hero.finalizedAtSeconds,
@@ -432,6 +437,8 @@ function ReplayStage({
           crashPointBps={hero.crashPointBps}
           displayCrashPoint={hero.displayCrashPoint}
           finalizeTransactionUrl={hero.finalizeTransactionUrl}
+          playerTierBps={playerTierBps}
+          playerWon={playerWon}
           tiers={hero.tiers}
         />
         <ResultHandoffRow hero={hero} live={live} />
@@ -446,6 +453,7 @@ function ReplayStage({
         <ReplayCurve
           crashPointBps={hero.crashPointBps}
           playerTierBps={playerTierBps}
+          playerWon={playerWon}
           progress={clock.progress}
         />
       </div>

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -15,7 +15,6 @@ import { getTierCloseProgress } from "@/lib/round-replay";
 import {
   ENTRY_LEVERAGE_TIERS_BPS,
   formatLeverageBps,
-  isWinningTicket,
   type CrashTicket,
 } from "@/lib/margin-call-crash";
 import {
@@ -25,6 +24,7 @@ import {
 import type { RoundTimeline } from "@/lib/round-timeline";
 import { getTheaterAudio } from "@/lib/theater-audio";
 import { formatCountdown, TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
+import { ticketLanding } from "./landing-frame";
 import { theaterCopy } from "./theater-copy";
 import { FinalizeLink } from "./finalize-link";
 import {
@@ -409,10 +409,7 @@ function ReplayStage({
 }) {
   const [restartNonce, setRestartNonce] = useState(0);
   const playerTierBps = playerTicket?.leverageBps ?? null;
-  const playerWon =
-    playerTicket === null
-      ? null
-      : isWinningTicket(playerTicket.leverageBps, hero.crashPointBps);
+  const landing = ticketLanding(playerTicket, hero.crashPointBps);
   const clock = useReplayClock({
     crashPointBps: hero.crashPointBps,
     finalizedAtSeconds: hero.finalizedAtSeconds,
@@ -437,8 +434,8 @@ function ReplayStage({
           crashPointBps={hero.crashPointBps}
           displayCrashPoint={hero.displayCrashPoint}
           finalizeTransactionUrl={hero.finalizeTransactionUrl}
+          landing={landing}
           playerTierBps={playerTierBps}
-          playerWon={playerWon}
           tiers={hero.tiers}
         />
         <ResultHandoffRow hero={hero} live={live} />
@@ -452,8 +449,8 @@ function ReplayStage({
       <div className="mc-crt-reveal" key={restartNonce}>
         <ReplayCurve
           crashPointBps={hero.crashPointBps}
+          landing={landing}
           playerTierBps={playerTierBps}
-          playerWon={playerWon}
           progress={clock.progress}
         />
       </div>

--- a/src/components/round-theater/theater-copy.ts
+++ b/src/components/round-theater/theater-copy.ts
@@ -24,6 +24,17 @@ export const theaterCopy = {
   nextRoundOpening: countdownCopy.nextRoundOpeningNamed,
   nextRoundEntryOpen: countdownCopy.nextRoundEntryOpen,
   verifiedCrashPoint: "Verified Crash Point",
+  /** Eyebrow above a personal Won / Margin called freeze. */
+  yourTicket: "Your Ticket",
+  /** Supporting line under a personal outcome freeze: `Crash Point 2.50x`. */
+  crashPointSupporting: (crashPoint: string) => `Crash Point ${crashPoint}`,
+  /** Signed-in player landed: Ticket closed at or below the Crash Point. */
+  playerWon: "Won",
+  playerWonDetail:
+    "Your Arcade Leverage closed at or below the verified Crash Point.",
+  /** Signed-in player landed: Ticket still open when the market died. */
+  playerMarginCalled: "Margin called",
+  playerMarginCalledDetail: "The Crash Point died below your Arcade Leverage.",
   marginCall: "Margin call",
   marginCallDetail:
     "Hard stop — every Ticket still open takes the margin call.",


### PR DESCRIPTION
## Summary
- After the post-finalization climb, the chart freezes on **Won** or **Margin called** for the signed-in player's Ticket (Crash Point moves to supporting copy).
- Spectators still land on the verified Crash Point + margin-call phone; reduced-motion static card matches the same landing frame.
- Replay still re-runs the climb; settlement stays on the ticket rail.

## Test plan
- [ ] Finalize a round with a winning Ticket → climb ends on **Won**, Crash Point as supporting copy, no phone stamp
- [ ] Finalize a round with a losing Ticket → climb ends on **Margin called**, phone stamp present
- [ ] Spectator / no Ticket → Crash Point remains the hero
- [ ] Reduced motion + Ticket → static card shows the same outcome immediately
- [ ] Replay button re-runs climb then freezes on the same outcome; no claim/settle in theater
- [ ] `pnpm exec vitest run src/components/round-theater/round-theater.test.tsx`


Made with [Cursor](https://cursor.com)