### PR TITLE
Add wallet dialog with sponsored tUSD transfers

### DIFF
--- a/src/components/auth/auth-controls.test.tsx
+++ b/src/components/auth/auth-controls.test.tsx
@@ -45,6 +45,18 @@ vi.mock("@/hooks/use-desk-dollars-balance", () => ({
   useDeskDollarsBalance: () => sdk.balance,
 }));
 
+vi.mock("@/hooks/use-desk-dollars-transfer", () => ({
+  useDeskDollarsTransfer: () => ({
+    status: "idle",
+    error: null,
+    lastHash: null,
+    canTransfer: true,
+    canRetry: false,
+    transfer: vi.fn(),
+    retry: vi.fn(),
+  }),
+}));
+
 import { AuthControls } from "@/components/auth/auth-controls";
 
 function embeddedUser() {
@@ -140,6 +152,19 @@ describe("AuthControls", () => {
     expect(screen.getByText("0x1234")).not.toBeNull();
     expect(screen.getByText("100 tUSD")).not.toBeNull();
     expect(screen.queryByText("+15555550123")).toBeNull();
+  });
+
+  it("opens the wallet dialog from the header chip", () => {
+    renderSignedInControls();
+    expect(screen.queryByTestId("wallet-dialog")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("wallet-chip"));
+
+    expect(screen.getByTestId("wallet-dialog")).not.toBeNull();
+    expect(screen.getByTestId("wallet-dialog-address").textContent).toBe(
+      "0x1234"
+    );
+    expect(screen.getByRole("heading", { name: "Wallet" })).not.toBeNull();
   });
 
   it("shows logout pending and ignores rapid duplicate submissions", () => {

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -3,6 +3,7 @@
 import { useLogin, usePrivy, useWallets } from "@privy-io/react-auth";
 import { useCallback, useRef, useState } from "react";
 import { FlashValue } from "@/components/ui/flash-value";
+import { WalletDialog } from "@/components/wallet/wallet-dialog";
 import { formatDeskDollarsBalanceLabel } from "@/lib/desk-dollars";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 import { formatShortAddress } from "@/lib/utils";
@@ -19,6 +20,7 @@ export function AuthControls() {
   const [loginError, setLoginError] = useState(false);
   const [logoutPending, setLogoutPending] = useState(false);
   const [logoutError, setLogoutError] = useState(false);
+  const [walletOpen, setWalletOpen] = useState(false);
   const logoutInFlight = useRef(false);
   const { login } = useLogin({
     onError: () => setLoginError(true),
@@ -48,6 +50,7 @@ export function AuthControls() {
     logoutInFlight.current = true;
     setLogoutError(false);
     setLogoutPending(true);
+    setWalletOpen(false);
 
     try {
       await logout();
@@ -60,6 +63,9 @@ export function AuthControls() {
   }, [logout]);
 
   const balanceLabel = formatDeskDollarsBalanceLabel(balance, decimals);
+  const showWallet =
+    !!walletAddress &&
+    (state.status === "signed-in" || state.status === "logout-error");
 
   return (
     <div
@@ -69,18 +75,31 @@ export function AuthControls() {
       <p aria-live="polite" className="text-xs text-[var(--t-muted)]">
         {state.message}
       </p>
-      {walletAddress &&
-      (state.status === "signed-in" || state.status === "logout-error") ? (
-        <div className="flex flex-wrap items-center gap-2 text-xs tabular-nums">
-          <span className="text-[var(--t-text)]">
-            {formatShortAddress(walletAddress)}
-          </span>
-          {balanceLabel && balance !== null ? (
-            <FlashValue className="text-[var(--t-green-hot)]" value={balance}>
-              {balanceLabel}
-            </FlashValue>
-          ) : null}
-        </div>
+      {walletAddress && showWallet ? (
+        <>
+          <button
+            aria-expanded={walletOpen}
+            aria-haspopup="dialog"
+            className="flex flex-wrap items-center gap-2 rounded-sm border border-transparent px-2 py-1 text-xs tabular-nums text-[var(--t-text)] transition-colors hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--t-accent)]"
+            data-testid="wallet-chip"
+            onClick={() => setWalletOpen(true)}
+            type="button"
+          >
+            <span>{formatShortAddress(walletAddress)}</span>
+            {balanceLabel && balance !== null ? (
+              <FlashValue className="text-[var(--t-green-hot)]" value={balance}>
+                {balanceLabel}
+              </FlashValue>
+            ) : null}
+          </button>
+          <WalletDialog
+            balance={balance}
+            decimals={decimals}
+            onOpenChange={setWalletOpen}
+            open={walletOpen}
+            walletAddress={walletAddress}
+          />
+        </>
       ) : null}
       {state.action === "login" ? (
         <button

--- a/src/components/wallet/wallet-dialog.test.tsx
+++ b/src/components/wallet/wallet-dialog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  transfer: vi.fn(),
+  retry: vi.fn(),
+  status: "idle" as string,
+  error: null as string | null,
+  lastHash: null as string | null,
+  canTransfer: true,
+  canRetry: false,
+}));
+
+vi.mock("@/hooks/use-desk-dollars-transfer", () => ({
+  useDeskDollarsTransfer: () => ({
+    status: sdk.status,
+    error: sdk.error,
+    lastHash: sdk.lastHash,
+    canTransfer: sdk.canTransfer,
+    canRetry: sdk.canRetry,
+    transfer: sdk.transfer,
+    retry: sdk.retry,
+  }),
+}));
+
+import { WalletDialog } from "./wallet-dialog";
+
+const FROM = "0x0000000000000000000000000000000000000003" as const;
+const TO = "0x0000000000000000000000000000000000000004" as const;
+
+describe("WalletDialog", () => {
+  beforeEach(() => {
+    sdk.transfer.mockReset().mockResolvedValue(true);
+    sdk.retry.mockReset().mockResolvedValue(true);
+    sdk.status = "idle";
+    sdk.error = null;
+    sdk.lastHash = null;
+    sdk.canTransfer = true;
+    sdk.canRetry = false;
+  });
+
+  afterEach(cleanup);
+
+  it("renders address, balance, and submits a transfer", async () => {
+    render(
+      <WalletDialog
+        balance={100_000_000n}
+        decimals={6}
+        onOpenChange={vi.fn()}
+        open
+        walletAddress={FROM}
+      />
+    );
+
+    expect(screen.getByTestId("wallet-dialog-address").textContent).toBe(FROM);
+    expect(screen.getByText("100 tUSD")).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Recipient"), {
+      target: { value: TO },
+    });
+    fireEvent.change(screen.getByLabelText("Amount (tUSD)"), {
+      target: { value: "10" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send tUSD" }));
+
+    await waitFor(() =>
+      expect(sdk.transfer).toHaveBeenCalledWith({
+        recipient: TO,
+        amount: "10",
+        balance: 100_000_000n,
+      })
+    );
+  });
+
+  it("fills the amount field from Max", () => {
+    render(
+      <WalletDialog
+        balance={12_500_000n}
+        decimals={6}
+        onOpenChange={vi.fn()}
+        open
+        walletAddress={FROM}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Max" }));
+    expect(
+      (screen.getByLabelText("Amount (tUSD)") as HTMLInputElement).value
+    ).toBe("12.5");
+  });
+
+  it("retries when the transfer hook reports a retryable error", async () => {
+    sdk.status = "error";
+    sdk.error =
+      "Your transfer was submitted, but we couldn't confirm it yet. Retry to check its status.";
+    sdk.canRetry = true;
+    sdk.canTransfer = false;
+
+    render(
+      <WalletDialog
+        balance={100_000_000n}
+        decimals={6}
+        onOpenChange={vi.fn()}
+        open
+        walletAddress={FROM}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(sdk.retry).toHaveBeenCalledTimes(1));
+    expect(sdk.transfer).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { Dialog } from "@base-ui/react/dialog";
+import { useCallback, useState, type FormEvent } from "react";
+import type { Address } from "viem";
+import { FlashValue } from "@/components/ui/flash-value";
+import { GameButton } from "@/components/ui/game-button";
+import { useDeskDollarsTransfer } from "@/hooks/use-desk-dollars-transfer";
+import {
+  formatDeskDollars,
+  formatDeskDollarsBalanceLabel,
+  TUSD_DECIMALS,
+} from "@/lib/desk-dollars";
+import {
+  getBaseSepoliaAddressUrl,
+  getBaseSepoliaTransactionUrl,
+} from "@/lib/base-sepolia-explorer";
+import {
+  DIALOG_BACKDROP_CLASS,
+  dialogPopupClass,
+  TERMINAL_ACTION_BUTTON_CLASS,
+} from "@/lib/utils";
+
+type WalletDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  walletAddress: Address;
+  balance: bigint | null;
+  decimals: number | null;
+};
+
+/**
+ * Signed-in wallet surface: full address utilities and a sponsored tUSD send.
+ */
+export function WalletDialog({
+  open,
+  onOpenChange,
+  walletAddress,
+  balance,
+  decimals,
+}: WalletDialogProps) {
+  const transfer = useDeskDollarsTransfer(walletAddress);
+  const [recipient, setRecipient] = useState("");
+  const [amount, setAmount] = useState("");
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
+    "idle"
+  );
+
+  const balanceLabel =
+    formatDeskDollarsBalanceLabel(balance, decimals) ?? "— tUSD";
+  const isBusy =
+    transfer.status === "submitting" || transfer.status === "pending";
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(walletAddress);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  }, [walletAddress]);
+
+  const handleMax = useCallback(() => {
+    if (balance === null) return;
+    setAmount(formatDeskDollars(balance, decimals ?? TUSD_DECIMALS));
+  }, [balance, decimals]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (transfer.canRetry) {
+        void transfer.retry();
+        return;
+      }
+      void transfer.transfer({ recipient, amount, balance });
+    },
+    [amount, balance, recipient, transfer]
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={DIALOG_BACKDROP_CLASS} />
+        <Dialog.Popup
+          className={`${dialogPopupClass("sm")} overflow-y-auto p-5`}
+          data-testid="wallet-dialog"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <Dialog.Title className="font-[family-name:var(--font-plex-sans)] text-lg font-bold uppercase tracking-wide text-[var(--t-accent)]">
+              Wallet
+            </Dialog.Title>
+            <Dialog.Close
+              aria-label="Close wallet"
+              className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-muted)] hover:text-[var(--t-text)]"
+            >
+              Close
+            </Dialog.Close>
+          </div>
+
+          <Dialog.Description className="mt-2 text-xs text-[var(--t-muted)]">
+            Base Sepolia only. Desk Dollars (tUSD) have no real value.
+          </Dialog.Description>
+
+          <div className="mt-5 space-y-2">
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]">
+              Address
+            </p>
+            <p
+              className="break-all text-sm text-[var(--t-text)]"
+              data-testid="wallet-dialog-address"
+            >
+              {walletAddress}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                className={TERMINAL_ACTION_BUTTON_CLASS}
+                onClick={() => void handleCopy()}
+                type="button"
+              >
+                {copyState === "copied"
+                  ? "Copied"
+                  : copyState === "failed"
+                    ? "Copy failed"
+                    : "Copy"}
+              </button>
+              <a
+                className={TERMINAL_ACTION_BUTTON_CLASS}
+                href={getBaseSepoliaAddressUrl(walletAddress)}
+                rel="noreferrer"
+                target="_blank"
+              >
+                BaseScan
+              </a>
+            </div>
+          </div>
+
+          <p className="mt-5 text-sm text-[var(--t-text)]">
+            Balance:{" "}
+            {balance !== null ? (
+              <FlashValue className="text-[var(--t-green-hot)]" value={balance}>
+                {balanceLabel}
+              </FlashValue>
+            ) : (
+              balanceLabel
+            )}
+          </p>
+
+          <form
+            className="mt-6 border-t border-[var(--t-border)] pt-5"
+            onSubmit={handleSubmit}
+          >
+            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]">
+              Transfer Desk Dollars
+            </p>
+
+            <label
+              className="mt-4 block text-sm font-bold"
+              htmlFor="wallet-transfer-recipient"
+            >
+              Recipient
+            </label>
+            <input
+              autoComplete="off"
+              className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+              disabled={isBusy}
+              id="wallet-transfer-recipient"
+              onChange={(event) => setRecipient(event.target.value)}
+              placeholder="0x…"
+              spellCheck={false}
+              value={recipient}
+            />
+
+            <div className="mt-4 flex items-end justify-between gap-3">
+              <label
+                className="block text-sm font-bold"
+                htmlFor="wallet-transfer-amount"
+              >
+                Amount (tUSD)
+              </label>
+              <button
+                className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] disabled:opacity-50"
+                disabled={isBusy || balance === null || balance <= 0n}
+                onClick={handleMax}
+                type="button"
+              >
+                Max
+              </button>
+            </div>
+            <input
+              className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+              disabled={isBusy}
+              id="wallet-transfer-amount"
+              inputMode="decimal"
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="0.000000"
+              value={amount}
+            />
+
+            {transfer.status === "submitting" ? (
+              <p aria-live="polite" className="mt-3 text-sm">
+                Submitting your sponsored transfer…
+              </p>
+            ) : null}
+            {transfer.status === "pending" ? (
+              <p aria-live="polite" className="mt-3 text-sm">
+                Transfer pending until its Base Sepolia receipt succeeds…
+              </p>
+            ) : null}
+            {transfer.status === "confirmed" ? (
+              <p aria-live="polite" className="mt-3 text-sm">
+                Transfer confirmed on Base Sepolia.
+                {transfer.lastHash ? (
+                  <>
+                    {" "}
+                    <a
+                      className="underline"
+                      href={getBaseSepoliaTransactionUrl(transfer.lastHash)}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      View on BaseScan
+                    </a>
+                  </>
+                ) : null}
+              </p>
+            ) : null}
+            {transfer.status === "unavailable" ||
+            transfer.status === "error" ? (
+              <p role="alert" className="mt-3 text-sm">
+                {transfer.error}
+              </p>
+            ) : null}
+
+            <GameButton
+              className="mt-4 w-full"
+              disabled={
+                transfer.status === "unavailable" ||
+                (isBusy
+                  ? true
+                  : transfer.canRetry
+                    ? false
+                    : !transfer.canTransfer ||
+                      !recipient.trim() ||
+                      !amount.trim())
+              }
+              size="sm"
+              type="submit"
+            >
+              {transfer.canRetry
+                ? "Retry"
+                : transfer.status === "submitting"
+                  ? "Submitting…"
+                  : transfer.status === "pending"
+                    ? "Pending…"
+                    : "Send tUSD"}
+            </GameButton>
+          </form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/hooks/use-desk-dollars-transfer.test.ts
+++ b/src/hooks/use-desk-dollars-transfer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { validateDeskDollarsTransfer } from "./use-desk-dollars-transfer";
+
+const FROM = "0x0000000000000000000000000000000000000003" as const;
+const TO = "0x0000000000000000000000000000000000000004" as const;
+
+describe("validateDeskDollarsTransfer", () => {
+  it("accepts a valid recipient and amount within balance", () => {
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: TO,
+        amount: "10",
+        balance: 100_000_000n,
+      })
+    ).toEqual({ ok: true, to: TO, amount: 10_000_000n });
+  });
+
+  it("rejects invalid, zero, and self recipients", () => {
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: "not-an-address",
+        amount: "1",
+        balance: 100_000_000n,
+      }).ok
+    ).toBe(false);
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: "0x0000000000000000000000000000000000000000",
+        amount: "1",
+        balance: 100_000_000n,
+      })
+    ).toMatchObject({ error: "Cannot transfer to the zero address." });
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: FROM,
+        amount: "1",
+        balance: 100_000_000n,
+      })
+    ).toMatchObject({ error: "Cannot transfer to your own wallet." });
+  });
+
+  it("rejects empty, zero, over-precise, and over-balance amounts", () => {
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: TO,
+        amount: "",
+        balance: 100_000_000n,
+      }).ok
+    ).toBe(false);
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: TO,
+        amount: "0",
+        balance: 100_000_000n,
+      })
+    ).toMatchObject({ error: "Enter an amount greater than zero." });
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: TO,
+        amount: "1.1234567",
+        balance: 100_000_000n,
+      }).ok
+    ).toBe(false);
+    expect(
+      validateDeskDollarsTransfer({
+        from: FROM,
+        recipient: TO,
+        amount: "101",
+        balance: 100_000_000n,
+      })
+    ).toMatchObject({ error: "Amount exceeds your Desk Dollars balance." });
+  });
+});

