### PR TITLE
Settle ceremony: dramatic verify reveal, held results, and settlement tx links

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
+  // StrictMode's dev-only simulated remount makes @react-three/fiber 9.x
+  // schedule its unmount cleanup (renderer dispose + forceContextLoss) against
+  // the root it then reuses, killing the Floor's WebGL context ~500ms after
+  // mount and leaving the pit permanently white in `next dev`. Production
+  // never double-invokes effects, so this only changes dev behaviour.
+  reactStrictMode: false,
   transpilePackages: [
     "@margin-call/shared",
     "three",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -648,6 +648,71 @@
   transform-origin: 50% 20%;
 }
 
+/* ── Win celebration: curve head pulse + CSS confetti ── */
+
+@keyframes mc-head-pulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.45);
+    opacity: 0.85;
+  }
+}
+
+.mc-head-pulse {
+  animation: mc-head-pulse calc(var(--mc-dur-flash) * 1.5) var(--mc-ease-out)
+    infinite;
+}
+
+@keyframes mc-confetti-cannon {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+    opacity: 1;
+  }
+  18% {
+    transform: translate3d(calc(var(--mc-confetti-drift) * 0.35), -42vh, 0)
+      rotate(calc(var(--mc-confetti-rotate) * 0.3));
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--mc-confetti-drift), 12vh, 0)
+      rotate(var(--mc-confetti-rotate));
+    opacity: 0;
+  }
+}
+
+@keyframes mc-confetti-rain {
+  0% {
+    transform: translate3d(0, -8vh, 0) rotate(0deg);
+    opacity: 0;
+  }
+  8% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--mc-confetti-drift), 110vh, 0)
+      rotate(var(--mc-confetti-rotate));
+    opacity: 0.15;
+  }
+}
+
+.mc-confetti-cannon {
+  animation: mc-confetti-cannon var(--mc-confetti-duration) var(--mc-ease-out)
+    var(--mc-confetti-delay) both;
+  border-radius: 1px;
+  will-change: transform, opacity;
+}
+
+.mc-confetti-rain {
+  animation: mc-confetti-rain var(--mc-confetti-duration) linear
+    var(--mc-confetti-delay) both;
+  border-radius: 1px;
+  will-change: transform, opacity;
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -686,9 +751,17 @@
   .mc-shake,
   .mc-tier-pop,
   .mc-margin-call-flash,
-  .mc-phone-ring {
+  .mc-phone-ring,
+  .mc-head-pulse,
+  .mc-confetti-cannon,
+  .mc-confetti-rain {
     animation: none;
     opacity: 1;
+  }
+
+  .mc-confetti-cannon,
+  .mc-confetti-rain {
+    opacity: 0;
   }
 
   /* Held edge color instead of a flash pulse */

--- a/src/components/crash-stage/crash-canvas.tsx
+++ b/src/components/crash-stage/crash-canvas.tsx
@@ -20,7 +20,7 @@ export type CrashCanvasProps = {
   entries: readonly TicketTapeEntry[];
   playerAddress: string | null;
   chipStates: ReadonlyMap<string, TicketChipState>;
-  outcomeKind: TicketLanding["kind"] | null;
+  outcomeKind: Exclude<TicketLanding["kind"], "won"> | null;
 };
 
 /**

--- a/src/components/crash-stage/crash-canvas.tsx
+++ b/src/components/crash-stage/crash-canvas.tsx
@@ -82,6 +82,7 @@ function StageContent(props: CrashCanvasProps) {
   const showCountdown =
     props.mode === "countdown" ||
     props.mode === "awaiting-settle" ||
+    props.mode === "settling" ||
     props.mode === "expired" ||
     props.mode === "loading";
 
@@ -90,7 +91,10 @@ function StageContent(props: CrashCanvasProps) {
     props.mode !== "loading" &&
     (showCountdown || props.mode === "replay" || props.mode === "outcome");
 
-  const frozen = props.mode === "awaiting-settle" || props.mode === "expired";
+  const frozen =
+    props.mode === "awaiting-settle" ||
+    props.mode === "settling" ||
+    props.mode === "expired";
 
   return (
     <>

--- a/src/components/crash-stage/crash-canvas.tsx
+++ b/src/components/crash-stage/crash-canvas.tsx
@@ -43,6 +43,22 @@ export function CrashCanvas(props: CrashCanvasProps) {
       dpr={[1, 1.75]}
       frameloop={pageVisible ? "always" : "never"}
       gl={{ antialias: true, alpha: true, powerPreference: "high-performance" }}
+      onCreated={({ gl }) => {
+        // React StrictMode's simulated remount makes R3F's delayed unmount
+        // cleanup force a context loss on the still-live canvas (the root is
+        // reused across the remount), leaving the Floor permanently white in
+        // dev. The loss comes from WEBGL_lose_context, so it is restorable;
+        // a genuine GPU loss makes forceContextRestore a harmless no-op.
+        gl.domElement.addEventListener("webglcontextlost", () => {
+          window.setTimeout(() => {
+            try {
+              gl.forceContextRestore();
+            } catch {
+              // WEBGL_lose_context unsupported — nothing to restore with.
+            }
+          }, 1);
+        });
+      }}
       style={{
         position: "absolute",
         inset: 0,

--- a/src/components/crash-stage/crash-stage.tsx
+++ b/src/components/crash-stage/crash-stage.tsx
@@ -328,7 +328,11 @@ export function CrashStage() {
     entries,
     playerAddress,
     chipStates,
-    outcomeKind: mode === "outcome" ? (graphLanding?.kind ?? null) : null,
+    // Wins use WinConfetti on the DOM overlay; the pit only shatters losses.
+    outcomeKind:
+      mode === "outcome" && graphLanding !== null && graphLanding.kind !== "won"
+        ? graphLanding.kind
+        : null,
   };
 
   if (theater.live.kind === "error" || theater.live.kind === "unavailable") {
@@ -382,7 +386,6 @@ export function CrashStage() {
           <WinConfetti
             key={ceremonyClimb.startNonce}
             nonce={ceremonyClimb.startNonce}
-            reducedMotion={theater.reducedMotion}
           />
         ) : null}
         <StageHud

--- a/src/components/crash-stage/crash-stage.tsx
+++ b/src/components/crash-stage/crash-stage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { useCrashTicketSettlement } from "@/hooks/use-crash-ticket-settlement";
 import { useReplayClock } from "@/hooks/use-replay-clock";
@@ -10,11 +10,19 @@ import {
   type TheaterLive,
   type TheaterReplayHero,
 } from "@/hooks/use-round-theater";
+import { useSettleCeremony } from "@/hooks/use-settle-ceremony";
 import { useTheaterPlayerTicket } from "@/hooks/use-theater-player-ticket";
 import { useTheaterTierSounds } from "@/hooks/use-theater-tier-sounds";
-import { ticketLanding } from "@/components/round-theater/landing-frame";
 import {
+  ticketForRound,
+  ticketLanding,
+  type TicketLanding,
+} from "@/components/round-theater/landing-frame";
+import {
+  aggregateTierExposure,
   ENTRY_LEVERAGE_TIERS_BPS,
+  formatCrashPointBps,
+  isCrashPointPublished,
   type CrashRoundPhase,
   type TicketTapeEntry,
 } from "@/lib/margin-call-crash";
@@ -38,6 +46,8 @@ import type { TicketChipState } from "./scenes/ticket-field";
 import { StageActions } from "./overlay/stage-actions";
 import { StageHud } from "./overlay/stage-hud";
 import { StageOutcomeGraph } from "./overlay/stage-outcome-graph";
+import { StageOutcomePanel } from "./overlay/stage-outcome-panel";
+import { StageVerifyProgress } from "./overlay/stage-verify-progress";
 import {
   deriveCrashStageMode,
   type CrashStageMode,
@@ -61,20 +71,61 @@ export function CrashStage() {
   const liveRoundId = theaterLiveRoundId(theater.live);
   const { ticket: playerTicket } = useTheaterPlayerTicket(displayRoundId);
   const { ticket: liveRoundTicket } = useTheaterPlayerTicket(liveRoundId);
-  const settlement = useCrashTicketSettlement();
 
-  const previousSettlementStatus = useRef(settlement.status);
+  const reducedMotion = theater.reducedMotion;
+  const [ceremony, ceremonyDispatch] = useSettleCeremony(playerAddress);
+  const onCrashPointKnown = useCallback(
+    (crashPointBps: bigint) =>
+      ceremonyDispatch({
+        type: "crash-point-known",
+        crashPointBps,
+        reducedMotion,
+      }),
+    [ceremonyDispatch, reducedMotion]
+  );
+  const settlement = useCrashTicketSettlement({ onCrashPointKnown });
+
+  // The settlement recovery read is the stalest round source: re-check it when
+  // the live round flips so a cross-round ticket doesn't linger for a poll.
+  const { refreshIfIdle } = settlement;
+  const previousLiveRoundId = useRef(liveRoundId);
   useEffect(() => {
-    if (
-      !theater.reducedMotion &&
-      settlement.status === "confirmed" &&
-      previousSettlementStatus.current !== "confirmed" &&
-      settlement.outcome === "settled-win"
-    ) {
-      getTheaterAudio().playWinRegister();
+    if (liveRoundId !== null && previousLiveRoundId.current !== liveRoundId) {
+      refreshIfIdle();
     }
-    previousSettlementStatus.current = settlement.status;
-  }, [settlement.outcome, settlement.status, theater.reducedMotion]);
+    previousLiveRoundId.current = liveRoundId;
+  }, [liveRoundId, refreshIfIdle]);
+
+  // Freeze the ceremony snapshot at click time so poll churn cannot mutate
+  // the displayed graph, tiers, or ticket mid-sequence.
+  const liveTape = isTheaterLiveReady(theater.live) ? theater.live.tape : null;
+  const settlementTicket = settlement.ticket;
+  const beginCeremony = useCallback(() => {
+    if (!settlementTicket || settlementTicket.settled) return;
+    const tape =
+      liveTape && liveTape.roundId === settlementTicket.roundId
+        ? liveTape
+        : null;
+    ceremonyDispatch({
+      type: "start",
+      snapshot: {
+        roundId: settlementTicket.roundId,
+        ticket: settlementTicket,
+        tape,
+        tiers: tape?.tiers ?? aggregateTierExposure([]),
+      },
+    });
+  }, [ceremonyDispatch, liveTape, settlementTicket]);
+
+  // Flows that never touch the attestation (claim/settle on an externally
+  // finalized round, receipt resumes) reveal from the recovered round.
+  useEffect(() => {
+    if (ceremony.phase !== "verifying") return;
+    const round = settlement.round;
+    if (!round || round.id !== ceremony.snapshot.roundId) return;
+    if (!isCrashPointPublished(round)) return;
+    onCrashPointKnown(round.crashPointBps);
+  }, [ceremony, onCrashPointKnown, settlement.round]);
 
   const replayHero: TheaterReplayHero | null =
     theater.hero.type === "replay" ? theater.hero : null;
@@ -85,6 +136,10 @@ export function CrashStage() {
       ? settlement.ticket
       : null);
   const hasUnsettledTicket = unsettledTicket !== null;
+  const hasStaleUnsettledTicket =
+    unsettledTicket !== null &&
+    liveRoundId !== null &&
+    unsettledTicket.roundId < liveRoundId;
 
   const settleReceiptOk =
     settlement.status === "confirmed" ||
@@ -92,63 +147,164 @@ export function CrashStage() {
     Boolean(settlement.ticket?.settled);
   const mayClimb = !hasUnsettledTicket || settleReceiptOk;
 
+  const ceremonyClimb =
+    ceremony.phase === "climbing" || ceremony.phase === "landed"
+      ? ceremony
+      : null;
   const shouldRunReplayClock = replayHero !== null && mayClimb;
+  // The ceremony clock seeds from zero (null timestamps) so the settling
+  // player always sees the full climb; spectators keep the chain seek.
+  const clockCrashPoint = ceremonyClimb
+    ? ceremonyClimb.reveal.crashPointBps
+    : shouldRunReplayClock && replayHero
+      ? replayHero.crashPointBps
+      : null;
 
   const clock = useReplayClock({
-    crashPointBps:
-      shouldRunReplayClock && replayHero ? replayHero.crashPointBps : null,
+    crashPointBps: clockCrashPoint,
     finalizedAtSeconds:
-      shouldRunReplayClock && replayHero ? replayHero.finalizedAtSeconds : null,
+      !ceremonyClimb && shouldRunReplayClock && replayHero
+        ? replayHero.finalizedAtSeconds
+        : null,
     chainTimestamp:
-      shouldRunReplayClock && replayHero ? replayHero.chainTimestamp : null,
-    reducedMotion: theater.reducedMotion || !shouldRunReplayClock,
+      !ceremonyClimb && shouldRunReplayClock && replayHero
+        ? replayHero.chainTimestamp
+        : null,
+    reducedMotion: reducedMotion || clockCrashPoint === null,
+    restartNonce: ceremonyClimb?.startNonce ?? 0,
   });
 
-  const replayProgress = shouldRunReplayClock ? clock.progress : 0;
-  const climbComplete = shouldRunReplayClock && clock.isComplete;
+  const replayProgress =
+    ceremony.phase === "landed"
+      ? 1
+      : clockCrashPoint !== null
+        ? clock.progress
+        : 0;
+  const climbComplete =
+    ceremony.phase === "landed" ||
+    (clockCrashPoint !== null && clock.isComplete);
+
+  const clockComplete = clock.isComplete;
+  useEffect(() => {
+    if (ceremony.phase !== "climbing") return;
+    // Reduced motion mid-climb would otherwise stall the ceremony forever.
+    if (clockComplete || reducedMotion) {
+      ceremonyDispatch({ type: "climb-complete" });
+    }
+  }, [ceremony.phase, ceremonyDispatch, clockComplete, reducedMotion]);
 
   const mode = deriveCrashStageMode({
     live: theater.live,
+    ceremonyPhase: ceremony.phase,
     hasUnsettledTicket,
+    hasStaleUnsettledTicket,
     mayClimb,
     hasReplayHero: replayHero !== null,
     isReplayComplete: climbComplete,
   });
 
+  // Ceremony hero: locally built from the frozen snapshot + reveal so the 10s
+  // theater poll can never blank or swap the graph mid-ceremony.
+  const finalizeTransactionUrl =
+    settlement.transactions.find((t) => t.stage === "finalize")?.url ??
+    (theater.live.kind === "finalized" &&
+    ceremonyClimb !== null &&
+    theater.live.roundId === ceremonyClimb.snapshot.roundId
+      ? theater.live.finalizeTransactionUrl
+      : null);
+  const ceremonyHero: TheaterReplayHero | null = ceremonyClimb
+    ? {
+        type: "replay",
+        roundId: ceremonyClimb.snapshot.roundId,
+        crashPointBps: ceremonyClimb.reveal.crashPointBps,
+        displayCrashPoint: formatCrashPointBps(
+          ceremonyClimb.reveal.crashPointBps
+        ),
+        finalizedAtSeconds: null,
+        chainTimestamp: 0n,
+        finalizeTransactionUrl,
+        tape: ceremonyClimb.snapshot.tape,
+        tiers: ceremonyClimb.snapshot.tiers,
+      }
+    : null;
+  const graphHero = ceremonyHero ?? replayHero;
+
+  const activeTicket = unsettledTicket ?? playerTicket ?? settlement.ticket;
+  // Personal landing/tier readouts only apply to a ticket from the hero round.
+  const heroTicket = ceremonyClimb
+    ? ceremonyClimb.snapshot.ticket
+    : replayHero
+      ? ticketForRound(activeTicket, replayHero.roundId)
+      : null;
+
   useStageAudio({
     mode,
     liveKind: theater.live.kind,
     countdownSeconds: theaterCountdownSeconds(theater.live),
-    reducedMotion: theater.reducedMotion,
-    crashPointBps:
-      shouldRunReplayClock && replayHero ? replayHero.crashPointBps : null,
+    reducedMotion,
+    crashPointBps: clockCrashPoint,
     progress: replayProgress,
     isComplete: climbComplete,
-    playerTierBps:
-      unsettledTicket?.leverageBps ?? playerTicket?.leverageBps ?? null,
+    playerTierBps: heroTicket?.leverageBps ?? null,
+    restartNonce: ceremonyClimb?.startNonce ?? 0,
   });
 
-  const entries = theaterTapeEntries(theater);
-  const chipStates = useMemo(
-    () =>
-      buildChipStates(
-        entries,
-        replayHero?.crashPointBps ?? null,
-        mode === "replay" || mode === "outcome" ? replayProgress : 0,
-        mode === "outcome" || climbComplete
-      ),
-    [entries, replayHero?.crashPointBps, replayProgress, mode, climbComplete]
+  const entries = ceremonyClimb
+    ? (ceremonyClimb.snapshot.tape?.entries ?? [])
+    : theaterTapeEntries(theater);
+  const chipStates = buildChipStates(
+    entries,
+    graphHero ? graphHero.crashPointBps : null,
+    mode === "replay" || mode === "outcome" ? replayProgress : 0,
+    mode === "outcome" || climbComplete
   );
 
-  const activeTicket = unsettledTicket ?? playerTicket ?? settlement.ticket;
-  const graphLanding = replayHero
-    ? ticketLanding(activeTicket, replayHero.crashPointBps)
-    : null;
+  const graphLanding: TicketLanding | null = ceremonyClimb
+    ? ceremonyClimb.reveal.outcome === "won"
+      ? { kind: "won" }
+      : { kind: "margin-called" }
+    : replayHero
+      ? ticketLanding(heroTicket, replayHero.crashPointBps)
+      : null;
+
+  // The dock's settle actions open the ceremony before running their flow so
+  // the stage takes over on the same click.
+  const {
+    verifyAndSettle: rawVerifyAndSettle,
+    claim: rawClaim,
+    settleLoss: rawSettleLoss,
+    retry: rawRetry,
+    retryAction,
+  } = settlement;
+  const ceremonialVerifyAndSettle = useCallback(() => {
+    beginCeremony();
+    return rawVerifyAndSettle();
+  }, [beginCeremony, rawVerifyAndSettle]);
+  const ceremonialClaim = useCallback(() => {
+    beginCeremony();
+    return rawClaim();
+  }, [beginCeremony, rawClaim]);
+  const ceremonialSettleLoss = useCallback(() => {
+    beginCeremony();
+    return rawSettleLoss();
+  }, [beginCeremony, rawSettleLoss]);
+  const ceremonialRetry = useCallback(() => {
+    if (retryAction !== "refresh") beginCeremony();
+    return rawRetry();
+  }, [beginCeremony, rawRetry, retryAction]);
+  const stageSettlement: typeof settlement = {
+    ...settlement,
+    verifyAndSettle: ceremonialVerifyAndSettle,
+    claim: ceremonialClaim,
+    settleLoss: ceremonialSettleLoss,
+    retry: ceremonialRetry,
+  };
 
   const countdownSeconds = theaterCountdownSeconds(theater.live);
   const urgency = countdownUrgency(mode, countdownSeconds);
   const showLockedLabel =
     mode === "awaiting-settle" ||
+    mode === "settling" ||
     theater.live.kind === "delayed" ||
     theater.live.kind === "expired";
 
@@ -160,12 +316,12 @@ export function CrashStage() {
   const actionPhase = theaterLivePhase(theater.live);
   const actionRoundId = liveRoundId;
   const showOutcomeGraph =
-    (mode === "replay" || mode === "outcome") && replayHero !== null;
+    (mode === "replay" || mode === "outcome") && graphHero !== null;
 
   const canvasProps: CrashCanvasProps = {
     mode,
     countdownSeconds:
-      showLockedLabel && mode === "awaiting-settle" ? 0 : countdownSeconds,
+      mode === "awaiting-settle" || mode === "settling" ? 0 : countdownSeconds,
     urgency,
     locked: showLockedLabel && mode !== "countdown",
     entries,
@@ -222,32 +378,57 @@ export function CrashStage() {
         <StageHud
           countdownLabel={countdownLabel}
           countdownSeconds={countdownSeconds}
-          isAlert={settlement.status === "error"}
+          isAlert={settlement.status === "error" && ceremony.phase === "idle"}
           playerTicket={activeTicket}
-          statusMessage={stageStatusMessage(mode, settlement)}
+          statusMessage={
+            // The stepper and outcome panel own settlement messaging while a
+            // ceremony is active.
+            ceremony.phase === "idle"
+              ? stageStatusMessage(mode, settlement)
+              : null
+          }
           suggestSound={mode === "replay" || mode === "outcome"}
         />
 
         <div className="flex min-h-0 flex-1 flex-col justify-center px-4 py-2 sm:px-6">
-          {showOutcomeGraph && replayHero && graphLanding ? (
+          {mode === "settling" ? (
+            <StageVerifyProgress
+              onCancel={() => ceremonyDispatch({ type: "reset" })}
+              settlement={stageSettlement}
+            />
+          ) : showOutcomeGraph && graphHero && graphLanding ? (
             <StageOutcomeGraph
               landing={graphLanding}
-              playerTierBps={activeTicket?.leverageBps ?? null}
+              playerTierBps={heroTicket?.leverageBps ?? null}
               progress={replayProgress}
               reducedMotion={theater.reducedMotion}
-              replayHero={replayHero}
+              replayHero={graphHero}
             />
           ) : null}
         </div>
 
-        {actionRoundId !== null && actionPhase !== null ? (
+        {ceremony.phase === "landed" && ceremonyClimb ? (
+          <div className="shrink-0 px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-2 sm:px-6">
+            <StageOutcomePanel
+              finalizeTransactionUrl={finalizeTransactionUrl}
+              onContinue={() => ceremonyDispatch({ type: "acknowledge" })}
+              onRewatch={() => ceremonyDispatch({ type: "rewatch" })}
+              reducedMotion={theater.reducedMotion}
+              reveal={ceremonyClimb.reveal}
+              settleConfirmed={settleReceiptOk}
+              settlement={stageSettlement}
+              snapshot={ceremonyClimb.snapshot}
+            />
+          </div>
+        ) : ceremony.phase !== "idle" ? null : actionRoundId !== null &&
+          actionPhase !== null ? (
           <StageActions
             countdownSeconds={countdownSeconds ?? 0}
-            hasTicket={liveRoundTicket !== null}
+            hasTicket={liveRoundTicket !== null || hasStaleUnsettledTicket}
             mode={mode}
             phase={actionPhase}
             roundId={actionRoundId}
-            settlement={settlement}
+            settlement={stageSettlement}
           />
         ) : null}
       </div>
@@ -301,7 +482,7 @@ function ReducedMotionFloor({
         className={`font-[family-name:var(--font-plex-sans)] text-7xl font-black tabular-nums sm:text-9xl ${urgencyClass}`}
         data-testid="reduced-motion-countdown"
       >
-        {locked && mode === "awaiting-settle"
+        {locked && (mode === "awaiting-settle" || mode === "settling")
           ? "LOCKED"
           : countdownSeconds === null
             ? "—"
@@ -333,7 +514,9 @@ function countdownUrgency(
   mode: CrashStageMode,
   seconds: number | null
 ): CountdownUrgency {
-  if (mode === "awaiting-settle" || mode === "expired") return "locked";
+  if (mode === "awaiting-settle" || mode === "settling" || mode === "expired") {
+    return "locked";
+  }
   if (seconds === null) return "calm";
   if (seconds <= 5) return "threat";
   if (seconds <= 10) return "warn";
@@ -390,6 +573,7 @@ function useStageAudio(options: {
   progress: number;
   isComplete: boolean;
   playerTierBps: bigint | null;
+  restartNonce: number;
 }) {
   const previousKind = useRef(options.liveKind);
 
@@ -420,5 +604,6 @@ function useStageAudio(options: {
       !options.reducedMotion &&
       (options.mode === "replay" || options.mode === "outcome"),
     playerTierBps: options.playerTierBps,
+    restartNonce: options.restartNonce,
   });
 }

--- a/src/components/crash-stage/crash-stage.tsx
+++ b/src/components/crash-stage/crash-stage.tsx
@@ -48,6 +48,7 @@ import { StageHud } from "./overlay/stage-hud";
 import { StageOutcomeGraph } from "./overlay/stage-outcome-graph";
 import { StageOutcomePanel } from "./overlay/stage-outcome-panel";
 import { StageVerifyProgress } from "./overlay/stage-verify-progress";
+import { WinConfetti } from "./overlay/win-confetti";
 import {
   deriveCrashStageMode,
   type CrashStageMode,
@@ -375,6 +376,15 @@ export function CrashStage() {
       </div>
 
       <div className="pointer-events-none relative z-20 flex min-h-0 flex-1 flex-col pt-[6.75rem]">
+        {ceremony.phase === "landed" &&
+        ceremonyClimb?.reveal.outcome === "won" &&
+        !theater.reducedMotion ? (
+          <WinConfetti
+            key={ceremonyClimb.startNonce}
+            nonce={ceremonyClimb.startNonce}
+            reducedMotion={theater.reducedMotion}
+          />
+        ) : null}
         <StageHud
           countdownLabel={countdownLabel}
           countdownSeconds={countdownSeconds}

--- a/src/components/crash-stage/crash-stage.tsx
+++ b/src/components/crash-stage/crash-stage.tsx
@@ -261,9 +261,10 @@ export function CrashStage() {
   );
 
   const graphLanding: TicketLanding | null = ceremonyClimb
-    ? ceremonyClimb.reveal.outcome === "won"
-      ? { kind: "won" }
-      : { kind: "margin-called" }
+    ? ticketLanding(
+        ceremonyClimb.snapshot.ticket,
+        ceremonyClimb.reveal.crashPointBps
+      )
     : replayHero
       ? ticketLanding(heroTicket, replayHero.crashPointBps)
       : null;

--- a/src/components/crash-stage/overlay/stage-outcome-panel.test.tsx
+++ b/src/components/crash-stage/overlay/stage-outcome-panel.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  SettlementTransaction,
+  useCrashTicketSettlement,
+} from "@/hooks/use-crash-ticket-settlement";
+import type { CeremonyReveal, CeremonySnapshot } from "@/lib/settle-ceremony";
+
+vi.mock("@/components/desk-phone/margin-call-voice-trigger", () => ({
+  MarginCallVoiceTrigger: () => (
+    <div data-testid="voice-trigger">Call my desk phone</div>
+  ),
+}));
+
+import { StageOutcomePanel } from "./stage-outcome-panel";
+
+type Settlement = ReturnType<typeof useCrashTicketSettlement>;
+
+const ticket = {
+  id: 7n,
+  player: "0x0000000000000000000000000000000000000003" as const,
+  roundId: 12n,
+  margin: 5_000_000n,
+  leverageBps: 20_000n,
+  reservedPayout: 10_000_000n,
+  settled: false,
+  claimed: false,
+};
+
+const snapshot: CeremonySnapshot = {
+  roundId: 12n,
+  ticket,
+  tape: null,
+  tiers: [
+    {
+      leverageBps: 20_000n,
+      ticketCount: 1,
+      totalMargin: 5_000_000n,
+      reservedPayout: 10_000_000n,
+    },
+  ],
+};
+
+const wonReveal: CeremonyReveal = {
+  crashPointBps: 25_000n,
+  outcome: "won",
+  payout: 10_000_000n,
+};
+
+const lostReveal: CeremonyReveal = {
+  crashPointBps: 15_000n,
+  outcome: "lost",
+  payout: 0n,
+};
+
+const claimTx: SettlementTransaction = {
+  stage: "claim",
+  hash: "0xccc3",
+  url: "https://sepolia.basescan.org/tx/0xccc3",
+  confirmed: true,
+};
+
+function makeSettlement(overrides: Partial<Settlement> = {}): Settlement {
+  return {
+    status: "confirmed",
+    error: null,
+    walletAddress: "0x0000000000000000000000000000000000000003",
+    ticket,
+    round: null,
+    outcome: "settled-win",
+    payout: 10_000_000n,
+    phase: "finalized",
+    displayCrashPoint: "2.50x",
+    canVerify: false,
+    canClaim: false,
+    canSettle: false,
+    canRetry: false,
+    retryAction: null,
+    transactions: [claimTx],
+    verifyAndSettle: vi.fn(),
+    claim: vi.fn(),
+    settleLoss: vi.fn(),
+    retry: vi.fn(),
+    refresh: vi.fn(),
+    refreshIfIdle: vi.fn(),
+    ...overrides,
+  } as Settlement;
+}
+
+function renderPanel(
+  overrides: Partial<Parameters<typeof StageOutcomePanel>[0]> = {}
+) {
+  const props = {
+    reveal: wonReveal,
+    snapshot,
+    settlement: makeSettlement(),
+    finalizeTransactionUrl: "https://sepolia.basescan.org/tx/0xfff9",
+    settleConfirmed: true,
+    reducedMotion: false,
+    onRewatch: vi.fn(),
+    onContinue: vi.fn(),
+    ...overrides,
+  };
+  render(<StageOutcomePanel {...props} />);
+  return props;
+}
+
+afterEach(cleanup);
+
+describe("StageOutcomePanel", () => {
+  it("shows the paid amount on a win with the crash point", () => {
+    renderPanel();
+    const headline = screen.getByTestId("outcome-headline");
+    expect(headline.textContent).toContain("Won · paid");
+    expect(headline.textContent).toContain("USDC");
+    expect(screen.getByText(/Crash Point 2\.50x/)).toBeTruthy();
+    expect(screen.queryByTestId("voice-trigger")).toBeNull();
+  });
+
+  it("shows the lost margin and desk-phone trigger on a margin call", () => {
+    renderPanel({ reveal: lostReveal });
+    expect(screen.getByTestId("outcome-headline").textContent).toContain(
+      "Margin called"
+    );
+    expect(screen.getByTestId("voice-trigger")).toBeTruthy();
+  });
+
+  it("links the finalization and every settlement transaction", () => {
+    renderPanel();
+    const links = screen.getAllByRole("link");
+    expect(links.map((l) => l.getAttribute("href"))).toEqual([
+      "https://sepolia.basescan.org/tx/0xfff9",
+      "https://sepolia.basescan.org/tx/0xccc3",
+    ]);
+  });
+
+  it("gates Continue behind the settle receipt", () => {
+    const props = renderPanel({
+      settleConfirmed: false,
+      settlement: makeSettlement({ status: "claim-pending" }),
+    });
+    const button = screen.getByRole("button", { name: "Settling onchain…" });
+    expect(button.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(button);
+    expect(props.onContinue).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toContain("Claim pending");
+  });
+
+  it("continues and rewatches once confirmed", () => {
+    const props = renderPanel();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Continue to the Floor" })
+    );
+    expect(props.onContinue).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole("button", { name: "Replay" }));
+    expect(props.onRewatch).toHaveBeenCalledOnce();
+  });
+
+  it("hides the replay button and tier board under reduced motion", () => {
+    renderPanel({ reducedMotion: true });
+    expect(screen.queryByRole("button", { name: "Replay" })).toBeNull();
+    expect(
+      screen.queryByRole("list", { name: "Arcade Leverage tier closes" })
+    ).toBeNull();
+  });
+
+  it("surfaces a background settle failure with retry", () => {
+    const settlement = makeSettlement({
+      status: "error",
+      error: "We couldn't claim your payout. Please try again.",
+      canRetry: true,
+      retryAction: "claim",
+    });
+    renderPanel({ settleConfirmed: false, settlement });
+    expect(screen.getByRole("alert").textContent).toContain("couldn't claim");
+    fireEvent.click(screen.getByRole("button", { name: "Retry claim" }));
+    expect(settlement.retry).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/crash-stage/overlay/stage-outcome-panel.tsx
+++ b/src/components/crash-stage/overlay/stage-outcome-panel.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { MarginCallVoiceTrigger } from "@/components/desk-phone/margin-call-voice-trigger";
+import { FinalizeLink } from "@/components/round-theater/finalize-link";
+import { theaterCopy } from "@/components/round-theater/theater-copy";
+import { TierCloseBoard } from "@/components/round-theater/tier-close-board";
+import { GameButton } from "@/components/ui/game-button";
+import type { useCrashTicketSettlement } from "@/hooks/use-crash-ticket-settlement";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
+import {
+  formatCrashPointBps,
+  type TierExposure,
+} from "@/lib/margin-call-crash";
+import type { CeremonyReveal, CeremonySnapshot } from "@/lib/settle-ceremony";
+import {
+  settlementRetryLabels,
+  settlementStatusCopy,
+} from "@/lib/settlement-status-copy";
+import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
+
+type Settlement = ReturnType<typeof useCrashTicketSettlement>;
+
+export type StageOutcomePanelProps = {
+  reveal: CeremonyReveal;
+  snapshot: CeremonySnapshot;
+  settlement: Settlement;
+  finalizeTransactionUrl: string | null;
+  /** Claim/settle receipt landed — gates Continue. */
+  settleConfirmed: boolean;
+  reducedMotion: boolean;
+  onRewatch: () => void;
+  onContinue: () => void;
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  reveal: "Reveal tx",
+  finalize: "Finalize tx",
+  claim: "Claim tx",
+  settle: "Loss settlement tx",
+};
+
+/**
+ * Held result panel for the ceremony's `landed` phase: the payout number,
+ * per-tier closes, every settlement transaction, and the only exit — an
+ * explicit Continue. The next round never reclaims the stage on a timer.
+ */
+export function StageOutcomePanel({
+  reveal,
+  snapshot,
+  settlement,
+  finalizeTransactionUrl,
+  settleConfirmed,
+  reducedMotion,
+  onRewatch,
+  onContinue,
+}: StageOutcomePanelProps) {
+  const won = reveal.outcome === "won";
+  const isError = settlement.status === "error";
+  const pendingLine = settleConfirmed
+    ? null
+    : isError
+      ? settlement.error
+      : (settlementStatusCopy[settlement.status] ??
+        "Waiting for the settlement receipt on Base Sepolia…");
+  const retryLabel = settlement.retryAction
+    ? settlementRetryLabels[settlement.retryAction]
+    : "Retry";
+
+  return (
+    <div
+      className="pointer-events-auto mx-auto w-full max-w-xl rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 p-4 backdrop-blur-md sm:p-5"
+      data-testid="stage-outcome-panel"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p
+          className={`font-[family-name:var(--font-plex-sans)] text-lg font-black uppercase tracking-tight ${
+            won ? "text-[var(--t-green-hot)]" : "text-[var(--t-red-hot)]"
+          }`}
+          data-testid="outcome-headline"
+        >
+          {won
+            ? `Won · paid ${formatDeskDollarsAmount(reveal.payout)}`
+            : `Margin called · ${formatDeskDollarsAmount(snapshot.ticket.margin)} lost`}
+        </p>
+        <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)]">
+          {theaterCopy.crashPointSupporting(
+            formatCrashPointBps(reveal.crashPointBps)
+          )}
+        </p>
+      </div>
+
+      <div className="mt-2 max-h-[26svh] overflow-y-auto pr-1">
+        {/* Reduced motion renders RoundResultCard above — its tier board
+            already covers this. */}
+        {!reducedMotion && hasTickets(snapshot.tiers) ? (
+          <TierCloseBoard
+            crashPointBps={reveal.crashPointBps}
+            playerTierBps={snapshot.ticket.leverageBps}
+            progress={1}
+            tiers={snapshot.tiers}
+          />
+        ) : null}
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <FinalizeLink url={finalizeTransactionUrl} />
+          {settlement.transactions.map((t) => (
+            <a
+              className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
+              href={t.url}
+              key={t.hash}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {STAGE_LABELS[t.stage] ?? "Settlement tx"}
+              {t.confirmed ? "" : " (pending)"}
+            </a>
+          ))}
+        </div>
+
+        {!won && settlement.walletAddress ? (
+          <div className="mt-3">
+            <MarginCallVoiceTrigger
+              roundId={snapshot.ticket.roundId}
+              ticketId={snapshot.ticket.id}
+              walletAddress={settlement.walletAddress}
+            />
+          </div>
+        ) : null}
+      </div>
+
+      {pendingLine ? (
+        <p
+          className={`mt-3 text-sm ${
+            isError ? "text-[var(--t-red)]" : "text-[var(--t-muted)]"
+          }`}
+          role={isError ? "alert" : "status"}
+        >
+          {pendingLine}
+        </p>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <GameButton
+          className="flex-1 bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)] disabled:opacity-50"
+          disabled={!settleConfirmed}
+          onClick={onContinue}
+          size="hero"
+        >
+          {settleConfirmed ? "Continue to the Floor" : "Settling onchain…"}
+        </GameButton>
+        {!reducedMotion ? (
+          <button
+            className={TERMINAL_ACTION_BUTTON_CLASS}
+            onClick={onRewatch}
+            type="button"
+          >
+            {theaterCopy.replayAgain}
+          </button>
+        ) : null}
+        {isError && settlement.canRetry ? (
+          <button
+            className={TERMINAL_ACTION_BUTTON_CLASS}
+            onClick={() => void settlement.retry()}
+            type="button"
+          >
+            {retryLabel}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function hasTickets(tiers: readonly TierExposure[]): boolean {
+  return tiers.some((tier) => tier.ticketCount > 0);
+}

--- a/src/components/crash-stage/overlay/stage-outcome-panel.tsx
+++ b/src/components/crash-stage/overlay/stage-outcome-panel.tsx
@@ -66,9 +66,11 @@ export function StageOutcomePanel({
     ? settlementRetryLabels[settlement.retryAction]
     : "Retry";
 
+  const showTierBoard = !reducedMotion && hasTickets(snapshot.tiers);
+
   return (
     <div
-      className="pointer-events-auto mx-auto w-full max-w-xl rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 p-4 backdrop-blur-md sm:p-5"
+      className="pointer-events-auto mx-auto w-full max-w-3xl rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 p-4 backdrop-blur-md sm:p-5"
       data-testid="stage-outcome-panel"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-2">
@@ -89,10 +91,14 @@ export function StageOutcomePanel({
         </p>
       </div>
 
-      <div className="mt-2 max-h-[26svh] overflow-y-auto pr-1">
+      <div
+        className={
+          showTierBoard ? "mt-2 max-h-[26svh] overflow-y-auto pr-1" : "mt-2"
+        }
+      >
         {/* Reduced motion renders RoundResultCard above — its tier board
             already covers this. */}
-        {!reducedMotion && hasTickets(snapshot.tiers) ? (
+        {showTierBoard ? (
           <TierCloseBoard
             crashPointBps={reveal.crashPointBps}
             playerTierBps={snapshot.ticket.leverageBps}
@@ -139,18 +145,18 @@ export function StageOutcomePanel({
         </p>
       ) : null}
 
-      <div className="mt-4 flex flex-wrap items-center gap-3">
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-stretch">
         <GameButton
-          className="flex-1 bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)] disabled:opacity-50"
+          className="h-14 min-h-14 flex-1 whitespace-nowrap bg-[var(--t-accent)] py-0 text-sm leading-none tracking-[0.16em] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)] disabled:opacity-50 sm:text-base"
           disabled={!settleConfirmed}
           onClick={onContinue}
-          size="hero"
+          size="default"
         >
           {settleConfirmed ? "Continue to the Floor" : "Settling onchain…"}
         </GameButton>
         {!reducedMotion ? (
           <button
-            className={TERMINAL_ACTION_BUTTON_CLASS}
+            className={`${TERMINAL_ACTION_BUTTON_CLASS} inline-flex h-14 min-h-14 shrink-0 items-center justify-center whitespace-nowrap px-6 py-0 leading-none`}
             onClick={onRewatch}
             type="button"
           >
@@ -159,7 +165,7 @@ export function StageOutcomePanel({
         ) : null}
         {isError && settlement.canRetry ? (
           <button
-            className={TERMINAL_ACTION_BUTTON_CLASS}
+            className={`${TERMINAL_ACTION_BUTTON_CLASS} inline-flex h-14 min-h-14 shrink-0 items-center justify-center whitespace-nowrap px-6 py-0 leading-none`}
             onClick={() => void settlement.retry()}
             type="button"
           >

--- a/src/components/crash-stage/overlay/stage-verify-progress.test.tsx
+++ b/src/components/crash-stage/overlay/stage-verify-progress.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  SettlementTransaction,
+  useCrashTicketSettlement,
+} from "@/hooks/use-crash-ticket-settlement";
+import { StageVerifyProgress } from "./stage-verify-progress";
+
+type Settlement = ReturnType<typeof useCrashTicketSettlement>;
+
+function makeSettlement(overrides: Partial<Settlement> = {}): Settlement {
+  return {
+    status: "attesting",
+    error: null,
+    walletAddress: "0x0000000000000000000000000000000000000003",
+    ticket: {
+      id: 7n,
+      player: "0x0000000000000000000000000000000000000003",
+      roundId: 12n,
+      margin: 5_000_000n,
+      leverageBps: 20_000n,
+      reservedPayout: 10_000_000n,
+      settled: false,
+      claimed: false,
+    },
+    round: null,
+    outcome: "pending",
+    payout: 10_000_000n,
+    phase: "locked",
+    displayCrashPoint: null,
+    canVerify: false,
+    canClaim: false,
+    canSettle: false,
+    canRetry: false,
+    retryAction: null,
+    transactions: [],
+    verifyAndSettle: vi.fn(),
+    claim: vi.fn(),
+    settleLoss: vi.fn(),
+    retry: vi.fn(),
+    refresh: vi.fn(),
+    refreshIfIdle: vi.fn(),
+    ...overrides,
+  } as Settlement;
+}
+
+const revealTx: SettlementTransaction = {
+  stage: "reveal",
+  hash: "0xaaa1",
+  url: "https://sepolia.basescan.org/tx/0xaaa1",
+  confirmed: true,
+};
+
+afterEach(cleanup);
+
+describe("StageVerifyProgress", () => {
+  it("marks earlier steps done and the attest step active while attesting", () => {
+    render(
+      <StageVerifyProgress
+        onCancel={vi.fn()}
+        settlement={makeSettlement({
+          status: "attesting",
+          transactions: [revealTx],
+        })}
+      />
+    );
+
+    expect(
+      screen.getByTestId("verify-step-reveal").getAttribute("data-state")
+    ).toBe("done");
+    expect(
+      screen.getByTestId("verify-step-attest").getAttribute("data-state")
+    ).toBe("active");
+    expect(
+      screen.getByTestId("verify-step-finalize").getAttribute("data-state")
+    ).toBe("upcoming");
+    expect(
+      screen.getByTestId("verify-step-settle").getAttribute("data-state")
+    ).toBe("upcoming");
+  });
+
+  it("links each recorded transaction to BaseScan", () => {
+    render(
+      <StageVerifyProgress
+        onCancel={vi.fn()}
+        settlement={makeSettlement({
+          status: "claim-pending",
+          transactions: [
+            revealTx,
+            {
+              stage: "claim",
+              hash: "0xbbb2",
+              url: "https://sepolia.basescan.org/tx/0xbbb2",
+              confirmed: false,
+            },
+          ],
+        })}
+      />
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links.map((l) => l.getAttribute("href"))).toEqual([
+      "https://sepolia.basescan.org/tx/0xaaa1",
+      "https://sepolia.basescan.org/tx/0xbbb2",
+    ]);
+    expect(links[1]!.textContent).toContain("tx pending");
+    // Claim/settle transactions render under the settle step.
+    expect(
+      screen.getByTestId("verify-step-settle").getAttribute("data-state")
+    ).toBe("active");
+  });
+
+  it("shows the error on the failed step with retry and a way back", () => {
+    const onCancel = vi.fn();
+    const settlement = makeSettlement({
+      status: "error",
+      error: "We couldn't finalize your round. Please try again.",
+      canRetry: true,
+      retryAction: "verify",
+      transactions: [revealTx],
+    });
+    render(<StageVerifyProgress onCancel={onCancel} settlement={settlement} />);
+
+    // Reveal already confirmed, so a generic verify retry points at attest.
+    expect(
+      screen.getByTestId("verify-step-attest").getAttribute("data-state")
+    ).toBe("failed");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "couldn't finalize"
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry verify and settle" })
+    );
+    expect(settlement.retry).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to the Floor" }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("marks every step done once confirmed", () => {
+    render(
+      <StageVerifyProgress
+        onCancel={vi.fn()}
+        settlement={makeSettlement({ status: "confirmed" })}
+      />
+    );
+    for (const step of ["reveal", "attest", "finalize", "settle"]) {
+      expect(
+        screen.getByTestId(`verify-step-${step}`).getAttribute("data-state")
+      ).toBe("done");
+    }
+  });
+});

--- a/src/components/crash-stage/overlay/stage-verify-progress.tsx
+++ b/src/components/crash-stage/overlay/stage-verify-progress.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import type {
+  CrashSettlementRetryAction,
+  CrashSettlementStatus,
+  useCrashTicketSettlement,
+} from "@/hooks/use-crash-ticket-settlement";
+import { formatLeverageBps } from "@/lib/margin-call-crash";
+import { formatDeskDollarsAmount } from "@/lib/desk-dollars";
+import {
+  settlementRetryLabels,
+  settlementStatusCopy,
+} from "@/lib/settlement-status-copy";
+import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
+
+type Settlement = ReturnType<typeof useCrashTicketSettlement>;
+
+export type StageVerifyProgressProps = {
+  settlement: Settlement;
+  /** Escape hatch after an error: dismiss the ceremony back to the Floor. */
+  onCancel: () => void;
+};
+
+type StepId = "reveal" | "attest" | "finalize" | "settle";
+
+const STEPS: { id: StepId; title: string; detail: string }[] = [
+  {
+    id: "reveal",
+    title: "Reveal",
+    detail: "Request the round's encrypted crash entropy onchain.",
+  },
+  {
+    id: "attest",
+    title: "Attest",
+    detail: "Inco covalidators decrypt and co-sign the Crash Point.",
+  },
+  {
+    id: "finalize",
+    title: "Finalize",
+    detail: "Publish the attested Crash Point to Base Sepolia.",
+  },
+  {
+    id: "settle",
+    title: "Settle",
+    detail: "Claim the win or book the margin call.",
+  },
+];
+
+/**
+ * Full-stage verification stepper for the ceremony's `verifying` phase — the
+ * suspense window between clicking Verify and settle and the Crash Point
+ * reveal. Replaces the frozen LOCKED numeral + one grey status line.
+ */
+export function StageVerifyProgress({
+  settlement,
+  onCancel,
+}: StageVerifyProgressProps) {
+  const ticket = settlement.ticket;
+  const isError = settlement.status === "error";
+  const active = isError
+    ? errorStep(settlement.retryAction, settlement)
+    : activeStep(settlement.status);
+  const activeIndex =
+    active === null ? STEPS.length : STEPS.findIndex((s) => s.id === active);
+  const statusLine = isError
+    ? settlement.error
+    : (settlementStatusCopy[settlement.status] ?? null);
+  const retryLabel = settlement.retryAction
+    ? settlementRetryLabels[settlement.retryAction]
+    : "Retry";
+
+  return (
+    <div
+      className="pointer-events-auto mx-auto w-full max-w-xl rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 p-4 backdrop-blur-md sm:p-5"
+      data-testid="stage-verify-progress"
+    >
+      <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-[var(--t-muted)]">
+        Verifying the Crash Point
+      </p>
+      {ticket ? (
+        <p className="mt-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)]">
+          {formatDeskDollarsAmount(ticket.margin)} ·{" "}
+          {formatLeverageBps(ticket.leverageBps)} · Round{" "}
+          {ticket.roundId.toString()}
+        </p>
+      ) : null}
+
+      <ol className="mt-4 space-y-2">
+        {STEPS.map((step, index) => {
+          const done = index < activeIndex;
+          const isActive = index === activeIndex;
+          const failed = isError && isActive;
+          return (
+            <li
+              className={`flex items-start gap-3 border px-3 py-2 ${
+                failed
+                  ? "border-[var(--t-red)]/50"
+                  : isActive
+                    ? "border-[var(--t-accent)]/60"
+                    : done
+                      ? "border-[var(--t-green)]/40"
+                      : "border-[var(--t-divider)]"
+              }`}
+              data-testid={`verify-step-${step.id}`}
+              data-state={
+                failed
+                  ? "failed"
+                  : isActive
+                    ? "active"
+                    : done
+                      ? "done"
+                      : "upcoming"
+              }
+              key={step.id}
+            >
+              <span
+                aria-hidden
+                className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center border text-[10px] font-bold tabular-nums ${
+                  failed
+                    ? "border-[var(--t-red)] text-[var(--t-red-hot)]"
+                    : done
+                      ? "border-[var(--t-green)] text-[var(--t-green-hot)]"
+                      : isActive
+                        ? "border-[var(--t-accent)] text-[var(--t-accent)]"
+                        : "border-[var(--t-divider)] text-[var(--t-muted)]"
+                }`}
+              >
+                {done ? "✓" : failed ? "✕" : index + 1}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span
+                  className={`block text-xs font-bold uppercase tracking-[0.14em] ${
+                    failed
+                      ? "text-[var(--t-red-hot)]"
+                      : isActive
+                        ? "mc-shimmer text-[var(--t-accent)]"
+                        : done
+                          ? "text-[var(--t-green-hot)]"
+                          : "text-[var(--t-muted)]"
+                  }`}
+                >
+                  {step.title}
+                </span>
+                <span className="mt-0.5 block text-[11px] text-[var(--t-muted)]">
+                  {step.detail}
+                </span>
+                <StepTransactions settlement={settlement} step={step.id} />
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+
+      {statusLine ? (
+        <p
+          className={`mt-3 text-sm ${
+            isError ? "text-[var(--t-red)]" : "text-[var(--t-muted)]"
+          }`}
+          role={isError ? "alert" : "status"}
+        >
+          {statusLine}
+        </p>
+      ) : null}
+
+      {isError ? (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          {settlement.canRetry ? (
+            <button
+              className={TERMINAL_ACTION_BUTTON_CLASS}
+              onClick={() => void settlement.retry()}
+              type="button"
+            >
+              {retryLabel}
+            </button>
+          ) : null}
+          <button
+            className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-muted)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
+            onClick={onCancel}
+            type="button"
+          >
+            Back to the Floor
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StepTransactions({
+  settlement,
+  step,
+}: {
+  settlement: Settlement;
+  step: StepId;
+}) {
+  const transactions = settlement.transactions.filter((t) =>
+    step === "settle"
+      ? t.stage === "claim" || t.stage === "settle"
+      : t.stage === step
+  );
+  if (transactions.length === 0) return null;
+  return (
+    <span className="mt-1 flex flex-wrap gap-2">
+      {transactions.map((t) => (
+        <a
+          className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-2 hover:text-[var(--t-text)]"
+          href={t.url}
+          key={t.hash}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {t.confirmed ? "tx confirmed" : "tx pending"} · {shortHash(t.hash)}
+        </a>
+      ))}
+    </span>
+  );
+}
+
+function shortHash(hash: string): string {
+  return `${hash.slice(0, 10)}…`;
+}
+
+function activeStep(status: CrashSettlementStatus): StepId | null {
+  if (status === "reveal-submitting" || status === "reveal-pending") {
+    return "reveal";
+  }
+  if (status === "attesting") return "attest";
+  if (status === "finalize-submitting" || status === "finalize-pending") {
+    return "finalize";
+  }
+  if (
+    status === "claim-submitting" ||
+    status === "claim-pending" ||
+    status === "settle-submitting" ||
+    status === "settle-pending"
+  ) {
+    return "settle";
+  }
+  if (status === "confirmed") return null;
+  return "reveal";
+}
+
+/** Which step an error belongs to, from the retry action + recorded txs. */
+function errorStep(
+  retryAction: CrashSettlementRetryAction | null,
+  settlement: Settlement
+): StepId {
+  switch (retryAction) {
+    case "reveal-receipt-check":
+      return "reveal";
+    case "finalize-receipt-check":
+      return "finalize";
+    case "claim":
+    case "settle":
+    case "claim-receipt-check":
+    case "settle-receipt-check":
+      return "settle";
+    default:
+      // A generic verify retry after a confirmed reveal means the attestation
+      // (or a later stage) failed — point at attest, not the finished reveal.
+      return settlement.transactions.some(
+        (t) => t.stage === "reveal" && t.confirmed
+      )
+        ? "attest"
+        : "reveal";
+  }
+}

--- a/src/components/crash-stage/overlay/win-confetti.test.tsx
+++ b/src/components/crash-stage/overlay/win-confetti.test.tsx
@@ -18,12 +18,7 @@ describe("WinConfetti", () => {
     );
   });
 
-  it("renders nothing under reduced motion", () => {
-    render(<WinConfetti nonce={1} reducedMotion />);
-    expect(screen.queryByTestId("win-confetti")).toBeNull();
-  });
-
-  it("regenerates pieces when the nonce changes", () => {
+  it("regenerates pieces when remounted with a new nonce", () => {
     const { rerender } = render(<WinConfetti key={1} nonce={1} />);
     const firstLeft =
       screen.getAllByTestId("win-confetti-piece")[0]?.style.left;

--- a/src/components/crash-stage/overlay/win-confetti.test.tsx
+++ b/src/components/crash-stage/overlay/win-confetti.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WIN_CONFETTI_PIECE_COUNT, WinConfetti } from "./win-confetti";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("WinConfetti", () => {
+  it("renders the expected piece count for a win burst", () => {
+    render(<WinConfetti nonce={1} />);
+    expect(screen.getByTestId("win-confetti")).toBeTruthy();
+    expect(screen.getAllByTestId("win-confetti-piece")).toHaveLength(
+      WIN_CONFETTI_PIECE_COUNT
+    );
+  });
+
+  it("renders nothing under reduced motion", () => {
+    render(<WinConfetti nonce={1} reducedMotion />);
+    expect(screen.queryByTestId("win-confetti")).toBeNull();
+  });
+
+  it("regenerates pieces when the nonce changes", () => {
+    const { rerender } = render(<WinConfetti key={1} nonce={1} />);
+    const firstLeft =
+      screen.getAllByTestId("win-confetti-piece")[0]?.style.left;
+
+    rerender(<WinConfetti key={2} nonce={2} />);
+    const secondLeft =
+      screen.getAllByTestId("win-confetti-piece")[0]?.style.left;
+
+    expect(firstLeft).toBeTruthy();
+    expect(secondLeft).toBeTruthy();
+    expect(secondLeft).not.toBe(firstLeft);
+  });
+
+  it("unmounts after the celebration window", async () => {
+    vi.useFakeTimers();
+    render(<WinConfetti nonce={3} />);
+    expect(screen.getByTestId("win-confetti")).toBeTruthy();
+    await act(async () => {
+      vi.advanceTimersByTime(4_300);
+    });
+    expect(screen.queryByTestId("win-confetti")).toBeNull();
+  });
+});

--- a/src/components/crash-stage/overlay/win-confetti.tsx
+++ b/src/components/crash-stage/overlay/win-confetti.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export type WinConfettiProps = {
+  /** Bumps regenerate a fresh piece set (e.g. ceremony startNonce on Replay). */
+  nonce: number;
+  reducedMotion?: boolean;
+};
+
+type ConfettiPiece = {
+  id: number;
+  wave: "cannon" | "rain";
+  left: number;
+  delay: number;
+  duration: number;
+  drift: number;
+  rotate: number;
+  size: number;
+  color: string;
+};
+
+const PIECE_COUNT = 160;
+const CANNON_COUNT = 70;
+const COLORS = [
+  "var(--t-green-hot)",
+  "var(--t-green)",
+  "var(--t-accent)",
+  "var(--t-amber-hot)",
+  "var(--t-text)",
+] as const;
+
+/** Lifetime slightly past the longest piece duration + delay. */
+const LAYER_MS = 4_200;
+
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function buildPieces(nonce: number): ConfettiPiece[] {
+  const rand = mulberry32(nonce * 9973 + 42);
+  const pieces: ConfettiPiece[] = [];
+
+  for (let i = 0; i < PIECE_COUNT; i++) {
+    const isCannon = i < CANNON_COUNT;
+    pieces.push({
+      id: i,
+      wave: isCannon ? "cannon" : "rain",
+      left: isCannon ? 35 + rand() * 30 : rand() * 100,
+      delay: isCannon ? rand() * 0.35 : 0.15 + rand() * 0.9,
+      duration: isCannon ? 1.8 + rand() * 1.2 : 2.2 + rand() * 1.4,
+      drift: isCannon ? (rand() - 0.5) * 140 : (rand() - 0.5) * 80,
+      rotate: 360 + rand() * 720,
+      size: isCannon ? 6 + rand() * 8 : 4 + rand() * 7,
+      color: COLORS[Math.floor(rand() * COLORS.length)]!,
+    });
+  }
+
+  return pieces;
+}
+
+/**
+ * Full-viewport CSS confetti storm for a personal win. Two waves: a bottom
+ * cannon and a full-width rain. Finite; unmounts itself after the last piece.
+ * Remount (via `key={nonce}`) to fire again on Replay.
+ */
+export function WinConfetti({
+  nonce,
+  reducedMotion = false,
+}: WinConfettiProps) {
+  const [alive, setAlive] = useState(true);
+  const pieces = useMemo(() => buildPieces(nonce), [nonce]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setAlive(false), LAYER_MS);
+    return () => window.clearTimeout(timer);
+  }, [nonce]);
+
+  if (reducedMotion || !alive) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-40 overflow-hidden"
+      data-testid="win-confetti"
+    >
+      {pieces.map((piece) => (
+        <span
+          className={
+            piece.wave === "cannon"
+              ? "mc-confetti-cannon absolute bottom-0"
+              : "mc-confetti-rain absolute top-0"
+          }
+          data-testid="win-confetti-piece"
+          key={`${nonce}-${piece.id}`}
+          style={
+            {
+              left: `${piece.left}%`,
+              width: piece.size,
+              height: piece.size * (0.55 + (piece.id % 3) * 0.25),
+              backgroundColor: piece.color,
+              "--mc-confetti-delay": `${piece.delay}s`,
+              "--mc-confetti-duration": `${piece.duration}s`,
+              "--mc-confetti-drift": `${piece.drift}px`,
+              "--mc-confetti-rotate": `${piece.rotate}deg`,
+            } as React.CSSProperties
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+export const WIN_CONFETTI_PIECE_COUNT = PIECE_COUNT;

--- a/src/components/crash-stage/overlay/win-confetti.tsx
+++ b/src/components/crash-stage/overlay/win-confetti.tsx
@@ -3,9 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 
 export type WinConfettiProps = {
-  /** Bumps regenerate a fresh piece set (e.g. ceremony startNonce on Replay). */
+  /** Remount via key={nonce} to fire again on Replay. */
   nonce: number;
-  reducedMotion?: boolean;
 };
 
 type ConfettiPiece = {
@@ -66,14 +65,10 @@ function buildPieces(nonce: number): ConfettiPiece[] {
 }
 
 /**
- * Full-viewport CSS confetti storm for a personal win. Two waves: a bottom
- * cannon and a full-width rain. Finite; unmounts itself after the last piece.
- * Remount (via `key={nonce}`) to fire again on Replay.
+ * Full-viewport CSS confetti for a personal win. Parent gates reduced motion
+ * and remounts via key={nonce} on Replay; this layer only self-unmounts.
  */
-export function WinConfetti({
-  nonce,
-  reducedMotion = false,
-}: WinConfettiProps) {
+export function WinConfetti({ nonce }: WinConfettiProps) {
   const [alive, setAlive] = useState(true);
   const pieces = useMemo(() => buildPieces(nonce), [nonce]);
 
@@ -82,7 +77,7 @@ export function WinConfetti({
     return () => window.clearTimeout(timer);
   }, [nonce]);
 
-  if (reducedMotion || !alive) return null;
+  if (!alive) return null;
 
   return (
     <div

--- a/src/components/crash-stage/scenes/outcome-burst.tsx
+++ b/src/components/crash-stage/scenes/outcome-burst.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useFrame } from "@react-three/fiber";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { Group, Mesh } from "three";
-import type { TicketLanding } from "@/components/round-theater/landing-frame";
 
 export type OutcomeBurstProps = {
-  kind: TicketLanding["kind"];
+  /** Personal wins use WinConfetti; the pit only shatters on a margin call. */
+  kind: "margin-called" | "spectator";
 };
 
 type Particle = {
@@ -14,45 +14,37 @@ type Particle = {
   vy: number;
   vz: number;
   life: number;
-  color: string;
 };
 
-const PARTICLE_COUNT = 90;
-const WIN_COLORS = ["#92f5b8", "#79d49b", "#d6a660", "#f0d29a"] as const;
-const LOSS_COLOR = "#ff6b5c";
+const PARTICLE_COUNT = 36;
+const COLOR = "#ff6b5c";
 
-function seedParticles(isWin: boolean): Particle[] {
+function seedParticles(): Particle[] {
   const list: Particle[] = [];
   for (let i = 0; i < PARTICLE_COUNT; i++) {
-    const angle = (i / PARTICLE_COUNT) * Math.PI * 2 + (i % 5) * 0.17;
-    const speed = isWin ? 1.1 + (i % 7) * 0.18 : 1.2 + (i % 7) * 0.15;
+    const angle = (i / PARTICLE_COUNT) * Math.PI * 2;
+    const speed = 1.2 + (i % 7) * 0.15;
     list.push({
-      vx: Math.cos(angle) * speed * (isWin ? 0.85 : 1),
-      vy: isWin ? 1.6 + (i % 5) * 0.28 : (i % 3) * 0.4 - 0.2,
-      vz: Math.sin(angle) * speed * (isWin ? 0.85 : 1),
+      vx: Math.cos(angle) * speed,
+      vy: (i % 3) * 0.4 - 0.2,
+      vz: Math.sin(angle) * speed,
       life: 0,
-      color: isWin ? WIN_COLORS[i % WIN_COLORS.length]! : LOSS_COLOR,
     });
   }
   return list;
 }
 
 /**
- * Win fountain (green/amber particles rising) or shatter (red scatter).
- * Outcome labels live on the DOM graph, not in the pit.
+ * Margin-call shatter in the pit. Win celebration lives in WinConfetti so the
+ * Floor does not run two particle systems for the same moment.
  */
 export function OutcomeBurst({ kind }: OutcomeBurstProps) {
   const groupRef = useRef<Group>(null);
-  const particlesRef = useRef<Particle[]>(seedParticles(false));
-  const isWin = kind === "won";
-  const colors = useMemo(
-    () => seedParticles(isWin).map((p) => p.color),
-    [isWin]
-  );
+  const particlesRef = useRef<Particle[]>(seedParticles());
 
   useEffect(() => {
-    particlesRef.current = seedParticles(isWin);
-  }, [isWin]);
+    particlesRef.current = seedParticles();
+  }, [kind]);
 
   useFrame((_, delta) => {
     const group = groupRef.current;
@@ -63,21 +55,13 @@ export function OutcomeBurst({ kind }: OutcomeBurstProps) {
       const p = sim[i];
       if (!child || !p) continue;
       p.life += delta;
-      if (isWin) {
-        child.position.x += p.vx * delta;
-        child.position.y += (p.vy - p.life * 0.35) * delta;
-        child.position.z += p.vz * delta;
-        child.rotation.z += delta * 2.2;
-      } else {
-        child.position.x += p.vx * delta;
-        child.position.y += (p.vy - 2.2 * p.life) * delta;
-        child.position.z += p.vz * delta;
-        child.rotation.x += delta * 4;
-        child.rotation.z += delta * 3;
-      }
-      const lifeSpan = isWin ? 3.2 : 2.2;
-      const fade = Math.max(0, 1 - p.life / lifeSpan);
-      child.scale.setScalar((isWin ? 0.85 : 0.6) * fade + 0.2);
+      child.position.x += p.vx * delta;
+      child.position.y += (p.vy - 2.2 * p.life) * delta;
+      child.position.z += p.vz * delta;
+      child.rotation.x += delta * 4;
+      child.rotation.z += delta * 3;
+      const fade = Math.max(0, 1 - p.life / 2.2);
+      child.scale.setScalar(0.6 * fade + 0.2);
       child.visible = fade > 0.05;
     }
   });
@@ -86,11 +70,11 @@ export function OutcomeBurst({ kind }: OutcomeBurstProps) {
     <group ref={groupRef}>
       {Array.from({ length: PARTICLE_COUNT }, (_, i) => (
         <mesh key={i} position={[0, 0.2, 0]}>
-          <boxGeometry args={[0.14, 0.14, 0.14]} />
+          <boxGeometry args={[0.12, 0.12, 0.12]} />
           <meshStandardMaterial
-            color={colors[i] ?? LOSS_COLOR}
-            emissive={colors[i] ?? LOSS_COLOR}
-            emissiveIntensity={isWin ? 1.05 : 0.7}
+            color={COLOR}
+            emissive={COLOR}
+            emissiveIntensity={0.7}
           />
         </mesh>
       ))}

--- a/src/components/crash-stage/scenes/outcome-burst.tsx
+++ b/src/components/crash-stage/scenes/outcome-burst.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useFrame } from "@react-three/fiber";
-import { useEffect, useRef } from "react";
-import type { Group } from "three";
+import { useEffect, useMemo, useRef } from "react";
+import type { Group, Mesh } from "three";
 import type { TicketLanding } from "@/components/round-theater/landing-frame";
 
 export type OutcomeBurstProps = {
@@ -14,34 +14,41 @@ type Particle = {
   vy: number;
   vz: number;
   life: number;
+  color: string;
 };
 
-const PARTICLE_COUNT = 36;
+const PARTICLE_COUNT = 90;
+const WIN_COLORS = ["#92f5b8", "#79d49b", "#d6a660", "#f0d29a"] as const;
+const LOSS_COLOR = "#ff6b5c";
 
 function seedParticles(isWin: boolean): Particle[] {
   const list: Particle[] = [];
   for (let i = 0; i < PARTICLE_COUNT; i++) {
-    const angle = (i / PARTICLE_COUNT) * Math.PI * 2;
-    const speed = isWin ? 0.8 + (i % 5) * 0.1 : 1.2 + (i % 7) * 0.15;
+    const angle = (i / PARTICLE_COUNT) * Math.PI * 2 + (i % 5) * 0.17;
+    const speed = isWin ? 1.1 + (i % 7) * 0.18 : 1.2 + (i % 7) * 0.15;
     list.push({
-      vx: Math.cos(angle) * speed * (isWin ? 0.35 : 1),
-      vy: isWin ? 1.2 + (i % 4) * 0.2 : (i % 3) * 0.4 - 0.2,
-      vz: Math.sin(angle) * speed * (isWin ? 0.35 : 1),
+      vx: Math.cos(angle) * speed * (isWin ? 0.85 : 1),
+      vy: isWin ? 1.6 + (i % 5) * 0.28 : (i % 3) * 0.4 - 0.2,
+      vz: Math.sin(angle) * speed * (isWin ? 0.85 : 1),
       life: 0,
+      color: isWin ? WIN_COLORS[i % WIN_COLORS.length]! : LOSS_COLOR,
     });
   }
   return list;
 }
 
 /**
- * Win fountain (green particles rising) or shatter (red scatter).
+ * Win fountain (green/amber particles rising) or shatter (red scatter).
  * Outcome labels live on the DOM graph, not in the pit.
  */
 export function OutcomeBurst({ kind }: OutcomeBurstProps) {
   const groupRef = useRef<Group>(null);
   const particlesRef = useRef<Particle[]>(seedParticles(false));
   const isWin = kind === "won";
-  const color = isWin ? "#92f5b8" : "#ff6b5c";
+  const colors = useMemo(
+    () => seedParticles(isWin).map((p) => p.color),
+    [isWin]
+  );
 
   useEffect(() => {
     particlesRef.current = seedParticles(isWin);
@@ -52,14 +59,15 @@ export function OutcomeBurst({ kind }: OutcomeBurstProps) {
     const sim = particlesRef.current;
     if (!group) return;
     for (let i = 0; i < group.children.length; i++) {
-      const child = group.children[i];
+      const child = group.children[i] as Mesh | undefined;
       const p = sim[i];
       if (!child || !p) continue;
       p.life += delta;
       if (isWin) {
         child.position.x += p.vx * delta;
-        child.position.y += (p.vy - p.life * 0.4) * delta;
+        child.position.y += (p.vy - p.life * 0.35) * delta;
         child.position.z += p.vz * delta;
+        child.rotation.z += delta * 2.2;
       } else {
         child.position.x += p.vx * delta;
         child.position.y += (p.vy - 2.2 * p.life) * delta;
@@ -67,8 +75,9 @@ export function OutcomeBurst({ kind }: OutcomeBurstProps) {
         child.rotation.x += delta * 4;
         child.rotation.z += delta * 3;
       }
-      const fade = Math.max(0, 1 - p.life / 2.2);
-      child.scale.setScalar(0.6 * fade + 0.2);
+      const lifeSpan = isWin ? 3.2 : 2.2;
+      const fade = Math.max(0, 1 - p.life / lifeSpan);
+      child.scale.setScalar((isWin ? 0.85 : 0.6) * fade + 0.2);
       child.visible = fade > 0.05;
     }
   });
@@ -77,11 +86,11 @@ export function OutcomeBurst({ kind }: OutcomeBurstProps) {
     <group ref={groupRef}>
       {Array.from({ length: PARTICLE_COUNT }, (_, i) => (
         <mesh key={i} position={[0, 0.2, 0]}>
-          <boxGeometry args={[0.12, 0.12, 0.12]} />
+          <boxGeometry args={[0.14, 0.14, 0.14]} />
           <meshStandardMaterial
-            color={color}
-            emissive={color}
-            emissiveIntensity={0.7}
+            color={colors[i] ?? LOSS_COLOR}
+            emissive={colors[i] ?? LOSS_COLOR}
+            emissiveIntensity={isWin ? 1.05 : 0.7}
           />
         </mesh>
       ))}

--- a/src/components/crash-stage/use-crash-stage-mode.test.ts
+++ b/src/components/crash-stage/use-crash-stage-mode.test.ts
@@ -60,7 +60,9 @@ function baseInput(
 ): CrashStageModeInput {
   return {
     live: openLive(),
+    ceremonyPhase: "idle",
     hasUnsettledTicket: false,
+    hasStaleUnsettledTicket: false,
     mayClimb: true,
     hasReplayHero: false,
     isReplayComplete: false,
@@ -162,5 +164,79 @@ describe("deriveCrashStageMode", () => {
         })
       )
     ).toBe("expired");
+  });
+
+  it("lets the ceremony take over every ready live kind", () => {
+    for (const live of [openLive(), delayedLive(), finalizedLive()]) {
+      expect(
+        deriveCrashStageMode(baseInput({ live, ceremonyPhase: "verifying" }))
+      ).toBe("settling");
+      expect(
+        deriveCrashStageMode(baseInput({ live, ceremonyPhase: "climbing" }))
+      ).toBe("replay");
+      expect(
+        deriveCrashStageMode(baseInput({ live, ceremonyPhase: "landed" }))
+      ).toBe("outcome");
+    }
+  });
+
+  it("holds a landed ceremony across a flip to the next open round", () => {
+    expect(
+      deriveCrashStageMode(
+        baseInput({
+          live: openLive(),
+          ceremonyPhase: "landed",
+          hasUnsettledTicket: false,
+          mayClimb: true,
+        })
+      )
+    ).toBe("outcome");
+  });
+
+  it("blocks the next round's countdown behind a stale unsettled ticket", () => {
+    expect(
+      deriveCrashStageMode(
+        baseInput({
+          live: openLive(),
+          hasUnsettledTicket: true,
+          hasStaleUnsettledTicket: true,
+          mayClimb: false,
+        })
+      )
+    ).toBe("awaiting-settle");
+  });
+
+  it("keeps expired routing to refund over the stale-ticket gate", () => {
+    expect(
+      deriveCrashStageMode(
+        baseInput({
+          live: {
+            kind: "expired",
+            roundId: 12n,
+            tape: null,
+            timeline,
+          },
+          hasUnsettledTicket: true,
+          hasStaleUnsettledTicket: true,
+          mayClimb: false,
+        })
+      )
+    ).toBe("expired");
+  });
+
+  it("still returns loading and error over an active ceremony", () => {
+    expect(
+      deriveCrashStageMode(
+        baseInput({ live: { kind: "loading" }, ceremonyPhase: "verifying" })
+      )
+    ).toBe("loading");
+    expect(
+      deriveCrashStageMode(
+        baseInput({
+          live: { kind: "error", error: "boom" },
+          ceremonyPhase: "landed",
+        })
+      )
+    ).toBe("error");
   });
 });

--- a/src/components/crash-stage/use-crash-stage-mode.ts
+++ b/src/components/crash-stage/use-crash-stage-mode.ts
@@ -1,23 +1,30 @@
 /**
- * Derives CrashStage presentation mode from theater live phase and whether
- * the player may climb (settle receipt or no unsettled ticket). Pure — no hooks.
+ * Derives CrashStage presentation mode from theater live phase, the player's
+ * settle ceremony, and whether the player may climb (settle receipt or no
+ * unsettled ticket). Pure — no hooks.
  */
 
 import type { TheaterLive } from "@/hooks/use-round-theater";
+import type { SettleCeremonyPhase } from "@/lib/settle-ceremony";
 
 export type CrashStageMode =
   | "loading"
   | "error"
   | "countdown"
   | "awaiting-settle"
+  | "settling"
   | "replay"
   | "outcome"
   | "expired";
 
 export type CrashStageModeInput = {
   live: TheaterLive;
+  /** Player-local settle ceremony phase; non-idle takes over the stage. */
+  ceremonyPhase: SettleCeremonyPhase;
   /** Player has a ticket for the displayed round that is not yet settled. */
   hasUnsettledTicket: boolean;
+  /** Unsettled ticket left over from a round before the live one. */
+  hasStaleUnsettledTicket: boolean;
   /**
    * True when the player may see the attested climb: no unsettled ticket
    * (spectator / already settled onchain), or settlement receipt confirmed.
@@ -33,9 +40,14 @@ export type CrashStageModeInput = {
  * Presentation mode for the immersive floor.
  *
  * - countdown: open entry window (or delayed without a personal settle gate)
- * - awaiting-settle: locked/reveal with unsettled ticket — Verify CTA, no climb
- * - replay: attested climb graph after settle receipt, or for spectators after finalize
- * - outcome: win/loss freeze after the climb completes
+ * - awaiting-settle: unsettled ticket without a running ceremony — Verify CTA
+ * - settling: ceremony verifying (reveal → attest → finalize stepper)
+ * - replay: the climb — ceremony-owned for the settling player, chain-seeded
+ *   for spectators after finalize
+ * - outcome: win/loss freeze; a ceremony holds it until acknowledged
+ *
+ * Ceremony precedence beats every ready live kind, including a flip to the
+ * next open round: the player's own reveal is never interrupted by a poll.
  */
 export function deriveCrashStageMode(
   input: CrashStageModeInput
@@ -48,9 +60,32 @@ export function deriveCrashStageMode(
     case "error":
     case "unavailable":
       return "error";
+    default:
+      break;
+  }
+
+  switch (input.ceremonyPhase) {
+    case "verifying":
+      return "settling";
+    case "climbing":
+      return "replay";
+    case "landed":
+      return "outcome";
+    case "idle":
+      break;
+    default: {
+      const _exhaustive: never = input.ceremonyPhase;
+      return _exhaustive;
+    }
+  }
+
+  switch (live.kind) {
     case "expired":
       return "expired";
     case "open":
+      // A leftover unsettled ticket blocks the next round's countdown; the
+      // player finishes (or refunds) the old round before seeing a new one.
+      if (input.hasStaleUnsettledTicket) return "awaiting-settle";
       if (input.hasReplayHero && input.mayClimb) {
         if (input.isReplayComplete) return "outcome";
         return "replay";

--- a/src/components/history/personal-history.test.tsx
+++ b/src/components/history/personal-history.test.tsx
@@ -41,6 +41,7 @@ const sdk = vi.hoisted(() => {
     canVerify: false,
     canExpire: false,
     canRefund: false,
+    settlementTransaction: null,
   };
   const refundable: PlayerTicketHistoryItem = {
     ticket: {
@@ -76,6 +77,7 @@ const sdk = vi.hoisted(() => {
     canVerify: false,
     canExpire: false,
     canRefund: true,
+    settlementTransaction: null,
   };
   const settled: PlayerTicketHistoryItem = {
     ticket: {
@@ -111,6 +113,10 @@ const sdk = vi.hoisted(() => {
     canVerify: false,
     canExpire: false,
     canRefund: false,
+    settlementTransaction: {
+      kind: "claim" as const,
+      url: "https://sepolia.basescan.org/tx/0xeee5",
+    },
   };
 
   return {
@@ -178,6 +184,18 @@ describe("PersonalHistory", () => {
     // The settled row remains the only claimed label; pending claim does not
     // flip the unsettled ticket's displayed settlement state.
     expect(screen.getByText("Won — claim your payout")).toBeTruthy();
+  });
+
+  it("links a settled ticket to its settlement transaction on BaseScan", () => {
+    render(<PersonalHistory />);
+    const link = screen.getByRole("link", {
+      name: "View claim transaction on BaseScan",
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://sepolia.basescan.org/tx/0xeee5"
+    );
+    // Unsettled rows have no settlement to link yet.
+    expect(screen.queryAllByRole("link", { name: /BaseScan/ })).toHaveLength(1);
   });
 
   it("shows pending claim copy without marking the ticket claimed", () => {

--- a/src/components/history/personal-history.tsx
+++ b/src/components/history/personal-history.tsx
@@ -42,6 +42,12 @@ const amountLabels: Record<PlayerTicketHistoryItem["amountKind"], string> = {
   reserved: "Reserved payout",
 };
 
+const settlementLinkLabels: Record<string, string> = {
+  claim: "View claim transaction on BaseScan",
+  loss: "View loss settlement on BaseScan",
+  refund: "View refund transaction on BaseScan",
+};
+
 /**
  * Wallet-scoped ticket list with receipt-backed claim/refund actions.
  * Page chrome (title / lede) lives on /record.
@@ -200,6 +206,21 @@ function PersonalHistoryRow({
             {ticketOutcomeCopy[item.outcome]}
           </dd>
         </div>
+        {item.settlementTransaction ? (
+          <div className="sm:col-span-2">
+            <dt className="text-[var(--t-muted)]">Settlement</dt>
+            <dd>
+              <a
+                className="text-xs font-bold uppercase tracking-[0.12em] text-[var(--t-accent)] underline decoration-[var(--t-border)] underline-offset-4 hover:text-[var(--t-text)]"
+                href={item.settlementTransaction.url}
+                rel="noreferrer"
+                target="_blank"
+              >
+                {settlementLinkLabels[item.settlementTransaction.kind]}
+              </a>
+            </dd>
+          </div>
+        ) : null}
       </dl>
 
       <div className="mt-4 flex flex-wrap gap-3">

--- a/src/components/round-theater/landing-frame.test.ts
+++ b/src/components/round-theater/landing-frame.test.ts
@@ -88,6 +88,8 @@ describe("presentLanding", () => {
     expect(frame.showMarginCallStamp).toBe(false);
     expect(frame.stampDetail).toBeNull();
     expect(frame.heroColorClass).toContain("green");
+    expect(frame.plotAccent).toBe("var(--t-green-hot)");
+    expect(frame.panelInsetClass).toContain("146,245,184");
   });
 
   it("freezes margin-called with personal detail once and market stamp copy", () => {
@@ -98,6 +100,8 @@ describe("presentLanding", () => {
     // Stamp must not re-print the personal detail.
     expect(frame.stampDetail).toBe(theaterCopy.marginCallDetail);
     expect(frame.stampDetail).not.toBe(frame.outcomeDetail);
+    expect(frame.plotAccent).toBe("var(--t-red-hot)");
+    expect(frame.panelInsetClass).toContain("255,107,92");
   });
 
   it("freezes spectator on Crash Point in red with the market stamp", () => {
@@ -109,6 +113,8 @@ describe("presentLanding", () => {
     expect(frame.supportingCrashPoint).toBeNull();
     expect(frame.showMarginCallStamp).toBe(true);
     expect(frame.stampDetail).toBe(theaterCopy.marginCallDetail);
+    expect(frame.plotAccent).toBe("var(--t-red-hot)");
+    expect(frame.panelInsetClass).toBeNull();
   });
 
   it("covers every TicketLanding kind", () => {

--- a/src/components/round-theater/landing-frame.test.ts
+++ b/src/components/round-theater/landing-frame.test.ts
@@ -1,12 +1,41 @@
 import { describe, expect, it } from "vitest";
 import {
   presentLanding,
+  ticketForRound,
   ticketLanding,
   type TicketLanding,
 } from "./landing-frame";
 import { theaterCopy } from "./theater-copy";
 
 const CRASH = "2.50x";
+
+describe("ticketForRound", () => {
+  const ticket = {
+    id: 1n,
+    player: "0x00000000000000000000000000000000000000aa" as const,
+    roundId: 12n,
+    margin: 5_000_000n,
+    leverageBps: 20_000n,
+    reservedPayout: 10_000_000n,
+    settled: false,
+    claimed: false,
+  };
+
+  it("passes a ticket from the same round through", () => {
+    expect(ticketForRound(ticket, 12n)).toBe(ticket);
+  });
+
+  it("nulls a ticket from another round so it lands as spectator", () => {
+    expect(ticketForRound(ticket, 13n)).toBeNull();
+    expect(ticketLanding(ticketForRound(ticket, 13n), 25_000n)).toEqual({
+      kind: "spectator",
+    });
+  });
+
+  it("passes null through", () => {
+    expect(ticketForRound(null, 12n)).toBeNull();
+  });
+});
 
 describe("ticketLanding", () => {
   it("returns spectator when there is no ticket", () => {

--- a/src/components/round-theater/landing-frame.ts
+++ b/src/components/round-theater/landing-frame.ts
@@ -40,6 +40,18 @@ export function ticketLanding(
 }
 
 /**
+ * Null unless the ticket belongs to the given round. Guards personal landings
+ * against a recovered ticket from an earlier round being judged against
+ * another round's Crash Point.
+ */
+export function ticketForRound(
+  ticket: CrashTicket | null,
+  roundId: bigint
+): CrashTicket | null {
+  return ticket !== null && ticket.roundId === roundId ? ticket : null;
+}
+
+/**
  * Pure presentation of a finalized freeze. Both animated and reduced-motion
  * surfaces render these fields; they do not re-derive policy.
  */

--- a/src/components/round-theater/landing-frame.ts
+++ b/src/components/round-theater/landing-frame.ts
@@ -26,6 +26,10 @@ export type LandingPresentation = {
   stampDetail: string | null;
   /** Crash-moment edge flash color (curve juice only). */
   momentColor: string;
+  /** Stroke / area / head accent once the climb freezes. */
+  plotAccent: string;
+  /** Optional inset glow on the hero panel. */
+  panelInsetClass: string | null;
 };
 
 /** Domain boundary: ticket + Crash Point → personal or spectator landing. */
@@ -71,6 +75,8 @@ export function presentLanding(
         showMarginCallStamp: false,
         stampDetail: null,
         momentColor: "var(--t-safe)",
+        plotAccent: "var(--t-green-hot)",
+        panelInsetClass: "shadow-[inset_0_0_56px_rgba(146,245,184,0.16)]",
       };
     case "margin-called":
       return {
@@ -84,6 +90,8 @@ export function presentLanding(
         showMarginCallStamp: true,
         stampDetail: theaterCopy.marginCallDetail,
         momentColor: "var(--t-threat)",
+        plotAccent: "var(--t-red-hot)",
+        panelInsetClass: "shadow-[inset_0_0_56px_rgba(255,107,92,0.14)]",
       };
     case "spectator":
       return {
@@ -97,6 +105,8 @@ export function presentLanding(
         showMarginCallStamp: true,
         stampDetail: theaterCopy.marginCallDetail,
         momentColor: "var(--t-amber-hot)",
+        plotAccent: "var(--t-red-hot)",
+        panelInsetClass: null,
       };
     default: {
       const _exhaustive: never = landing;

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -1,32 +1,20 @@
 "use client";
 
-import { useId, useMemo } from "react";
-import {
-  ENTRY_LEVERAGE_TIERS_BPS,
-  formatCrashPointBps,
-  formatLeverageBps,
-} from "@/lib/margin-call-crash";
+import { useMemo } from "react";
 import {
   getReplayMultiplierBps,
   getReplayPathPoints,
-  getTierCloseProgress,
   isReplayComplete,
-  multiplierToY,
-  replayAreaPathD,
   replayPathD,
 } from "@/lib/round-replay";
+import { formatCrashPointBps } from "@/lib/margin-call-crash";
 import { MarginCallPhone } from "./margin-call-phone";
 import { presentLanding, type TicketLanding } from "./landing-frame";
+import { ReplayPlot } from "./replay-plot";
 import { theaterCopy } from "./theater-copy";
 
 const VIEW_W = 100;
 const VIEW_H = 56;
-/** Extra room so strokes, the head badge, and a missed-YOU rail never clip. */
-const PAD_X = 2;
-const PAD_Y = 4;
-const LABEL_MIN_GAP_PCT = 10;
-/** Top rail for a player tier that never closed (above the Crash Point). */
-const MISSED_YOU_Y = 1.5;
 
 export type ReplayCurveProps = {
   crashPointBps: bigint;
@@ -47,62 +35,9 @@ export type ReplayCurveProps = {
  */
 export const REPLAY_HERO_MIN_H = "min-h-[22rem] lg:min-h-[28rem]";
 
-type TierAnnotation = {
-  tier: bigint;
-  closeAt: number;
-  y: number;
-  isPlayerTier: boolean;
-  showLabel: boolean;
-};
-
 /**
- * Map a viewBox coordinate into a percentage of the padded plot area so the
- * DOM overlay stays locked to the stretched SVG geometry.
- */
-function plotPct(value: number, size: number, pad: number): number {
-  return ((value + pad) / (size + pad * 2)) * 100;
-}
-
-function pickVisibleTier(
-  tiers: readonly { tier: bigint; closeAt: number; y: number }[],
-  playerTierBps: bigint | null
-): TierAnnotation[] {
-  const heightPct = (y: number) => plotPct(y, VIEW_H, PAD_Y);
-  const sorted = [...tiers].sort((a, b) => a.y - b.y);
-  const placed: number[] = [];
-  const visible = new Set<string>();
-
-  const tryPlace = (tier: (typeof tiers)[number]) => {
-    const pct = heightPct(tier.y);
-    if (
-      placed.some((existing) => Math.abs(existing - pct) < LABEL_MIN_GAP_PCT)
-    ) {
-      return;
-    }
-    placed.push(pct);
-    visible.add(tier.tier.toString());
-  };
-
-  const player = sorted.find(
-    (t) => playerTierBps !== null && t.tier === playerTierBps
-  );
-  if (player) tryPlace(player);
-  for (const tier of sorted) {
-    if (player && tier.tier === player.tier) continue;
-    tryPlace(tier);
-  }
-
-  return tiers.map((tier) => ({
-    ...tier,
-    isPlayerTier: playerTierBps !== null && tier.tier === playerTierBps,
-    showLabel: visible.has(tier.tier.toString()),
-  }));
-}
-
-/**
- * SVG multiplier climb. Axes rescale with the live multiplier; hard stop at
- * the Crash Point. Signed-in players freeze on Won / Margin called; spectators
- * keep the Crash Point number and margin-call phone.
+ * SVG multiplier climb shell: hero freeze chrome around ReplayPlot. Axes
+ * rescale with the live multiplier; hard stop at the Crash Point.
  */
 export function ReplayCurve({
   crashPointBps,
@@ -112,48 +47,10 @@ export function ReplayCurve({
   landing = { kind: "spectator" },
   fill = false,
 }: ReplayCurveProps) {
-  const reactId = useId();
-  const strokeId = `replay-stroke-${reactId}`;
-  const areaId = `replay-area-${reactId}`;
-  const glowId = `replay-glow-${reactId}`;
-
-  // `progress` moves every animation frame, so memoizing on it buys nothing.
-  const points = getReplayPathPoints(crashPointBps, progress, {
-    width: VIEW_W,
-    height: VIEW_H,
-  });
-  const path = replayPathD(points);
-  const areaPath = replayAreaPathD(points, VIEW_H);
-  const head = points[points.length - 1] ?? { x: 0, y: VIEW_H };
   const multiplierBps = getReplayMultiplierBps(progress, crashPointBps);
   const displayMultiplier = formatCrashPointBps(multiplierBps);
   const isComplete = isReplayComplete(progress);
   const crashLabel = formatCrashPointBps(crashPointBps);
-
-  const tierLines = useMemo(
-    () =>
-      pickVisibleTier(
-        ENTRY_LEVERAGE_TIERS_BPS.flatMap((tier) => {
-          const closeAt = getTierCloseProgress(tier, crashPointBps);
-          if (closeAt === null) return [];
-          return [
-            { tier, closeAt, y: multiplierToY(tier, crashPointBps, VIEW_H) },
-          ];
-        }),
-        playerTierBps
-      ),
-    [crashPointBps, playerTierBps]
-  );
-
-  const missedYou =
-    playerTierBps !== null &&
-    getTierCloseProgress(playerTierBps, crashPointBps) === null
-      ? {
-          tier: playerTierBps,
-          y: MISSED_YOU_Y,
-          label: `${formatLeverageBps(playerTierBps)} · YOU`,
-        }
-      : null;
 
   // Crash-moment: climb finished and this is the result hero (not ambiance).
   // *When* freeze applies lives here; *what* it shows comes from presentLanding.
@@ -168,16 +65,6 @@ export function ReplayCurve({
   const heroIsMultiplier = freeze?.heroIsMultiplier ?? true;
   const isWinFreeze = freeze !== null && landing.kind === "won";
   const isLossFreeze = freeze !== null && landing.kind === "margin-called";
-  const headColor =
-    isComplete &&
-    (landing.kind === "margin-called" || landing.kind === "spectator")
-      ? "var(--t-red-hot)"
-      : "var(--t-green-hot)";
-
-  const headLeft = plotPct(head.x, VIEW_W, PAD_X);
-  const headTop = plotPct(head.y, VIEW_H, PAD_Y);
-  const baselineTop = plotPct(VIEW_H, VIEW_H, PAD_Y);
-  const crashY = multiplierToY(crashPointBps, crashPointBps, VIEW_H);
 
   return (
     <div
@@ -252,276 +139,15 @@ export function ReplayCurve({
         ) : null}
       </div>
 
-      <div
-        className={
-          fill
-            ? "relative mt-3 min-h-[13rem] w-full flex-1"
-            : "relative mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]"
-        }
-      >
-        <svg
-          aria-hidden="true"
-          className="h-full w-full"
-          preserveAspectRatio="none"
-          viewBox={`${-PAD_X} ${-PAD_Y} ${VIEW_W + PAD_X * 2} ${VIEW_H + PAD_Y * 2}`}
-        >
-          <defs>
-            <linearGradient id={strokeId} x1="0" x2="1" y1="0" y2="0">
-              <stop offset="0%" stopColor="var(--t-green)" />
-              <stop
-                offset="100%"
-                stopColor={
-                  isComplete && !isWinFreeze
-                    ? "var(--t-red-hot)"
-                    : "var(--t-green-hot)"
-                }
-              />
-            </linearGradient>
-            <linearGradient id={areaId} x1="0" x2="0" y1="0" y2="1">
-              <stop
-                offset="0%"
-                stopColor={
-                  isComplete && !isWinFreeze
-                    ? "var(--t-red-hot)"
-                    : "var(--t-green-hot)"
-                }
-                stopOpacity="0.42"
-              />
-              <stop
-                offset="55%"
-                stopColor={
-                  isComplete && !isWinFreeze
-                    ? "var(--t-red-hot)"
-                    : "var(--t-green-hot)"
-                }
-                stopOpacity="0.12"
-              />
-              <stop
-                offset="100%"
-                stopColor={
-                  isComplete && !isWinFreeze
-                    ? "var(--t-red-hot)"
-                    : "var(--t-green-hot)"
-                }
-                stopOpacity="0"
-              />
-            </linearGradient>
-            <filter
-              filterUnits="userSpaceOnUse"
-              height={VIEW_H + PAD_Y * 4}
-              id={glowId}
-              width={VIEW_W + PAD_X * 4}
-              x={-PAD_X * 2}
-              y={-PAD_Y * 2}
-            >
-              <feGaussianBlur stdDeviation="1.1" />
-            </filter>
-          </defs>
-
-          {/* Soft plot grid */}
-          {[0.2, 0.4, 0.6, 0.8].map((t) => (
-            <line
-              key={`bg-${t}`}
-              stroke="var(--t-divider)"
-              strokeWidth="0.75"
-              vectorEffect="non-scaling-stroke"
-              x1="0"
-              x2={VIEW_W}
-              y1={VIEW_H * t}
-              y2={VIEW_H * t}
-            />
-          ))}
-          <line
-            stroke="var(--t-divider)"
-            strokeWidth="1.25"
-            vectorEffect="non-scaling-stroke"
-            x1="0"
-            x2={VIEW_W}
-            y1={VIEW_H}
-            y2={VIEW_H}
-          />
-
-          {missedYou ? (
-            <line
-              stroke="var(--t-red-hot)"
-              strokeDasharray="2 2"
-              strokeWidth="2"
-              vectorEffect="non-scaling-stroke"
-              x1="0"
-              x2={VIEW_W}
-              y1={missedYou.y}
-              y2={missedYou.y}
-            />
-          ) : null}
-
-          {tierLines.map(({ tier, y, isPlayerTier }) => (
-            <g key={`grid-${tier.toString()}`}>
-              {isPlayerTier ? (
-                <line
-                  opacity="0.22"
-                  stroke="var(--t-accent)"
-                  strokeWidth="8"
-                  vectorEffect="non-scaling-stroke"
-                  x1="0"
-                  x2={VIEW_W}
-                  y1={y}
-                  y2={y}
-                />
-              ) : null}
-              <line
-                stroke={isPlayerTier ? "var(--t-accent)" : "var(--t-divider)"}
-                strokeDasharray={isPlayerTier ? undefined : "2 2.5"}
-                strokeWidth={isPlayerTier ? "2" : "1"}
-                vectorEffect="non-scaling-stroke"
-                x1="0"
-                x2={VIEW_W}
-                y1={y}
-                y2={y}
-              />
-            </g>
-          ))}
-
-          {areaPath ? (
-            <path d={areaPath} fill={`url(#${areaId})`} stroke="none" />
-          ) : null}
-
-          {/* Soft under-glow stroke, then crisp stroke on top */}
-          <path
-            d={path}
-            fill="none"
-            filter={`url(#${glowId})`}
-            opacity="0.85"
-            stroke={`url(#${strokeId})`}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="7"
-            vectorEffect="non-scaling-stroke"
-          />
-          <path
-            d={path}
-            fill="none"
-            stroke={`url(#${strokeId})`}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="3.25"
-            vectorEffect="non-scaling-stroke"
-          />
-
-          {/* Hard stop at the Crash Point once the climb finishes */}
-          {isComplete ? (
-            <line
-              stroke={headColor}
-              strokeDasharray="1.5 2"
-              strokeWidth="1.5"
-              vectorEffect="non-scaling-stroke"
-              x1={head.x}
-              x2={head.x}
-              y1={crashY}
-              y2={VIEW_H}
-            />
-          ) : null}
-        </svg>
-
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-0"
-        >
-          <span
-            className="absolute left-1 text-[9px] font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]"
-            style={{ top: `${baselineTop}%`, transform: "translateY(-120%)" }}
-          >
-            1.00x
-          </span>
-
-          {missedYou ? (
-            <span
-              className="absolute left-1 -translate-y-1/2 rounded-sm bg-[var(--t-bg)]/80 px-1.5 py-0.5 text-[10px] font-bold leading-none text-[var(--t-red-hot)] sm:text-[11px]"
-              data-testid="replay-curve-missed-you"
-              style={{ top: `${plotPct(missedYou.y, VIEW_H, PAD_Y)}%` }}
-            >
-              {missedYou.label}
-            </span>
-          ) : null}
-
-          {tierLines.map(({ tier, closeAt, y, isPlayerTier, showLabel }) => {
-            const top = plotPct(y, VIEW_H, PAD_Y);
-            const markerLeft = plotPct(closeAt * VIEW_W, VIEW_W, PAD_X);
-            return (
-              <div key={`anno-${tier.toString()}`}>
-                {showLabel ? (
-                  <span
-                    className={`absolute left-1 -translate-y-1/2 rounded-sm px-1.5 py-0.5 text-[10px] leading-none sm:text-[11px] ${
-                      isPlayerTier
-                        ? "bg-[var(--t-bg)]/80 font-bold text-[var(--t-accent)]"
-                        : "text-[var(--t-muted)]"
-                    }`}
-                    style={{ top: `${top}%` }}
-                  >
-                    {isPlayerTier
-                      ? `${formatLeverageBps(tier)} · YOU`
-                      : formatLeverageBps(tier)}
-                  </span>
-                ) : null}
-                {closeAt <= progress ? (
-                  <span
-                    className="absolute block -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--t-amber-hot)] ring-2 ring-[var(--t-bg)]"
-                    style={{
-                      left: `${markerLeft}%`,
-                      top: `${top}%`,
-                      width: isPlayerTier ? 11 : 8,
-                      height: isPlayerTier ? 11 : 8,
-                      boxShadow: isPlayerTier
-                        ? "0 0 10px rgba(214, 166, 96, 0.85)"
-                        : "0 0 6px rgba(214, 166, 96, 0.45)",
-                    }}
-                  />
-                ) : null}
-              </div>
-            );
-          })}
-
-          <span
-            className={`absolute -translate-x-1/2 -translate-y-1/2 ${
-              isComplete ? "mc-head-pulse" : ""
-            }`}
-            style={{
-              left: `${headLeft}%`,
-              top: `${headTop}%`,
-            }}
-          >
-            <span
-              className="absolute left-1/2 top-1/2 block -translate-x-1/2 -translate-y-1/2 rounded-full"
-              style={{
-                width: 18,
-                height: 18,
-                backgroundColor: headColor,
-                opacity: 0.28,
-              }}
-            />
-            <span
-              className="absolute left-1/2 top-1/2 block -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-[var(--t-bg)]"
-              style={{
-                width: 11,
-                height: 11,
-                backgroundColor: headColor,
-                boxShadow: `0 0 calc(14px * var(--mc-glow)) ${headColor}`,
-              }}
-            />
-            {isComplete ? (
-              <span
-                className={`absolute left-1/2 top-0 whitespace-nowrap rounded-sm bg-[var(--t-bg)]/90 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${
-                  isWinFreeze || landing.kind === "won"
-                    ? "text-[var(--t-green-hot)]"
-                    : "text-[var(--t-red-hot)]"
-                }`}
-                style={{ transform: "translate(-50%, calc(-100% - 8px))" }}
-              >
-                {crashLabel}
-              </span>
-            ) : null}
-          </span>
-        </div>
-      </div>
+      <ReplayPlot
+        crashPointBps={crashPointBps}
+        fill={fill}
+        freeze={freeze}
+        isComplete={isComplete}
+        landing={landing}
+        playerTierBps={playerTierBps}
+        progress={progress}
+      />
 
       <p className="mt-2 text-[10px] leading-4 text-[var(--t-muted)]">
         {ambiance

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 import {
   ENTRY_LEVERAGE_TIERS_BPS,
   formatCrashPointBps,
@@ -12,6 +12,7 @@ import {
   getTierCloseProgress,
   isReplayComplete,
   multiplierToY,
+  replayAreaPathD,
   replayPathD,
 } from "@/lib/round-replay";
 import { MarginCallPhone } from "./margin-call-phone";
@@ -20,6 +21,12 @@ import { theaterCopy } from "./theater-copy";
 
 const VIEW_W = 100;
 const VIEW_H = 56;
+/** Extra room so strokes, the head badge, and a missed-YOU rail never clip. */
+const PAD_X = 2;
+const PAD_Y = 4;
+const LABEL_MIN_GAP_PCT = 10;
+/** Top rail for a player tier that never closed (above the Crash Point). */
+const MISSED_YOU_Y = 1.5;
 
 export type ReplayCurveProps = {
   crashPointBps: bigint;
@@ -40,6 +47,58 @@ export type ReplayCurveProps = {
  */
 export const REPLAY_HERO_MIN_H = "min-h-[22rem] lg:min-h-[28rem]";
 
+type TierAnnotation = {
+  tier: bigint;
+  closeAt: number;
+  y: number;
+  isPlayerTier: boolean;
+  showLabel: boolean;
+};
+
+/**
+ * Map a viewBox coordinate into a percentage of the padded plot area so the
+ * DOM overlay stays locked to the stretched SVG geometry.
+ */
+function plotPct(value: number, size: number, pad: number): number {
+  return ((value + pad) / (size + pad * 2)) * 100;
+}
+
+function pickVisibleTier(
+  tiers: readonly { tier: bigint; closeAt: number; y: number }[],
+  playerTierBps: bigint | null
+): TierAnnotation[] {
+  const heightPct = (y: number) => plotPct(y, VIEW_H, PAD_Y);
+  const sorted = [...tiers].sort((a, b) => a.y - b.y);
+  const placed: number[] = [];
+  const visible = new Set<string>();
+
+  const tryPlace = (tier: (typeof tiers)[number]) => {
+    const pct = heightPct(tier.y);
+    if (
+      placed.some((existing) => Math.abs(existing - pct) < LABEL_MIN_GAP_PCT)
+    ) {
+      return;
+    }
+    placed.push(pct);
+    visible.add(tier.tier.toString());
+  };
+
+  const player = sorted.find(
+    (t) => playerTierBps !== null && t.tier === playerTierBps
+  );
+  if (player) tryPlace(player);
+  for (const tier of sorted) {
+    if (player && tier.tier === player.tier) continue;
+    tryPlace(tier);
+  }
+
+  return tiers.map((tier) => ({
+    ...tier,
+    isPlayerTier: playerTierBps !== null && tier.tier === playerTierBps,
+    showLabel: visible.has(tier.tier.toString()),
+  }));
+}
+
 /**
  * SVG multiplier climb. Axes rescale with the live multiplier; hard stop at
  * the Crash Point. Signed-in players freeze on Won / Margin called; spectators
@@ -53,12 +112,18 @@ export function ReplayCurve({
   landing = { kind: "spectator" },
   fill = false,
 }: ReplayCurveProps) {
+  const reactId = useId();
+  const strokeId = `replay-stroke-${reactId}`;
+  const areaId = `replay-area-${reactId}`;
+  const glowId = `replay-glow-${reactId}`;
+
   // `progress` moves every animation frame, so memoizing on it buys nothing.
   const points = getReplayPathPoints(crashPointBps, progress, {
     width: VIEW_W,
     height: VIEW_H,
   });
   const path = replayPathD(points);
+  const areaPath = replayAreaPathD(points, VIEW_H);
   const head = points[points.length - 1] ?? { x: 0, y: VIEW_H };
   const multiplierBps = getReplayMultiplierBps(progress, crashPointBps);
   const displayMultiplier = formatCrashPointBps(multiplierBps);
@@ -67,15 +132,28 @@ export function ReplayCurve({
 
   const tierLines = useMemo(
     () =>
-      ENTRY_LEVERAGE_TIERS_BPS.flatMap((tier) => {
-        const closeAt = getTierCloseProgress(tier, crashPointBps);
-        if (closeAt === null) return [];
-        return [
-          { tier, closeAt, y: multiplierToY(tier, crashPointBps, VIEW_H) },
-        ];
-      }),
-    [crashPointBps]
+      pickVisibleTier(
+        ENTRY_LEVERAGE_TIERS_BPS.flatMap((tier) => {
+          const closeAt = getTierCloseProgress(tier, crashPointBps);
+          if (closeAt === null) return [];
+          return [
+            { tier, closeAt, y: multiplierToY(tier, crashPointBps, VIEW_H) },
+          ];
+        }),
+        playerTierBps
+      ),
+    [crashPointBps, playerTierBps]
   );
+
+  const missedYou =
+    playerTierBps !== null &&
+    getTierCloseProgress(playerTierBps, crashPointBps) === null
+      ? {
+          tier: playerTierBps,
+          y: MISSED_YOU_Y,
+          label: `${formatLeverageBps(playerTierBps)} · YOU`,
+        }
+      : null;
 
   // Crash-moment: climb finished and this is the result hero (not ambiance).
   // *When* freeze applies lives here; *what* it shows comes from presentLanding.
@@ -88,12 +166,30 @@ export function ReplayCurve({
   const heroValue = freeze?.heroValue ?? displayMultiplier;
   const heroColor = freeze?.heroColorClass ?? "text-[var(--t-green-hot)]";
   const heroIsMultiplier = freeze?.heroIsMultiplier ?? true;
+  const isWinFreeze = freeze !== null && landing.kind === "won";
+  const isLossFreeze = freeze !== null && landing.kind === "margin-called";
+  const headColor =
+    isComplete &&
+    (landing.kind === "margin-called" || landing.kind === "spectator")
+      ? "var(--t-red-hot)"
+      : "var(--t-green-hot)";
+
+  const headLeft = plotPct(head.x, VIEW_W, PAD_X);
+  const headTop = plotPct(head.y, VIEW_H, PAD_Y);
+  const baselineTop = plotPct(VIEW_H, VIEW_H, PAD_Y);
+  const crashY = multiplierToY(crashPointBps, crashPointBps, VIEW_H);
 
   return (
     <div
       className={`terminal-panel relative overflow-hidden p-3 sm:p-5 ${
         fill ? "flex h-full min-h-0 w-full flex-col" : REPLAY_HERO_MIN_H
-      } ${crashMoment ? "mc-shake" : ""}`}
+      } ${crashMoment ? "mc-shake" : ""} ${
+        isWinFreeze
+          ? "shadow-[inset_0_0_56px_rgba(146,245,184,0.16)]"
+          : isLossFreeze
+            ? "shadow-[inset_0_0_56px_rgba(255,107,92,0.14)]"
+            : ""
+      }`}
       data-testid={ambiance ? "replay-curve-ambiance" : "replay-curve"}
     >
       {freeze ? (
@@ -112,9 +208,9 @@ export function ReplayCurve({
           </p>
           <p
             aria-live="polite"
-            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] text-5xl font-bold sm:text-6xl lg:text-7xl ${
-              heroIsMultiplier ? "tabular-nums" : ""
-            } ${heroColor}`}
+            className={`mc-live-value mt-1 font-[family-name:var(--font-plex-sans)] font-bold ${
+              fill ? "text-5xl sm:text-6xl" : "text-5xl sm:text-6xl lg:text-7xl"
+            } ${heroIsMultiplier ? "tabular-nums" : ""} ${heroColor}`}
             data-testid={
               freeze
                 ? landing.kind === "spectator"
@@ -156,73 +252,276 @@ export function ReplayCurve({
         ) : null}
       </div>
 
-      <svg
-        aria-hidden="true"
+      <div
         className={
           fill
-            ? "mt-2 min-h-[8rem] w-full flex-1"
-            : "mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]"
+            ? "relative mt-3 min-h-[13rem] w-full flex-1"
+            : "relative mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]"
         }
-        preserveAspectRatio="none"
-        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
       >
-        <defs>
-          <linearGradient id="replay-stroke" x1="0" x2="1" y1="0" y2="0">
-            <stop offset="0%" stopColor="var(--t-green)" />
-            <stop offset="100%" stopColor="var(--t-green-hot)" />
-          </linearGradient>
-        </defs>
-        {tierLines.map(({ tier, closeAt, y }) => {
-          const isPlayerTier = playerTierBps !== null && tier === playerTierBps;
-          return (
-            <g key={tier.toString()}>
+        <svg
+          aria-hidden="true"
+          className="h-full w-full"
+          preserveAspectRatio="none"
+          viewBox={`${-PAD_X} ${-PAD_Y} ${VIEW_W + PAD_X * 2} ${VIEW_H + PAD_Y * 2}`}
+        >
+          <defs>
+            <linearGradient id={strokeId} x1="0" x2="1" y1="0" y2="0">
+              <stop offset="0%" stopColor="var(--t-green)" />
+              <stop
+                offset="100%"
+                stopColor={
+                  isComplete && !isWinFreeze
+                    ? "var(--t-red-hot)"
+                    : "var(--t-green-hot)"
+                }
+              />
+            </linearGradient>
+            <linearGradient id={areaId} x1="0" x2="0" y1="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor={
+                  isComplete && !isWinFreeze
+                    ? "var(--t-red-hot)"
+                    : "var(--t-green-hot)"
+                }
+                stopOpacity="0.42"
+              />
+              <stop
+                offset="55%"
+                stopColor={
+                  isComplete && !isWinFreeze
+                    ? "var(--t-red-hot)"
+                    : "var(--t-green-hot)"
+                }
+                stopOpacity="0.12"
+              />
+              <stop
+                offset="100%"
+                stopColor={
+                  isComplete && !isWinFreeze
+                    ? "var(--t-red-hot)"
+                    : "var(--t-green-hot)"
+                }
+                stopOpacity="0"
+              />
+            </linearGradient>
+            <filter
+              filterUnits="userSpaceOnUse"
+              height={VIEW_H + PAD_Y * 4}
+              id={glowId}
+              width={VIEW_W + PAD_X * 4}
+              x={-PAD_X * 2}
+              y={-PAD_Y * 2}
+            >
+              <feGaussianBlur stdDeviation="1.1" />
+            </filter>
+          </defs>
+
+          {/* Soft plot grid */}
+          {[0.2, 0.4, 0.6, 0.8].map((t) => (
+            <line
+              key={`bg-${t}`}
+              stroke="var(--t-divider)"
+              strokeWidth="0.75"
+              vectorEffect="non-scaling-stroke"
+              x1="0"
+              x2={VIEW_W}
+              y1={VIEW_H * t}
+              y2={VIEW_H * t}
+            />
+          ))}
+          <line
+            stroke="var(--t-divider)"
+            strokeWidth="1.25"
+            vectorEffect="non-scaling-stroke"
+            x1="0"
+            x2={VIEW_W}
+            y1={VIEW_H}
+            y2={VIEW_H}
+          />
+
+          {missedYou ? (
+            <line
+              stroke="var(--t-red-hot)"
+              strokeDasharray="2 2"
+              strokeWidth="2"
+              vectorEffect="non-scaling-stroke"
+              x1="0"
+              x2={VIEW_W}
+              y1={missedYou.y}
+              y2={missedYou.y}
+            />
+          ) : null}
+
+          {tierLines.map(({ tier, y, isPlayerTier }) => (
+            <g key={`grid-${tier.toString()}`}>
+              {isPlayerTier ? (
+                <line
+                  opacity="0.22"
+                  stroke="var(--t-accent)"
+                  strokeWidth="8"
+                  vectorEffect="non-scaling-stroke"
+                  x1="0"
+                  x2={VIEW_W}
+                  y1={y}
+                  y2={y}
+                />
+              ) : null}
               <line
                 stroke={isPlayerTier ? "var(--t-accent)" : "var(--t-divider)"}
-                strokeDasharray={isPlayerTier ? undefined : "1 1.5"}
-                strokeWidth={isPlayerTier ? "0.4" : "0.25"}
+                strokeDasharray={isPlayerTier ? undefined : "2 2.5"}
+                strokeWidth={isPlayerTier ? "2" : "1"}
+                vectorEffect="non-scaling-stroke"
                 x1="0"
                 x2={VIEW_W}
                 y1={y}
                 y2={y}
               />
-              <text
-                fill={isPlayerTier ? "var(--t-accent)" : "var(--t-muted)"}
-                fontSize="2.4"
-                fontWeight={isPlayerTier ? "bold" : undefined}
-                x="1"
-                y={Math.max(3, y - 1)}
-              >
-                {isPlayerTier
-                  ? `${formatLeverageBps(tier)} · YOU`
-                  : formatLeverageBps(tier)}
-              </text>
-              {closeAt <= progress ? (
-                <circle
-                  cx={closeAt * VIEW_W}
-                  cy={y}
-                  fill="var(--t-amber-hot)"
-                  r={isPlayerTier ? 1.3 : 0.9}
-                />
-              ) : null}
             </g>
-          );
-        })}
-        <path
-          d={path}
-          fill="none"
-          stroke="url(#replay-stroke)"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="1.1"
-        />
-        <circle
-          className={isComplete ? "mc-margin-call-flash" : ""}
-          cx={head.x}
-          cy={head.y}
-          fill={isComplete ? "var(--t-red-hot)" : "var(--t-green-hot)"}
-          r="1.4"
-        />
-      </svg>
+          ))}
+
+          {areaPath ? (
+            <path d={areaPath} fill={`url(#${areaId})`} stroke="none" />
+          ) : null}
+
+          {/* Soft under-glow stroke, then crisp stroke on top */}
+          <path
+            d={path}
+            fill="none"
+            filter={`url(#${glowId})`}
+            opacity="0.85"
+            stroke={`url(#${strokeId})`}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="7"
+            vectorEffect="non-scaling-stroke"
+          />
+          <path
+            d={path}
+            fill="none"
+            stroke={`url(#${strokeId})`}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="3.25"
+            vectorEffect="non-scaling-stroke"
+          />
+
+          {/* Hard stop at the Crash Point once the climb finishes */}
+          {isComplete ? (
+            <line
+              stroke={headColor}
+              strokeDasharray="1.5 2"
+              strokeWidth="1.5"
+              vectorEffect="non-scaling-stroke"
+              x1={head.x}
+              x2={head.x}
+              y1={crashY}
+              y2={VIEW_H}
+            />
+          ) : null}
+        </svg>
+
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0"
+        >
+          <span
+            className="absolute left-1 text-[9px] font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]"
+            style={{ top: `${baselineTop}%`, transform: "translateY(-120%)" }}
+          >
+            1.00x
+          </span>
+
+          {missedYou ? (
+            <span
+              className="absolute left-1 -translate-y-1/2 rounded-sm bg-[var(--t-bg)]/80 px-1.5 py-0.5 text-[10px] font-bold leading-none text-[var(--t-red-hot)] sm:text-[11px]"
+              data-testid="replay-curve-missed-you"
+              style={{ top: `${plotPct(missedYou.y, VIEW_H, PAD_Y)}%` }}
+            >
+              {missedYou.label}
+            </span>
+          ) : null}
+
+          {tierLines.map(({ tier, closeAt, y, isPlayerTier, showLabel }) => {
+            const top = plotPct(y, VIEW_H, PAD_Y);
+            const markerLeft = plotPct(closeAt * VIEW_W, VIEW_W, PAD_X);
+            return (
+              <div key={`anno-${tier.toString()}`}>
+                {showLabel ? (
+                  <span
+                    className={`absolute left-1 -translate-y-1/2 rounded-sm px-1.5 py-0.5 text-[10px] leading-none sm:text-[11px] ${
+                      isPlayerTier
+                        ? "bg-[var(--t-bg)]/80 font-bold text-[var(--t-accent)]"
+                        : "text-[var(--t-muted)]"
+                    }`}
+                    style={{ top: `${top}%` }}
+                  >
+                    {isPlayerTier
+                      ? `${formatLeverageBps(tier)} · YOU`
+                      : formatLeverageBps(tier)}
+                  </span>
+                ) : null}
+                {closeAt <= progress ? (
+                  <span
+                    className="absolute block -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--t-amber-hot)] ring-2 ring-[var(--t-bg)]"
+                    style={{
+                      left: `${markerLeft}%`,
+                      top: `${top}%`,
+                      width: isPlayerTier ? 11 : 8,
+                      height: isPlayerTier ? 11 : 8,
+                      boxShadow: isPlayerTier
+                        ? "0 0 10px rgba(214, 166, 96, 0.85)"
+                        : "0 0 6px rgba(214, 166, 96, 0.45)",
+                    }}
+                  />
+                ) : null}
+              </div>
+            );
+          })}
+
+          <span
+            className={`absolute -translate-x-1/2 -translate-y-1/2 ${
+              isComplete ? "mc-head-pulse" : ""
+            }`}
+            style={{
+              left: `${headLeft}%`,
+              top: `${headTop}%`,
+            }}
+          >
+            <span
+              className="absolute left-1/2 top-1/2 block -translate-x-1/2 -translate-y-1/2 rounded-full"
+              style={{
+                width: 18,
+                height: 18,
+                backgroundColor: headColor,
+                opacity: 0.28,
+              }}
+            />
+            <span
+              className="absolute left-1/2 top-1/2 block -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-[var(--t-bg)]"
+              style={{
+                width: 11,
+                height: 11,
+                backgroundColor: headColor,
+                boxShadow: `0 0 calc(14px * var(--mc-glow)) ${headColor}`,
+              }}
+            />
+            {isComplete ? (
+              <span
+                className={`absolute left-1/2 top-0 whitespace-nowrap rounded-sm bg-[var(--t-bg)]/90 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${
+                  isWinFreeze || landing.kind === "won"
+                    ? "text-[var(--t-green-hot)]"
+                    : "text-[var(--t-red-hot)]"
+                }`}
+                style={{ transform: "translate(-50%, calc(-100% - 8px))" }}
+              >
+                {crashLabel}
+              </span>
+            ) : null}
+          </span>
+        </div>
+      </div>
 
       <p className="mt-2 text-[10px] leading-4 text-[var(--t-muted)]">
         {ambiance
@@ -269,6 +568,7 @@ export function ReplayCurveThumb({ crashPointBps }: { crashPointBps: bigint }) {
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth="1.4"
+          vectorEffect="non-scaling-stroke"
         />
         <circle cx={head.x} cy={head.y} fill="var(--t-red-hot)" r="1.6" />
       </svg>

--- a/src/components/round-theater/replay-curve.tsx
+++ b/src/components/round-theater/replay-curve.tsx
@@ -63,20 +63,12 @@ export function ReplayCurve({
   const heroValue = freeze?.heroValue ?? displayMultiplier;
   const heroColor = freeze?.heroColorClass ?? "text-[var(--t-green-hot)]";
   const heroIsMultiplier = freeze?.heroIsMultiplier ?? true;
-  const isWinFreeze = freeze !== null && landing.kind === "won";
-  const isLossFreeze = freeze !== null && landing.kind === "margin-called";
 
   return (
     <div
       className={`terminal-panel relative overflow-hidden p-3 sm:p-5 ${
         fill ? "flex h-full min-h-0 w-full flex-col" : REPLAY_HERO_MIN_H
-      } ${crashMoment ? "mc-shake" : ""} ${
-        isWinFreeze
-          ? "shadow-[inset_0_0_56px_rgba(146,245,184,0.16)]"
-          : isLossFreeze
-            ? "shadow-[inset_0_0_56px_rgba(255,107,92,0.14)]"
-            : ""
-      }`}
+      } ${crashMoment ? "mc-shake" : ""} ${freeze?.panelInsetClass ?? ""}`}
       data-testid={ambiance ? "replay-curve-ambiance" : "replay-curve"}
     >
       {freeze ? (
@@ -144,7 +136,6 @@ export function ReplayCurve({
         fill={fill}
         freeze={freeze}
         isComplete={isComplete}
-        landing={landing}
         playerTierBps={playerTierBps}
         progress={progress}
       />

--- a/src/components/round-theater/replay-plot.tsx
+++ b/src/components/round-theater/replay-plot.tsx
@@ -13,7 +13,7 @@ import {
   replayAreaPathD,
   replayPathD,
 } from "@/lib/round-replay";
-import type { LandingPresentation, TicketLanding } from "./landing-frame";
+import type { LandingPresentation } from "./landing-frame";
 
 const VIEW_W = 100;
 const VIEW_H = 56;
@@ -28,7 +28,6 @@ export type ReplayPlotProps = {
   crashPointBps: bigint;
   progress: number;
   playerTierBps?: bigint | null;
-  landing: TicketLanding;
   /** Null while the climb is still running. */
   freeze: LandingPresentation | null;
   isComplete: boolean;
@@ -96,7 +95,6 @@ export function ReplayPlot({
   crashPointBps,
   progress,
   playerTierBps = null,
-  landing,
   freeze,
   isComplete,
   fill = false,
@@ -140,14 +138,9 @@ export function ReplayPlot({
         }
       : null;
 
-  const isWinFreeze = freeze !== null && landing.kind === "won";
-  const headColor =
-    isComplete &&
-    (landing.kind === "margin-called" || landing.kind === "spectator")
-      ? "var(--t-red-hot)"
-      : "var(--t-green-hot)";
-  const accentHot =
-    isComplete && !isWinFreeze ? "var(--t-red-hot)" : "var(--t-green-hot)";
+  const climbAccent = "var(--t-green-hot)";
+  const plotAccent = freeze?.plotAccent ?? climbAccent;
+  const headColor = isComplete ? plotAccent : climbAccent;
 
   const headLeft = plotPct(head.x, VIEW_W, PAD_X);
   const headTop = plotPct(head.y, VIEW_H, PAD_Y);
@@ -171,12 +164,12 @@ export function ReplayPlot({
         <defs>
           <linearGradient id={strokeId} x1="0" x2="1" y1="0" y2="0">
             <stop offset="0%" stopColor="var(--t-green)" />
-            <stop offset="100%" stopColor={accentHot} />
+            <stop offset="100%" stopColor={plotAccent} />
           </linearGradient>
           <linearGradient id={areaId} x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor={accentHot} stopOpacity="0.42" />
-            <stop offset="55%" stopColor={accentHot} stopOpacity="0.12" />
-            <stop offset="100%" stopColor={accentHot} stopOpacity="0" />
+            <stop offset="0%" stopColor={plotAccent} stopOpacity="0.42" />
+            <stop offset="55%" stopColor={plotAccent} stopOpacity="0.12" />
+            <stop offset="100%" stopColor={plotAccent} stopOpacity="0" />
           </linearGradient>
           <filter
             filterUnits="userSpaceOnUse"
@@ -375,12 +368,11 @@ export function ReplayPlot({
           />
           {isComplete ? (
             <span
-              className={`absolute left-1/2 top-0 whitespace-nowrap rounded-sm bg-[var(--t-bg)]/90 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${
-                isWinFreeze || landing.kind === "won"
-                  ? "text-[var(--t-green-hot)]"
-                  : "text-[var(--t-red-hot)]"
-              }`}
-              style={{ transform: "translate(-50%, calc(-100% - 8px))" }}
+              className="absolute left-1/2 top-0 whitespace-nowrap rounded-sm bg-[var(--t-bg)]/90 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em]"
+              style={{
+                color: plotAccent,
+                transform: "translate(-50%, calc(-100% - 8px))",
+              }}
             >
               {crashLabel}
             </span>

--- a/src/components/round-theater/replay-plot.tsx
+++ b/src/components/round-theater/replay-plot.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useId, useMemo } from "react";
+import {
+  ENTRY_LEVERAGE_TIERS_BPS,
+  formatCrashPointBps,
+  formatLeverageBps,
+} from "@/lib/margin-call-crash";
+import {
+  getReplayPathPoints,
+  getTierCloseProgress,
+  multiplierToY,
+  replayAreaPathD,
+  replayPathD,
+} from "@/lib/round-replay";
+import type { LandingPresentation, TicketLanding } from "./landing-frame";
+
+const VIEW_W = 100;
+const VIEW_H = 56;
+/** Extra room so strokes, the head badge, and a missed-YOU rail never clip. */
+const PAD_X = 2;
+const PAD_Y = 4;
+const LABEL_MIN_GAP_PCT = 10;
+/** Top rail for a player tier that never closed (above the Crash Point). */
+const MISSED_YOU_Y = 1.5;
+
+export type ReplayPlotProps = {
+  crashPointBps: bigint;
+  progress: number;
+  playerTierBps?: bigint | null;
+  landing: TicketLanding;
+  /** Null while the climb is still running. */
+  freeze: LandingPresentation | null;
+  isComplete: boolean;
+  /** Floor outcome: fill the remaining viewport instead of a fixed height. */
+  fill?: boolean;
+};
+
+type TierAnnotation = {
+  tier: bigint;
+  closeAt: number;
+  y: number;
+  isPlayerTier: boolean;
+  showLabel: boolean;
+};
+
+/**
+ * Map a viewBox coordinate into a percentage of the padded plot area so the
+ * DOM overlay stays locked to the stretched SVG geometry.
+ */
+function plotPct(value: number, size: number, pad: number): number {
+  return ((value + pad) / (size + pad * 2)) * 100;
+}
+
+function pickVisibleTier(
+  tiers: readonly { tier: bigint; closeAt: number; y: number }[],
+  playerTierBps: bigint | null
+): TierAnnotation[] {
+  const heightPct = (y: number) => plotPct(y, VIEW_H, PAD_Y);
+  const sorted = [...tiers].sort((a, b) => a.y - b.y);
+  const placed: number[] = [];
+  const visible = new Set<string>();
+
+  const tryPlace = (tier: (typeof tiers)[number]) => {
+    const pct = heightPct(tier.y);
+    if (
+      placed.some((existing) => Math.abs(existing - pct) < LABEL_MIN_GAP_PCT)
+    ) {
+      return;
+    }
+    placed.push(pct);
+    visible.add(tier.tier.toString());
+  };
+
+  const player = sorted.find(
+    (t) => playerTierBps !== null && t.tier === playerTierBps
+  );
+  if (player) tryPlace(player);
+  for (const tier of sorted) {
+    if (player && tier.tier === player.tier) continue;
+    tryPlace(tier);
+  }
+
+  return tiers.map((tier) => ({
+    ...tier,
+    isPlayerTier: playerTierBps !== null && tier.tier === playerTierBps,
+    showLabel: visible.has(tier.tier.toString()),
+  }));
+}
+
+/**
+ * Dramatized climb plot: SVG geometry + DOM labels/markers. Hero chrome lives
+ * in ReplayCurve; this module owns only the chart surface.
+ */
+export function ReplayPlot({
+  crashPointBps,
+  progress,
+  playerTierBps = null,
+  landing,
+  freeze,
+  isComplete,
+  fill = false,
+}: ReplayPlotProps) {
+  const reactId = useId();
+  const strokeId = `replay-stroke-${reactId}`;
+  const areaId = `replay-area-${reactId}`;
+  const glowId = `replay-glow-${reactId}`;
+
+  const points = getReplayPathPoints(crashPointBps, progress, {
+    width: VIEW_W,
+    height: VIEW_H,
+  });
+  const path = replayPathD(points);
+  const areaPath = replayAreaPathD(points, VIEW_H);
+  const head = points[points.length - 1] ?? { x: 0, y: VIEW_H };
+  const crashLabel = formatCrashPointBps(crashPointBps);
+
+  const tierLines = useMemo(
+    () =>
+      pickVisibleTier(
+        ENTRY_LEVERAGE_TIERS_BPS.flatMap((tier) => {
+          const closeAt = getTierCloseProgress(tier, crashPointBps);
+          if (closeAt === null) return [];
+          return [
+            { tier, closeAt, y: multiplierToY(tier, crashPointBps, VIEW_H) },
+          ];
+        }),
+        playerTierBps
+      ),
+    [crashPointBps, playerTierBps]
+  );
+
+  const missedYou =
+    playerTierBps !== null &&
+    getTierCloseProgress(playerTierBps, crashPointBps) === null
+      ? {
+          tier: playerTierBps,
+          y: MISSED_YOU_Y,
+          label: `${formatLeverageBps(playerTierBps)} · YOU`,
+        }
+      : null;
+
+  const isWinFreeze = freeze !== null && landing.kind === "won";
+  const headColor =
+    isComplete &&
+    (landing.kind === "margin-called" || landing.kind === "spectator")
+      ? "var(--t-red-hot)"
+      : "var(--t-green-hot)";
+  const accentHot =
+    isComplete && !isWinFreeze ? "var(--t-red-hot)" : "var(--t-green-hot)";
+
+  const headLeft = plotPct(head.x, VIEW_W, PAD_X);
+  const headTop = plotPct(head.y, VIEW_H, PAD_Y);
+  const baselineTop = plotPct(VIEW_H, VIEW_H, PAD_Y);
+  const crashY = multiplierToY(crashPointBps, crashPointBps, VIEW_H);
+
+  return (
+    <div
+      className={
+        fill
+          ? "relative mt-3 min-h-[13rem] w-full flex-1"
+          : "relative mt-4 h-[14rem] w-full sm:h-[18rem] lg:h-[22rem]"
+      }
+    >
+      <svg
+        aria-hidden="true"
+        className="h-full w-full"
+        preserveAspectRatio="none"
+        viewBox={`${-PAD_X} ${-PAD_Y} ${VIEW_W + PAD_X * 2} ${VIEW_H + PAD_Y * 2}`}
+      >
+        <defs>
+          <linearGradient id={strokeId} x1="0" x2="1" y1="0" y2="0">
+            <stop offset="0%" stopColor="var(--t-green)" />
+            <stop offset="100%" stopColor={accentHot} />
+          </linearGradient>
+          <linearGradient id={areaId} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={accentHot} stopOpacity="0.42" />
+            <stop offset="55%" stopColor={accentHot} stopOpacity="0.12" />
+            <stop offset="100%" stopColor={accentHot} stopOpacity="0" />
+          </linearGradient>
+          <filter
+            filterUnits="userSpaceOnUse"
+            height={VIEW_H + PAD_Y * 4}
+            id={glowId}
+            width={VIEW_W + PAD_X * 4}
+            x={-PAD_X * 2}
+            y={-PAD_Y * 2}
+          >
+            <feGaussianBlur stdDeviation="1.1" />
+          </filter>
+        </defs>
+
+        {[0.2, 0.4, 0.6, 0.8].map((t) => (
+          <line
+            key={`bg-${t}`}
+            stroke="var(--t-divider)"
+            strokeWidth="0.75"
+            vectorEffect="non-scaling-stroke"
+            x1="0"
+            x2={VIEW_W}
+            y1={VIEW_H * t}
+            y2={VIEW_H * t}
+          />
+        ))}
+        <line
+          stroke="var(--t-divider)"
+          strokeWidth="1.25"
+          vectorEffect="non-scaling-stroke"
+          x1="0"
+          x2={VIEW_W}
+          y1={VIEW_H}
+          y2={VIEW_H}
+        />
+
+        {missedYou ? (
+          <line
+            stroke="var(--t-red-hot)"
+            strokeDasharray="2 2"
+            strokeWidth="2"
+            vectorEffect="non-scaling-stroke"
+            x1="0"
+            x2={VIEW_W}
+            y1={missedYou.y}
+            y2={missedYou.y}
+          />
+        ) : null}
+
+        {tierLines.map(({ tier, y, isPlayerTier }) => (
+          <g key={`grid-${tier.toString()}`}>
+            {isPlayerTier ? (
+              <line
+                opacity="0.22"
+                stroke="var(--t-accent)"
+                strokeWidth="8"
+                vectorEffect="non-scaling-stroke"
+                x1="0"
+                x2={VIEW_W}
+                y1={y}
+                y2={y}
+              />
+            ) : null}
+            <line
+              stroke={isPlayerTier ? "var(--t-accent)" : "var(--t-divider)"}
+              strokeDasharray={isPlayerTier ? undefined : "2 2.5"}
+              strokeWidth={isPlayerTier ? "2" : "1"}
+              vectorEffect="non-scaling-stroke"
+              x1="0"
+              x2={VIEW_W}
+              y1={y}
+              y2={y}
+            />
+          </g>
+        ))}
+
+        {areaPath ? (
+          <path d={areaPath} fill={`url(#${areaId})`} stroke="none" />
+        ) : null}
+
+        <path
+          d={path}
+          fill="none"
+          filter={`url(#${glowId})`}
+          opacity="0.85"
+          stroke={`url(#${strokeId})`}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="7"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d={path}
+          fill="none"
+          stroke={`url(#${strokeId})`}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="3.25"
+          vectorEffect="non-scaling-stroke"
+        />
+
+        {isComplete ? (
+          <line
+            stroke={headColor}
+            strokeDasharray="1.5 2"
+            strokeWidth="1.5"
+            vectorEffect="non-scaling-stroke"
+            x1={head.x}
+            x2={head.x}
+            y1={crashY}
+            y2={VIEW_H}
+          />
+        ) : null}
+      </svg>
+
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+        <span
+          className="absolute left-1 text-[9px] font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]"
+          style={{ top: `${baselineTop}%`, transform: "translateY(-120%)" }}
+        >
+          1.00x
+        </span>
+
+        {missedYou ? (
+          <span
+            className="absolute left-1 -translate-y-1/2 rounded-sm bg-[var(--t-bg)]/80 px-1.5 py-0.5 text-[10px] font-bold leading-none text-[var(--t-red-hot)] sm:text-[11px]"
+            data-testid="replay-curve-missed-you"
+            style={{ top: `${plotPct(missedYou.y, VIEW_H, PAD_Y)}%` }}
+          >
+            {missedYou.label}
+          </span>
+        ) : null}
+
+        {tierLines.map(({ tier, closeAt, y, isPlayerTier, showLabel }) => {
+          const top = plotPct(y, VIEW_H, PAD_Y);
+          const markerLeft = plotPct(closeAt * VIEW_W, VIEW_W, PAD_X);
+          return (
+            <div key={`anno-${tier.toString()}`}>
+              {showLabel ? (
+                <span
+                  className={`absolute left-1 -translate-y-1/2 rounded-sm px-1.5 py-0.5 text-[10px] leading-none sm:text-[11px] ${
+                    isPlayerTier
+                      ? "bg-[var(--t-bg)]/80 font-bold text-[var(--t-accent)]"
+                      : "text-[var(--t-muted)]"
+                  }`}
+                  style={{ top: `${top}%` }}
+                >
+                  {isPlayerTier
+                    ? `${formatLeverageBps(tier)} · YOU`
+                    : formatLeverageBps(tier)}
+                </span>
+              ) : null}
+              {closeAt <= progress ? (
+                <span
+                  className="absolute block -translate-x-1/2 -translate-y-1/2 rounded-full bg-[var(--t-amber-hot)] ring-2 ring-[var(--t-bg)]"
+                  style={{
+                    left: `${markerLeft}%`,
+                    top: `${top}%`,
+                    width: isPlayerTier ? 11 : 8,
+                    height: isPlayerTier ? 11 : 8,
+                    boxShadow: isPlayerTier
+                      ? "0 0 10px rgba(214, 166, 96, 0.85)"
+                      : "0 0 6px rgba(214, 166, 96, 0.45)",
+                  }}
+                />
+              ) : null}
+            </div>
+          );
+        })}
+
+        <span
+          className={`absolute -translate-x-1/2 -translate-y-1/2 ${
+            isComplete ? "mc-head-pulse" : ""
+          }`}
+          style={{
+            left: `${headLeft}%`,
+            top: `${headTop}%`,
+          }}
+        >
+          <span
+            className="absolute left-1/2 top-1/2 block -translate-x-1/2 -translate-y-1/2 rounded-full"
+            style={{
+              width: 18,
+              height: 18,
+              backgroundColor: headColor,
+              opacity: 0.28,
+            }}
+          />
+          <span
+            className="absolute left-1/2 top-1/2 block -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-[var(--t-bg)]"
+            style={{
+              width: 11,
+              height: 11,
+              backgroundColor: headColor,
+              boxShadow: `0 0 calc(14px * var(--mc-glow)) ${headColor}`,
+            }}
+          />
+          {isComplete ? (
+            <span
+              className={`absolute left-1/2 top-0 whitespace-nowrap rounded-sm bg-[var(--t-bg)]/90 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.12em] ${
+                isWinFreeze || landing.kind === "won"
+                  ? "text-[var(--t-green-hot)]"
+                  : "text-[var(--t-red-hot)]"
+              }`}
+              style={{ transform: "translate(-50%, calc(-100% - 8px))" }}
+            >
+              {crashLabel}
+            </span>
+          ) : null}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-crash-ticket-settlement.test.tsx
+++ b/src/hooks/use-crash-ticket-settlement.test.tsx
@@ -147,4 +147,88 @@ describe("useCrashTicketSettlement", () => {
     });
     expect(sdk.transaction.submit).toHaveBeenCalled();
   });
+
+  it("keeps confirmed status observable and records the claim transaction", async () => {
+    // Initial load recovers the unsettled ticket; the post-flow refresh sees
+    // it settled onchain.
+    sdk.readPlayerRecentTicket
+      .mockResolvedValueOnce({ ticket, round: finalizedRound })
+      .mockResolvedValue({
+        ticket: { ...ticket, settled: true, claimed: true },
+        round: finalizedRound,
+      });
+    const { result } = renderHook(() => useCrashTicketSettlement());
+    await waitFor(() => expect(result.current.canClaim).toBe(true));
+
+    await act(async () => {
+      await result.current.claim();
+    });
+
+    // Regression: refresh() after the flow used to batch a loading overwrite
+    // into the same render, so "confirmed" was never observable.
+    expect(result.current.status).toBe("confirmed");
+    expect(result.current.transactions).toEqual([
+      {
+        stage: "claim",
+        hash: "0xabc",
+        url: expect.stringContaining("/tx/0xabc"),
+        confirmed: true,
+      },
+    ]);
+  });
+
+  it("records each verify stage hash and reports the crash point early", async () => {
+    // Round still Open onchain: the full reveal → attest → finalize path runs.
+    sdk.readPlayerRecentTicket
+      .mockResolvedValueOnce({
+        ticket,
+        round: { ...finalizedRound, status: 1 as const, crashPointBps: 0n },
+      })
+      .mockResolvedValue({
+        ticket: { ...ticket, settled: true, claimed: true },
+        round: { ...finalizedRound, crashPointBps: 20_000n },
+      });
+    // 99_000_000 / (10_000 - 5_050) = 20_000 bps — the ticket's tier, a win.
+    sdk.fetchCrashAttestation.mockResolvedValue({
+      plaintext: 5_050n,
+      signatures: ["0x01"],
+    });
+    sdk.transaction.getSubmittedHash
+      .mockReturnValueOnce("0xaaa1")
+      .mockReturnValueOnce("0xaaa2")
+      .mockReturnValueOnce("0xaaa3");
+
+    const onCrashPointKnown = vi.fn();
+    const { result } = renderHook(() =>
+      useCrashTicketSettlement({ onCrashPointKnown })
+    );
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    await act(async () => {
+      await result.current.verifyAndSettle();
+    });
+
+    expect(onCrashPointKnown).toHaveBeenCalledWith(20_000n);
+    expect(result.current.transactions).toEqual([
+      {
+        stage: "reveal",
+        hash: "0xaaa1",
+        url: expect.stringContaining("/tx/0xaaa1"),
+        confirmed: true,
+      },
+      {
+        stage: "finalize",
+        hash: "0xaaa2",
+        url: expect.stringContaining("/tx/0xaaa2"),
+        confirmed: true,
+      },
+      {
+        stage: "claim",
+        hash: "0xaaa3",
+        url: expect.stringContaining("/tx/0xaaa3"),
+        confirmed: true,
+      },
+    ]);
+    expect(result.current.status).toBe("confirmed");
+  });
 });

--- a/src/hooks/use-crash-ticket-settlement.ts
+++ b/src/hooks/use-crash-ticket-settlement.ts
@@ -1,6 +1,8 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import type { Hex } from "viem";
+import { getBaseSepoliaTransactionUrl } from "@/lib/base-sepolia-explorer";
 import { runVerifyAndSettleFlow } from "@/lib/crash-settlement-flow";
 import {
   claimRequest,
@@ -17,7 +19,17 @@ import {
 
 type Stage = "reveal" | "finalize" | "claim" | "settle";
 
+const STAGE_ORDER: readonly Stage[] = ["reveal", "finalize", "claim", "settle"];
+
 export type CrashSettlementStatus = CrashTicketStageStatus<Stage, "attesting">;
+
+/** Submitted settlement transaction with its BaseScan link. */
+export type SettlementTransaction = {
+  stage: Stage;
+  hash: Hex;
+  url: string;
+  confirmed: boolean;
+};
 
 export type CrashSettlementRetryAction =
   | "refresh"
@@ -59,8 +71,16 @@ const stageCopy: Record<Stage, StageErrorCopy> = {
 /**
  * Recovers a returning player's recent ticket and drives verify/claim/settle
  * through receipt-confirmed sponsored transactions.
+ *
+ * `onCrashPointKnown` (optional) fires as soon as the Crash Point is
+ * determined client-side during `verifyAndSettle` — before the finalize and
+ * claim/settle receipts — so presentation can start revealing the outcome
+ * while the remaining transactions confirm.
  */
-export function useCrashTicketSettlement() {
+export function useCrashTicketSettlement(options?: {
+  onCrashPointKnown?: (crashPointBps: bigint) => void;
+}) {
+  const onCrashPointKnown = options?.onCrashPointKnown;
   const {
     walletAddress,
     gameConfig,
@@ -71,7 +91,9 @@ export function useCrashTicketSettlement() {
     pendingStageRef,
     retryKind,
     pendingReceiptStage,
+    stageHashes,
     refresh,
+    refreshIfIdle,
     runStage,
     resumePending,
     runFlow,
@@ -86,6 +108,23 @@ export function useCrashTicketSettlement() {
     unavailable,
     loadFailed,
   });
+
+  const transactions = useMemo<SettlementTransaction[]>(
+    () =>
+      STAGE_ORDER.flatMap((stage) => {
+        const recorded = stageHashes[stage];
+        if (!recorded) return [];
+        return [
+          {
+            stage,
+            hash: recorded.hash,
+            url: getBaseSepoliaTransactionUrl(recorded.hash),
+            confirmed: recorded.confirmed,
+          },
+        ];
+      }),
+    [stageHashes]
+  );
 
   const settleTicket = useCallback(
     async (mode: "claim" | "settle" | "resume" = "claim"): Promise<boolean> => {
@@ -149,11 +188,13 @@ export function useCrashTicketSettlement() {
           })),
         onRoundChange: (round) =>
           setState((current) => ({ ...current, round })),
+        onCrashPointKnown,
       })
     );
   }, [
     gameConfig,
     inFlightRef,
+    onCrashPointKnown,
     pendingStageRef,
     retryKindRef,
     runFlow,
@@ -218,10 +259,12 @@ export function useCrashTicketSettlement() {
     canSettle: outcome === "lost" && canAct,
     canRetry,
     retryAction,
+    transactions,
     verifyAndSettle,
     claim,
     settleLoss,
     retry,
     refresh,
+    refreshIfIdle,
   };
 }

--- a/src/hooks/use-crash-ticket-stages.ts
+++ b/src/hooks/use-crash-ticket-stages.ts
@@ -40,6 +40,9 @@ export type CrashTicketStageStatus<
   | "confirmed"
   | "error";
 
+/** Submitted stage transaction: hash is known at submit, confirmed at receipt. */
+export type StageTransactionState = { hash: Hex; confirmed: boolean };
+
 /**
  * Shared core of the ticket resolution hooks: recovers a returning player's
  * recent ticket, keeps it fresh across wallet-balance changes and a phase
@@ -67,48 +70,68 @@ export function useCrashTicketStages<
     round?: CrashRound;
     status: Status;
     error: string | null;
-  }>({ status: "loading", error: null });
+    stageHashes: Partial<Record<Stage, StageTransactionState>>;
+  }>({ status: "loading", error: null, stageHashes: {} });
   const [, setClock] = useState(Date.now);
   const inFlightRef = useRef(false);
   const retryKindRef = useRef<Stage | ExtraRetryKind | "refresh" | null>(null);
   const pendingStageRef = useRef<{ stage: Stage; hash: Hex } | null>(null);
 
-  const refresh = useCallback(async (): Promise<boolean> => {
-    if (!gameConfig || !walletAddress) return false;
-    setState((current) => ({ ...current, status: "loading", error: null }));
-    try {
-      const currentRoundId = await baseSepoliaPublicClient.readContract({
-        address: gameConfig.address,
-        abi: marginCallCrashAbi,
-        functionName: "currentRoundId",
-      });
-      const found = await readPlayerRecentTicket(
-        gameConfig.address,
-        currentRoundId,
-        walletAddress
-      );
-      retryKindRef.current = null;
-      setState({
-        ticket: found?.ticket,
-        round: found?.round,
-        status: "ready",
-        error: null,
-      });
-      return true;
-    } catch {
-      retryKindRef.current = "refresh";
-      setState((current) => ({
-        ...current,
-        status: "error",
-        error: loadFailed,
-      }));
-      return false;
-    }
-  }, [gameConfig, loadFailed, walletAddress]);
+  const refresh = useCallback(
+    async (options?: { preserveStatus?: boolean }): Promise<boolean> => {
+      if (!gameConfig || !walletAddress) return false;
+      const preserveStatus = options?.preserveStatus ?? false;
+      // preserveStatus keeps a just-set "confirmed" observable: the loading
+      // overwrite would otherwise batch into the same render and erase it.
+      if (!preserveStatus) {
+        setState((current) => ({ ...current, status: "loading", error: null }));
+      }
+      try {
+        const currentRoundId = await baseSepoliaPublicClient.readContract({
+          address: gameConfig.address,
+          abi: marginCallCrashAbi,
+          functionName: "currentRoundId",
+        });
+        const found = await readPlayerRecentTicket(
+          gameConfig.address,
+          currentRoundId,
+          walletAddress
+        );
+        retryKindRef.current = null;
+        setState((current) => ({
+          ticket: found?.ticket,
+          round: found?.round,
+          // A confirmed flow that left the ticket unsettled (receipt-only
+          // resume) falls back to ready so its next action stays reachable.
+          status:
+            preserveStatus && (found?.ticket?.settled ?? true)
+              ? current.status
+              : "ready",
+          error: null,
+          // Stage hashes describe one ticket's settlement; drop them once the
+          // recovered ticket changes.
+          stageHashes:
+            found?.ticket && current.ticket?.id === found.ticket.id
+              ? current.stageHashes
+              : {},
+        }));
+        return true;
+      } catch {
+        retryKindRef.current = "refresh";
+        setState((current) => ({
+          ...current,
+          status: "error",
+          error: loadFailed,
+        }));
+        return false;
+      }
+    },
+    [gameConfig, loadFailed, walletAddress]
+  );
 
   useEffect(() => {
     if (!gameConfig) {
-      setState({ status: "unavailable", error: unavailable });
+      setState({ status: "unavailable", error: unavailable, stageHashes: {} });
       return;
     }
     if (walletAddress) void refresh();
@@ -137,10 +160,20 @@ export function useCrashTicketStages<
     return () => window.clearInterval(tick);
   }, [state.round, state.ticket]);
 
+  const markStageConfirmed = useCallback((stage: Stage) => {
+    setState((current) => {
+      const recorded = current.stageHashes[stage];
+      if (!recorded || recorded.confirmed) return current;
+      const stageHashes = { ...current.stageHashes };
+      stageHashes[stage] = { ...recorded, confirmed: true };
+      return { ...current, stageHashes };
+    });
+  }, []);
+
   const runStage = useCallback(
-    (stage: Stage, request: { to: Address; data: Hex }) => {
+    async (stage: Stage, request: { to: Address; data: Hex }) => {
       retryKindRef.current = stage;
-      return runSponsoredStage({
+      await runSponsoredStage({
         transaction,
         pendingStage: pendingStageRef,
         stage,
@@ -148,23 +181,31 @@ export function useCrashTicketStages<
         request,
         onStatus: (status) =>
           setState((current) => ({ ...current, status, error: null })),
+        onHash: (hash) =>
+          setState((current) => {
+            const stageHashes = { ...current.stageHashes };
+            stageHashes[stage] = { hash, confirmed: false };
+            return { ...current, stageHashes };
+          }),
       });
+      // runSponsoredStage throws on every non-confirmed outcome.
+      markStageConfirmed(stage);
     },
-    [stages, transaction]
+    [markStageConfirmed, stages, transaction]
   );
 
-  const resumePending = useCallback(
-    () =>
-      resumeSponsoredStage({
-        pendingStage: pendingStageRef,
-        copyByStage: stages,
-        onStatus: (status, stage) => {
-          retryKindRef.current = stage;
-          setState((current) => ({ ...current, status, error: null }));
-        },
-      }),
-    [stages]
-  );
+  const resumePending = useCallback(async () => {
+    const stage = await resumeSponsoredStage({
+      pendingStage: pendingStageRef,
+      copyByStage: stages,
+      onStatus: (status, stage) => {
+        retryKindRef.current = stage;
+        setState((current) => ({ ...current, status, error: null }));
+      },
+    });
+    if (stage !== null) markStageConfirmed(stage);
+    return stage;
+  }, [markStageConfirmed, stages]);
 
   const runFlow = useCallback(
     async (fallback: string, flow: () => Promise<void>): Promise<boolean> => {
@@ -177,7 +218,7 @@ export function useCrashTicketStages<
           error: null,
         }));
         notifyWalletBalancesChanged();
-        return refresh();
+        return refresh({ preserveStatus: true });
       } catch (error) {
         const message = error instanceof Error ? error.message : fallback;
         setState((current) => ({
@@ -192,6 +233,12 @@ export function useCrashTicketStages<
     },
     [refresh]
   );
+
+  /** Refresh unless a settlement flow is mid-flight (e.g. on a round flip). */
+  const refreshIfIdle = useCallback(() => {
+    if (inFlightRef.current) return;
+    void refresh();
+  }, [refresh]);
 
   const ticket = state.ticket ?? null;
   const round = state.round ?? null;
@@ -222,7 +269,9 @@ export function useCrashTicketStages<
     pendingStageRef,
     retryKind,
     pendingReceiptStage,
+    stageHashes: state.stageHashes,
     refresh,
+    refreshIfIdle,
     runStage,
     resumePending,
     runFlow,

--- a/src/hooks/use-settle-ceremony.ts
+++ b/src/hooks/use-settle-ceremony.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useReducer, useRef, type Dispatch } from "react";
+import {
+  advanceCeremony,
+  IDLE_CEREMONY,
+  type CeremonyEvent,
+  type SettleCeremony,
+} from "@/lib/settle-ceremony";
+
+/**
+ * Owns one settle-ceremony instance for the Floor. All transition logic lives
+ * in `advanceCeremony`; this hook only adds the wallet-change reset so a
+ * ceremony can never present another account's result.
+ */
+export function useSettleCeremony(
+  walletAddress: string | null
+): [SettleCeremony, Dispatch<CeremonyEvent>] {
+  const [ceremony, dispatch] = useReducer(advanceCeremony, IDLE_CEREMONY);
+
+  const previousWallet = useRef(walletAddress);
+  useEffect(() => {
+    if (previousWallet.current !== walletAddress) {
+      previousWallet.current = walletAddress;
+      dispatch({ type: "reset" });
+    }
+  }, [walletAddress]);
+
+  return [ceremony, dispatch];
+}

--- a/src/lib/crash-settlement-flow.test.ts
+++ b/src/lib/crash-settlement-flow.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const attestation = vi.hoisted(() => ({
+  requestCrashAttestation: vi.fn(),
+}));
+
+vi.mock("./inco-attestation", () => ({
+  requestCrashAttestation: (...args: unknown[]) =>
+    attestation.requestCrashAttestation(...args),
+}));
+
+import {
+  runVerifyAndSettleFlow,
+  type SettlementStage,
+} from "./crash-settlement-flow";
+import {
+  computeCrashPointBps,
+  ROUND_STATUS,
+  type CrashRound,
+  type CrashTicket,
+} from "./margin-call-crash";
+
+const contractAddress = "0x0000000000000000000000000000000000000001" as const;
+
+const ticket: CrashTicket = {
+  id: 7n,
+  player: "0x0000000000000000000000000000000000000003",
+  roundId: 12n,
+  margin: 5_000_000n,
+  leverageBps: 20_000n,
+  reservedPayout: 10_000_000n,
+  settled: false,
+  claimed: false,
+};
+
+const baseRound: CrashRound = {
+  id: 12n,
+  openAt: 1_000n,
+  lockAt: 1_045n,
+  expiresAt: 1_945n,
+  crashRandom:
+    "0x000000000000000000000000000000000000000000000000000000000000cafe",
+  crashPointBps: 0n,
+  totalMargin: 5_000_000n,
+  reservedPayout: 10_000_000n,
+  status: ROUND_STATUS.open,
+};
+
+// 99_000_000 / (10_000 - 5_050) = 20_000 bps — exactly the ticket tier, a win.
+const WINNING_PLAINTEXT = 5_050n;
+
+function makeRecorder() {
+  const events: string[] = [];
+  const runStage = vi.fn(async (stage: SettlementStage): Promise<void> => {
+    events.push(`stage:${stage}`);
+  });
+  const onCrashPointKnown = vi.fn((crashPointBps: bigint) => {
+    events.push(`crash-point:${crashPointBps}`);
+  });
+  return { events, runStage, onCrashPointKnown };
+}
+
+describe("runVerifyAndSettleFlow onCrashPointKnown", () => {
+  beforeEach(() => {
+    attestation.requestCrashAttestation.mockReset();
+  });
+
+  it("fires after attestation and before the finalize stage", async () => {
+    attestation.requestCrashAttestation.mockResolvedValue({
+      plaintext: WINNING_PLAINTEXT,
+      signatures: ["0x01"],
+    });
+    const { events, runStage, onCrashPointKnown } = makeRecorder();
+
+    await runVerifyAndSettleFlow({
+      contractAddress,
+      ticket,
+      round: baseRound,
+      runStage,
+      onAttesting: () => events.push("attesting"),
+      onCrashPointKnown,
+    });
+
+    const expected = computeCrashPointBps(WINNING_PLAINTEXT);
+    expect(onCrashPointKnown).toHaveBeenCalledTimes(1);
+    expect(onCrashPointKnown).toHaveBeenCalledWith(expected);
+    expect(events).toEqual([
+      "stage:reveal",
+      "attesting",
+      `crash-point:${expected}`,
+      "stage:finalize",
+      "stage:claim",
+    ]);
+  });
+
+  it("fires immediately for an already-finalized round without attesting", async () => {
+    const { events, runStage, onCrashPointKnown } = makeRecorder();
+
+    await runVerifyAndSettleFlow({
+      contractAddress,
+      ticket,
+      round: {
+        ...baseRound,
+        status: ROUND_STATUS.finalized,
+        crashPointBps: 34_200n,
+      },
+      runStage,
+      onAttesting: () => events.push("attesting"),
+      onCrashPointKnown,
+    });
+
+    expect(onCrashPointKnown).toHaveBeenCalledWith(34_200n);
+    expect(attestation.requestCrashAttestation).not.toHaveBeenCalled();
+    expect(events).toEqual(["crash-point:34200", "stage:claim"]);
+  });
+
+  it("routes a losing ticket to the settle stage after the reveal", async () => {
+    // 99_000_000 / (10_000 - 1_000) = 11_000 bps — below the 2.00x tier.
+    attestation.requestCrashAttestation.mockResolvedValue({
+      plaintext: 1_000n,
+      signatures: ["0x01"],
+    });
+    const { events, runStage, onCrashPointKnown } = makeRecorder();
+
+    await runVerifyAndSettleFlow({
+      contractAddress,
+      ticket,
+      round: baseRound,
+      runStage,
+      onAttesting: () => events.push("attesting"),
+      onCrashPointKnown,
+    });
+
+    expect(events.at(-1)).toBe("stage:settle");
+  });
+
+  it("never fires when attestation fails", async () => {
+    attestation.requestCrashAttestation.mockRejectedValue(
+      new Error("covalidators unavailable")
+    );
+    const { runStage, onCrashPointKnown } = makeRecorder();
+
+    await expect(
+      runVerifyAndSettleFlow({
+        contractAddress,
+        ticket,
+        round: baseRound,
+        runStage,
+        onAttesting: () => undefined,
+        onCrashPointKnown,
+      })
+    ).rejects.toThrow("covalidators unavailable");
+
+    expect(onCrashPointKnown).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/crash-settlement-flow.ts
+++ b/src/lib/crash-settlement-flow.ts
@@ -20,6 +20,13 @@ export type SettlementStage = "reveal" | "finalize" | "claim" | "settle";
  * settlement hook and the personal-history actions. `runStage` submits one
  * receipt-confirmed transaction and throws on failure; `onRoundChange` reports
  * each round-status advance so callers can mirror it into their state.
+ *
+ * `onCrashPointKnown` fires at the earliest moment the Crash Point is
+ * determined client-side: immediately for an already-finalized round, or as
+ * soon as the covalidator attestation returns — before the finalize receipt.
+ * The crash point is a pure function of the attested plaintext, so a
+ * presentation layer may reveal the outcome while finalize/claim confirm in
+ * the background.
  */
 export async function runVerifyAndSettleFlow(options: {
   contractAddress: Address;
@@ -31,11 +38,22 @@ export async function runVerifyAndSettleFlow(options: {
   ) => Promise<void>;
   onAttesting: () => void;
   onRoundChange?: (round: CrashRound) => void;
+  onCrashPointKnown?: (crashPointBps: bigint) => void;
 }): Promise<void> {
-  const { contractAddress, ticket, runStage, onAttesting, onRoundChange } =
-    options;
+  const {
+    contractAddress,
+    ticket,
+    runStage,
+    onAttesting,
+    onRoundChange,
+    onCrashPointKnown,
+  } = options;
 
   let round = options.round;
+  if (round.status === ROUND_STATUS.finalized) {
+    onCrashPointKnown?.(round.crashPointBps);
+  }
+
   // Locked rounds still store Open until reveal is requested.
   if (round.status === ROUND_STATUS.open) {
     await runStage("reveal", revealRequest(contractAddress, round.id));
@@ -46,6 +64,8 @@ export async function runVerifyAndSettleFlow(options: {
   if (round.status === ROUND_STATUS.revealRequested) {
     onAttesting();
     const attestation = await requestCrashAttestation(round.crashRandom);
+    const crashPointBps = computeCrashPointBps(attestation.plaintext);
+    onCrashPointKnown?.(crashPointBps);
     await runStage(
       "finalize",
       finalizeRequest(
@@ -58,7 +78,7 @@ export async function runVerifyAndSettleFlow(options: {
     round = {
       ...round,
       status: ROUND_STATUS.finalized,
-      crashPointBps: computeCrashPointBps(attestation.plaintext),
+      crashPointBps,
     };
     onRoundChange?.(round);
   }

--- a/src/lib/margin-call-crash.test.ts
+++ b/src/lib/margin-call-crash.test.ts
@@ -998,3 +998,50 @@ function makeRound(overrides: Partial<CrashRound> = {}): CrashRound {
     ...overrides,
   };
 }
+
+describe("buildPlayerSettlementUrlMap", () => {
+  it("maps each settlement event kind to a per-round BaseScan link", async () => {
+    const { buildPlayerSettlementUrlMap } = await import("./margin-call-crash");
+    const map = buildPlayerSettlementUrlMap({
+      claimed: [
+        {
+          args: { roundId: 12n },
+          transactionHash: OPENING_TRANSACTION_HASH,
+        },
+      ],
+      lossSettled: [
+        {
+          args: { roundId: 13n },
+          transactionHash: REVEAL_TRANSACTION_HASH,
+        },
+      ],
+      refunded: [
+        {
+          args: { roundId: 14n },
+          transactionHash: FINALIZE_TRANSACTION_HASH,
+        },
+      ],
+    });
+
+    expect(map.get("12")).toEqual({
+      kind: "claim",
+      url: expect.stringContaining(`/tx/${OPENING_TRANSACTION_HASH}`),
+    });
+    expect(map.get("13")?.kind).toBe("loss");
+    expect(map.get("14")?.kind).toBe("refund");
+    expect(map.size).toBe(3);
+  });
+
+  it("skips rows without a round id or transaction hash", async () => {
+    const { buildPlayerSettlementUrlMap } = await import("./margin-call-crash");
+    const map = buildPlayerSettlementUrlMap({
+      claimed: [
+        { args: {}, transactionHash: OPENING_TRANSACTION_HASH },
+        { args: { roundId: 15n }, transactionHash: null },
+      ],
+      lossSettled: [],
+      refunded: [],
+    });
+    expect(map.size).toBe(0);
+  });
+});

--- a/src/lib/margin-call-crash.ts
+++ b/src/lib/margin-call-crash.ts
@@ -98,6 +98,10 @@ const ticketRefundedEvent = getAbiItem({
   abi: marginCallCrashAbi,
   name: "TicketRefunded",
 });
+const ticketLossSettledEvent = getAbiItem({
+  abi: marginCallCrashAbi,
+  name: "TicketLossSettled",
+});
 
 // A round can be initialized at most one 60-second epoch early. A 512-block
 // window provides ample Base Sepolia reorg/block-time margin without an
@@ -183,6 +187,14 @@ export type PlayerTicketHistoryItem = {
   canVerify: boolean;
   canExpire: boolean;
   canRefund: boolean;
+  /** BaseScan link for this ticket's settlement, when one exists onchain. */
+  settlementTransaction: PlayerSettlementTransaction | null;
+};
+
+/** Player-scoped settlement transaction link for one round. */
+export type PlayerSettlementTransaction = {
+  kind: "claim" | "loss" | "refund";
+  url: string;
 };
 
 export const ROUND_STATUS = {
@@ -634,15 +646,91 @@ export async function readPlayerTicketHistory(
     functionName: "currentRoundId",
     blockNumber: block.number,
   });
-  const found = await scanPlayerTickets(
-    config.address,
-    currentRoundId,
-    player,
-    block.number
-  );
+  const [found, settlementUrls] = await Promise.all([
+    scanPlayerTickets(config.address, currentRoundId, player, block.number),
+    // Rows degrade to no link when the log scan fails — never the whole list.
+    readPlayerSettlementTransactionUrls(config, player, block.number).catch(
+      () => new Map<string, PlayerSettlementTransaction>()
+    ),
+  ]);
   return found.map(({ ticket, round }) =>
-    toPlayerTicketHistoryItem(ticket, round, block.timestamp)
+    toPlayerTicketHistoryItem(
+      ticket,
+      round,
+      block.timestamp,
+      settlementUrls.get(ticket.roundId.toString()) ?? null
+    )
   );
+}
+
+/**
+ * BaseScan links for every settlement the player holds onchain — claims,
+ * loss settlements, and refunds — keyed by roundId string. All three events
+ * index the player, so the scan stays player-filtered from deployment.
+ */
+export async function readPlayerSettlementTransactionUrls(
+  config: MarginCallCrashConfig,
+  player: Address,
+  toBlock?: bigint
+): Promise<Map<string, PlayerSettlementTransaction>> {
+  const fromBlock = config.deploymentBlock;
+  const [claimed, lossSettled, refunded] = await Promise.all([
+    baseSepoliaPublicClient.getLogs({
+      address: config.address,
+      event: ticketClaimedEvent,
+      args: { player },
+      fromBlock,
+      toBlock,
+      strict: true,
+    }),
+    baseSepoliaPublicClient.getLogs({
+      address: config.address,
+      event: ticketLossSettledEvent,
+      args: { player },
+      fromBlock,
+      toBlock,
+      strict: true,
+    }),
+    baseSepoliaPublicClient.getLogs({
+      address: config.address,
+      event: ticketRefundedEvent,
+      args: { player },
+      fromBlock,
+      toBlock,
+      strict: true,
+    }),
+  ]);
+  return buildPlayerSettlementUrlMap({ claimed, lossSettled, refunded });
+}
+
+type PlayerSettlementLog = {
+  args: { roundId?: bigint };
+  transactionHash: Hash | null;
+};
+
+/** Pure log → per-round settlement link mapping (one settlement per round). */
+export function buildPlayerSettlementUrlMap(logs: {
+  claimed: ReadonlyArray<PlayerSettlementLog>;
+  lossSettled: ReadonlyArray<PlayerSettlementLog>;
+  refunded: ReadonlyArray<PlayerSettlementLog>;
+}): Map<string, PlayerSettlementTransaction> {
+  const map = new Map<string, PlayerSettlementTransaction>();
+  const add = (
+    kind: PlayerSettlementTransaction["kind"],
+    rows: ReadonlyArray<PlayerSettlementLog>
+  ) => {
+    for (const row of rows) {
+      if (row.args.roundId === undefined || !row.transactionHash) continue;
+      map.set(row.args.roundId.toString(), {
+        kind,
+        url: getBaseSepoliaTransactionUrl(row.transactionHash),
+      });
+    }
+  };
+  add("claim", logs.claimed);
+  add("loss", logs.lossSettled);
+  add("refund", logs.refunded);
+  return map;
 }
 
 /** Loads initialized rounds in the global lookback, newest first. */
@@ -767,7 +855,8 @@ function deriveHistoryState(
 function toPlayerTicketHistoryItem(
   ticket: CrashTicket,
   round: CrashRound,
-  chainTimestamp: bigint
+  chainTimestamp: bigint,
+  settlementTransaction: PlayerSettlementTransaction | null = null
 ): PlayerTicketHistoryItem {
   const phase = deriveRoundPhase(round, chainTimestamp);
   const outcome = deriveTicketOutcome(ticket, round);
@@ -805,6 +894,7 @@ function toPlayerTicketHistoryItem(
       !ticket.settled && (phase === "locked" || phase === "reveal-requested"),
     canExpire: !ticket.settled && phase === "expired-eligible",
     canRefund: outcome === "refundable",
+    settlementTransaction,
   };
 }
 

--- a/src/lib/round-replay.test.ts
+++ b/src/lib/round-replay.test.ts
@@ -5,10 +5,12 @@ import {
   getReplayDurationMs,
   getReplayMultiplierBps,
   getReplayPath,
+  getReplayPathPoints,
   getReplayProgress,
   getTierCloseProgress,
   isReplayComplete,
   isReplayHoldActive,
+  replayAreaPathD,
   REPLAY_DURATION_MAX_MS,
   REPLAY_DURATION_MIN_MS,
   REPLAY_HOLD_BEAT_SECONDS,
@@ -96,6 +98,20 @@ describe("round-replay math", () => {
     expect(path.startsWith("M ")).toBe(true);
     expect(path.includes(" L ")).toBe(true);
     expect(getReplayPath(30_000n, 0).startsWith("M ")).toBe(true);
+  });
+
+  it("closes an area path under the climb to the baseline", () => {
+    expect(replayAreaPathD([], 56)).toBe("");
+
+    const points = getReplayPathPoints(30_000n, 1, {
+      width: 100,
+      height: 56,
+    });
+    const area = replayAreaPathD(points, 56);
+    expect(area.startsWith("M ")).toBe(true);
+    expect(area.endsWith(" Z")).toBe(true);
+    expect(area).toContain(" L 100.00 56.00");
+    expect(area).toContain(` L ${points[0]!.x.toFixed(2)} 56.00 Z`);
   });
 
   it("holds the display round through the replay plus the result beat", () => {

--- a/src/lib/round-replay.ts
+++ b/src/lib/round-replay.ts
@@ -96,7 +96,7 @@ export type ReplayPathPoint = { x: number; y: number };
 
 // Vertical headroom above the Crash Point so the head never kisses the
 // viewBox edge. Shared by the curve and anything annotating it (tier lines).
-const Y_HEADROOM = 1.08;
+const Y_HEADROOM = 1.16;
 
 // Invert y so 1.00x sits at the bottom and crash sits near the top.
 function yForMultiplier(
@@ -148,6 +148,22 @@ export function replayPathD(points: readonly ReplayPathPoint[]): string {
     d += ` L ${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
   }
   return d;
+}
+
+/**
+ * Closed area path under the climb: curve points, then down to the baseline
+ * and back to the start. Used for the gradient fill beneath the stroke.
+ */
+export function replayAreaPathD(
+  points: readonly ReplayPathPoint[],
+  baselineY: number
+): string {
+  if (points.length === 0) return "";
+
+  const stroke = replayPathD(points);
+  const last = points[points.length - 1]!;
+  const first = points[0]!;
+  return `${stroke} L ${last.x.toFixed(2)} ${baselineY.toFixed(2)} L ${first.x.toFixed(2)} ${baselineY.toFixed(2)} Z`;
 }
 
 /** Sampled polyline points for the climb up to `progress`. */

--- a/src/lib/settle-ceremony.test.ts
+++ b/src/lib/settle-ceremony.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  advanceCeremony,
+  buildCeremonyReveal,
+  IDLE_CEREMONY,
+  type CeremonySnapshot,
+  type SettleCeremony,
+} from "./settle-ceremony";
+import type { CrashTicket } from "./margin-call-crash";
+
+const ticket: CrashTicket = {
+  id: 7n,
+  player: "0x0000000000000000000000000000000000000003",
+  roundId: 12n,
+  margin: 5_000_000n,
+  leverageBps: 20_000n,
+  reservedPayout: 10_000_000n,
+  settled: false,
+  claimed: false,
+};
+
+const snapshot: CeremonySnapshot = {
+  roundId: 12n,
+  ticket,
+  tape: null,
+  tiers: [],
+};
+
+function verifying(): SettleCeremony {
+  return advanceCeremony(IDLE_CEREMONY, { type: "start", snapshot });
+}
+
+function climbing(): SettleCeremony {
+  return advanceCeremony(verifying(), {
+    type: "crash-point-known",
+    crashPointBps: 25_000n,
+    reducedMotion: false,
+  });
+}
+
+function landed(): SettleCeremony {
+  return advanceCeremony(climbing(), { type: "climb-complete" });
+}
+
+describe("advanceCeremony", () => {
+  it("starts from idle only", () => {
+    expect(verifying()).toEqual({ phase: "verifying", snapshot });
+    const held = landed();
+    expect(advanceCeremony(held, { type: "start", snapshot })).toBe(held);
+  });
+
+  it("reveals to climbing with the locally computed outcome and payout", () => {
+    const state = climbing();
+    expect(state.phase).toBe("climbing");
+    if (state.phase !== "climbing") throw new Error("unreachable");
+    expect(state.reveal).toEqual({
+      crashPointBps: 25_000n,
+      outcome: "won",
+      payout: 10_000_000n,
+    });
+    expect(state.startNonce).toBe(0);
+    expect(state.snapshot).toBe(snapshot);
+  });
+
+  it("computes a loss when the tier is above the crash point", () => {
+    const reveal = buildCeremonyReveal(ticket, 15_000n);
+    expect(reveal.outcome).toBe("lost");
+    expect(reveal.payout).toBe(0n);
+  });
+
+  it("skips the climb under reduced motion", () => {
+    const state = advanceCeremony(verifying(), {
+      type: "crash-point-known",
+      crashPointBps: 25_000n,
+      reducedMotion: true,
+    });
+    expect(state.phase).toBe("landed");
+  });
+
+  it("ignores duplicate crash-point-known once revealed", () => {
+    const state = climbing();
+    expect(
+      advanceCeremony(state, {
+        type: "crash-point-known",
+        crashPointBps: 99_000n,
+        reducedMotion: false,
+      })
+    ).toBe(state);
+  });
+
+  it("lands when the climb completes and ignores it elsewhere", () => {
+    expect(landed().phase).toBe("landed");
+    const idle = IDLE_CEREMONY;
+    expect(advanceCeremony(idle, { type: "climb-complete" })).toBe(idle);
+    const pre = verifying();
+    expect(advanceCeremony(pre, { type: "climb-complete" })).toBe(pre);
+  });
+
+  it("rewatches from landed with a bumped nonce", () => {
+    const state = advanceCeremony(landed(), { type: "rewatch" });
+    expect(state.phase).toBe("climbing");
+    if (state.phase !== "climbing") throw new Error("unreachable");
+    expect(state.startNonce).toBe(1);
+    const relanded = advanceCeremony(state, { type: "climb-complete" });
+    const again = advanceCeremony(relanded, { type: "rewatch" });
+    if (again.phase !== "climbing") throw new Error("unreachable");
+    expect(again.startNonce).toBe(2);
+  });
+
+  it("exits landed only through acknowledge", () => {
+    const held = landed();
+    expect(advanceCeremony(held, { type: "acknowledge" })).toBe(IDLE_CEREMONY);
+    // Acknowledge elsewhere is a no-op: nothing to dismiss mid-verify.
+    const pre = verifying();
+    expect(advanceCeremony(pre, { type: "acknowledge" })).toBe(pre);
+  });
+
+  it("resets from any phase", () => {
+    for (const state of [IDLE_CEREMONY, verifying(), climbing(), landed()]) {
+      expect(advanceCeremony(state, { type: "reset" })).toBe(IDLE_CEREMONY);
+    }
+  });
+});

--- a/src/lib/settle-ceremony.ts
+++ b/src/lib/settle-ceremony.ts
@@ -1,0 +1,137 @@
+/**
+ * Player-local settle ceremony: the client-owned state machine that takes
+ * over the Floor from the moment the player clicks Verify and settle until
+ * they acknowledge the result.
+ *
+ * Polled chain state cannot drive this reveal — the theater, ticket, and
+ * settlement reads each lag up to 10s, so the settling player routinely used
+ * to miss their own climb. The ceremony freezes a snapshot at click time,
+ * reveals from the locally computed Crash Point, and holds the landed result
+ * until an explicit acknowledge. Settlement errors do NOT transition the
+ * ceremony: retry renders inside whatever phase is active, so a failed
+ * background transaction can never destroy a held result.
+ */
+
+import {
+  computeTicketPayout,
+  isWinningTicket,
+  type CrashTicket,
+  type RoundTicketTape,
+  type TierExposure,
+} from "@/lib/margin-call-crash";
+
+/** Data frozen at click time so poll churn cannot mutate the ceremony. */
+export type CeremonySnapshot = {
+  roundId: bigint;
+  ticket: CrashTicket;
+  tape: RoundTicketTape | null;
+  tiers: TierExposure[];
+};
+
+/** Locally computed result, available before the settle receipts land. */
+export type CeremonyReveal = {
+  crashPointBps: bigint;
+  outcome: "won" | "lost";
+  payout: bigint;
+};
+
+export type SettleCeremonyPhase = SettleCeremony["phase"];
+
+export type SettleCeremony =
+  | { phase: "idle" }
+  | { phase: "verifying"; snapshot: CeremonySnapshot }
+  | {
+      phase: "climbing";
+      snapshot: CeremonySnapshot;
+      reveal: CeremonyReveal;
+      /** Bump restarts the climb; feeds the replay clock's restartNonce. */
+      startNonce: number;
+    }
+  | {
+      phase: "landed";
+      snapshot: CeremonySnapshot;
+      reveal: CeremonyReveal;
+      startNonce: number;
+    };
+
+export type CeremonyEvent =
+  | { type: "start"; snapshot: CeremonySnapshot }
+  | {
+      type: "crash-point-known";
+      crashPointBps: bigint;
+      /** Reduced motion skips the climb and lands immediately. */
+      reducedMotion: boolean;
+    }
+  | { type: "climb-complete" }
+  | { type: "rewatch" }
+  | { type: "acknowledge" }
+  | { type: "reset" };
+
+export const IDLE_CEREMONY: SettleCeremony = { phase: "idle" };
+
+/**
+ * Pure transition function. Out-of-phase events are ignored rather than
+ * thrown so racing pollers and duplicate callbacks are harmless:
+ *
+ *   idle → verifying → climbing → landed → idle
+ *                 (reduced motion skips climbing)
+ *
+ * `acknowledge` is the only exit from `landed` — the live round never
+ * reclaims the stage on a timer.
+ */
+export function advanceCeremony(
+  state: SettleCeremony,
+  event: CeremonyEvent
+): SettleCeremony {
+  switch (event.type) {
+    case "start":
+      return state.phase === "idle"
+        ? { phase: "verifying", snapshot: event.snapshot }
+        : state;
+    case "crash-point-known": {
+      if (state.phase !== "verifying") return state;
+      const reveal = buildCeremonyReveal(
+        state.snapshot.ticket,
+        event.crashPointBps
+      );
+      return {
+        phase: event.reducedMotion ? "landed" : "climbing",
+        snapshot: state.snapshot,
+        reveal,
+        startNonce: 0,
+      };
+    }
+    case "climb-complete":
+      return state.phase === "climbing" ? { ...state, phase: "landed" } : state;
+    case "rewatch":
+      return state.phase === "landed"
+        ? { ...state, phase: "climbing", startNonce: state.startNonce + 1 }
+        : state;
+    case "acknowledge":
+      return state.phase === "landed" ? IDLE_CEREMONY : state;
+    case "reset":
+      return IDLE_CEREMONY;
+    default: {
+      const _exhaustive: never = event;
+      return _exhaustive;
+    }
+  }
+}
+
+/** Outcome and payout are pure functions of the frozen ticket + Crash Point. */
+export function buildCeremonyReveal(
+  ticket: CrashTicket,
+  crashPointBps: bigint
+): CeremonyReveal {
+  return {
+    crashPointBps,
+    outcome: isWinningTicket(ticket.leverageBps, crashPointBps)
+      ? "won"
+      : "lost",
+    payout: computeTicketPayout(
+      ticket.margin,
+      ticket.leverageBps,
+      crashPointBps
+    ),
+  };
+}

--- a/src/lib/sponsored-call.ts
+++ b/src/lib/sponsored-call.ts
@@ -91,11 +91,15 @@ export async function runSponsoredStage<Stage extends string>(options: {
   copy: StageErrorCopy;
   request: { to: Address; data: Hex };
   onStatus: (status: `${Stage}-submitting` | `${Stage}-pending`) => void;
+  /** Reports the submitted transaction hash before its receipt resolves. */
+  onHash?: (hash: Hex) => void;
 }): Promise<void> {
-  const { transaction, pendingStage, stage, copy, request, onStatus } = options;
+  const { transaction, pendingStage, stage, copy, request, onStatus, onHash } =
+    options;
   onStatus(`${stage}-submitting`);
   const result = await submitSponsoredCall(transaction, request, (hash) => {
     pendingStage.current = { stage, hash };
+    onHash?.(hash);
     onStatus(`${stage}-pending`);
   });
   applyStageResult(pendingStage, copy, result);


### PR DESCRIPTION
## What

Clicking **Verify and settle** now runs a player-local "settle ceremony" that owns the stage from the click until the player dismisses the result:

1. **Verifying** — a 4-step stepper (Reveal ▸ Attest ▸ Finalize ▸ Settle) with live status copy, shimmer on the active step, BaseScan tx chips as each transaction submits, and inline retry with a "Back to the Floor" escape hatch. Replaces the frozen LOCKED numeral + one grey status line.
2. **Climbing** — the climb starts from 1.00x the instant the covalidator attestation returns. The Crash Point is a pure function of the attested plaintext, so the finalize and claim/settle receipts confirm in the background while the graph climbs. Tier SFX, crash bell, and phone ring play during the ceremony.
3. **Landed** — the freeze now shows the **payout amount**, the tier-close board, the finalize link, every settlement transaction, the desk-phone trigger on losses, and a Re-watch button. **Continue to the Floor** is the only exit and stays disabled until the settle receipt confirms.

No new round is shown until the old one is finished: ceremony phases override every live round kind, and a stale unsettled ticket now blocks the next round's countdown (`open` + stale ticket → `awaiting-settle`). Expired rounds keep routing to refund.

`/record` rows now link to the player's claim / loss settlement / refund on BaseScan, derived from player-indexed logs (including the previously unqueried `TicketLossSettled` event), degrading gracefully to unlinked rows if the log scan fails.

## Bug fixes

- **The settling player usually missed their own climb**: the replay clock seeded from `chainTimestamp − finalizedAtSeconds`, so by the time receipts and the 10s theater poll landed, progress seeded ≥ 1 and the stage jumped to a static freeze. The ceremony clock seeds from zero.
- **`confirmed` status never rendered**: `runFlow`'s `setState("confirmed")` was batched away by `refresh()`'s immediate `loading` overwrite. `refresh({ preserveStatus })` keeps it observable (falling back to `ready` when the ticket is still unsettled so retry actions stay reachable).
- **Wrong-round landing**: the outcome graph could judge a ticket recovered from up to 20 rounds back against a different round's Crash Point (`ticketForRound` guard).
- The settlement recovery read now refreshes on round flips instead of waiting for a wallet-balance event.

## Plumbing

- `runSponsoredStage` gained `onHash`; `useCrashTicketStages` tracks per-stage `{hash, confirmed}`; `useCrashTicketSettlement` exposes `transactions` with BaseScan URLs and a new `onCrashPointKnown` option, fired by `runVerifyAndSettleFlow` at the earliest moment the Crash Point is knowable (immediately for already-finalized rounds).
- New pure modules: `settle-ceremony.ts` (reducer state machine) + `use-settle-ceremony` hook; `deriveCrashStageMode` gained `settling` mode, `ceremonyPhase`, and `hasStaleUnsettledTicket`.

## Testing

- 28 new unit tests: ceremony reducer transition table, mode precedence (ceremony over every live kind, stale-ticket gating, expired-over-stale), `onCrashPointKnown` ordering (after attestation / immediate on finalized / never on attest failure), stage-hash accumulation, confirmed-status regression, stepper states + tx links, outcome panel (payout formatting, gated Continue, loss voice trigger, reduced-motion parity), player settlement URL mapping, `/record` links.
- `pnpm test` 333 passed · `pnpm lint` clean · `pnpm typecheck` clean · `pnpm build` succeeds.
- Reduced-motion parity: `crash-point-known` lands immediately, panel gates identically, RoundResultCard path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)