### PR TITLE
Move recent rounds into a /history nav tab

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,25 @@
+import { GlobalHistory } from "@/components/history/global-history";
+
+/**
+ * Global round history — attested Crash Points and honest empty/delayed/
+ * expired states for the lookback window.
+ */
+export default function HistoryPage() {
+  return (
+    <div>
+      <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
+        Base Sepolia · Global history
+      </p>
+      <h1 className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl">
+        Recent rounds
+      </h1>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--t-muted)]">
+        Finalized rounds show the attested Crash Point. Empty, delayed, and
+        expired rounds never invent a multiplier.
+      </p>
+      <div className="mt-8">
+        <GlobalHistory />
+      </div>
+    </div>
+  );
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,4 +1,5 @@
 import { GlobalHistory } from "@/components/history/global-history";
+import { RoutePageIntro } from "@/components/route-page-intro";
 
 /**
  * Global round history — attested Crash Points and honest empty/delayed/
@@ -6,20 +7,18 @@ import { GlobalHistory } from "@/components/history/global-history";
  */
 export default function HistoryPage() {
   return (
-    <div>
-      <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
-        Base Sepolia · Global history
-      </p>
-      <h1 className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl">
-        Recent rounds
-      </h1>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--t-muted)]">
+    <section aria-labelledby="history-heading">
+      <RoutePageIntro
+        eyebrow="Base Sepolia · Global history"
+        title="Recent rounds"
+        titleId="history-heading"
+      >
         Finalized rounds show the attested Crash Point. Empty, delayed, and
         expired rounds never invent a multiplier.
-      </p>
+      </RoutePageIntro>
       <div className="mt-8">
         <GlobalHistory />
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/app/lp/page.tsx
+++ b/src/app/lp/page.tsx
@@ -1,5 +1,6 @@
 import { AuthGate } from "@/components/auth/auth-gate";
 import { LpDesk } from "@/components/lp-desk/lp-desk";
+import { RoutePageIntro } from "@/components/route-page-intro";
 
 /**
  * Liquidity desk — vault metrics, deposit, and withdraw. Sign-in required for
@@ -7,20 +8,18 @@ import { LpDesk } from "@/components/lp-desk/lp-desk";
  */
 export default function LpPage() {
   return (
-    <div className="mx-auto max-w-3xl">
-      <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
-        Base Sepolia · Liquidity
-      </p>
-      <h1 className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl">
-        LP Desk
-      </h1>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--t-muted)]">
+    <section aria-labelledby="lp-heading" className="mx-auto max-w-3xl">
+      <RoutePageIntro
+        eyebrow="Base Sepolia · Liquidity"
+        title="LP Desk"
+        titleId="lp-heading"
+      >
         Provide Desk Dollars (tUSD) to receive vault shares. Sign in to deposit
         or withdraw.
-      </p>
+      </RoutePageIntro>
       <AuthGate>
         <LpDesk />
       </AuthGate>
-    </div>
+    </section>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,30 +3,26 @@ import { CurrentRound } from "@/components/current-round/current-round";
 import { CrashTicketRefund } from "@/components/current-round/crash-ticket-refund";
 import { CrashTicketSettlement } from "@/components/current-round/crash-ticket-settlement";
 import { DeskDollarsPanel } from "@/components/desk-dollars/desk-dollars-panel";
-import { GlobalHistory } from "@/components/history/global-history";
 import { PersonalHistory } from "@/components/history/personal-history";
 import { RoundTheater } from "@/components/round-theater/round-theater";
 
 /**
- * Chart-first play floor: hero replay + entry rail, then player actions and
- * recent rounds. LP Desk lives on /lp.
+ * Chart-first play floor: hero replay + entry rail and player actions.
+ * Recent rounds live on /history; LP Desk on /lp.
  */
 export default function Home() {
   return (
-    <div className="space-y-8">
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.65fr)_minmax(18rem,1fr)] lg:items-start">
-        <RoundTheater />
-        <div className="space-y-6">
-          <CurrentRound />
-          <AuthGate>
-            <CrashTicketSettlement />
-            <CrashTicketRefund />
-            <DeskDollarsPanel />
-            <PersonalHistory />
-          </AuthGate>
-        </div>
+    <div className="grid gap-8 lg:grid-cols-[minmax(0,1.65fr)_minmax(18rem,1fr)] lg:items-start">
+      <RoundTheater />
+      <div className="space-y-6">
+        <CurrentRound />
+        <AuthGate>
+          <CrashTicketSettlement />
+          <CrashTicketRefund />
+          <DeskDollarsPanel />
+          <PersonalHistory />
+        </AuthGate>
       </div>