--- a/src/hooks/use-desk-dollars-transfer.test.tsx
+++ b/src/hooks/use-desk-dollars-transfer.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdk = vi.hoisted(() => ({
+  submit: vi.fn(),
+  getSubmittedHash: vi.fn(),
+  submissionError: null as string | null,
+  wait: vi.fn(),
+  notify: vi.fn(),
+}));
+
+vi.mock("@/lib/base-sepolia", () => ({
+  BASE_SEPOLIA_CHAIN_ID: 84532,
+  baseSepoliaPublicClient: {
+    waitForTransactionReceipt: (...args: unknown[]) => sdk.wait(...args),
+  },
+}));
+vi.mock("@/lib/desk-dollars", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/desk-dollars")>(
+      "@/lib/desk-dollars"
+    );
+  return {
+    ...actual,
+    getDeskDollarsTokenAddress: () =>
+      "0x0000000000000000000000000000000000000001",
+  };
+});
+vi.mock("@/lib/wallet-balance-sync", () => ({
+  notifyWalletBalancesChanged: () => sdk.notify(),
+}));
+vi.mock("./use-privy-sponsored-transaction", () => ({
+  usePrivySponsoredTransaction: () => ({
+    submit: sdk.submit,
+    getSubmittedHash: sdk.getSubmittedHash,
+    getSubmissionError: () => sdk.submissionError,
+  }),
+}));
+
+import { useDeskDollarsTransfer } from "./use-desk-dollars-transfer";
+
+const FROM = "0x0000000000000000000000000000000000000003" as const;
+const TO = "0x0000000000000000000000000000000000000004" as const;
+
+describe("useDeskDollarsTransfer", () => {
+  beforeEach(() => {
+    sdk.submit.mockReset().mockResolvedValue(true);
+    sdk.getSubmittedHash.mockReset().mockReturnValue("0xabc");
+    sdk.submissionError = null;
+    sdk.wait.mockReset().mockResolvedValue({ status: "success" });
+    sdk.notify.mockReset();
+  });
+
+  afterEach(() => cleanup());
+
+  it("keeps a transfer pending until a successful receipt, then notifies balances", async () => {
+    let resolveReceipt: (value: { status: "success" }) => void;
+    sdk.wait.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReceipt = resolve;
+        })
+    );
+    const { result } = renderHook(() => useDeskDollarsTransfer(FROM));
+
+    act(() => {
+      void result.current.transfer({
+        recipient: TO,
+        amount: "10",
+        balance: 100_000_000n,
+      });
+    });
+    await waitFor(() => expect(result.current.status).toBe("pending"));
+    expect(result.current.canTransfer).toBe(false);
+
+    await act(async () => {
+      resolveReceipt!({ status: "success" });
+    });
+    await waitFor(() => expect(result.current.status).toBe("confirmed"));
+    expect(sdk.notify).toHaveBeenCalledTimes(1);
+    expect(sdk.wait).toHaveBeenCalledWith({ hash: "0xabc" });
+  });
+
+  it("re-checks the same transfer hash after a receipt-wait failure instead of resubmitting", async () => {
+    sdk.wait
+      .mockRejectedValueOnce(new Error("rpc timeout"))
+      .mockResolvedValueOnce({ status: "success" });
+    const { result } = renderHook(() => useDeskDollarsTransfer(FROM));
+
+    await act(async () => {
+      await result.current.transfer({
+        recipient: TO,
+        amount: "5",
+        balance: 100_000_000n,
+      });
+    });
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe(
+      "Your transfer was submitted, but we couldn't confirm it yet. Retry to check its status."
+    );
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    expect(sdk.wait).toHaveBeenCalledTimes(2);
+    expect(sdk.wait).toHaveBeenNthCalledWith(2, { hash: "0xabc" });
+    await waitFor(() => expect(result.current.status).toBe("confirmed"));
+  });
+
+  it("retries a submission failure with the same transfer request", async () => {
+    sdk.submit.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useDeskDollarsTransfer(FROM));
+
+    await act(async () => {
+      await result.current.transfer({
+        recipient: TO,
+        amount: "1",
+        balance: 100_000_000n,
+      });
+    });
+    expect(result.current.canRetry).toBe(true);
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(2);
+    expect(sdk.submit.mock.calls[1][0]).toEqual(sdk.submit.mock.calls[0][0]);
+    expect(sdk.submit.mock.calls[0][0]).toMatchObject({
+      to: "0x0000000000000000000000000000000000000001",
+      chainId: 84532,
+    });
+  });
+
+  it("surfaces validation failures without submitting", async () => {
+    const { result } = renderHook(() => useDeskDollarsTransfer(FROM));
+
+    await act(async () => {
+      await result.current.transfer({
+        recipient: FROM,
+        amount: "1",
+        balance: 100_000_000n,
+      });
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("Cannot transfer to your own wallet.");
+    expect(result.current.canRetry).toBe(false);
+    expect(sdk.submit).not.toHaveBeenCalled();
+  });
+
+  it("suppresses duplicate transfers while one submission is in flight", async () => {
+    let resolveSubmit: (value: boolean) => void;
+    sdk.submit.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSubmit = resolve;
+        })
+    );
+    const { result } = renderHook(() => useDeskDollarsTransfer(FROM));
+
+    let first: Promise<boolean>;
+    let duplicate: Promise<boolean>;
+    act(() => {
+      first = result.current.transfer({
+        recipient: TO,
+        amount: "1",
+        balance: 100_000_000n,
+      });
+      duplicate = result.current.transfer({
+        recipient: TO,
+        amount: "1",
+        balance: 100_000_000n,
+      });
+    });
+    expect(sdk.submit).toHaveBeenCalledTimes(1);
+    await expect(duplicate!).resolves.toBe(false);
+    await act(async () => {
+      resolveSubmit!(true);
+      await first!;
+    });
+  });
+});

