### PR TITLE
Promote round stages and tighten Floor chrome

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,8 +5,8 @@ A shared-round crash game on Base Sepolia: every minute a round opens, players p
 ## Language
 
 **Desk Dollars (tUSD)**:
-The project-deployed 6-decimal testnet ERC-20 used for all margin, payouts, and LP deposits. Claimable from the in-app faucet; explicitly worthless and never presented as Circle USDC or real dollars. Mainnet intent is real Circle USDC.
-_Avoid_: tUSDC, USDC, test USDC
+The project-deployed 6-decimal testnet ERC-20 used for all margin, payouts, and LP deposits. Claimable from the in-app faucet; explicitly worthless and never presented as Circle USDC or real dollars. Mainnet intent is real Circle USDC. Player-facing UI shows the ticker as `USDC`; the onchain symbol remains `tUSD` and must never be presented as Circle USDC.
+_Avoid_: tUSDC, test USDC, Circle USDC (in testnet UI)
 
 **Arcade Leverage**:
 The fixed multiplier tier a player selects at entry — exactly one of `1.25x`, `1.50x`, `2.00x`, `3.00x`, `5.00x`, or `10.00x`. It is both the automatic close threshold and the gross payout multiple.

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -10,7 +10,7 @@ export default function HistoryPage() {
     <section aria-labelledby="history-heading">
       <RoutePageIntro
         eyebrow="Base Sepolia · Global history"
-        title="Recent rounds"
+        title="Rounds"
         titleId="history-heading"
       >
         Finalized rounds show the attested Crash Point. Empty, delayed, and

--- a/src/app/lp/page.tsx
+++ b/src/app/lp/page.tsx
@@ -14,7 +14,7 @@ export default function LpPage() {
         title="LP Desk"
         titleId="lp-heading"
       >
-        Provide Desk Dollars (tUSD) to receive vault shares. Sign in to deposit
+        Provide Desk Dollars (USDC) to receive vault shares. Sign in to deposit
         or withdraw.
       </RoutePageIntro>
       <AuthGate>

--- a/src/app/lp/page.tsx
+++ b/src/app/lp/page.tsx
@@ -1,6 +1,7 @@
 import { AuthGate } from "@/components/auth/auth-gate";
 import { LpDesk } from "@/components/lp-desk/lp-desk";
 import { RoutePageIntro } from "@/components/route-page-intro";
+import { DISPLAY_ASSET_SYMBOL } from "@/lib/desk-dollars";
 
 /**
  * Liquidity desk — vault metrics, deposit, and withdraw. Sign-in required for
@@ -14,8 +15,8 @@ export default function LpPage() {
         title="LP Desk"
         titleId="lp-heading"
       >
-        Provide Desk Dollars (USDC) to receive vault shares. Sign in to deposit
-        or withdraw.
+        Provide Desk Dollars ({DISPLAY_ASSET_SYMBOL}) to receive vault shares.
+        Sign in to deposit or withdraw.
       </RoutePageIntro>
       <AuthGate>
         <LpDesk />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,11 @@ import { CurrentRound } from "@/components/current-round/current-round";
 import { CrashTicketRefund } from "@/components/current-round/crash-ticket-refund";
 import { CrashTicketSettlement } from "@/components/current-round/crash-ticket-settlement";
 import { DeskDollarsPanel } from "@/components/desk-dollars/desk-dollars-panel";
-import { PersonalHistory } from "@/components/history/personal-history";
 import { RoundTheater } from "@/components/round-theater/round-theater";
 
 /**
  * Chart-first play floor: hero replay + entry rail and player actions.
- * Recent rounds live on /history; LP Desk on /lp.
+ * Record lives on /record; recent rounds on /history; LP Desk on /lp.
  */
 export default function Home() {
   return (
@@ -20,7 +19,6 @@ export default function Home() {
           <CrashTicketSettlement />
           <CrashTicketRefund />
           <DeskDollarsPanel />
-          <PersonalHistory />
         </AuthGate>
       </div>
     </div>

--- a/src/app/record/page.tsx
+++ b/src/app/record/page.tsx
@@ -1,0 +1,28 @@
+import { AuthGate } from "@/components/auth/auth-gate";
+import { PersonalHistory } from "@/components/history/personal-history";
+import { RoutePageIntro } from "@/components/route-page-intro";
+
+/**
+ * Wallet-scoped ticket record — lookback tickets with receipt-backed
+ * claim and refund actions.
+ */
+export default function RecordPage() {
+  return (
+    <section aria-labelledby="record-heading">
+      <RoutePageIntro
+        eyebrow="Base Sepolia · Your tickets"
+        title="Record"
+        titleId="record-heading"
+      >
+        Every ticket in the lookback window. Claim and refund actions wait for
+        Base Sepolia receipts — a transaction hash alone never changes
+        settlement state.
+      </RoutePageIntro>
+      <div className="mt-8">
+        <AuthGate>
+          <PersonalHistory />
+        </AuthGate>
+      </div>
+    </section>
+  );
+}

--- a/src/components/app-shell/app-shell.test.tsx
+++ b/src/components/app-shell/app-shell.test.tsx
@@ -43,7 +43,7 @@ describe("AppShell", () => {
 
   afterEach(cleanup);
 
-  it("renders Floor, Recent rounds, and LP Desk navigation links", () => {
+  it("renders Floor, Record, Rounds, and LP navigation links", () => {
     render(
       <AppShell>
         <p>Floor content</p>
@@ -53,19 +53,38 @@ describe("AppShell", () => {
     const nav = screen.getByTestId("app-shell-nav");
     expect(nav).toBeTruthy();
     const floor = screen.getByRole("link", { name: "Floor" });
-    const history = screen.getByRole("link", { name: "Recent rounds" });
-    const lp = screen.getByRole("link", { name: "LP Desk" });
+    const record = screen.getByRole("link", { name: "Record" });
+    const rounds = screen.getByRole("link", { name: "Rounds" });
+    const lp = screen.getByRole("link", { name: "LP" });
     expect(floor.getAttribute("href")).toBe("/");
-    expect(history.getAttribute("href")).toBe("/history");
+    expect(record.getAttribute("href")).toBe("/record");
+    expect(rounds.getAttribute("href")).toBe("/history");
     expect(lp.getAttribute("href")).toBe("/lp");
     expect(floor.getAttribute("aria-current")).toBe("page");
-    expect(history.getAttribute("aria-current")).toBeNull();
+    expect(record.getAttribute("aria-current")).toBeNull();
+    expect(rounds.getAttribute("aria-current")).toBeNull();
     expect(lp.getAttribute("aria-current")).toBeNull();
     expect(screen.getByTestId("no-real-value-disclosure")).toBeTruthy();
     expect(screen.getByText("Floor content")).toBeTruthy();
   });
 
-  it("marks Recent rounds as current on /history", () => {
+  it("marks Record as current on /record", () => {
+    sdk.pathname = "/record";
+    render(
+      <AppShell>
+        <p>Record content</p>
+      </AppShell>
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Record" }).getAttribute("aria-current")
+    ).toBe("page");
+    expect(
+      screen.getByRole("link", { name: "Floor" }).getAttribute("aria-current")
+    ).toBeNull();
+  });
+
+  it("marks Rounds as current on /history", () => {
     sdk.pathname = "/history";
     render(
       <AppShell>
@@ -74,19 +93,17 @@ describe("AppShell", () => {
     );
 
     expect(
-      screen
-        .getByRole("link", { name: "Recent rounds" })
-        .getAttribute("aria-current")
+      screen.getByRole("link", { name: "Rounds" }).getAttribute("aria-current")
     ).toBe("page");
     expect(
       screen.getByRole("link", { name: "Floor" }).getAttribute("aria-current")
     ).toBeNull();
     expect(
-      screen.getByRole("link", { name: "LP Desk" }).getAttribute("aria-current")
+      screen.getByRole("link", { name: "LP" }).getAttribute("aria-current")
     ).toBeNull();
   });
 
-  it("marks LP Desk as current on /lp", () => {
+  it("marks LP as current on /lp", () => {
     sdk.pathname = "/lp";
     render(
       <AppShell>
@@ -95,15 +112,13 @@ describe("AppShell", () => {
     );
 
     expect(
-      screen.getByRole("link", { name: "LP Desk" }).getAttribute("aria-current")
+      screen.getByRole("link", { name: "LP" }).getAttribute("aria-current")
     ).toBe("page");
     expect(
       screen.getByRole("link", { name: "Floor" }).getAttribute("aria-current")
     ).toBeNull();
     expect(
-      screen
-        .getByRole("link", { name: "Recent rounds" })
-        .getAttribute("aria-current")
+      screen.getByRole("link", { name: "Rounds" }).getAttribute("aria-current")
     ).toBeNull();
   });
 });

--- a/src/components/app-shell/app-shell.tsx
+++ b/src/components/app-shell/app-shell.tsx
@@ -7,12 +7,13 @@ import { NoRealValueDisclosure } from "@/components/no-real-value-disclosure";
 
 const NAV = [
   { href: "/", label: "Floor" },
-  { href: "/history", label: "Recent rounds" },
-  { href: "/lp", label: "LP Desk" },
+  { href: "/record", label: "Record" },
+  { href: "/history", label: "Rounds" },
+  { href: "/lp", label: "LP" },
 ] as const;
 
 /**
- * Shared chrome: brand, Floor / Recent rounds / LP Desk nav, compact auth,
+ * Shared chrome: brand, Floor / Record / Rounds / LP nav, compact auth,
  * disclosure. Leaves page content as the primary workspace.
  */
 export function AppShell({
@@ -25,8 +26,8 @@ export function AppShell({
   return (
     <div className="min-h-screen bg-[var(--t-bg)] font-mono text-[var(--t-text)]">
       <header className="border-b border-[var(--t-border)] bg-[var(--t-panel-strong)]">
-        <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-4 sm:px-6">
-          <div className="flex flex-wrap items-center gap-6">
+        <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 sm:px-6">
+          <div className="flex min-w-0 flex-wrap items-center gap-4 sm:gap-6">
             <Link
               className="font-[family-name:var(--font-plex-sans)] text-xl font-black uppercase tracking-tight text-[var(--t-accent)] sm:text-2xl"
               href="/"
@@ -46,7 +47,7 @@ export function AppShell({
                 return (
                   <Link
                     aria-current={isActive ? "page" : undefined}
-                    className={`px-3 py-1.5 text-xs font-bold uppercase tracking-[0.16em] transition-colors duration-[var(--mc-dur-fast)] ${
+                    className={`px-2.5 py-1 text-xs font-bold uppercase tracking-[0.16em] transition-colors duration-[var(--mc-dur-fast)] sm:px-3 ${
                       isActive
                         ? "border-b-2 border-[var(--t-accent)] text-[var(--t-accent)]"
                         : "text-[var(--t-muted)] hover:text-[var(--t-text)]"
@@ -62,7 +63,7 @@ export function AppShell({
           </div>
           <AuthControls />
         </div>
-        <div className="mx-auto w-full max-w-7xl px-4 pb-3 sm:px-6">
+        <div className="mx-auto w-full max-w-7xl px-4 pb-2 sm:px-6">
           <NoRealValueDisclosure />
         </div>
       </header>

--- a/src/components/auth/auth-controls.test.tsx
+++ b/src/components/auth/auth-controls.test.tsx
@@ -152,10 +152,10 @@ describe("AuthControls", () => {
     expect(sdk.login).toHaveBeenCalledTimes(2);
   });
 
-  it("shows truncated wallet, tUSD balance, and Desk phone switch when signed in", () => {
+  it("shows truncated wallet, USDC balance, and Desk phone switch when signed in", () => {
     renderSignedInControls();
     expect(screen.getByText("0x1234")).not.toBeNull();
-    expect(screen.getByText("100 tUSD")).not.toBeNull();
+    expect(screen.getByText("100 USDC")).not.toBeNull();
     expect(screen.queryByText("+15555550123")).toBeNull();
     expect(screen.getByRole("button", { name: /Desk phone/i })).not.toBeNull();
   });

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -12,7 +12,7 @@ import { useDeskDollarsBalance } from "@/hooks/use-desk-dollars-balance";
 import { getAuthBoundaryState } from "./auth-boundary";
 
 /**
- * Compact shell auth: login/logout, wallet chip, live tUSD balance,
+ * Compact shell auth: login/logout, wallet chip, live USDC balance,
  * and the Desk phone switch for liquidation calls.
  * Does not gate children — use AuthGate for signed-in-only surfaces.
  */

--- a/src/components/current-round/crash-live-ticket.tsx
+++ b/src/components/current-round/crash-live-ticket.tsx
@@ -137,7 +137,7 @@ export function CrashLiveTicket({
         <div>
           <dt className="text-[var(--t-muted)]">Margin</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(ticket.margin, TUSD_DECIMALS)} tUSD
+            {formatDeskDollars(ticket.margin, TUSD_DECIMALS)} USDC
           </dd>
         </div>
         <div>
@@ -160,7 +160,7 @@ export function CrashLiveTicket({
           </dt>
           <dd className="tabular-nums text-[var(--t-green-hot)]">
             {formatDeskDollars(payout ?? ticket.reservedPayout, TUSD_DECIMALS)}{" "}
-            tUSD
+            USDC
           </dd>
         </div>
         {outcome ? (

--- a/src/components/current-round/crash-live-ticket.tsx
+++ b/src/components/current-round/crash-live-ticket.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
 import {
   formatLeverageBps,
   type CrashTicket,
@@ -137,7 +137,7 @@ export function CrashLiveTicket({
         <div>
           <dt className="text-[var(--t-muted)]">Margin</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(ticket.margin, TUSD_DECIMALS)} USDC
+            {formatDeskDollarsAmount(ticket.margin)}
           </dd>
         </div>
         <div>
@@ -159,8 +159,7 @@ export function CrashLiveTicket({
             {outcome ? amountLabelCopy[outcome] : "Reserved maximum payout"}
           </dt>
           <dd className="tabular-nums text-[var(--t-green-hot)]">
-            {formatDeskDollars(payout ?? ticket.reservedPayout, TUSD_DECIMALS)}{" "}
-            USDC
+            {formatDeskDollarsAmount(payout ?? ticket.reservedPayout)}
           </dd>
         </div>
         {outcome ? (

--- a/src/components/current-round/crash-round-entry.test.tsx
+++ b/src/components/current-round/crash-round-entry.test.tsx
@@ -80,7 +80,7 @@ describe("CrashRoundEntry", () => {
       screen.getByText(/0x0000000000000000000000000000000000000002/)
     ).toBeTruthy();
     expect(
-      screen.getByText(/One-time bounded approval: 1000 tUSD/)
+      screen.getByText(/One-time bounded approval: 1000 USDC/)
     ).toBeTruthy();
     expect(
       screen.getByText(/never requests an unlimited allowance/)
@@ -109,9 +109,9 @@ describe("CrashRoundEntry", () => {
     render(<CrashRoundEntry {...sdk.props} />);
     expect(screen.getByText("Your live ticket")).toBeTruthy();
     expect(screen.getByText("7")).toBeTruthy();
-    expect(screen.getByText("5 tUSD")).toBeTruthy();
+    expect(screen.getByText("5 USDC")).toBeTruthy();
     expect(screen.getByText("2.00x")).toBeTruthy();
-    expect(screen.getByText("10 tUSD")).toBeTruthy();
+    expect(screen.getByText("10 USDC")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /enter/i })).toBeNull();
   });
 

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -22,7 +22,7 @@ import { CrashLiveTicket } from "./crash-live-ticket";
 
 const statusCopy: Partial<Record<CrashEntryStatus, string>> = {
   loading: "Loading your entry state…",
-  "approval-submitting": "Submitting a one-time 1,000 tUSD approval…",
+  "approval-submitting": "Submitting a one-time 1,000 USDC approval…",
   "approval-pending":
     "Bounded approval pending until its Base Sepolia receipt succeeds…",
   "entry-submitting": "Submitting your sponsored entry…",
@@ -51,7 +51,7 @@ function formatTUsd(value: bigint) {
 
 /**
  * Player entry surface for the current Crash round.
- * Offers 1/5/10 tUSD margins and six leverage tiers only into initialized
+ * Offers 1/5/10 USDC margins and six leverage tiers only into initialized
  * open rounds with more than five seconds remaining before lock.
  */
 export function CrashRoundEntry({
@@ -153,7 +153,7 @@ export function CrashRoundEntry({
         legend="Margin"
         options={ENTRY_MARGINS_TUSD}
         selected={entry.selectedMargin}
-        format={(margin) => `${formatTUsd(margin)} tUSD`}
+        format={(margin) => `${formatTUsd(margin)} USDC`}
         onSelect={entry.selectMargin}
       />
 
@@ -172,26 +172,26 @@ export function CrashRoundEntry({
             {entry.tUsdBalance === undefined
               ? "—"
               : formatTUsd(entry.tUsdBalance)}{" "}
-            tUSD
+            USDC
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Expected maximum payout</dt>
           <dd className="tabular-nums text-[var(--t-green-hot)]">
-            {formatTUsd(entry.expectedPayout)} tUSD
+            {formatTUsd(entry.expectedPayout)} USDC
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Current vault allowance</dt>
           <dd className="tabular-nums">
             {entry.allowance === undefined ? "—" : formatTUsd(entry.allowance)}{" "}
-            tUSD
+            USDC
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Selected margin</dt>
           <dd className="tabular-nums">
-            {formatTUsd(entry.selectedMargin)} tUSD
+            {formatTUsd(entry.selectedMargin)} USDC
           </dd>
         </div>
       </dl>
@@ -210,7 +210,7 @@ export function CrashRoundEntry({
         </p>
         <p className="mt-2">
           One-time bounded approval: {formatTUsd(BOUNDED_ENTRY_ALLOWANCE_TUSD)}{" "}
-          tUSD. Later entries reuse this allowance with sponsored enter-only
+          USDC. Later entries reuse this allowance with sponsored enter-only
           transactions. This interface never requests an unlimited allowance.
         </p>
         <p className="mt-2">

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -16,13 +16,17 @@ import {
   formatLeverageBps,
   type CrashRoundPhase,
 } from "@/lib/margin-call-crash";
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import {
+  DISPLAY_ASSET_SYMBOL,
+  formatDeskDollarsAmount,
+  formatDeskDollarsAmountLabel,
+} from "@/lib/desk-dollars";
 import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { CrashLiveTicket } from "./crash-live-ticket";
 
 const statusCopy: Partial<Record<CrashEntryStatus, string>> = {
   loading: "Loading your entry state…",
-  "approval-submitting": "Submitting a one-time 1,000 USDC approval…",
+  "approval-submitting": `Submitting a one-time 1,000 ${DISPLAY_ASSET_SYMBOL} approval…`,
   "approval-pending":
     "Bounded approval pending until its Base Sepolia receipt succeeds…",
   "entry-submitting": "Submitting your sponsored entry…",
@@ -44,10 +48,6 @@ type CrashRoundEntryProps = {
   phase: CrashRoundPhase;
   countdownSeconds: number;
 };
-
-function formatTUsd(value: bigint) {
-  return formatDeskDollars(value, TUSD_DECIMALS);
-}
 
 /**
  * Player entry surface for the current Crash round.
@@ -153,7 +153,7 @@ export function CrashRoundEntry({
         legend="Margin"
         options={ENTRY_MARGINS_TUSD}
         selected={entry.selectedMargin}
-        format={(margin) => `${formatTUsd(margin)} USDC`}
+        format={(margin) => formatDeskDollarsAmount(margin)}
         onSelect={entry.selectMargin}
       />
 
@@ -169,29 +169,25 @@ export function CrashRoundEntry({
         <div>
           <dt className="text-[var(--t-muted)]">Wallet Desk Dollars</dt>
           <dd className="tabular-nums">
-            {entry.tUsdBalance === undefined
-              ? "—"
-              : formatTUsd(entry.tUsdBalance)}{" "}
-            USDC
+            {formatDeskDollarsAmountLabel(entry.tUsdBalance)}
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Expected maximum payout</dt>
           <dd className="tabular-nums text-[var(--t-green-hot)]">
-            {formatTUsd(entry.expectedPayout)} USDC
+            {formatDeskDollarsAmount(entry.expectedPayout)}
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Current vault allowance</dt>
           <dd className="tabular-nums">
-            {entry.allowance === undefined ? "—" : formatTUsd(entry.allowance)}{" "}
-            USDC
+            {formatDeskDollarsAmountLabel(entry.allowance)}
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Selected margin</dt>
           <dd className="tabular-nums">
-            {formatTUsd(entry.selectedMargin)} USDC
+            {formatDeskDollarsAmount(entry.selectedMargin)}
           </dd>
         </div>
       </dl>
@@ -209,9 +205,10 @@ export function CrashRoundEntry({
           ) : null}
         </p>
         <p className="mt-2">
-          One-time bounded approval: {formatTUsd(BOUNDED_ENTRY_ALLOWANCE_TUSD)}{" "}
-          USDC. Later entries reuse this allowance with sponsored enter-only
-          transactions. This interface never requests an unlimited allowance.
+          One-time bounded approval:{" "}
+          {formatDeskDollarsAmount(BOUNDED_ENTRY_ALLOWANCE_TUSD)}. Later entries
+          reuse this allowance with sponsored enter-only transactions. This
+          interface never requests an unlimited allowance.
         </p>
         <p className="mt-2">
           Game contract

--- a/src/components/current-round/crash-ticket-refund.tsx
+++ b/src/components/current-round/crash-ticket-refund.tsx
@@ -7,14 +7,14 @@ import {
 } from "@/hooks/use-crash-ticket-refund";
 import { isExpiryRefundTicket } from "@/lib/margin-call-crash";
 import { CrashLiveTicket } from "./crash-live-ticket";
+import { DISPLAY_ASSET_SYMBOL } from "@/lib/desk-dollars";
 
 const statusCopy: Partial<Record<CrashRefundStatus, string>> = {
   loading: "Loading your ticket refund state…",
   "expire-submitting": "Submitting round expiry…",
   "expire-pending": "Expiry pending until its Base Sepolia receipt succeeds…",
   "refund-submitting": "Submitting your margin refund…",
-  "refund-pending":
-    "Refund pending until its Base Sepolia receipt succeeds. USDC will not update until confirmation.",
+  "refund-pending": `Refund pending until its Base Sepolia receipt succeeds. ${DISPLAY_ASSET_SYMBOL} will not update until confirmation.`,
   confirmed: "Refund confirmed on Base Sepolia.",
 };
 

--- a/src/components/current-round/crash-ticket-refund.tsx
+++ b/src/components/current-round/crash-ticket-refund.tsx
@@ -14,7 +14,7 @@ const statusCopy: Partial<Record<CrashRefundStatus, string>> = {
   "expire-pending": "Expiry pending until its Base Sepolia receipt succeeds…",
   "refund-submitting": "Submitting your margin refund…",
   "refund-pending":
-    "Refund pending until its Base Sepolia receipt succeeds. tUSD will not update until confirmation.",
+    "Refund pending until its Base Sepolia receipt succeeds. USDC will not update until confirmation.",
   confirmed: "Refund confirmed on Base Sepolia.",
 };
 

--- a/src/components/current-round/crash-ticket-settlement.test.tsx
+++ b/src/components/current-round/crash-ticket-settlement.test.tsx
@@ -63,8 +63,11 @@ const voice = vi.hoisted(() => ({
 }));
 
 vi.mock("@/components/desk-phone/margin-call-voice-trigger", () => ({
-  MarginCallVoiceTrigger: (props: { ticketId: bigint; roundId: bigint }) =>
-    voice.trigger(props),
+  MarginCallVoiceTrigger: (props: {
+    ticketId: bigint;
+    roundId: bigint;
+    walletAddress: `0x${string}`;
+  }) => voice.trigger(props),
 }));
 
 import { CrashTicketSettlement } from "./crash-ticket-settlement";
@@ -126,6 +129,7 @@ describe("CrashTicketSettlement", () => {
     expect(voice.trigger).toHaveBeenCalledWith({
       roundId: 12n,
       ticketId: 7n,
+      walletAddress: "0x0000000000000000000000000000000000000003",
     });
   });
 
@@ -140,6 +144,7 @@ describe("CrashTicketSettlement", () => {
     expect(voice.trigger).toHaveBeenCalledWith({
       roundId: 12n,
       ticketId: 7n,
+      walletAddress: "0x0000000000000000000000000000000000000003",
     });
   });
 

--- a/src/components/current-round/crash-ticket-settlement.tsx
+++ b/src/components/current-round/crash-ticket-settlement.tsx
@@ -11,6 +11,7 @@ import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { isExpiryRefundTicket } from "@/lib/margin-call-crash";
 import { getTheaterAudio } from "@/lib/theater-audio";
 import { CrashLiveTicket } from "./crash-live-ticket";
+import { DISPLAY_ASSET_SYMBOL } from "@/lib/desk-dollars";
 
 const statusCopy: Partial<Record<CrashSettlementStatus, string>> = {
   loading: "Loading your ticket settlement state…",
@@ -21,8 +22,7 @@ const statusCopy: Partial<Record<CrashSettlementStatus, string>> = {
   "finalize-pending":
     "Finalization pending until its Base Sepolia receipt succeeds…",
   "claim-submitting": "Submitting your claim…",
-  "claim-pending":
-    "Claim pending until its Base Sepolia receipt succeeds. USDC will not update until confirmation.",
+  "claim-pending": `Claim pending until its Base Sepolia receipt succeeds. ${DISPLAY_ASSET_SYMBOL} will not update until confirmation.`,
   "settle-submitting": "Submitting loss settlement…",
   "settle-pending":
     "Loss settlement pending until its Base Sepolia receipt succeeds…",

--- a/src/components/current-round/crash-ticket-settlement.tsx
+++ b/src/components/current-round/crash-ticket-settlement.tsx
@@ -22,7 +22,7 @@ const statusCopy: Partial<Record<CrashSettlementStatus, string>> = {
     "Finalization pending until its Base Sepolia receipt succeeds…",
   "claim-submitting": "Submitting your claim…",
   "claim-pending":
-    "Claim pending until its Base Sepolia receipt succeeds. tUSD will not update until confirmation.",
+    "Claim pending until its Base Sepolia receipt succeeds. USDC will not update until confirmation.",
   "settle-submitting": "Submitting loss settlement…",
   "settle-pending":
     "Loss settlement pending until its Base Sepolia receipt succeeds…",

--- a/src/components/current-round/crash-ticket-settlement.tsx
+++ b/src/components/current-round/crash-ticket-settlement.tsx
@@ -103,6 +103,7 @@ export function CrashTicketSettlement() {
           <MarginCallVoiceTrigger
             roundId={settlement.ticket.roundId}
             ticketId={settlement.ticket.id}
+            walletAddress={settlement.walletAddress}
           />
         ) : null}
         <CrashLiveTicket

--- a/src/components/current-round/current-round.test.tsx
+++ b/src/components/current-round/current-round.test.tsx
@@ -77,8 +77,9 @@ describe("CurrentRound", () => {
     const ready = sdk.makeReadyRound();
     render(<CurrentRound />);
 
-    expect(screen.getByText("Round 12")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Entry open" })).toBeTruthy();
     expect(screen.getAllByText("Entry open").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Round 12")).toBeNull();
     // Open phase now explains itself instead of rendering nothing.
     expect(
       screen.getByText(/Commit Margin at an Arcade Leverage/)
@@ -165,7 +166,7 @@ describe("CurrentRound", () => {
     rerender(<CurrentRound />);
     expect(screen.getByText("Awaiting reveal request")).toBeTruthy();
     expect(screen.getByTestId("next-round-notice").textContent).toBe(
-      "Entries reopen in 00:33 · Round 13"
+      "Entries reopen in 00:33"
     );
 
     sdk.round = {

--- a/src/components/current-round/current-round.tsx
+++ b/src/components/current-round/current-round.tsx
@@ -37,6 +37,7 @@ export function CurrentRound() {
   if (round.status !== "ready") return <CurrentRoundFailure round={round} />;
 
   const phase = round.phase;
+  const copy = roundPhaseCopy[phase];
   return (
     <section
       aria-labelledby="current-round-heading"
@@ -57,17 +58,19 @@ export function CurrentRound() {
                 className="live-pulse h-1.5 w-1.5 bg-[var(--t-green-hot)]"
               />
             ) : null}
-            {roundPhaseCopy[phase].badge}
+            {copy.badge}
           </span>
         </div>
         <h2
           id="current-round-heading"
           className="mt-3 font-[family-name:var(--font-plex-sans)] text-3xl font-bold uppercase tracking-tight text-[var(--t-text)] sm:text-4xl"
         >
-          Round {round.roundId.toString()}
+          {copy.title}
         </h2>
+        <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">
+          {copy.body}
+        </p>
 
-        <PhaseStatusCopy phase={phase} />
         <NextRoundNotice phase={phase} timeline={round.timeline} />
         <CrashRoundEntry
           countdownSeconds={round.countdownSeconds}
@@ -82,11 +85,6 @@ export function CurrentRound() {
       </div>
     </section>
   );
-}
-
-function PhaseStatusCopy({ phase }: { phase: CrashRoundPhase }) {
-  const copy = roundPhaseCopy[phase];
-  return <StatusCopy title={copy.title} body={copy.body} />;
 }
 
 /** Post-lock affordance: when and where entry comes back. */
@@ -164,15 +162,6 @@ function VerificationLinks({ round }: { round: ReadyRound }) {
         </li>
       ))}
     </ul>
-  );
-}
-
-function StatusCopy({ title, body }: { title: string; body: string }) {
-  return (
-    <div className="mt-4">
-      <p className="text-sm font-bold text-[var(--t-text)]">{title}</p>
-      <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">{body}</p>
-    </div>
   );
 }
 

--- a/src/components/desk-dollars/desk-dollars-panel.test.tsx
+++ b/src/components/desk-dollars/desk-dollars-panel.test.tsx
@@ -2,13 +2,15 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDeskDollarsFaucetChrome } from "@/hooks/use-desk-dollars-faucet";
 
 const sdk = vi.hoisted(() => {
   const readyFaucet = () => ({
-    balance: 123450000n,
-    decimals: 6,
-    status: "ready",
-    error: null,
+    balance: 123450000n as bigint | null,
+    decimals: 6 as number | null,
+    status: "ready" as
+      "loading" | "ready" | "pending" | "confirmed" | "error" | "unavailable",
+    error: null as string | null,
     eligible: true,
     cooldownSeconds: 0n,
     canClaim: true,
@@ -33,9 +35,15 @@ const sdk = vi.hoisted(() => {
 vi.mock("@privy-io/react-auth", () => ({
   usePrivy: () => ({ user: sdk.user }),
 }));
-vi.mock("@/hooks/use-desk-dollars-faucet", () => ({
-  useDeskDollarsFaucet: () => sdk.faucet,
-}));
+vi.mock("@/hooks/use-desk-dollars-faucet", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/use-desk-dollars-faucet")
+  >("@/hooks/use-desk-dollars-faucet");
+  return {
+    ...actual,
+    useDeskDollarsFaucet: () => sdk.faucet,
+  };
+});
 
 import { DeskDollarsPanel } from "./desk-dollars-panel";
 
@@ -43,6 +51,45 @@ beforeEach(() => {
   sdk.faucet = sdk.readyFaucet();
 });
 afterEach(() => cleanup());
+
+describe("getDeskDollarsFaucetChrome", () => {
+  it("hides claim while balance is unknown", () => {
+    expect(
+      getDeskDollarsFaucetChrome({
+        balance: null,
+        status: "loading",
+        canRetry: false,
+      })
+    ).toEqual({ showOffer: false, showClaimButton: false });
+  });
+
+  it("offers claim only for a known empty balance", () => {
+    expect(
+      getDeskDollarsFaucetChrome({
+        balance: 0n,
+        status: "ready",
+        canRetry: false,
+      })
+    ).toEqual({ showOffer: true, showClaimButton: true });
+  });
+
+  it("hides claim when funded unless a claim is in flight", () => {
+    expect(
+      getDeskDollarsFaucetChrome({
+        balance: 83_000_000n,
+        status: "ready",
+        canRetry: false,
+      })
+    ).toEqual({ showOffer: false, showClaimButton: false });
+    expect(
+      getDeskDollarsFaucetChrome({
+        balance: 83_000_000n,
+        status: "pending",
+        canRetry: false,
+      })
+    ).toEqual({ showOffer: false, showClaimButton: true });
+  });
+});
 
 describe("DeskDollarsPanel", () => {
   it("hides claim when the wallet already has a balance and uses USDC copy", () => {
@@ -80,19 +127,37 @@ describe("DeskDollarsPanel", () => {
     ).not.toBeNull();
   });
 
-  it("reports cooldown and pending receipt semantics honestly when unfunded", () => {
+  it("does not flash claim while the balance is still loading", () => {
     sdk.faucet = {
       ...sdk.faucet,
-      balance: 0n,
+      balance: null,
+      status: "loading",
+      canClaim: false,
+      eligible: false,
+    };
+    render(<DeskDollarsPanel />);
+    expect(screen.getByText(/Loading Desk Dollars balance/)).not.toBeNull();
+    expect(screen.queryByRole("button", { name: /Claim/ })).toBeNull();
+  });
+
+  it("keeps pending claim chrome visible even when already funded", () => {
+    sdk.faucet = {
+      ...sdk.faucet,
+      balance: 83_000_000n,
       status: "pending",
       eligible: false,
-      cooldownSeconds: 3600n,
       canClaim: false,
     };
-    const { rerender } = render(<DeskDollarsPanel />);
+    render(<DeskDollarsPanel />);
     expect(
       screen.getByText(/pending until its Base Sepolia receipt succeeds/)
     ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Claim pending…" })
+    ).not.toBeNull();
+  });
+
+  it("reports cooldown honestly when unfunded", () => {
     sdk.faucet = {
       ...sdk.faucet,
       balance: 0n,
@@ -101,7 +166,7 @@ describe("DeskDollarsPanel", () => {
       eligible: false,
       canClaim: false,
     };
-    rerender(<DeskDollarsPanel />);
+    render(<DeskDollarsPanel />);
     expect(
       screen.getByText("Next 100 USDC faucet claim in 60 minutes.")
     ).not.toBeNull();

--- a/src/components/desk-dollars/desk-dollars-panel.test.tsx
+++ b/src/components/desk-dollars/desk-dollars-panel.test.tsx
@@ -45,26 +45,45 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("DeskDollarsPanel", () => {
-  it("uses required testnet/value copy and never presents the balance as USD", () => {
+  it("hides claim when the wallet already has a balance and uses USDC copy", () => {
     render(<DeskDollarsPanel />);
     expect(
       screen.getByText(
         (_, element) =>
           element?.tagName === "P" &&
-          element.textContent === "Balance: 123.45 tUSD"
+          element.textContent === "Balance: 123.45 USDC"
       )
     ).not.toBeNull();
     expect(screen.getByText(/Base Sepolia only/)).not.toBeNull();
     expect(screen.getByText(/no real value/)).not.toBeNull();
+    expect(screen.getByText("Desk Dollars (USDC)")).not.toBeNull();
     expect(
-      screen.getByText("Eligible to claim 100 tUSD from the faucet.")
-    ).not.toBeNull();
+      screen.queryByText("Eligible to claim 100 USDC from the faucet.")
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Claim 100 USDC" })).toBeNull();
     expect(screen.queryByText(/\$/)).toBeNull();
   });
 
-  it("reports cooldown and pending receipt semantics honestly", () => {
+  it("shows claim when the wallet balance is zero", () => {
     sdk.faucet = {
       ...sdk.faucet,
+      balance: 0n,
+      eligible: true,
+      canClaim: true,
+    };
+    render(<DeskDollarsPanel />);
+    expect(
+      screen.getByText("Eligible to claim 100 USDC from the faucet.")
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Claim 100 USDC" })
+    ).not.toBeNull();
+  });
+
+  it("reports cooldown and pending receipt semantics honestly when unfunded", () => {
+    sdk.faucet = {
+      ...sdk.faucet,
+      balance: 0n,
       status: "pending",
       eligible: false,
       cooldownSeconds: 3600n,
@@ -74,10 +93,17 @@ describe("DeskDollarsPanel", () => {
     expect(
       screen.getByText(/pending until its Base Sepolia receipt succeeds/)
     ).not.toBeNull();
-    sdk.faucet = { ...sdk.faucet, status: "ready", cooldownSeconds: 3600n };
+    sdk.faucet = {
+      ...sdk.faucet,
+      balance: 0n,
+      status: "ready",
+      cooldownSeconds: 3600n,
+      eligible: false,
+      canClaim: false,
+    };
     rerender(<DeskDollarsPanel />);
     expect(
-      screen.getByText("Next 100 tUSD faucet claim in 60 minutes.")
+      screen.getByText("Next 100 USDC faucet claim in 60 minutes.")
     ).not.toBeNull();
   });
 });

--- a/src/components/desk-dollars/desk-dollars-panel.tsx
+++ b/src/components/desk-dollars/desk-dollars-panel.tsx
@@ -7,7 +7,10 @@ import {
   formatDeskDollarsBalanceLabel,
 } from "@/lib/desk-dollars";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
-import { useDeskDollarsFaucet } from "@/hooks/use-desk-dollars-faucet";
+import {
+  getDeskDollarsFaucetChrome,
+  useDeskDollarsFaucet,
+} from "@/hooks/use-desk-dollars-faucet";
 
 function formatCooldown(seconds: bigint) {
   const minutes = Number((seconds + 59n) / 60n);
@@ -21,10 +24,11 @@ export function DeskDollarsPanel() {
   const balance =
     formatDeskDollarsBalanceLabel(faucet.balance, faucet.decimals) ??
     `— ${DISPLAY_ASSET_SYMBOL}`;
-  const isFunded = faucet.balance !== null && faucet.balance > 0n;
-  const showFaucetOffer = !isFunded && faucet.status === "ready";
-  const showClaimButton =
-    !isFunded || faucet.status === "pending" || faucet.canRetry;
+  const chrome = getDeskDollarsFaucetChrome({
+    balance: faucet.balance,
+    status: faucet.status,
+    canRetry: faucet.canRetry,
+  });
 
   return (
     <section
@@ -73,18 +77,18 @@ export function DeskDollarsPanel() {
           {faucet.error}
         </p>
       ) : null}
-      {showFaucetOffer && !faucet.eligible ? (
+      {chrome.showOffer && !faucet.eligible ? (
         <p className="mt-3 text-sm">
           Next 100 {DISPLAY_ASSET_SYMBOL} faucet claim in{" "}
           {formatCooldown(faucet.cooldownSeconds)}.
         </p>
       ) : null}
-      {showFaucetOffer && faucet.eligible ? (
+      {chrome.showOffer && faucet.eligible ? (
         <p className="mt-3 text-sm">
           Eligible to claim 100 {DISPLAY_ASSET_SYMBOL} from the faucet.
         </p>
       ) : null}
-      {showClaimButton ? (
+      {chrome.showClaimButton ? (
         <button
           className="mt-4 rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
           disabled={!faucet.canClaim && !faucet.canRetry}

--- a/src/components/desk-dollars/desk-dollars-panel.tsx
+++ b/src/components/desk-dollars/desk-dollars-panel.tsx
@@ -2,7 +2,10 @@
 
 import { usePrivy } from "@privy-io/react-auth";
 import { FlashValue } from "@/components/ui/flash-value";
-import { formatDeskDollarsBalanceLabel } from "@/lib/desk-dollars";
+import {
+  DISPLAY_ASSET_SYMBOL,
+  formatDeskDollarsBalanceLabel,
+} from "@/lib/desk-dollars";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 import { useDeskDollarsFaucet } from "@/hooks/use-desk-dollars-faucet";
 
@@ -16,7 +19,12 @@ export function DeskDollarsPanel() {
   const walletAddress = getEvmWalletAddress(user);
   const faucet = useDeskDollarsFaucet(walletAddress);
   const balance =
-    formatDeskDollarsBalanceLabel(faucet.balance, faucet.decimals) ?? "— tUSD";
+    formatDeskDollarsBalanceLabel(faucet.balance, faucet.decimals) ??
+    `— ${DISPLAY_ASSET_SYMBOL}`;
+  const isFunded = faucet.balance !== null && faucet.balance > 0n;
+  const showFaucetOffer = !isFunded && faucet.status === "ready";
+  const showClaimButton =
+    !isFunded || faucet.status === "pending" || faucet.canRetry;
 
   return (
     <section
@@ -27,7 +35,7 @@ export function DeskDollarsPanel() {
         id="desk-dollars-heading"
         className="font-bold text-[var(--t-accent)]"
       >
-        Desk Dollars (tUSD)
+        Desk Dollars ({DISPLAY_ASSET_SYMBOL})
       </h2>
       <p className="mt-2 text-sm text-[var(--t-text)]">
         Balance:{" "}
@@ -65,29 +73,33 @@ export function DeskDollarsPanel() {
           {faucet.error}
         </p>
       ) : null}
-      {faucet.status === "ready" && !faucet.eligible ? (
+      {showFaucetOffer && !faucet.eligible ? (
         <p className="mt-3 text-sm">
-          Next 100 tUSD faucet claim in {formatCooldown(faucet.cooldownSeconds)}
-          .
+          Next 100 {DISPLAY_ASSET_SYMBOL} faucet claim in{" "}
+          {formatCooldown(faucet.cooldownSeconds)}.
         </p>
       ) : null}
-      {faucet.status === "ready" && faucet.eligible ? (
+      {showFaucetOffer && faucet.eligible ? (
         <p className="mt-3 text-sm">
-          Eligible to claim 100 tUSD from the faucet.
+          Eligible to claim 100 {DISPLAY_ASSET_SYMBOL} from the faucet.
         </p>
       ) : null}
-      <button
-        className="mt-4 rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
-        disabled={!faucet.canClaim && !faucet.canRetry}
-        onClick={() => void (faucet.canRetry ? faucet.retry() : faucet.claim())}
-        type="button"
-      >
-        {faucet.canRetry
-          ? "Retry"
-          : faucet.status === "pending"
-            ? "Claim pending…"
-            : "Claim 100 tUSD"}
-      </button>
+      {showClaimButton ? (
+        <button
+          className="mt-4 rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
+          disabled={!faucet.canClaim && !faucet.canRetry}
+          onClick={() =>
+            void (faucet.canRetry ? faucet.retry() : faucet.claim())
+          }
+          type="button"
+        >
+          {faucet.canRetry
+            ? "Retry"
+            : faucet.status === "pending"
+              ? "Claim pending…"
+              : `Claim 100 ${DISPLAY_ASSET_SYMBOL}`}
+        </button>
+      ) : null}
     </section>
   );
 }

--- a/src/components/desk-phone/margin-call-voice-trigger.tsx
+++ b/src/components/desk-phone/margin-call-voice-trigger.tsx
@@ -1,26 +1,23 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
 import { useMarginCallVoice } from "@/hooks/use-margin-call-voice";
-import { getEvmWalletAddress } from "@/lib/privy/wallet";
 
 type MarginCallVoiceTriggerProps = {
   ticketId: bigint;
   roundId: bigint;
+  /** Embedded wallet already proven by AuthGate / settlement. */
+  walletAddress: `0x${string}`;
 };
 
 /**
- * Owns Privy wallet resolution and the promotional desk-phone mutation.
- * Mount only when a personal liquidation is already known (ticket settlement).
- * Renders nothing.
+ * Promotional desk-phone mutation for a known personal liquidation.
+ * Mount only from ticket settlement. Renders nothing.
  */
 export function MarginCallVoiceTrigger({
   ticketId,
   roundId,
+  walletAddress,
 }: MarginCallVoiceTriggerProps) {
-  const { user } = usePrivy();
-  const walletAddress = getEvmWalletAddress(user);
-
   useMarginCallVoice({
     ticketId: ticketId.toString(),
     roundId: roundId.toString(),

--- a/src/components/history/personal-history.test.tsx
+++ b/src/components/history/personal-history.test.tsx
@@ -160,7 +160,7 @@ describe("PersonalHistory", () => {
   it("lists every ticket with claim and refund actions when unsettled", () => {
     render(<PersonalHistory />);
 
-    expect(screen.getByText("Personal history")).toBeTruthy();
+    expect(screen.getByText("Record")).toBeTruthy();
     expect(screen.getByText("Won — claim your payout")).toBeTruthy();
     expect(screen.getByText("Round expired — refund your margin")).toBeTruthy();
     expect(screen.getByText("Payout claimed")).toBeTruthy();

--- a/src/components/history/personal-history.test.tsx
+++ b/src/components/history/personal-history.test.tsx
@@ -160,7 +160,7 @@ describe("PersonalHistory", () => {
   it("lists every ticket with claim and refund actions when unsettled", () => {
     render(<PersonalHistory />);
 
-    expect(screen.getByText("Record")).toBeTruthy();
+    expect(screen.queryByText("Record")).toBeNull();
     expect(screen.getByText("Won — claim your payout")).toBeTruthy();
     expect(screen.getByText("Round expired — refund your margin")).toBeTruthy();
     expect(screen.getByText("Payout claimed")).toBeTruthy();

--- a/src/components/history/personal-history.tsx
+++ b/src/components/history/personal-history.tsx
@@ -43,7 +43,8 @@ const amountLabels: Record<PlayerTicketHistoryItem["amountKind"], string> = {
 };
 
 /**
- * Wallet-scoped ticket history with receipt-backed claim/refund actions.
+ * Wallet-scoped ticket list with receipt-backed claim/refund actions.
+ * Page chrome (title / lede) lives on /record.
  */
 export function PersonalHistory() {
   const history = usePersonalHistory();
@@ -53,12 +54,8 @@ export function PersonalHistory() {
 
   if (history.status === "unavailable" || history.status === "error") {
     return (
-      <section aria-labelledby="personal-history-error" className="text-left">
-        <p
-          id="personal-history-error"
-          className="text-sm text-[var(--t-red-hot)]"
-          role="alert"
-        >
+      <div className="text-left">
+        <p className="text-sm text-[var(--t-red-hot)]" role="alert">
           {history.error}
         </p>
         <button
@@ -68,50 +65,36 @@ export function PersonalHistory() {
         >
           Retry
         </button>
-      </section>
+      </div>
     );
   }
 
   if (history.status !== "ready") {
     return (
-      <section className="text-left">
-        <p className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
-          Loading your ticket history…
-        </p>
-      </section>
+      <p className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
+        Loading your ticket history…
+      </p>
+    );
+  }
+
+  if (history.tickets.length === 0) {
+    return (
+      <p className="text-sm text-[var(--t-muted)]">
+        No tickets found for this wallet in the recent lookback.
+      </p>
     );
   }
 
   return (
-    <section aria-labelledby="personal-history-heading" className="text-left">
-      <h2
-        id="personal-history-heading"
-        className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]"
-      >
-        Record
-      </h2>
-      <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
-        Every ticket in the lookback window. Claim and refund actions wait for
-        Base Sepolia receipts — a transaction hash alone never changes
-        settlement state.
-      </p>
-
-      {history.tickets.length === 0 ? (
-        <p className="mt-4 text-sm text-[var(--t-muted)]">
-          No tickets found for this wallet in the recent lookback.
-        </p>
-      ) : (
-        <ul className="mt-4 space-y-4">
-          {history.tickets.map((item) => (
-            <PersonalHistoryRow
-              actions={actions}
-              item={item}
-              key={item.ticket.id.toString()}
-            />
-          ))}
-        </ul>
-      )}
-    </section>
+    <ul className="space-y-4 text-left">
+      {history.tickets.map((item) => (
+        <PersonalHistoryRow
+          actions={actions}
+          item={item}
+          key={item.ticket.id.toString()}
+        />
+      ))}
+    </ul>
   );
 }
 

--- a/src/components/history/personal-history.tsx
+++ b/src/components/history/personal-history.tsx
@@ -5,7 +5,7 @@ import {
   type HistoryTicketActionStatus,
 } from "@/hooks/use-history-ticket-actions";
 import { usePersonalHistory } from "@/hooks/use-personal-history";
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
 import {
   formatLeverageBps,
   type PlayerTicketHistoryItem,
@@ -182,7 +182,7 @@ function PersonalHistoryRow({
         <div>
           <dt className="text-[var(--t-muted)]">Margin</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(item.ticket.margin, TUSD_DECIMALS)} USDC
+            {formatDeskDollarsAmount(item.ticket.margin)}
           </dd>
         </div>
         <div>
@@ -208,7 +208,7 @@ function PersonalHistoryRow({
             {amountLabels[item.amountKind]}
           </dt>
           <dd className="tabular-nums text-[var(--t-green-hot)]">
-            {formatDeskDollars(item.displayAmount, TUSD_DECIMALS)} USDC
+            {formatDeskDollarsAmount(item.displayAmount)}
           </dd>
         </div>
         <div className="sm:col-span-2">

--- a/src/components/history/personal-history.tsx
+++ b/src/components/history/personal-history.tsx
@@ -53,10 +53,7 @@ export function PersonalHistory() {
 
   if (history.status === "unavailable" || history.status === "error") {
     return (
-      <section
-        aria-labelledby="personal-history-error"
-        className="mt-8 text-left"
-      >
+      <section aria-labelledby="personal-history-error" className="text-left">
         <p
           id="personal-history-error"
           className="text-sm text-[var(--t-red-hot)]"
@@ -77,7 +74,7 @@ export function PersonalHistory() {
 
   if (history.status !== "ready") {
     return (
-      <section className="mt-8 text-left">
+      <section className="text-left">
         <p className="text-xs uppercase tracking-[0.2em] text-[var(--t-muted)]">
           Loading your ticket history…
         </p>
@@ -86,15 +83,12 @@ export function PersonalHistory() {
   }
 
   return (
-    <section
-      aria-labelledby="personal-history-heading"
-      className="mt-8 text-left"
-    >
+    <section aria-labelledby="personal-history-heading" className="text-left">
       <h2
         id="personal-history-heading"
         className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.24em] text-[var(--t-muted)]"
       >
-        Personal history
+        Record
       </h2>
       <p className="mt-3 max-w-2xl text-xs leading-5 text-[var(--t-muted)]">
         Every ticket in the lookback window. Claim and refund actions wait for
@@ -188,7 +182,7 @@ function PersonalHistoryRow({
         <div>
           <dt className="text-[var(--t-muted)]">Margin</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(item.ticket.margin, TUSD_DECIMALS)} tUSD
+            {formatDeskDollars(item.ticket.margin, TUSD_DECIMALS)} USDC
           </dd>
         </div>
         <div>
@@ -214,7 +208,7 @@ function PersonalHistoryRow({
             {amountLabels[item.amountKind]}
           </dt>
           <dd className="tabular-nums text-[var(--t-green-hot)]">
-            {formatDeskDollars(item.displayAmount, TUSD_DECIMALS)} tUSD
+            {formatDeskDollars(item.displayAmount, TUSD_DECIMALS)} USDC
           </dd>
         </div>
         <div className="sm:col-span-2">

--- a/src/components/history/round-verification-record.tsx
+++ b/src/components/history/round-verification-record.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { RoundHistoryDetail } from "@/lib/margin-call-crash";
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
 import { historyStateCopy } from "./history-state-copy";
 
 type RoundVerificationRecordProps = {
@@ -92,13 +92,13 @@ export function RoundVerificationRecord({
         <div>
           <dt className="text-[var(--t-muted)]">Aggregate margin</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(round.totalMargin, TUSD_DECIMALS)} USDC
+            {formatDeskDollarsAmount(round.totalMargin)}
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Reserved payouts</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(round.reservedPayout, TUSD_DECIMALS)} USDC
+            {formatDeskDollarsAmount(round.reservedPayout)}
           </dd>
         </div>
         <div>

--- a/src/components/history/round-verification-record.tsx
+++ b/src/components/history/round-verification-record.tsx
@@ -92,13 +92,13 @@ export function RoundVerificationRecord({
         <div>
           <dt className="text-[var(--t-muted)]">Aggregate margin</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(round.totalMargin, TUSD_DECIMALS)} tUSD
+            {formatDeskDollars(round.totalMargin, TUSD_DECIMALS)} USDC
           </dd>
         </div>
         <div>
           <dt className="text-[var(--t-muted)]">Reserved payouts</dt>
           <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollars(round.reservedPayout, TUSD_DECIMALS)} tUSD
+            {formatDeskDollars(round.reservedPayout, TUSD_DECIMALS)} USDC
           </dd>
         </div>
         <div>

--- a/src/components/lp-desk/lp-desk.test.tsx
+++ b/src/components/lp-desk/lp-desk.test.tsx
@@ -144,44 +144,44 @@ describe("LpDesk", () => {
     render(<LpDesk />);
     expect(
       screen.getByText("Wallet Desk Dollars").nextElementSibling?.textContent
-    ).toBe("123.45 tUSD");
+    ).toBe("123.45 USDC");
     expect(
       screen.getByText("Wallet vault shares").nextElementSibling?.textContent
     ).toBe("50 vault shares");
     expect(
       screen.getByText("Share price (assets per share)").nextElementSibling
         ?.textContent
-    ).toBe("1 tUSD");
+    ).toBe("1 USDC");
     expect(
       screen.getByText("Realized vault gain/loss").nextElementSibling
         ?.textContent
-    ).toBe("−0.25 tUSD");
+    ).toBe("−0.25 USDC");
     expect(
       screen.getByText("Gross assets").nextElementSibling?.textContent
-    ).toBe("25000 tUSD");
+    ).toBe("25000 USDC");
     expect(
       screen.getByText("Reserved liabilities").nextElementSibling?.textContent
-    ).toBe("1250 tUSD");
+    ).toBe("1250 USDC");
     expect(
       screen.getByText("Safety buffer").nextElementSibling?.textContent
-    ).toBe("5000 tUSD");
+    ).toBe("5000 USDC");
     expect(
       screen.getByText("Global free liquidity").nextElementSibling?.textContent
-    ).toBe("18750 tUSD");
+    ).toBe("18750 USDC");
     expect(
       screen.getByText("Utilization").nextElementSibling?.textContent
     ).toBe("5.00%");
     expect(
-      screen.getByText("Your immediately withdrawable tUSD").nextElementSibling
+      screen.getByText("Your immediately withdrawable USDC").nextElementSibling
         ?.textContent
-    ).toBe("37.5 tUSD");
+    ).toBe("37.5 USDC");
     expect(screen.getByText("1.25x")).not.toBeNull();
-    expect(screen.getByText(/80 tUSD max margin/)).not.toBeNull();
+    expect(screen.getByText(/80 USDC max margin/)).not.toBeNull();
     expect(
       screen.getByText(/Global free liquidity is the vault-wide capacity/)
     ).not.toBeNull();
     expect(
-      screen.getByText(/Liquidity providers can lose tUSD when players win/i)
+      screen.getByText(/Liquidity providers can lose USDC when players win/i)
     ).not.toBeNull();
     expect(screen.getByText(/Base Sepolia/)).not.toBeNull();
   });
@@ -249,7 +249,7 @@ describe("LpDesk", () => {
 
   it("validates an exact six-decimal asset amount against the wallet balance", () => {
     render(<LpDesk />);
-    const input = screen.getByLabelText("LP deposit amount (tUSD)");
+    const input = screen.getByLabelText("LP deposit amount (USDC)");
     fireEvent.change(input, { target: { value: "1.0000001" } });
     expect(screen.getByText(/no more than 6 decimal places/)).not.toBeNull();
     fireEvent.change(input, { target: { value: "124" } });
@@ -271,7 +271,7 @@ describe("LpDesk", () => {
       tUsdBalance: undefined,
     };
     const { rerender } = render(<LpDesk />);
-    const input = screen.getByLabelText("LP deposit amount (tUSD)");
+    const input = screen.getByLabelText("LP deposit amount (USDC)");
     fireEvent.change(input, { target: { value: "5" } });
     expect(screen.queryByText(/still loading/)).toBeNull();
     sdk.vault = {
@@ -301,9 +301,9 @@ describe("LpDesk", () => {
     ).toBe("50 vault shares");
   });
 
-  it("parses and submits an exact six-decimal tUSD withdrawal within maxWithdraw", () => {
+  it("parses and submits an exact six-decimal USDC withdrawal within maxWithdraw", () => {
     render(<LpDesk />);
-    const input = screen.getByLabelText("LP withdrawal amount (tUSD)");
+    const input = screen.getByLabelText("LP withdrawal amount (USDC)");
     fireEvent.change(input, { target: { value: "12.345678" } });
     fireEvent.submit(input.closest("form")!);
     expect(sdk.vault.withdraw).toHaveBeenCalledWith(12345678n);
@@ -311,12 +311,12 @@ describe("LpDesk", () => {
 
   it("validates positive withdrawals and the authoritative maxWithdraw limit", () => {
     render(<LpDesk />);
-    const input = screen.getByLabelText("LP withdrawal amount (tUSD)");
+    const input = screen.getByLabelText("LP withdrawal amount (USDC)");
     fireEvent.change(input, { target: { value: "0" } });
-    expect(screen.getByText("Enter a positive tUSD amount.")).not.toBeNull();
+    expect(screen.getByText("Enter a positive USDC amount.")).not.toBeNull();
     fireEvent.change(input, { target: { value: "37.500001" } });
     expect(
-      screen.getByText(/cannot exceed your immediately withdrawable tUSD limit/)
+      screen.getByText(/cannot exceed your immediately withdrawable USDC limit/)
     ).not.toBeNull();
     fireEvent.change(input, { target: { value: "1.0000001" } });
     expect(screen.getAllByText(/no more than 6 decimal places/)).toHaveLength(
@@ -340,14 +340,14 @@ describe("LpDesk", () => {
     ).not.toBeNull();
     expect(
       screen.getByText("Wallet Desk Dollars").nextElementSibling?.textContent
-    ).toBe("123.45 tUSD");
+    ).toBe("123.45 USDC");
     expect(
       screen.getByText("Wallet vault shares").nextElementSibling?.textContent
     ).toBe("50 vault shares");
     expect(
-      screen.getByText("Your immediately withdrawable tUSD").nextElementSibling
+      screen.getByText("Your immediately withdrawable USDC").nextElementSibling
         ?.textContent
-    ).toBe("37.5 tUSD");
+    ).toBe("37.5 USDC");
   });
 
   it("renders withdrawal lifecycle, corrected-limit recovery, and unambiguous retry actions", () => {
@@ -400,10 +400,10 @@ describe("LpDesk", () => {
     expect(
       screen.queryByRole("button", { name: "Retry withdrawal" })
     ).toBeNull();
-    const input = screen.getByLabelText("LP withdrawal amount (tUSD)");
+    const input = screen.getByLabelText("LP withdrawal amount (USDC)");
     fireEvent.change(input, { target: { value: "12" } });
     expect(
-      screen.getByText(/cannot exceed your immediately withdrawable tUSD limit/)
+      screen.getByText(/cannot exceed your immediately withdrawable USDC limit/)
     ).not.toBeNull();
     fireEvent.change(input, { target: { value: "10" } });
     fireEvent.submit(input.closest("form")!);
@@ -429,7 +429,7 @@ describe("LpDesk", () => {
     const { rerender } = render(<LpDesk />);
     sdk.vault = { ...sdk.vault, status: "approval-pending", canDeposit: false };
     rerender(<LpDesk />);
-    expect(screen.getByText(/Exact tUSD approval pending/)).not.toBeNull();
+    expect(screen.getByText(/Exact USDC approval pending/)).not.toBeNull();
     sdk.vault = { ...sdk.vault, status: "confirmed", canDeposit: false };
     rerender(<LpDesk />);
     expect(screen.getByText(/LP deposit confirmed/)).not.toBeNull();

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -15,24 +15,29 @@ import {
 } from "@/hooks/use-lp-freeze-actions";
 import type { BlockingRoundDetail, TierCapacity } from "@/lib/bankroll-vault";
 import {
+  DISPLAY_ASSET_SYMBOL,
   formatDeskDollars,
+  formatDeskDollarsAmountLabel,
+  formatDeskDollarsSignedAmount,
   parseTUsdInput,
   TUSD_DECIMALS,
 } from "@/lib/desk-dollars";
 import { formatHundredths } from "@/lib/margin-call-crash";
 import { getEvmWalletAddress } from "@/lib/privy/wallet";
 
-function formatAmount(value: bigint | undefined, unit: string) {
+function formatAmount(value: bigint | undefined, unit?: string) {
+  if (unit === undefined || unit === DISPLAY_ASSET_SYMBOL) {
+    return formatDeskDollarsAmountLabel(value);
+  }
   return value === undefined
     ? `— ${unit}`
     : `${formatDeskDollars(value, TUSD_DECIMALS)} ${unit}`;
 }
 
 function formatSignedAmount(value: bigint | undefined) {
-  if (value === undefined) return "— USDC";
-  const sign = value < 0n ? "−" : value > 0n ? "+" : "";
-  const abs = value < 0n ? -value : value;
-  return `${sign}${formatDeskDollars(abs, TUSD_DECIMALS)} USDC`;
+  return value === undefined
+    ? formatDeskDollarsAmountLabel(null)
+    : formatDeskDollarsSignedAmount(value);
 }
 
 function formatUtilization(bps: bigint | undefined) {
@@ -61,9 +66,8 @@ const depositAmountCopy = {
 };
 
 const withdrawalAmountCopy = {
-  limitLoading: "Your withdrawable USDC limit is still loading.",
-  overLimit:
-    "Withdrawal amount cannot exceed your immediately withdrawable USDC limit.",
+  limitLoading: `Your withdrawable ${DISPLAY_ASSET_SYMBOL} limit is still loading.`,
+  overLimit: `Withdrawal amount cannot exceed your immediately withdrawable ${DISPLAY_ASSET_SYMBOL} limit.`,
 };
 
 function validateAmount(
@@ -75,8 +79,8 @@ function validateAmount(
 ): string | null {
   if (amount.length === 0) return null;
   if (parsed === null)
-    return `Enter a USDC amount with no more than ${TUSD_DECIMALS} decimal places.`;
-  if (parsed <= 0n) return "Enter a positive USDC amount.";
+    return `Enter a ${DISPLAY_ASSET_SYMBOL} amount with no more than ${TUSD_DECIMALS} decimal places.`;
+  if (parsed <= 0n) return `Enter a positive ${DISPLAY_ASSET_SYMBOL} amount.`;
   if (limit === undefined) {
     return status === "loading" ? copy.limitLoading : null;
   }
@@ -86,9 +90,8 @@ function validateAmount(
 
 const statusCopy: Partial<Record<BankrollVaultDepositStatus, string>> = {
   loading: "Loading your Bankroll Vault balances…",
-  "approval-submitting": "Submitting an exact USDC approval…",
-  "approval-pending":
-    "Exact USDC approval pending until its Base Sepolia receipt succeeds…",
+  "approval-submitting": `Submitting an exact ${DISPLAY_ASSET_SYMBOL} approval…`,
+  "approval-pending": `Exact ${DISPLAY_ASSET_SYMBOL} approval pending until its Base Sepolia receipt succeeds…`,
   "deposit-submitting": "Submitting your LP deposit…",
   "deposit-pending":
     "LP deposit pending until its Base Sepolia receipt succeeds. Vault shares will not update until confirmation.",
@@ -98,8 +101,7 @@ const statusCopy: Partial<Record<BankrollVaultDepositStatus, string>> = {
 const withdrawalPhaseCopy: Partial<Record<BankrollVaultDepositStatus, string>> =
   {
     "withdrawal-submitting": "Submitting your LP withdrawal…",
-    "withdrawal-pending":
-      "LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet USDC, shares, and limits will not update until confirmation.",
+    "withdrawal-pending": `LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet ${DISPLAY_ASSET_SYMBOL}, shares, and limits will not update until confirmation.`,
     "withdrawal-confirmed": "LP withdrawal confirmed on Base Sepolia.",
   };
 
@@ -253,7 +255,9 @@ function TierCapacityList({ tiers }: { tiers: TierCapacity[] | undefined }) {
       {tiers.map((tier) => (
         <li key={tier.label}>
           <span className="text-[var(--t-muted)]">{tier.label}</span>
-          <div>{formatAmount(tier.maxMargin, "USDC max margin")}</div>
+          <div>
+            {formatAmount(tier.maxMargin, `${DISPLAY_ASSET_SYMBOL} max margin`)}
+          </div>
         </li>
       ))}
     </ul>
@@ -335,11 +339,11 @@ export function LpDesk() {
         </p>
       </div>
       <p className="mt-2 text-sm text-[var(--t-text)]">
-        Provide Desk Dollars (USDC) to receive vault shares.
+        Provide Desk Dollars ({DISPLAY_ASSET_SYMBOL}) to receive vault shares.
       </p>
       <p className="mt-3 border border-[var(--t-amber)] p-3 text-sm text-[var(--t-text)]">
         Warning: vault-share value can decline as game results are realized.
-        Liquidity providers can lose USDC when players win.
+        Liquidity providers can lose {DISPLAY_ASSET_SYMBOL} when players win.
       </p>
 
       {isFrozen ? (
@@ -353,7 +357,7 @@ export function LpDesk() {
       <dl className="mt-5 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
         <Metric
           label="Wallet Desk Dollars"
-          value={formatAmount(vault.tUsdBalance, "USDC")}
+          value={formatAmount(vault.tUsdBalance)}
         />
         <Metric
           label="Wallet vault shares"
@@ -361,19 +365,16 @@ export function LpDesk() {
         />
         <Metric
           label="Share price (assets per share)"
-          value={formatAmount(vault.assetsPerShare, "USDC")}
+          value={formatAmount(vault.assetsPerShare)}
         />
         <Metric
           label="Realized vault gain/loss"
           value={formatSignedAmount(vault.realizedGamePnl)}
         />
-        <Metric
-          label="Gross assets"
-          value={formatAmount(vault.grossAssets, "USDC")}
-        />
+        <Metric label="Gross assets" value={formatAmount(vault.grossAssets)} />
         <Metric
           label="Net total assets"
-          value={formatAmount(vault.totalAssets, "USDC")}
+          value={formatAmount(vault.totalAssets)}
         />
         <Metric
           label="Total supply"
@@ -381,31 +382,31 @@ export function LpDesk() {
         />
         <Metric
           label="Pending obligations"
-          value={formatAmount(vault.pendingObligations, "USDC")}
+          value={formatAmount(vault.pendingObligations)}
         />
         <Metric
           label="Unrecognized margin"
-          value={formatAmount(vault.unrecognizedMargin, "USDC")}
+          value={formatAmount(vault.unrecognizedMargin)}
         />
         <Metric
           label="Reserved liabilities"
-          value={formatAmount(vault.reservedLiabilities, "USDC")}
+          value={formatAmount(vault.reservedLiabilities)}
         />
         <Metric
           label="Safety buffer"
-          value={formatAmount(vault.safetyBuffer, "USDC")}
+          value={formatAmount(vault.safetyBuffer)}
         />
         <Metric
           label="Global free liquidity"
-          value={formatAmount(vault.freeLiquidity, "USDC")}
+          value={formatAmount(vault.freeLiquidity)}
         />
         <Metric
           label="Utilization"
           value={formatUtilization(vault.utilizationBps)}
         />
         <Metric
-          label="Your immediately withdrawable USDC"
-          value={formatAmount(vault.maxWithdraw, "USDC")}
+          label={`Your immediately withdrawable ${DISPLAY_ASSET_SYMBOL}`}
+          value={formatAmount(vault.maxWithdraw)}
         />
       </dl>
 
@@ -421,10 +422,10 @@ export function LpDesk() {
       </div>
 
       <p className="mt-3 text-xs text-[var(--t-muted)]">
-        Gross assets are live vault USDC. Net total assets price shares after
-        pending obligations and unrecognized margin. Share price marks to market
-        the moment a round finalizes — before any claim is pulled. Realized
-        vault gain/loss is the cumulative verified game result.
+        Gross assets are live vault {DISPLAY_ASSET_SYMBOL}. Net total assets
+        price shares after pending obligations and unrecognized margin. Share
+        price marks to market the moment a round finalizes — before any claim is
+        pulled. Realized vault gain/loss is the cumulative verified game result.
       </p>
       <p className="mt-2 text-xs text-[var(--t-muted)]">
         Global free liquidity is the vault-wide capacity after reservations and
@@ -437,7 +438,7 @@ export function LpDesk() {
         onSubmit={submit}
       >
         <label className="block text-sm font-bold" htmlFor="lp-deposit-amount">
-          LP deposit amount (USDC)
+          LP deposit amount ({DISPLAY_ASSET_SYMBOL})
         </label>
         <input
           aria-describedby="lp-deposit-help lp-deposit-validation"
@@ -452,7 +453,7 @@ export function LpDesk() {
         <p id="lp-deposit-help" className="mt-2 text-xs text-[var(--t-muted)]">
           {isFrozen
             ? "Deposits are blocked while share operations are frozen."
-            : "An exact USDC approval for this deposit may occur first. The LP Desk never requests unlimited approval."}
+            : `An exact ${DISPLAY_ASSET_SYMBOL} approval for this deposit may occur first. The LP Desk never requests unlimited approval.`}
         </p>
         {validationError ? (
           <p id="lp-deposit-validation" role="alert" className="mt-2 text-sm">
@@ -470,7 +471,7 @@ export function LpDesk() {
               ? "LP deposit pending…"
               : isFrozen
                 ? "Deposits frozen"
-                : "Deposit USDC"}
+                : `Deposit ${DISPLAY_ASSET_SYMBOL}`}
         </button>
       </form>
 
@@ -482,7 +483,7 @@ export function LpDesk() {
           className="block text-sm font-bold"
           htmlFor="lp-withdrawal-amount"
         >
-          LP withdrawal amount (USDC)
+          LP withdrawal amount ({DISPLAY_ASSET_SYMBOL})
         </label>
         <input
           aria-describedby="lp-withdrawal-help lp-withdrawal-validation"
@@ -500,7 +501,7 @@ export function LpDesk() {
         >
           {isFrozen
             ? "Withdrawals are blocked while share operations are frozen."
-            : "Withdraw USDC, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity."}
+            : `Withdraw ${DISPLAY_ASSET_SYMBOL}, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity.`}
         </p>
         {withdrawalValidationError ? (
           <p
@@ -522,7 +523,7 @@ export function LpDesk() {
               ? "Withdrawal pending…"
               : isFrozen
                 ? "Withdrawals frozen"
-                : "Withdraw USDC"}
+                : `Withdraw ${DISPLAY_ASSET_SYMBOL}`}
         </button>
       </form>
 

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -29,10 +29,10 @@ function formatAmount(value: bigint | undefined, unit: string) {
 }
 
 function formatSignedAmount(value: bigint | undefined) {
-  if (value === undefined) return "— tUSD";
+  if (value === undefined) return "— USDC";
   const sign = value < 0n ? "−" : value > 0n ? "+" : "";
   const abs = value < 0n ? -value : value;
-  return `${sign}${formatDeskDollars(abs, TUSD_DECIMALS)} tUSD`;
+  return `${sign}${formatDeskDollars(abs, TUSD_DECIMALS)} USDC`;
 }
 
 function formatUtilization(bps: bigint | undefined) {
@@ -61,9 +61,9 @@ const depositAmountCopy = {
 };
 
 const withdrawalAmountCopy = {
-  limitLoading: "Your withdrawable tUSD limit is still loading.",
+  limitLoading: "Your withdrawable USDC limit is still loading.",
   overLimit:
-    "Withdrawal amount cannot exceed your immediately withdrawable tUSD limit.",
+    "Withdrawal amount cannot exceed your immediately withdrawable USDC limit.",
 };
 
 function validateAmount(
@@ -75,8 +75,8 @@ function validateAmount(
 ): string | null {
   if (amount.length === 0) return null;
   if (parsed === null)
-    return `Enter a tUSD amount with no more than ${TUSD_DECIMALS} decimal places.`;
-  if (parsed <= 0n) return "Enter a positive tUSD amount.";
+    return `Enter a USDC amount with no more than ${TUSD_DECIMALS} decimal places.`;
+  if (parsed <= 0n) return "Enter a positive USDC amount.";
   if (limit === undefined) {
     return status === "loading" ? copy.limitLoading : null;
   }
@@ -86,9 +86,9 @@ function validateAmount(
 
 const statusCopy: Partial<Record<BankrollVaultDepositStatus, string>> = {
   loading: "Loading your Bankroll Vault balances…",
-  "approval-submitting": "Submitting an exact tUSD approval…",
+  "approval-submitting": "Submitting an exact USDC approval…",
   "approval-pending":
-    "Exact tUSD approval pending until its Base Sepolia receipt succeeds…",
+    "Exact USDC approval pending until its Base Sepolia receipt succeeds…",
   "deposit-submitting": "Submitting your LP deposit…",
   "deposit-pending":
     "LP deposit pending until its Base Sepolia receipt succeeds. Vault shares will not update until confirmation.",
@@ -99,7 +99,7 @@ const withdrawalPhaseCopy: Partial<Record<BankrollVaultDepositStatus, string>> =
   {
     "withdrawal-submitting": "Submitting your LP withdrawal…",
     "withdrawal-pending":
-      "LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet tUSD, shares, and limits will not update until confirmation.",
+      "LP withdrawal pending until its Base Sepolia receipt succeeds. Wallet USDC, shares, and limits will not update until confirmation.",
     "withdrawal-confirmed": "LP withdrawal confirmed on Base Sepolia.",
   };
 
@@ -253,7 +253,7 @@ function TierCapacityList({ tiers }: { tiers: TierCapacity[] | undefined }) {
       {tiers.map((tier) => (
         <li key={tier.label}>
           <span className="text-[var(--t-muted)]">{tier.label}</span>
-          <div>{formatAmount(tier.maxMargin, "tUSD max margin")}</div>
+          <div>{formatAmount(tier.maxMargin, "USDC max margin")}</div>
         </li>
       ))}
     </ul>
@@ -335,11 +335,11 @@ export function LpDesk() {
         </p>
       </div>
       <p className="mt-2 text-sm text-[var(--t-text)]">
-        Provide Desk Dollars (tUSD) to receive vault shares.
+        Provide Desk Dollars (USDC) to receive vault shares.
       </p>
       <p className="mt-3 border border-[var(--t-amber)] p-3 text-sm text-[var(--t-text)]">
         Warning: vault-share value can decline as game results are realized.
-        Liquidity providers can lose tUSD when players win.
+        Liquidity providers can lose USDC when players win.
       </p>
 
       {isFrozen ? (
@@ -353,7 +353,7 @@ export function LpDesk() {
       <dl className="mt-5 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
         <Metric
           label="Wallet Desk Dollars"
-          value={formatAmount(vault.tUsdBalance, "tUSD")}
+          value={formatAmount(vault.tUsdBalance, "USDC")}
         />
         <Metric
           label="Wallet vault shares"
@@ -361,7 +361,7 @@ export function LpDesk() {
         />
         <Metric
           label="Share price (assets per share)"
-          value={formatAmount(vault.assetsPerShare, "tUSD")}
+          value={formatAmount(vault.assetsPerShare, "USDC")}
         />
         <Metric
           label="Realized vault gain/loss"
@@ -369,11 +369,11 @@ export function LpDesk() {
         />
         <Metric
           label="Gross assets"
-          value={formatAmount(vault.grossAssets, "tUSD")}
+          value={formatAmount(vault.grossAssets, "USDC")}
         />
         <Metric
           label="Net total assets"
-          value={formatAmount(vault.totalAssets, "tUSD")}
+          value={formatAmount(vault.totalAssets, "USDC")}
         />
         <Metric
           label="Total supply"
@@ -381,31 +381,31 @@ export function LpDesk() {
         />
         <Metric
           label="Pending obligations"
-          value={formatAmount(vault.pendingObligations, "tUSD")}
+          value={formatAmount(vault.pendingObligations, "USDC")}
         />
         <Metric
           label="Unrecognized margin"
-          value={formatAmount(vault.unrecognizedMargin, "tUSD")}
+          value={formatAmount(vault.unrecognizedMargin, "USDC")}
         />
         <Metric
           label="Reserved liabilities"
-          value={formatAmount(vault.reservedLiabilities, "tUSD")}
+          value={formatAmount(vault.reservedLiabilities, "USDC")}
         />
         <Metric
           label="Safety buffer"
-          value={formatAmount(vault.safetyBuffer, "tUSD")}
+          value={formatAmount(vault.safetyBuffer, "USDC")}
         />
         <Metric
           label="Global free liquidity"
-          value={formatAmount(vault.freeLiquidity, "tUSD")}
+          value={formatAmount(vault.freeLiquidity, "USDC")}
         />
         <Metric
           label="Utilization"
           value={formatUtilization(vault.utilizationBps)}
         />
         <Metric
-          label="Your immediately withdrawable tUSD"
-          value={formatAmount(vault.maxWithdraw, "tUSD")}
+          label="Your immediately withdrawable USDC"
+          value={formatAmount(vault.maxWithdraw, "USDC")}
         />
       </dl>
 
@@ -421,7 +421,7 @@ export function LpDesk() {
       </div>
 
       <p className="mt-3 text-xs text-[var(--t-muted)]">
-        Gross assets are live vault tUSD. Net total assets price shares after
+        Gross assets are live vault USDC. Net total assets price shares after
         pending obligations and unrecognized margin. Share price marks to market
         the moment a round finalizes — before any claim is pulled. Realized
         vault gain/loss is the cumulative verified game result.
@@ -437,7 +437,7 @@ export function LpDesk() {
         onSubmit={submit}
       >
         <label className="block text-sm font-bold" htmlFor="lp-deposit-amount">
-          LP deposit amount (tUSD)
+          LP deposit amount (USDC)
         </label>
         <input
           aria-describedby="lp-deposit-help lp-deposit-validation"
@@ -452,7 +452,7 @@ export function LpDesk() {
         <p id="lp-deposit-help" className="mt-2 text-xs text-[var(--t-muted)]">
           {isFrozen
             ? "Deposits are blocked while share operations are frozen."
-            : "An exact tUSD approval for this deposit may occur first. The LP Desk never requests unlimited approval."}
+            : "An exact USDC approval for this deposit may occur first. The LP Desk never requests unlimited approval."}
         </p>
         {validationError ? (
           <p id="lp-deposit-validation" role="alert" className="mt-2 text-sm">
@@ -470,7 +470,7 @@ export function LpDesk() {
               ? "LP deposit pending…"
               : isFrozen
                 ? "Deposits frozen"
-                : "Deposit tUSD"}
+                : "Deposit USDC"}
         </button>
       </form>
 
@@ -482,7 +482,7 @@ export function LpDesk() {
           className="block text-sm font-bold"
           htmlFor="lp-withdrawal-amount"
         >
-          LP withdrawal amount (tUSD)
+          LP withdrawal amount (USDC)
         </label>
         <input
           aria-describedby="lp-withdrawal-help lp-withdrawal-validation"
@@ -500,7 +500,7 @@ export function LpDesk() {
         >
           {isFrozen
             ? "Withdrawals are blocked while share operations are frozen."
-            : "Withdraw tUSD, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity."}
+            : "Withdraw USDC, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity."}
         </p>
         {withdrawalValidationError ? (
           <p
@@ -522,7 +522,7 @@ export function LpDesk() {
               ? "Withdrawal pending…"
               : isFrozen
                 ? "Withdrawals frozen"
-                : "Withdraw tUSD"}
+                : "Withdraw USDC"}
         </button>
       </form>
 

--- a/src/components/no-real-value-disclosure.tsx
+++ b/src/components/no-real-value-disclosure.tsx
@@ -7,9 +7,9 @@ export function NoRealValueDisclosure() {
     <p
       role="note"
       data-testid="no-real-value-disclosure"
-      className="border border-[var(--t-amber)] px-3 py-2 text-xs leading-5 text-[var(--t-muted)]"
+      className="text-[10px] leading-4 text-[var(--t-muted)] sm:text-xs sm:leading-5"
     >
-      Base Sepolia only. Desk Dollars (tUSD) and vault shares have no real value
+      Base Sepolia only. Desk Dollars (USDC) and vault shares have no real value
       and no claim on real US dollars.
     </p>
   );

--- a/src/components/no-real-value-disclosure.tsx
+++ b/src/components/no-real-value-disclosure.tsx
@@ -1,3 +1,5 @@
+import { DISPLAY_ASSET_SYMBOL } from "@/lib/desk-dollars";
+
 /**
  * Persistent Base Sepolia / no-real-value disclosure visible outside AuthGate.
  * Faucet and LP panels repeat the same warning; this keeps it on every path.
@@ -9,8 +11,8 @@ export function NoRealValueDisclosure() {
       data-testid="no-real-value-disclosure"
       className="text-[10px] leading-4 text-[var(--t-muted)] sm:text-xs sm:leading-5"
     >
-      Base Sepolia only. Desk Dollars (USDC) and vault shares have no real value
-      and no claim on real US dollars.
+      Base Sepolia only. Desk Dollars ({DISPLAY_ASSET_SYMBOL}) and vault shares
+      have no real value and no claim on real US dollars.
     </p>
   );
 }

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -207,7 +207,7 @@ describe("RoundTheater", () => {
 
     expect(sdk.ticketRoundId).toBe(12n);
     expect(screen.getByTestId("theater-player-ticket").textContent).toContain(
-      "Your Ticket · 5 tUSD · 2.00x"
+      "Your Ticket · 5 USDC · 2.00x"
     );
   });
 
@@ -225,7 +225,7 @@ describe("RoundTheater", () => {
     );
     expect(screen.getByTestId("round-explainer")).toBeTruthy();
     expect(
-      screen.getAllByText((_, el) => el?.textContent === "1 tUSD").length
+      screen.getAllByText((_, el) => el?.textContent === "1 USDC").length
     ).toBeGreaterThan(0);
     expect(screen.getAllByText("1.25x").length).toBeGreaterThan(0);
     // Theater never offers entry or settlement actions.
@@ -298,7 +298,7 @@ describe("RoundTheater", () => {
 
     expect(screen.getByTestId("theater-finalized-replay")).toBeTruthy();
     expect(screen.getByTestId("theater-next-round").textContent).toBe(
-      "Next round 13 opens in 00:05"
+      "Next round opens in 00:05"
     );
     // Spectator freeze: Crash Point stays the hero; no personal outcome stamp.
     expect(screen.getByTestId("replay-curve-crash-point").textContent).toBe(
@@ -391,7 +391,7 @@ describe("RoundTheater", () => {
     expect(screen.getByTestId("theater-finalized-replay")).toBeTruthy();
     expect(screen.getByText("Round 12 result")).toBeTruthy();
     expect(screen.getByTestId("theater-next-round").textContent).toBe(
-      "Round 13 entry is open — closes in 00:30"
+      "Entry is open — closes in 00:30"
     );
     expect(screen.getByTestId("round-timeline-countdown").textContent).toBe(
       "Entry closes in 00:30"

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -511,16 +511,10 @@ function replayHandoffLabel(
   switch (live.kind) {
     case "open":
       return hero.roundId !== live.roundId
-        ? formatNextRoundHandoff({
-            roundId: live.roundId,
-            countdown: live.timeline.countdown,
-          })
+        ? formatNextRoundHandoff(live.timeline.countdown)
         : null;
     case "finalized":
-      return formatNextRoundHandoff({
-        roundId: live.roundId + 1n,
-        countdown: live.timeline.countdown,
-      });
+      return formatNextRoundHandoff(live.timeline.countdown);
     case "delayed":
     case "expired":
     case "loading":

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -301,7 +301,7 @@ function OpenStage({
                 className="live-pulse h-1.5 w-1.5 bg-[var(--t-accent)]"
               />
               Your Ticket ·{" "}
-              {formatDeskDollars(playerTicket.margin, TUSD_DECIMALS)} tUSD ·{" "}
+              {formatDeskDollars(playerTicket.margin, TUSD_DECIMALS)} USDC ·{" "}
               {formatLeverageBps(playerTicket.leverageBps)}
             </p>
           ) : null}

--- a/src/components/round-theater/round-theater.tsx
+++ b/src/components/round-theater/round-theater.tsx
@@ -10,7 +10,7 @@ import {
   type TheaterView,
 } from "@/hooks/use-round-theater";
 import { useTheaterPlayerTicket } from "@/hooks/use-theater-player-ticket";
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
 import { getTierCloseProgress } from "@/lib/round-replay";
 import {
   ENTRY_LEVERAGE_TIERS_BPS,
@@ -300,8 +300,7 @@ function OpenStage({
                 aria-hidden="true"
                 className="live-pulse h-1.5 w-1.5 bg-[var(--t-accent)]"
               />
-              Your Ticket ·{" "}
-              {formatDeskDollars(playerTicket.margin, TUSD_DECIMALS)} USDC ·{" "}
+              Your Ticket · {formatDeskDollarsAmount(playerTicket.margin)} ·{" "}
               {formatLeverageBps(playerTicket.leverageBps)}
             </p>
           ) : null}

--- a/src/components/round-theater/round-timeline-strip.tsx
+++ b/src/components/round-theater/round-timeline-strip.tsx
@@ -42,9 +42,16 @@ export function RoundTimelineStrip({ timeline }: { timeline: RoundTimeline }) {
       data-testid="round-timeline"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-        <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.18em] text-[var(--t-muted)]">
-          Round {timeline.roundId.toString()} ·{" "}
-          <span className="text-[var(--t-text)]">{copy.badge}</span>
+        <p className="text-[var(--t-type-label)] font-bold uppercase tracking-[0.18em] text-[var(--t-text)]">
+          {timeline.phase === "open" ? (
+            <span className="mr-1.5 inline-flex items-center gap-1.5">
+              <span
+                aria-hidden="true"
+                className="live-pulse h-1.5 w-1.5 bg-[var(--t-green-hot)]"
+              />
+            </span>
+          ) : null}
+          {copy.badge}
         </p>
         <p
           aria-live="polite"
@@ -55,18 +62,24 @@ export function RoundTimelineStrip({ timeline }: { timeline: RoundTimeline }) {
         </p>
       </div>
 
-      <ol aria-hidden="true" className="mt-2 flex gap-1">
+      <ol aria-hidden="true" className="mt-2.5 flex gap-1.5">
         {timeline.segments.map((segment) => (
           <li className={`min-w-0 ${segmentGrow[segment.id]}`} key={segment.id}>
             <p
-              className={`truncate text-[9px] font-bold uppercase tracking-[0.14em] ${
+              className={`flex items-center gap-1 truncate text-[10px] font-bold uppercase tracking-[0.14em] sm:text-[11px] ${
                 segment.state === "active"
-                  ? "text-[var(--t-text)]"
+                  ? "text-[var(--t-accent)]"
                   : segment.state === "skipped"
                     ? "text-[var(--t-muted)] line-through"
                     : "text-[var(--t-muted)]"
               }`}
             >
+              {segment.state === "active" ? (
+                <span
+                  aria-hidden="true"
+                  className="live-pulse h-1.5 w-1.5 shrink-0 bg-[var(--t-accent)]"
+                />
+              ) : null}
               {segmentLabels[segment.id]}
             </p>
             <SegmentTrack segment={segment} />

--- a/src/components/round-theater/theater-copy.ts
+++ b/src/components/round-theater/theater-copy.ts
@@ -20,9 +20,6 @@ export const theaterCopy = {
   openAmbianceNote: "Previous result — not the live round.",
   openAmbianceEmpty: "No prior finalized round to replay yet.",
   resultCaption: (roundId: string) => `Round ${roundId} result`,
-  nextRoundOpens: countdownCopy.nextRoundOpensNamed,
-  nextRoundOpening: countdownCopy.nextRoundOpeningNamed,
-  nextRoundEntryOpen: countdownCopy.nextRoundEntryOpen,
   verifiedCrashPoint: "Verified Crash Point",
   /** Eyebrow above a personal Won / Margin called freeze. */
   yourTicket: "Your Ticket",

--- a/src/components/round-theater/ticket-tape.tsx
+++ b/src/components/round-theater/ticket-tape.tsx
@@ -4,7 +4,7 @@ import {
   formatLeverageBps,
   type TicketTapeEntry,
 } from "@/lib/margin-call-crash";
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
 import { formatShortAddress } from "@/lib/utils";
 import { theaterCopy } from "./theater-copy";
 
@@ -38,7 +38,7 @@ export function TicketTape({
       key={entry.ticketId.toString()}
     >
       <span className="text-[var(--t-green-hot)]">
-        {formatDeskDollars(entry.margin, TUSD_DECIMALS)} USDC
+        {formatDeskDollarsAmount(entry.margin)}
       </span>
       <span className="text-[var(--t-amber-hot)]">
         {formatLeverageBps(entry.leverageBps)}

--- a/src/components/round-theater/ticket-tape.tsx
+++ b/src/components/round-theater/ticket-tape.tsx
@@ -38,7 +38,7 @@ export function TicketTape({
       key={entry.ticketId.toString()}
     >
       <span className="text-[var(--t-green-hot)]">
-        {formatDeskDollars(entry.margin, TUSD_DECIMALS)} tUSD
+        {formatDeskDollars(entry.margin, TUSD_DECIMALS)} USDC
       </span>
       <span className="text-[var(--t-amber-hot)]">
         {formatLeverageBps(entry.leverageBps)}

--- a/src/components/round-theater/tier-close-board.tsx
+++ b/src/components/round-theater/tier-close-board.tsx
@@ -70,8 +70,8 @@ export function TierCloseBoard({
               {tier.ticketCount === 0
                 ? theaterCopy.noTicketsAtTier
                 : wins && closed
-                  ? `${formatDeskDollars(tier.reservedPayout, TUSD_DECIMALS)} tUSD · ${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"}`
-                  : `${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"} · ${formatDeskDollars(tier.totalMargin, TUSD_DECIMALS)} tUSD margin`}
+                  ? `${formatDeskDollars(tier.reservedPayout, TUSD_DECIMALS)} USDC · ${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"}`
+                  : `${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"} · ${formatDeskDollars(tier.totalMargin, TUSD_DECIMALS)} USDC margin`}
             </span>
           </li>
         );

--- a/src/components/round-theater/tier-close-board.tsx
+++ b/src/components/round-theater/tier-close-board.tsx
@@ -5,7 +5,7 @@ import {
   isWinningTicket,
   type TierExposure,
 } from "@/lib/margin-call-crash";
-import { formatDeskDollars, TUSD_DECIMALS } from "@/lib/desk-dollars";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
 import { getTierCloseProgress } from "@/lib/round-replay";
 import { theaterCopy } from "./theater-copy";
 
@@ -70,8 +70,8 @@ export function TierCloseBoard({
               {tier.ticketCount === 0
                 ? theaterCopy.noTicketsAtTier
                 : wins && closed
-                  ? `${formatDeskDollars(tier.reservedPayout, TUSD_DECIMALS)} USDC · ${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"}`
-                  : `${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"} · ${formatDeskDollars(tier.totalMargin, TUSD_DECIMALS)} USDC margin`}
+                  ? `${formatDeskDollarsAmount(tier.reservedPayout)} · ${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"}`
+                  : `${tier.ticketCount} Ticket${tier.ticketCount === 1 ? "" : "s"} · ${formatDeskDollarsAmount(tier.totalMargin)} margin`}
             </span>
           </li>
         );

--- a/src/components/ui/flash-value.test.tsx
+++ b/src/components/ui/flash-value.test.tsx
@@ -8,28 +8,28 @@ describe("FlashValue", () => {
   afterEach(cleanup);
 
   it("renders without a flash direction on first paint", () => {
-    render(<FlashValue value={100n}>100 tUSD</FlashValue>);
-    const span = screen.getByText("100 tUSD");
+    render(<FlashValue value={100n}>100 USDC</FlashValue>);
+    const span = screen.getByText("100 USDC");
     expect(span.getAttribute("data-dir")).toBeNull();
   });
 
   it("flashes up on increases and down on decreases", () => {
-    const { rerender } = render(<FlashValue value={100n}>100 tUSD</FlashValue>);
+    const { rerender } = render(<FlashValue value={100n}>100 USDC</FlashValue>);
 
-    rerender(<FlashValue value={150n}>150 tUSD</FlashValue>);
-    expect(screen.getByText("150 tUSD").getAttribute("data-dir")).toBe("up");
+    rerender(<FlashValue value={150n}>150 USDC</FlashValue>);
+    expect(screen.getByText("150 USDC").getAttribute("data-dir")).toBe("up");
 
-    rerender(<FlashValue value={40n}>40 tUSD</FlashValue>);
-    expect(screen.getByText("40 tUSD").getAttribute("data-dir")).toBe("down");
+    rerender(<FlashValue value={40n}>40 USDC</FlashValue>);
+    expect(screen.getByText("40 USDC").getAttribute("data-dir")).toBe("down");
   });
 
   it("keeps the rendered label as the source of truth", () => {
     render(
       <FlashValue className="balance" value={5n}>
-        5 tUSD
+        5 USDC
       </FlashValue>
     );
-    const span = screen.getByText("5 tUSD");
+    const span = screen.getByText("5 USDC");
     expect(span.className).toContain("mc-num-flash");
     expect(span.className).toContain("balance");
   });

--- a/src/components/wallet/wallet-dialog.test.tsx
+++ b/src/components/wallet/wallet-dialog.test.tsx
@@ -61,15 +61,15 @@ describe("WalletDialog", () => {
     );
 
     expect(screen.getByTestId("wallet-dialog-address").textContent).toBe(FROM);
-    expect(screen.getByText("100 tUSD")).not.toBeNull();
+    expect(screen.getByText("100 USDC")).not.toBeNull();
 
     fireEvent.change(screen.getByLabelText("Recipient"), {
       target: { value: TO },
     });
-    fireEvent.change(screen.getByLabelText("Amount (tUSD)"), {
+    fireEvent.change(screen.getByLabelText("Amount (USDC)"), {
       target: { value: "10" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Send tUSD" }));
+    fireEvent.click(screen.getByRole("button", { name: "Send USDC" }));
 
     await waitFor(() =>
       expect(sdk.transfer).toHaveBeenCalledWith({
@@ -93,7 +93,7 @@ describe("WalletDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Max" }));
     expect(
-      (screen.getByLabelText("Amount (tUSD)") as HTMLInputElement).value
+      (screen.getByLabelText("Amount (USDC)") as HTMLInputElement).value
     ).toBe("12.5");
   });
 

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -90,7 +90,7 @@ function TransferStatusCopy({
 }
 
 /**
- * Signed-in wallet surface: full address utilities and a sponsored tUSD send.
+ * Signed-in wallet surface: full address utilities and a sponsored USDC send.
  */
 export function WalletDialog({
   open,
@@ -107,7 +107,7 @@ export function WalletDialog({
   );
 
   const balanceLabel =
-    formatDeskDollarsBalanceLabel(balance, decimals) ?? "— tUSD";
+    formatDeskDollarsBalanceLabel(balance, decimals) ?? "— USDC";
   const isBusy =
     transfer.status === "submitting" || transfer.status === "pending";
   const isRetry = transfer.canRetry;
@@ -122,7 +122,7 @@ export function WalletDialog({
       : "Pending…"
     : isRetry
       ? "Retry"
-      : "Send tUSD";
+      : "Send USDC";
 
   const handleCopy = useCallback(async () => {
     try {
@@ -171,7 +171,7 @@ export function WalletDialog({
           </div>
 
           <Dialog.Description className="mt-2 text-xs text-[var(--t-muted)]">
-            Base Sepolia only. Desk Dollars (tUSD) have no real value.
+            Base Sepolia only. Desk Dollars (USDC) have no real value.
           </Dialog.Description>
 
           <div className="mt-5 space-y-2">
@@ -248,7 +248,7 @@ export function WalletDialog({
                 className="block text-sm font-bold"
                 htmlFor="wallet-transfer-amount"
               >
-                Amount (tUSD)
+                Amount (USDC)
               </label>
               <button
                 className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] disabled:opacity-50"

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -8,7 +8,9 @@ import { GameButton } from "@/components/ui/game-button";
 import { useDeskDollarsTransfer } from "@/hooks/use-desk-dollars-transfer";
 import type { DeskDollarsTransferStatus } from "@/hooks/use-desk-dollars-transfer";
 import {
+  DISPLAY_ASSET_SYMBOL,
   formatDeskDollars,
+  formatDeskDollarsAmountLabel,
   formatDeskDollarsBalanceLabel,
   TUSD_DECIMALS,
 } from "@/lib/desk-dollars";
@@ -107,7 +109,8 @@ export function WalletDialog({
   );
 
   const balanceLabel =
-    formatDeskDollarsBalanceLabel(balance, decimals) ?? "— USDC";
+    formatDeskDollarsBalanceLabel(balance, decimals) ??
+    formatDeskDollarsAmountLabel(null);
   const isBusy =
     transfer.status === "submitting" || transfer.status === "pending";
   const isRetry = transfer.canRetry;
@@ -122,7 +125,7 @@ export function WalletDialog({
       : "Pending…"
     : isRetry
       ? "Retry"
-      : "Send USDC";
+      : `Send ${DISPLAY_ASSET_SYMBOL}`;
 
   const handleCopy = useCallback(async () => {
     try {
@@ -171,7 +174,8 @@ export function WalletDialog({
           </div>
 
           <Dialog.Description className="mt-2 text-xs text-[var(--t-muted)]">
-            Base Sepolia only. Desk Dollars (USDC) have no real value.
+            Base Sepolia only. Desk Dollars ({DISPLAY_ASSET_SYMBOL}) have no
+            real value.
           </Dialog.Description>
 
           <div className="mt-5 space-y-2">
@@ -248,7 +252,7 @@ export function WalletDialog({
                 className="block text-sm font-bold"
                 htmlFor="wallet-transfer-amount"
               >
-                Amount (USDC)
+                Amount ({DISPLAY_ASSET_SYMBOL})
               </label>
               <button
                 className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] disabled:opacity-50"

--- a/src/hooks/use-bankroll-vault-deposit.ts
+++ b/src/hooks/use-bankroll-vault-deposit.ts
@@ -7,7 +7,7 @@ import {
   getBankrollVaultConfig,
   readBankrollVaultState,
 } from "@/lib/bankroll-vault";
-import { deskDollarsAbi } from "@/lib/desk-dollars";
+import { DISPLAY_ASSET_SYMBOL, deskDollarsAbi } from "@/lib/desk-dollars";
 import {
   applyStageResult,
   confirmSponsoredCall,
@@ -72,9 +72,8 @@ const withdrawalFailedAndRefreshFailed =
   "Your LP withdrawal did not complete, and we couldn't reload your balances and limits. Retry reloads them.";
 const stageCopy: Record<Stage, StageErrorCopy> = {
   approval: {
-    failed: "We couldn't approve this exact USDC amount. Please try again.",
-    unconfirmed:
-      "Your USDC approval was submitted, but we couldn't confirm it yet. Retry to check its status.",
+    failed: `We couldn't approve this exact ${DISPLAY_ASSET_SYMBOL} amount. Please try again.`,
+    unconfirmed: `Your ${DISPLAY_ASSET_SYMBOL} approval was submitted, but we couldn't confirm it yet. Retry to check its status.`,
   },
   deposit: {
     failed:

--- a/src/hooks/use-bankroll-vault-deposit.ts
+++ b/src/hooks/use-bankroll-vault-deposit.ts
@@ -72,9 +72,9 @@ const withdrawalFailedAndRefreshFailed =
   "Your LP withdrawal did not complete, and we couldn't reload your balances and limits. Retry reloads them.";
 const stageCopy: Record<Stage, StageErrorCopy> = {
   approval: {
-    failed: "We couldn't approve this exact tUSD amount. Please try again.",
+    failed: "We couldn't approve this exact USDC amount. Please try again.",
     unconfirmed:
-      "Your tUSD approval was submitted, but we couldn't confirm it yet. Retry to check its status.",
+      "Your USDC approval was submitted, but we couldn't confirm it yet. Retry to check its status.",
   },
   deposit: {
     failed:

--- a/src/hooks/use-crash-round-entry.test.tsx
+++ b/src/hooks/use-crash-round-entry.test.tsx
@@ -89,7 +89,7 @@ describe("useCrashRoundEntry", () => {
 
   afterEach(() => cleanup());
 
-  it("approves a bounded 1,000 tUSD allowance once, then enters", async () => {
+  it("approves a bounded 1,000 USDC allowance once, then enters", async () => {
     const { result } = renderHook(() => useCrashRoundEntry({ roundId }));
     await waitFor(() => expect(result.current.status).toBe("ready"));
     await act(async () => {

--- a/src/hooks/use-crash-round-entry.ts
+++ b/src/hooks/use-crash-round-entry.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { encodeFunctionData, type Address, type Hex } from "viem";
 import { getBankrollVaultConfig } from "@/lib/bankroll-vault";
 import { baseSepoliaPublicClient } from "@/lib/base-sepolia";
-import { deskDollarsAbi } from "@/lib/desk-dollars";
+import { DISPLAY_ASSET_SYMBOL, deskDollarsAbi } from "@/lib/desk-dollars";
 import {
   BOUNDED_ENTRY_ALLOWANCE_TUSD,
   computeMaximumPayout,
@@ -73,10 +73,8 @@ const unavailable =
 const loadFailed = "We couldn't load your entry state. Please try again.";
 const stageCopy: Record<Stage, StageErrorCopy> = {
   approval: {
-    failed:
-      "We couldn't approve the bounded 1,000 USDC allowance. Please try again.",
-    unconfirmed:
-      "Your USDC approval was submitted, but we couldn't confirm it yet. Retry to check its status.",
+    failed: `We couldn't approve the bounded 1,000 ${DISPLAY_ASSET_SYMBOL} allowance. Please try again.`,
+    unconfirmed: `Your ${DISPLAY_ASSET_SYMBOL} approval was submitted, but we couldn't confirm it yet. Retry to check its status.`,
   },
   entry: {
     failed: "We couldn't complete your entry. Please try again.",

--- a/src/hooks/use-crash-round-entry.ts
+++ b/src/hooks/use-crash-round-entry.ts
@@ -74,9 +74,9 @@ const loadFailed = "We couldn't load your entry state. Please try again.";
 const stageCopy: Record<Stage, StageErrorCopy> = {
   approval: {
     failed:
-      "We couldn't approve the bounded 1,000 tUSD allowance. Please try again.",
+      "We couldn't approve the bounded 1,000 USDC allowance. Please try again.",
     unconfirmed:
-      "Your tUSD approval was submitted, but we couldn't confirm it yet. Retry to check its status.",
+      "Your USDC approval was submitted, but we couldn't confirm it yet. Retry to check its status.",
   },
   entry: {
     failed: "We couldn't complete your entry. Please try again.",
@@ -115,7 +115,7 @@ async function readEntryState(
 }
 
 /**
- * Orchestrates the bounded 1,000 tUSD approval and subsequent sponsored enter calls.
+ * Orchestrates the bounded 1,000 USDC approval and subsequent sponsored enter calls.
  * Approval is requested once when allowance is below the selected margin; entry never
  * requests an unlimited allowance.
  */

--- a/src/hooks/use-desk-dollars-balance.ts
+++ b/src/hooks/use-desk-dollars-balance.ts
@@ -15,7 +15,7 @@ type BalanceState = {
 };
 
 /**
- * Display-only tUSD balance for always-mounted chrome (AppShell header).
+ * Display-only USDC balance for always-mounted chrome (AppShell header).
  * Unlike useDeskDollarsFaucet, it carries no claim plumbing and no cooldown
  * ticker, so consumers never re-render on the faucet's one-second interval.
  */

--- a/src/hooks/use-desk-dollars-faucet.ts
+++ b/src/hooks/use-desk-dollars-faucet.ts
@@ -26,6 +26,30 @@ type FaucetState = {
   error: string | null;
 };
 
+export type DeskDollarsFaucetChrome = {
+  /** Eligible / cooldown copy for an empty wallet. */
+  showOffer: boolean;
+  /** Claim / pending / retry control. */
+  showClaimButton: boolean;
+};
+
+/**
+ * Faucet visibility policy: hide claim chrome when funded, never flash claim
+ * while balance is unknown, and keep pending/retry visible during an in-flight claim.
+ */
+export function getDeskDollarsFaucetChrome(input: {
+  balance: bigint | null;
+  status: FaucetState["status"];
+  canRetry: boolean;
+}): DeskDollarsFaucetChrome {
+  const claimInFlight = input.status === "pending" || input.canRetry;
+  const offerEmptyFaucet = input.status === "ready" && input.balance === 0n;
+  return {
+    showOffer: offerEmptyFaucet,
+    showClaimButton: claimInFlight || offerEmptyFaucet,
+  };
+}
+
 const initialState: FaucetState = {
   balance: null,
   decimals: null,

--- a/src/hooks/use-desk-dollars-transfer.ts
+++ b/src/hooks/use-desk-dollars-transfer.ts
@@ -49,7 +49,7 @@ const stageCopy: Record<Stage, StageErrorCopy> = {
 };
 
 /**
- * Validates a tUSD transfer form before any sponsored call is submitted.
+ * Validates a USDC transfer form before any sponsored call is submitted.
  * Rejects the zero address, the sender's own wallet, zero amounts, and
  * amounts above the known balance.
  */
@@ -73,7 +73,7 @@ export function validateDeskDollarsTransfer(
   if (amount === null) {
     return {
       ok: false,
-      error: "Enter a tUSD amount with up to 6 decimal places.",
+      error: "Enter a USDC amount with up to 6 decimal places.",
     };
   }
   if (amount <= 0n) {

--- a/src/hooks/use-desk-dollars-transfer.ts
+++ b/src/hooks/use-desk-dollars-transfer.ts
@@ -10,6 +10,7 @@ import {
   type Hex,
 } from "viem";
 import {
+  DISPLAY_ASSET_SYMBOL,
   deskDollarsAbi,
   getDeskDollarsTokenAddress,
   parseTUsdInput,
@@ -73,7 +74,7 @@ export function validateDeskDollarsTransfer(
   if (amount === null) {
     return {
       ok: false,
-      error: "Enter a USDC amount with up to 6 decimal places.",
+      error: `Enter a ${DISPLAY_ASSET_SYMBOL} amount with up to 6 decimal places.`,
     };
   }
   if (amount <= 0n) {

--- a/src/lib/desk-dollars.ts
+++ b/src/lib/desk-dollars.ts
@@ -109,13 +109,41 @@ export function formatDeskDollars(value: bigint, decimals: number) {
   return fraction ? `${whole}.${fraction}` : whole.toString();
 }
 
+/** Player-facing amount with ticker, e.g. "100 USDC". */
+export function formatDeskDollarsAmount(
+  value: bigint,
+  decimals: number = TUSD_DECIMALS
+): string {
+  return `${formatDeskDollars(value, decimals)} ${DISPLAY_ASSET_SYMBOL}`;
+}
+
+/** Amount label, or "— USDC" when the read has not landed. */
+export function formatDeskDollarsAmountLabel(
+  value: bigint | null | undefined,
+  decimals: number = TUSD_DECIMALS
+): string {
+  return value === null || value === undefined
+    ? `— ${DISPLAY_ASSET_SYMBOL}`
+    : formatDeskDollarsAmount(value, decimals);
+}
+
+/** Signed amount for P&L-style vault metrics, e.g. "+1.25 USDC". */
+export function formatDeskDollarsSignedAmount(
+  value: bigint,
+  decimals: number = TUSD_DECIMALS
+): string {
+  const sign = value < 0n ? "−" : value > 0n ? "+" : "";
+  const abs = value < 0n ? -value : value;
+  return `${sign}${formatDeskDollarsAmount(abs, decimals)}`;
+}
+
 /** "100 USDC" once both reads have landed, null while either is pending. */
 export function formatDeskDollarsBalanceLabel(
   balance: bigint | null,
   decimals: number | null
 ): string | null {
   return balance !== null && decimals !== null
-    ? `${formatDeskDollars(balance, decimals)} ${DISPLAY_ASSET_SYMBOL}`
+    ? formatDeskDollarsAmount(balance, decimals)
     : null;
 }
 

--- a/src/lib/desk-dollars.ts
+++ b/src/lib/desk-dollars.ts
@@ -3,6 +3,9 @@ import { baseSepoliaPublicClient } from "./base-sepolia";
 
 export const TUSD_DECIMALS = 6;
 
+/** Player-facing ticker. Onchain symbol remains tUSD; never Circle USDC. */
+export const DISPLAY_ASSET_SYMBOL = "USDC";
+
 // Desk Dollars is a plain ERC-20 to its consumers; the faucet ABI below is
 // the only custom surface.
 export const deskDollarsAbi = erc20Abi;
@@ -106,13 +109,13 @@ export function formatDeskDollars(value: bigint, decimals: number) {
   return fraction ? `${whole}.${fraction}` : whole.toString();
 }
 
-/** "100 tUSD" once both reads have landed, null while either is pending. */
+/** "100 USDC" once both reads have landed, null while either is pending. */
 export function formatDeskDollarsBalanceLabel(
   balance: bigint | null,
   decimals: number | null
 ): string | null {
   return balance !== null && decimals !== null
-    ? `${formatDeskDollars(balance, decimals)} tUSD`
+    ? `${formatDeskDollars(balance, decimals)} ${DISPLAY_ASSET_SYMBOL}`
     : null;
 }
 

--- a/src/lib/round-phase-copy.ts
+++ b/src/lib/round-phase-copy.ts
@@ -65,7 +65,6 @@ export const countdownCopy = {
   nextRoundOpening: "Next round opening…",
   nextRoundEntryOpen: (clock: string) => `Entry is open — closes in ${clock}`,
   entriesReopen: (clock: string) => `Entries reopen in ${clock}`,
-  entriesOpening: "Next round opening…",
 } as const;
 
 /** Full strip sentence for the active timeline countdown. */
@@ -87,18 +86,14 @@ export function formatTimelineCountdownLabel(timeline: RoundTimeline): string {
 }
 
 /** Result handoff line — stage-first; live chrome does not name round ids. */
-export function formatNextRoundHandoff(next: {
-  roundId: bigint;
-  countdown: RoundTimelineCountdown;
-}): string {
-  void next.roundId;
-  if (next.countdown.kind === "entry-closes") {
-    return countdownCopy.nextRoundEntryOpen(
-      formatCountdown(next.countdown.seconds)
-    );
+export function formatNextRoundHandoff(
+  countdown: RoundTimelineCountdown
+): string {
+  if (countdown.kind === "entry-closes") {
+    return countdownCopy.nextRoundEntryOpen(formatCountdown(countdown.seconds));
   }
-  return next.countdown.seconds > 0
-    ? `${countdownCopy.nextRoundOpensIn} ${formatCountdown(next.countdown.seconds)}`
+  return countdown.seconds > 0
+    ? `${countdownCopy.nextRoundOpensIn} ${formatCountdown(countdown.seconds)}`
     : countdownCopy.nextRoundOpening;
 }
 
@@ -111,5 +106,5 @@ export function formatEntriesReopenNotice(timeline: RoundTimeline): string {
     timeline.countdown.kind === "next-opens" ? timeline.countdown.seconds : 0;
   return seconds > 0
     ? countdownCopy.entriesReopen(formatCountdown(seconds))
-    : countdownCopy.entriesOpening;
+    : countdownCopy.nextRoundOpening;
 }

--- a/src/lib/round-phase-copy.ts
+++ b/src/lib/round-phase-copy.ts
@@ -63,14 +63,9 @@ export const countdownCopy = {
   entryClosesIn: "Entry closes in",
   nextRoundOpensIn: "Next round opens in",
   nextRoundOpening: "Next round opening…",
-  nextRoundOpensNamed: (roundId: string, clock: string) =>
-    `Next round ${roundId} opens in ${clock}`,
-  nextRoundOpeningNamed: (roundId: string) => `Next round ${roundId} opening…`,
-  nextRoundEntryOpen: (roundId: string, clock: string) =>
-    `Round ${roundId} entry is open — closes in ${clock}`,
-  entriesReopen: (clock: string, roundId: string) =>
-    `Entries reopen in ${clock} · Round ${roundId}`,
-  entriesOpening: (roundId: string) => `Round ${roundId} opening…`,
+  nextRoundEntryOpen: (clock: string) => `Entry is open — closes in ${clock}`,
+  entriesReopen: (clock: string) => `Entries reopen in ${clock}`,
+  entriesOpening: "Next round opening…",
 } as const;
 
 /** Full strip sentence for the active timeline countdown. */
@@ -91,24 +86,20 @@ export function formatTimelineCountdownLabel(timeline: RoundTimeline): string {
     : countdownCopy.nextRoundOpensIn;
 }
 
-/** Result handoff line; names the upcoming round because the caption is the result. */
+/** Result handoff line — stage-first; live chrome does not name round ids. */
 export function formatNextRoundHandoff(next: {
   roundId: bigint;
   countdown: RoundTimelineCountdown;
 }): string {
-  const roundId = next.roundId.toString();
+  void next.roundId;
   if (next.countdown.kind === "entry-closes") {
     return countdownCopy.nextRoundEntryOpen(
-      roundId,
       formatCountdown(next.countdown.seconds)
     );
   }
   return next.countdown.seconds > 0
-    ? countdownCopy.nextRoundOpensNamed(
-        roundId,
-        formatCountdown(next.countdown.seconds)
-      )
-    : countdownCopy.nextRoundOpeningNamed(roundId);
+    ? `${countdownCopy.nextRoundOpensIn} ${formatCountdown(next.countdown.seconds)}`
+    : countdownCopy.nextRoundOpening;
 }
 
 /**
@@ -116,10 +107,9 @@ export function formatNextRoundHandoff(next: {
  * `next-opens`; otherwise treats the next epoch as due.
  */
 export function formatEntriesReopenNotice(timeline: RoundTimeline): string {
-  const nextRoundId = (timeline.roundId + 1n).toString();
   const seconds =
     timeline.countdown.kind === "next-opens" ? timeline.countdown.seconds : 0;
   return seconds > 0
-    ? countdownCopy.entriesReopen(formatCountdown(seconds), nextRoundId)
-    : countdownCopy.entriesOpening(nextRoundId);
+    ? countdownCopy.entriesReopen(formatCountdown(seconds))
+    : countdownCopy.entriesOpening;
 }

--- a/src/lib/round-timeline.test.ts
+++ b/src/lib/round-timeline.test.ts
@@ -239,11 +239,8 @@ describe("countdown formatters", () => {
   });
 
   it("formats the result handoff without naming the round id", () => {
-    expect(
-      formatNextRoundHandoff({
-        roundId: 13n,
-        countdown: { kind: "next-opens", seconds: 5 },
-      })
-    ).toBe("Next round opens in 00:05");
+    expect(formatNextRoundHandoff({ kind: "next-opens", seconds: 5 })).toBe(
+      "Next round opens in 00:05"
+    );
   });
 });

--- a/src/lib/round-timeline.test.ts
+++ b/src/lib/round-timeline.test.ts
@@ -235,17 +235,15 @@ describe("countdown formatters", () => {
 
   it("formats the rail notice from next-opens seconds", () => {
     const locked = getRoundTimeline(makeRound(), LOCK_AT + 3n);
-    expect(formatEntriesReopenNotice(locked)).toBe(
-      "Entries reopen in 00:12 · Round 13"
-    );
+    expect(formatEntriesReopenNotice(locked)).toBe("Entries reopen in 00:12");
   });
 
-  it("names the upcoming round on the result handoff", () => {
+  it("formats the result handoff without naming the round id", () => {
     expect(
       formatNextRoundHandoff({
         roundId: 13n,
         countdown: { kind: "next-opens", seconds: 5 },
       })
-    ).toBe("Next round 13 opens in 00:05");
+    ).toBe("Next round opens in 00:05");
   });
 });


### PR DESCRIPTION
## Summary
- Lead live Floor chrome with round stages instead of round numbers, and make the timeline strip emphasize the active phase.
- Move personal ticket history onto a dedicated `/record` tab; compact primary nav to Floor / Record / Rounds / LP.
- Show USDC as the player-facing ticker (onchain Desk Dollars / `tUSD` unchanged) and hide the faucet claim when the wallet already has a balance.

## Test plan
- [ ] Floor: confirm Current Round heading is the phase title (e.g. Entry open), not `Round N`
- [ ] Floor: timeline strip shows phase badge + clearer Entry/Locked/Reveal/Result/Next, without leading round id
- [ ] Signed in with balance > 0: Desk Dollars panel shows balance, no Claim button
- [ ] Signed in with balance 0: Claim / eligibility / cooldown still work
- [ ] Header balance, entry rail, wallet dialog, LP Desk, Record rows all say USDC; no-real-value disclosure still present
- [ ] Nav: Floor / Record / Rounds / LP; `/record` lists wallet tickets; Floor no longer embeds personal history
- [ ] `pnpm test` / typecheck for touched surfaces


Made with [Cursor](https://cursor.com)