-      <GlobalHistory />
     </div>
   );
 }

--- a/src/components/app-shell/app-shell.test.tsx
+++ b/src/components/app-shell/app-shell.test.tsx
@@ -43,7 +43,7 @@ describe("AppShell", () => {
 
   afterEach(cleanup);
 
-  it("renders Floor and LP Desk navigation links", () => {
+  it("renders Floor, Recent rounds, and LP Desk navigation links", () => {
     render(
       <AppShell>
         <p>Floor content</p>
@@ -53,13 +53,37 @@ describe("AppShell", () => {
     const nav = screen.getByTestId("app-shell-nav");
     expect(nav).toBeTruthy();
     const floor = screen.getByRole("link", { name: "Floor" });
+    const history = screen.getByRole("link", { name: "Recent rounds" });
     const lp = screen.getByRole("link", { name: "LP Desk" });
     expect(floor.getAttribute("href")).toBe("/");
+    expect(history.getAttribute("href")).toBe("/history");
     expect(lp.getAttribute("href")).toBe("/lp");
     expect(floor.getAttribute("aria-current")).toBe("page");
+    expect(history.getAttribute("aria-current")).toBeNull();
     expect(lp.getAttribute("aria-current")).toBeNull();
     expect(screen.getByTestId("no-real-value-disclosure")).toBeTruthy();
     expect(screen.getByText("Floor content")).toBeTruthy();
+  });
+
+  it("marks Recent rounds as current on /history", () => {
+    sdk.pathname = "/history";
+    render(
+      <AppShell>
+        <p>History content</p>
+      </AppShell>
+    );
+
+    expect(
+      screen
+        .getByRole("link", { name: "Recent rounds" })
+        .getAttribute("aria-current")
+    ).toBe("page");
+    expect(
+      screen.getByRole("link", { name: "Floor" }).getAttribute("aria-current")
+    ).toBeNull();
+    expect(
+      screen.getByRole("link", { name: "LP Desk" }).getAttribute("aria-current")
+    ).toBeNull();
   });
 
   it("marks LP Desk as current on /lp", () => {
@@ -75,6 +99,11 @@ describe("AppShell", () => {
     ).toBe("page");
     expect(
       screen.getByRole("link", { name: "Floor" }).getAttribute("aria-current")
+    ).toBeNull();
+    expect(
+      screen
+        .getByRole("link", { name: "Recent rounds" })
+        .getAttribute("aria-current")
     ).toBeNull();
   });
 });

--- a/src/components/app-shell/app-shell.tsx
+++ b/src/components/app-shell/app-shell.tsx
@@ -7,12 +7,13 @@ import { NoRealValueDisclosure } from "@/components/no-real-value-disclosure";
 
 const NAV = [
   { href: "/", label: "Floor" },
+  { href: "/history", label: "Recent rounds" },
   { href: "/lp", label: "LP Desk" },
 ] as const;
 
 /**
- * Shared chrome: brand, Floor / LP Desk nav, compact auth, disclosure.
- * Leaves page content as the primary workspace.
+ * Shared chrome: brand, Floor / Recent rounds / LP Desk nav, compact auth,
+ * disclosure. Leaves page content as the primary workspace.
  */
 export function AppShell({
   children,

--- a/src/components/history/global-history.tsx
+++ b/src/components/history/global-history.tsx
@@ -7,7 +7,7 @@ import type {
   RoundHistoryState,
 } from "@/lib/margin-call-crash";
 import { ReplayCurveThumb } from "@/components/round-theater/replay-curve";
-import { historyStateCopy } from "./history-state-copy";
+import { historyRowLabel, historyStateCopy } from "./history-state-copy";
 import { RoundVerificationRecord } from "./round-verification-record";
 
 const historyStateColors: Record<RoundHistoryState, string> = {
@@ -19,38 +19,27 @@ const historyStateColors: Record<RoundHistoryState, string> = {
 };
 
 /**
- * Public global history: ≥20 lookback rounds with honest delayed/expired
- * states and expandable verification records. Page chrome (heading, eyebrow)
- * lives on /history.
+ * Global history list content: lookback rounds with honest delayed/expired
+ * states and expandable verification records. Page chrome lives on /history.
  */
 export function GlobalHistory() {
   const history = useGlobalHistory();
 
   if (history.status === "loading") {
     return (
-      <section
+      <p
         aria-busy="true"
-        aria-labelledby="global-history-loading"
-        className="text-left"
+        className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]"
       >
-        <p
-          id="global-history-loading"
-          className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]"
-        >
-          Reading round history from Base Sepolia…
-        </p>
-      </section>
+        Reading round history from Base Sepolia…
+      </p>
     );
   }
 
   if (history.status !== "ready") {
     return (
-      <section aria-labelledby="global-history-error" className="text-left">
-        <p
-          id="global-history-error"
-          className="text-sm text-[var(--t-red-hot)]"
-          role="alert"
-        >
+      <div>
+        <p className="text-sm text-[var(--t-red-hot)]" role="alert">
           {history.error}
         </p>
         <button
@@ -60,44 +49,40 @@ export function GlobalHistory() {
         >
           Retry
         </button>
-      </section>
+      </div>
     );
   }
 
   if (history.rounds.length === 0) {
     return (
-      <section aria-label="Recent rounds" className="text-left">
-        <p className="text-sm text-[var(--t-muted)]">
-          No initialized rounds in the lookback window yet.
-        </p>
-      </section>
+      <p className="text-sm text-[var(--t-muted)]">
+        No initialized rounds in the lookback window yet.
+      </p>
     );
   }
 
   return (
-    <section aria-label="Recent rounds" className="text-left">
-      <ul className="divide-y divide-[var(--t-divider)] border-y border-[var(--t-divider)]">
-        {history.rounds.map((item) => {
-          const isSelected = history.selectedRoundId === item.round.id;
-          return (
-            <HistoryRoundRow
-              detail={isSelected ? history.detail : null}
-              detailStatus={isSelected ? history.detailStatus : "idle"}
-              item={item}
-              key={item.round.id.toString()}
-              onSelect={() => {
-                if (isSelected) {
-                  history.clearSelection();
-                  return;
-                }
-                history.selectRound(item.round.id);
-              }}
-              selected={isSelected}
-            />
-          );
-        })}
-      </ul>
-    </section>
+    <ul className="divide-y divide-[var(--t-divider)] border-y border-[var(--t-divider)]">
+      {history.rounds.map((item) => {
+        const isSelected = history.selectedRoundId === item.round.id;
+        return (
+          <HistoryRoundRow
+            detail={isSelected ? history.detail : null}
+            detailStatus={isSelected ? history.detailStatus : "idle"}
+            item={item}
+            key={item.round.id.toString()}
+            onSelect={() => {
+              if (isSelected) {
+                history.clearSelection();
+                return;
+              }
+              history.selectRound(item.round.id);
+            }}
+            selected={isSelected}
+          />
+        );
+      })}
+    </ul>
   );
 }
 
@@ -114,16 +99,7 @@ function HistoryRoundRow({
   detail: RoundHistoryDetail | null;
   detailStatus: "idle" | "loading" | "ready" | "error";
 }) {
-  const crashLabel =
-    item.historyState === "finalized" && item.displayCrashPoint
-      ? item.displayCrashPoint
-      : item.historyState === "delayed"
-        ? "Awaiting attestation"
-        : item.historyState === "empty"
-          ? "No entries"
-          : item.historyState === "expired"
-            ? "Expired — no result"
-            : "—";
+  const crashLabel = historyRowLabel(item.historyState, item.displayCrashPoint);
   const showThumb =
     item.historyState === "finalized" && item.round.crashPointBps > 0n;
 

--- a/src/components/history/global-history.tsx
+++ b/src/components/history/global-history.tsx
@@ -20,7 +20,8 @@ const historyStateColors: Record<RoundHistoryState, string> = {
 
 /**
  * Public global history: ≥20 lookback rounds with honest delayed/expired
- * states and expandable verification records.
+ * states and expandable verification records. Page chrome (heading, eyebrow)
+ * lives on /history.
  */
 export function GlobalHistory() {
   const history = useGlobalHistory();
@@ -30,7 +31,7 @@ export function GlobalHistory() {
       <section
         aria-busy="true"
         aria-labelledby="global-history-loading"
-        className="border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
+        className="text-left"
       >
         <p
           id="global-history-loading"
@@ -44,10 +45,7 @@ export function GlobalHistory() {
 
   if (history.status !== "ready") {
     return (
-      <section
-        aria-labelledby="global-history-error"
-        className="border-y border-[var(--t-border)] px-5 py-8 text-left sm:px-8"
-      >
+      <section aria-labelledby="global-history-error" className="text-left">
         <p
           id="global-history-error"
           className="text-sm text-[var(--t-red-hot)]"
@@ -66,52 +64,39 @@ export function GlobalHistory() {
     );
   }
 
-  return (
-    <section
-      aria-labelledby="global-history-heading"
-      className="border-y border-[var(--t-border)] bg-[var(--t-panel)] px-5 py-6 text-left sm:px-8 sm:py-8"
-    >
-      <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
-        Base Sepolia · Global history
-      </p>
-      <h2
-        id="global-history-heading"
-        className="mt-3 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl"
-      >
-        Recent rounds
-      </h2>
-      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        Finalized rounds show the attested Crash Point. Empty, delayed, and
-        expired rounds never invent a multiplier.
-      </p>
-
-      {history.rounds.length === 0 ? (
-        <p className="mt-6 text-sm text-[var(--t-muted)]">
+  if (history.rounds.length === 0) {
+    return (
+      <section aria-label="Recent rounds" className="text-left">
+        <p className="text-sm text-[var(--t-muted)]">
           No initialized rounds in the lookback window yet.
         </p>
-      ) : (
-        <ul className="mt-6 divide-y divide-[var(--t-divider)] border-y border-[var(--t-divider)]">
-          {history.rounds.map((item) => {
-            const isSelected = history.selectedRoundId === item.round.id;
-            return (
-              <HistoryRoundRow
-                detail={isSelected ? history.detail : null}
-                detailStatus={isSelected ? history.detailStatus : "idle"}
-                item={item}
-                key={item.round.id.toString()}
-                onSelect={() => {
-                  if (isSelected) {
-                    history.clearSelection();
-                    return;
-                  }
-                  history.selectRound(item.round.id);
-                }}
-                selected={isSelected}
-              />
-            );
-          })}
-        </ul>
-      )}
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Recent rounds" className="text-left">
+      <ul className="divide-y divide-[var(--t-divider)] border-y border-[var(--t-divider)]">
+        {history.rounds.map((item) => {
+          const isSelected = history.selectedRoundId === item.round.id;
+          return (
+            <HistoryRoundRow
+              detail={isSelected ? history.detail : null}
+              detailStatus={isSelected ? history.detailStatus : "idle"}
+              item={item}
+              key={item.round.id.toString()}
+              onSelect={() => {
+                if (isSelected) {
+                  history.clearSelection();
+                  return;
+                }
+                history.selectRound(item.round.id);
+              }}
+              selected={isSelected}
+            />
+          );
+        })}
+      </ul>
     </section>
   );
 }

--- a/src/components/history/history-state-copy.test.ts
+++ b/src/components/history/history-state-copy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { historyRowLabel, historyStateCopy } from "./history-state-copy";
+
+describe("historyRowLabel", () => {
+  it("returns attested crash point for finalized rounds", () => {
+    expect(historyRowLabel("finalized", "3.42x")).toBe("3.42x");
+    expect(historyRowLabel("finalized", null)).toBe("—");
+  });
+
+  it("uses canonical copy for every non-crash-point state", () => {
+    expect(historyRowLabel("open", null)).toBe(historyStateCopy.open.rowLabel);
+    expect(historyRowLabel("delayed", null)).toBe(
+      historyStateCopy.delayed.rowLabel
+    );
+    expect(historyRowLabel("empty", null)).toBe(
+      historyStateCopy.empty.rowLabel
+    );
+    expect(historyRowLabel("expired", null)).toBe(
+      historyStateCopy.expired.rowLabel
+    );
+  });
+});

--- a/src/components/history/history-state-copy.ts
+++ b/src/components/history/history-state-copy.ts
@@ -1,13 +1,45 @@
 import type { RoundHistoryState } from "@/lib/margin-call-crash";
 
-/** Badge and long-form copy per honest history state — never invent a multiplier. */
-export const historyStateCopy: Record<
-  RoundHistoryState,
-  { badge: string; detail: string }
-> = {
-  open: { badge: "Open", detail: "Open" },
-  delayed: { badge: "Delayed", detail: "Delayed — awaiting attestation" },
-  empty: { badge: "Empty", detail: "Empty — no tickets entered" },
-  finalized: { badge: "Finalized", detail: "Finalized" },
-  expired: { badge: "Expired", detail: "Expired — no invented multiplier" },
+type HistoryStateCopy = {
+  badge: string;
+  detail: string;
+  /** Primary row label, or `"crashPoint"` to use the attested display value. */
+  rowLabel: string | "crashPoint";
 };
+
+/** Badge, long-form, and row labels per honest history state — never invent a multiplier. */
+export const historyStateCopy: Record<RoundHistoryState, HistoryStateCopy> = {
+  open: { badge: "Open", detail: "Open", rowLabel: "—" },
+  delayed: {
+    badge: "Delayed",
+    detail: "Delayed — awaiting attestation",
+    rowLabel: "Awaiting attestation",
+  },
+  empty: {
+    badge: "Empty",
+    detail: "Empty — no tickets entered",
+    rowLabel: "No entries",
+  },
+  finalized: {
+    badge: "Finalized",
+    detail: "Finalized",
+    rowLabel: "crashPoint",
+  },
+  expired: {
+    badge: "Expired",
+    detail: "Expired — no invented multiplier",
+    rowLabel: "Expired — no result",
+  },
+};
+
+/** Resolves the primary history-row label for a given state. */
+export function historyRowLabel(
+  state: RoundHistoryState,
+  displayCrashPoint: string | null
+): string {
+  const { rowLabel } = historyStateCopy[state];
+  if (rowLabel === "crashPoint") {
+    return displayCrashPoint ?? "—";
+  }
+  return rowLabel;
+}

--- a/src/components/route-page-intro.tsx
+++ b/src/components/route-page-intro.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+type RoutePageIntroProps = {
+  eyebrow: string;
+  title: string;
+  titleId: string;
+  children: ReactNode;
+};
+
+/**
+ * Shared desk-route chrome: eyebrow, page title, and one-line lede.
+ * Width/layout wrappers stay on the page.
+ */
+export function RoutePageIntro({
+  eyebrow,
+  title,
+  titleId,
+  children,
+}: RoutePageIntroProps) {
+  return (
+    <>
+      <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]">
+        {eyebrow}
+      </p>
+      <h1
+        className="mt-2 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl"
+        id={titleId}
+      >
+        {title}
+      </h1>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--t-muted)]">
+        {children}
+      </p>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a **Recent rounds** header nav item that routes to `/history`
- Move global round history off the Floor onto that page with page-level heading chrome
- Slim `GlobalHistory` so it no longer repeats the eyebrow/title/footer-band treatment

## Test plan
- [ ] Floor (`/`) shows theater + action rail only — no recent rounds strip at the bottom
- [ ] Header shows Floor / Recent rounds / LP Desk; Recent rounds is active on `/history`
- [ ] `/history` lists lookback rounds with honest empty/delayed/expired states and expandable verification records
- [ ] Personal history still appears in the signed-in Floor rail
- [ ] `pnpm exec vitest run src/components/app-shell/app-shell.test.tsx src/components/history/global-history.test.tsx`


Made with [Cursor](https://cursor.com)