--- a/src/hooks/use-desk-dollars-transfer.ts
+++ b/src/hooks/use-desk-dollars-transfer.ts
@@ -1,0 +1,244 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import {
+  encodeFunctionData,
+  getAddress,
+  isAddress,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from "viem";
+import {
+  deskDollarsAbi,
+  getDeskDollarsTokenAddress,
+  parseTUsdInput,
+} from "@/lib/desk-dollars";
+import {
+  confirmSponsoredCall,
+  submitSponsoredCall,
+} from "@/lib/sponsored-call";
+import { notifyWalletBalancesChanged } from "@/lib/wallet-balance-sync";
+import { usePrivySponsoredTransaction } from "./use-privy-sponsored-transaction";
+
+export type DeskDollarsTransferStatus =
+  "idle" | "submitting" | "pending" | "confirmed" | "error" | "unavailable";
+
+export type DeskDollarsTransferInput = {
+  recipient: string;
+  amount: string;
+  balance: bigint | null;
+};
+
+export type DeskDollarsTransferValidation =
+  { ok: true; to: Address; amount: bigint } | { ok: false; error: string };
+
+const transferFailed =
+  "We couldn't complete your Desk Dollars transfer. Please try again.";
+const transferUnconfirmed =
+  "Your transfer was submitted, but we couldn't confirm it yet. Retry to check its status.";
+const tokenUnavailable =
+  "Desk Dollars is not configured for this Base Sepolia deployment.";
+
+/**
+ * Validates a tUSD transfer form before any sponsored call is submitted.
+ * Rejects the zero address, the sender's own wallet, zero amounts, and
+ * amounts above the known balance.
+ */
+export function validateDeskDollarsTransfer(
+  input: DeskDollarsTransferInput & { from: Address }
+): DeskDollarsTransferValidation {
+  const trimmed = input.recipient.trim();
+  if (!trimmed || !isAddress(trimmed)) {
+    return { ok: false, error: "Enter a valid 0x wallet address." };
+  }
+
+  const to = getAddress(trimmed);
+  if (to === zeroAddress) {
+    return { ok: false, error: "Cannot transfer to the zero address." };
+  }
+  if (to.toLowerCase() === input.from.toLowerCase()) {
+    return { ok: false, error: "Cannot transfer to your own wallet." };
+  }
+
+  const amount = parseTUsdInput(input.amount.trim());
+  if (amount === null) {
+    return {
+      ok: false,
+      error: "Enter a tUSD amount with up to 6 decimal places.",
+    };
+  }
+  if (amount <= 0n) {
+    return { ok: false, error: "Enter an amount greater than zero." };
+  }
+  if (input.balance === null) {
+    return { ok: false, error: "Your Desk Dollars balance is still loading." };
+  }
+  if (amount > input.balance) {
+    return { ok: false, error: "Amount exceeds your Desk Dollars balance." };
+  }
+
+  return { ok: true, to, amount };
+}
+
+/**
+ * Sponsored ERC-20 transfer of Desk Dollars from the signed-in embedded wallet.
+ * Pending-hash recovery mirrors the faucet: confirmation-unknown retries re-check
+ * the same receipt and never resubmit.
+ */
+export function useDeskDollarsTransfer(walletAddress: Address | null) {
+  const transaction = usePrivySponsoredTransaction();
+  const tokenAddress = getDeskDollarsTokenAddress();
+  const [status, setStatus] = useState<DeskDollarsTransferStatus>(
+    tokenAddress ? "idle" : "unavailable"
+  );
+  const [error, setError] = useState<string | null>(
+    tokenAddress ? null : tokenUnavailable
+  );
+  const [lastHash, setLastHash] = useState<Hex | null>(null);
+  const inFlight = useRef(false);
+  const pendingTransfer = useRef<Hex | null>(null);
+  const lastRequest = useRef<{ to: Address; amount: bigint } | null>(null);
+  const retryKind = useRef<"transfer" | "receipt-check" | null>(null);
+
+  const submitTransfer = useCallback(
+    async (to: Address, amount: bigint): Promise<boolean> => {
+      if (!tokenAddress || !walletAddress || inFlight.current) return false;
+
+      inFlight.current = true;
+      lastRequest.current = { to, amount };
+      retryKind.current = "transfer";
+      setStatus("submitting");
+      setError(null);
+
+      try {
+        const result = pendingTransfer.current
+          ? await confirmSponsoredCall(pendingTransfer.current)
+          : await submitSponsoredCall(
+              transaction,
+              {
+                to: tokenAddress,
+                data: encodeFunctionData({
+                  abi: deskDollarsAbi,
+                  functionName: "transfer",
+                  args: [to, amount],
+                }) as Hex,
+              },
+              (hash) => {
+                pendingTransfer.current = hash;
+                setLastHash(hash);
+                setStatus("pending");
+              }
+            );
+
+        if (result.outcome !== "confirmation-unknown") {
+          pendingTransfer.current = null;
+        }
+        if (result.outcome === "confirmed") {
+          retryKind.current = null;
+          setStatus("confirmed");
+          setError(null);
+          setLastHash(result.hash);
+          notifyWalletBalancesChanged();
+          return true;
+        }
+        if (result.outcome === "confirmation-unknown") {
+          retryKind.current = "receipt-check";
+          setStatus("error");
+          setError(transferUnconfirmed);
+          setLastHash(result.hash);
+          return false;
+        }
+        retryKind.current = "transfer";
+        setStatus("error");
+        setError(
+          result.outcome === "submission-failed"
+            ? (result.message ?? transferFailed)
+            : transferFailed
+        );
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    },
+    [tokenAddress, transaction, walletAddress]
+  );
+
+  const transfer = useCallback(
+    async (input: DeskDollarsTransferInput): Promise<boolean> => {
+      if (!walletAddress) return false;
+      if (!tokenAddress) {
+        setStatus("unavailable");
+        setError(tokenUnavailable);
+        return false;
+      }
+
+      const validated = validateDeskDollarsTransfer({
+        ...input,
+        from: walletAddress,
+      });
+      if (!validated.ok) {
+        setStatus("error");
+        setError(validated.error);
+        retryKind.current = null;
+        return false;
+      }
+
+      return submitTransfer(validated.to, validated.amount);
+    },
+    [submitTransfer, tokenAddress, walletAddress]
+  );
+
+  const retry = useCallback(async (): Promise<boolean> => {
+    if (retryKind.current === "receipt-check" && pendingTransfer.current) {
+      if (inFlight.current) return false;
+      inFlight.current = true;
+      setStatus("pending");
+      setError(null);
+      try {
+        const result = await confirmSponsoredCall(pendingTransfer.current);
+        if (result.outcome === "confirmed") {
+          pendingTransfer.current = null;
+          retryKind.current = null;
+          setStatus("confirmed");
+          setError(null);
+          setLastHash(result.hash);
+          notifyWalletBalancesChanged();
+          return true;
+        }
+        if (result.outcome === "confirmation-unknown") {
+          retryKind.current = "receipt-check";
+          setStatus("error");
+          setError(transferUnconfirmed);
+          return false;
+        }
+        pendingTransfer.current = null;
+        retryKind.current = "transfer";
+        setStatus("error");
+        setError(transferFailed);
+        return false;
+      } finally {
+        inFlight.current = false;
+      }
+    }
+
+    const request = lastRequest.current;
+    if (!request) return false;
+    return submitTransfer(request.to, request.amount);
+  }, [submitTransfer]);
+
+  return {
+    status,
+    error,
+    lastHash,
+    canTransfer:
+      !!tokenAddress &&
+      !!walletAddress &&
+      (status === "idle" || status === "confirmed" || status === "error") &&
+      !inFlight.current &&
+      retryKind.current !== "receipt-check",
+    canRetry: status === "error" && retryKind.current !== null,
+    transfer,
+    retry,
+  };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,7 @@ const DIALOG_POPUP_BASE_CLASS =
   "fixed left-1/2 top-1/2 z-50 max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] -translate-x-1/2 -translate-y-1/2 overflow-hidden border border-[var(--t-border)] bg-[var(--t-bg)] font-mono shadow-2xl shadow-black/60 sm:max-h-[88vh]";
 
 const DIALOG_POPUP_SIZE_CLASS = {
+  sm: "max-w-md sm:w-[min(28rem,92vw)]",
   lg: "max-w-2xl sm:w-[92vw]",
   xl: "max-w-4xl sm:w-[94vw]",
 } as const;


### PR DESCRIPTION
## Summary
- Make the signed-in header wallet chip open a terminal-style wallet dialog with full address, copy, and BaseScan links
- Add a sponsored Desk Dollars (`tUSD`) ERC-20 transfer flow with recipient/amount validation, Max fill, and receipt retry
- Sync balances across header, faucet, and LP Desk after a confirmed transfer

## Test plan
- [ ] Sign in, click the top-right wallet chip, and confirm the dialog opens with full address + live balance
- [ ] Copy address and open BaseScan from the dialog
- [ ] Send a small tUSD amount to another wallet and confirm header/faucet balances refresh
- [ ] Verify invalid recipient, self-transfer, zero amount, and over-balance amounts are blocked
- [ ] Confirm Max fills the current balance and Retry re-checks an unresolved receipt without resubmitting
- [ ] `pnpm test` / `pnpm typecheck`


Made with [Cursor](https://cursor.com)