### PR TITLE
Follow up wallet dialog review cleanups

### DIFF
--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -63,9 +63,11 @@ export function AuthControls() {
   }, [logout]);
 
   const balanceLabel = formatDeskDollarsBalanceLabel(balance, decimals);
-  const showWallet =
-    !!walletAddress &&
-    (state.status === "signed-in" || state.status === "logout-error");
+  const signedInWallet =
+    walletAddress &&
+    (state.status === "signed-in" || state.status === "logout-error")
+      ? walletAddress
+      : null;
 
   return (
     <div
@@ -75,7 +77,7 @@ export function AuthControls() {
       <p aria-live="polite" className="text-xs text-[var(--t-muted)]">
         {state.message}
       </p>
-      {walletAddress && showWallet ? (
+      {signedInWallet ? (
         <>
           <button
             aria-expanded={walletOpen}
@@ -85,7 +87,7 @@ export function AuthControls() {
             onClick={() => setWalletOpen(true)}
             type="button"
           >
-            <span>{formatShortAddress(walletAddress)}</span>
+            <span>{formatShortAddress(signedInWallet)}</span>
             {balanceLabel && balance !== null ? (
               <FlashValue className="text-[var(--t-green-hot)]" value={balance}>
                 {balanceLabel}
@@ -97,7 +99,7 @@ export function AuthControls() {
             decimals={decimals}
             onOpenChange={setWalletOpen}
             open={walletOpen}
-            walletAddress={walletAddress}
+            walletAddress={signedInWallet}
           />
         </>
       ) : null}

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -50,6 +50,19 @@ export function WalletDialog({
     formatDeskDollarsBalanceLabel(balance, decimals) ?? "— tUSD";
   const isBusy =
     transfer.status === "submitting" || transfer.status === "pending";
+  const isRetry = transfer.canRetry;
+  const canSubmit =
+    transfer.status !== "unavailable" &&
+    !isBusy &&
+    (isRetry ||
+      (transfer.canTransfer && !!recipient.trim() && !!amount.trim()));
+  const submitLabel = isBusy
+    ? transfer.status === "submitting"
+      ? "Submitting…"
+      : "Pending…"
+    : isRetry
+      ? "Retry"
+      : "Send tUSD";
 
   const handleCopy = useCallback(async () => {
     try {
@@ -68,13 +81,13 @@ export function WalletDialog({
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      if (transfer.canRetry) {
+      if (isRetry) {
         void transfer.retry();
         return;
       }
       void transfer.transfer({ recipient, amount, balance });
     },
-    [amount, balance, recipient, transfer]
+    [amount, balance, isRetry, recipient, transfer]
   );
 
   return (
@@ -233,26 +246,11 @@ export function WalletDialog({
 
             <GameButton
               className="mt-4 w-full"
-              disabled={
-                transfer.status === "unavailable" ||
-                (isBusy
-                  ? true
-                  : transfer.canRetry
-                    ? false
-                    : !transfer.canTransfer ||
-                      !recipient.trim() ||
-                      !amount.trim())
-              }
+              disabled={!canSubmit}
               size="sm"
               type="submit"
             >
-              {transfer.canRetry
-                ? "Retry"
-                : transfer.status === "submitting"
-                  ? "Submitting…"
-                  : transfer.status === "pending"
-                    ? "Pending…"
-                    : "Send tUSD"}
+              {submitLabel}
             </GameButton>
           </form>
         </Dialog.Popup>

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -6,6 +6,7 @@ import type { Address } from "viem";
 import { FlashValue } from "@/components/ui/flash-value";
 import { GameButton } from "@/components/ui/game-button";
 import { useDeskDollarsTransfer } from "@/hooks/use-desk-dollars-transfer";
+import type { DeskDollarsTransferStatus } from "@/hooks/use-desk-dollars-transfer";
 import {
   formatDeskDollars,
   formatDeskDollarsBalanceLabel,
@@ -28,6 +29,65 @@ type WalletDialogProps = {
   balance: bigint | null;
   decimals: number | null;
 };
+
+type TransferStatusMessage = {
+  status: DeskDollarsTransferStatus;
+  error: string | null;
+  lastHash: `0x${string}` | null;
+};
+
+function TransferStatusCopy({
+  status,
+  error,
+  lastHash,
+}: TransferStatusMessage) {
+  switch (status) {
+    case "submitting":
+      return (
+        <p aria-live="polite" className="mt-3 text-sm">
+          Submitting your sponsored transfer…
+        </p>
+      );
+    case "pending":
+      return (
+        <p aria-live="polite" className="mt-3 text-sm">
+          Transfer pending until its Base Sepolia receipt succeeds…
+        </p>
+      );
+    case "confirmed":
+      return (
+        <p aria-live="polite" className="mt-3 text-sm">
+          Transfer confirmed on Base Sepolia.
+          {lastHash ? (
+            <>
+              {" "}
+              <a
+                className="underline"
+                href={getBaseSepoliaTransactionUrl(lastHash)}
+                rel="noreferrer"
+                target="_blank"
+              >
+                View on BaseScan
+              </a>
+            </>
+          ) : null}
+        </p>
+      );
+    case "unavailable":
+    case "error":
+      return error ? (
+        <p role="alert" className="mt-3 text-sm">
+          {error}
+        </p>
+      ) : null;
+    case "idle":
+      return null;
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
+  }
+}
 
 /**
  * Signed-in wallet surface: full address utilities and a sponsored tUSD send.
@@ -209,40 +269,11 @@ export function WalletDialog({
               value={amount}
             />
 
-            {transfer.status === "submitting" ? (
-              <p aria-live="polite" className="mt-3 text-sm">
-                Submitting your sponsored transfer…
-              </p>
-            ) : null}
-            {transfer.status === "pending" ? (
-              <p aria-live="polite" className="mt-3 text-sm">
-                Transfer pending until its Base Sepolia receipt succeeds…
-              </p>
-            ) : null}
-            {transfer.status === "confirmed" ? (
-              <p aria-live="polite" className="mt-3 text-sm">
-                Transfer confirmed on Base Sepolia.
-                {transfer.lastHash ? (
-                  <>
-                    {" "}
-                    <a
-                      className="underline"
-                      href={getBaseSepoliaTransactionUrl(transfer.lastHash)}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      View on BaseScan
-                    </a>
-                  </>
-                ) : null}
-              </p>
-            ) : null}
-            {transfer.status === "unavailable" ||
-            transfer.status === "error" ? (
-              <p role="alert" className="mt-3 text-sm">
-                {transfer.error}
-              </p>
-            ) : null}
+            <TransferStatusCopy
+              error={transfer.error}
+              lastHash={transfer.lastHash}
+              status={transfer.status}
+            />
 
             <GameButton
               className="mt-4 w-full"

--- a/src/hooks/use-desk-dollars-transfer.ts
+++ b/src/hooks/use-desk-dollars-transfer.ts
@@ -15,11 +15,14 @@ import {
   parseTUsdInput,
 } from "@/lib/desk-dollars";
 import {
-  confirmSponsoredCall,
-  submitSponsoredCall,
+  resumeSponsoredStage,
+  runSponsoredStage,
+  type StageErrorCopy,
 } from "@/lib/sponsored-call";
 import { notifyWalletBalancesChanged } from "@/lib/wallet-balance-sync";
 import { usePrivySponsoredTransaction } from "./use-privy-sponsored-transaction";
+
+type Stage = "transfer";
 
 export type DeskDollarsTransferStatus =
   "idle" | "submitting" | "pending" | "confirmed" | "error" | "unavailable";
@@ -33,12 +36,17 @@ export type DeskDollarsTransferInput = {
 export type DeskDollarsTransferValidation =
   { ok: true; to: Address; amount: bigint } | { ok: false; error: string };
 
-const transferFailed =
-  "We couldn't complete your Desk Dollars transfer. Please try again.";
-const transferUnconfirmed =
-  "Your transfer was submitted, but we couldn't confirm it yet. Retry to check its status.";
 const tokenUnavailable =
   "Desk Dollars is not configured for this Base Sepolia deployment.";
+
+const stageCopy: Record<Stage, StageErrorCopy> = {
+  transfer: {
+    failed:
+      "We couldn't complete your Desk Dollars transfer. Please try again.",
+    unconfirmed:
+      "Your transfer was submitted, but we couldn't confirm it yet. Retry to check its status.",
+  },
+};
 
 /**
  * Validates a tUSD transfer form before any sponsored call is submitted.
@@ -83,8 +91,8 @@ export function validateDeskDollarsTransfer(
 
 /**
  * Sponsored ERC-20 transfer of Desk Dollars from the signed-in embedded wallet.
- * Pending-hash recovery mirrors the faucet: confirmation-unknown retries re-check
- * the same receipt and never resubmit.
+ * Uses the canonical sponsored-stage helpers so pending-hash resume never
+ * resubmits and outcome copy stays centralized in applyStageResult.
  */
 export function useDeskDollarsTransfer(walletAddress: Address | null) {
   const transaction = usePrivySponsoredTransaction();
@@ -97,71 +105,68 @@ export function useDeskDollarsTransfer(walletAddress: Address | null) {
   );
   const [lastHash, setLastHash] = useState<Hex | null>(null);
   const inFlight = useRef(false);
-  const pendingTransfer = useRef<Hex | null>(null);
+  const pendingStage = useRef<{ stage: Stage; hash: Hex } | null>(null);
   const lastRequest = useRef<{ to: Address; amount: bigint } | null>(null);
-  const retryKind = useRef<"transfer" | "receipt-check" | null>(null);
+  const retryKind = useRef<Stage | null>(null);
+
+  const onStageStatus = useCallback(
+    (next: `${Stage}-submitting` | `${Stage}-pending`) => {
+      if (next === "transfer-pending" && pendingStage.current) {
+        setLastHash(pendingStage.current.hash);
+      }
+      setStatus(next === "transfer-submitting" ? "submitting" : "pending");
+      setError(null);
+    },
+    []
+  );
 
   const submitTransfer = useCallback(
     async (to: Address, amount: bigint): Promise<boolean> => {
-      if (!tokenAddress || !walletAddress || inFlight.current) return false;
+      if (
+        !tokenAddress ||
+        !walletAddress ||
+        inFlight.current ||
+        pendingStage.current
+      ) {
+        return false;
+      }
 
       inFlight.current = true;
       lastRequest.current = { to, amount };
       retryKind.current = "transfer";
-      setStatus("submitting");
-      setError(null);
 
       try {
-        const result = pendingTransfer.current
-          ? await confirmSponsoredCall(pendingTransfer.current)
-          : await submitSponsoredCall(
-              transaction,
-              {
-                to: tokenAddress,
-                data: encodeFunctionData({
-                  abi: deskDollarsAbi,
-                  functionName: "transfer",
-                  args: [to, amount],
-                }) as Hex,
-              },
-              (hash) => {
-                pendingTransfer.current = hash;
-                setLastHash(hash);
-                setStatus("pending");
-              }
-            );
-
-        if (result.outcome !== "confirmation-unknown") {
-          pendingTransfer.current = null;
-        }
-        if (result.outcome === "confirmed") {
-          retryKind.current = null;
-          setStatus("confirmed");
-          setError(null);
-          setLastHash(result.hash);
-          notifyWalletBalancesChanged();
-          return true;
-        }
-        if (result.outcome === "confirmation-unknown") {
-          retryKind.current = "receipt-check";
-          setStatus("error");
-          setError(transferUnconfirmed);
-          setLastHash(result.hash);
-          return false;
-        }
-        retryKind.current = "transfer";
+        await runSponsoredStage({
+          transaction,
+          pendingStage,
+          stage: "transfer",
+          copy: stageCopy.transfer,
+          request: {
+            to: tokenAddress,
+            data: encodeFunctionData({
+              abi: deskDollarsAbi,
+              functionName: "transfer",
+              args: [to, amount],
+            }) as Hex,
+          },
+          onStatus: onStageStatus,
+        });
+        retryKind.current = null;
+        setStatus("confirmed");
+        setError(null);
+        notifyWalletBalancesChanged();
+        return true;
+      } catch (caught) {
         setStatus("error");
         setError(
-          result.outcome === "submission-failed"
-            ? (result.message ?? transferFailed)
-            : transferFailed
+          caught instanceof Error ? caught.message : stageCopy.transfer.failed
         );
         return false;
       } finally {
         inFlight.current = false;
       }
     },
-    [tokenAddress, transaction, walletAddress]
+    [onStageStatus, tokenAddress, transaction, walletAddress]
   );
 
   const transfer = useCallback(
@@ -190,32 +195,25 @@ export function useDeskDollarsTransfer(walletAddress: Address | null) {
   );
 
   const retry = useCallback(async (): Promise<boolean> => {
-    if (retryKind.current === "receipt-check" && pendingTransfer.current) {
+    if (pendingStage.current) {
       if (inFlight.current) return false;
       inFlight.current = true;
-      setStatus("pending");
-      setError(null);
       try {
-        const result = await confirmSponsoredCall(pendingTransfer.current);
-        if (result.outcome === "confirmed") {
-          pendingTransfer.current = null;
-          retryKind.current = null;
-          setStatus("confirmed");
-          setError(null);
-          setLastHash(result.hash);
-          notifyWalletBalancesChanged();
-          return true;
-        }
-        if (result.outcome === "confirmation-unknown") {
-          retryKind.current = "receipt-check";
-          setStatus("error");
-          setError(transferUnconfirmed);
-          return false;
-        }
-        pendingTransfer.current = null;
-        retryKind.current = "transfer";
+        await resumeSponsoredStage({
+          pendingStage,
+          copyByStage: stageCopy,
+          onStatus: onStageStatus,
+        });
+        retryKind.current = null;
+        setStatus("confirmed");
+        setError(null);
+        notifyWalletBalancesChanged();
+        return true;
+      } catch (caught) {
         setStatus("error");
-        setError(transferFailed);
+        setError(
+          caught instanceof Error ? caught.message : stageCopy.transfer.failed
+        );
         return false;
       } finally {
         inFlight.current = false;
@@ -225,7 +223,7 @@ export function useDeskDollarsTransfer(walletAddress: Address | null) {
     const request = lastRequest.current;
     if (!request) return false;
     return submitTransfer(request.to, request.amount);
-  }, [submitTransfer]);
+  }, [onStageStatus, submitTransfer]);
 
   return {
     status,
@@ -236,7 +234,7 @@ export function useDeskDollarsTransfer(walletAddress: Address | null) {
       !!walletAddress &&
       (status === "idle" || status === "confirmed" || status === "error") &&
       !inFlight.current &&
-      retryKind.current !== "receipt-check",
+      pendingStage.current === null,
     canRetry: status === "error" && retryKind.current !== null,
     transfer,
     retry,


### PR DESCRIPTION
## Summary
- Land the thermo-nuclear review fixes that landed after #381 was already merged
- Rewrite tUSD transfer onto `runSponsoredStage` / `resumeSponsoredStage`
- Flatten wallet dialog submit locals, collapse status copy into one switch, and narrow `signedInWallet` once in auth controls

## Test plan
- [ ] Open wallet dialog, send tUSD, confirm pending/retry still works without double-submit
- [ ] Confirm submit button labels (`Send` / `Submitting…` / `Pending…` / `Retry`) still match state
- [ ] `pnpm test` / `pnpm typecheck`


Made with [Cursor](https://cursor.com)