### PR TITLE
Replace Privy transaction modal with app-owned UX

### DIFF
--- a/src/components/crash-stage/overlay/stage-actions.test.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.test.tsx
@@ -87,6 +87,26 @@ describe("StageActions", () => {
     expect(sdk.settlement.verifyAndSettle).toHaveBeenCalledOnce();
   });
 
+  it("disables and relabels verify while settlement is in flight", () => {
+    sdk.settlement = sdk.makeSettlement({
+      status: "reveal-submitting",
+      canVerify: true,
+      canClaim: false,
+    });
+    render(
+      <StageActions
+        countdownSeconds={8}
+        hasTicket
+        mode="awaiting-settle"
+        phase="locked"
+        roundId={12n}
+        settlement={sdk.settlement}
+      />
+    );
+    const button = screen.getByRole("button", { name: "Verifying…" });
+    expect(button).toHaveProperty("disabled", true);
+  });
+
   it("shows the enter form during open countdown without a ticket", () => {
     sdk.settlement = sdk.makeSettlement({
       ticket: null,

--- a/src/components/crash-stage/overlay/stage-actions.test.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.test.tsx
@@ -32,6 +32,7 @@ const sdk = vi.hoisted(() => {
       canSettle: false,
       canRetry: false,
       retryAction: null,
+      busy: false,
       verifyAndSettle: vi.fn(),
       claim: vi.fn(),
       settleLoss: vi.fn(),
@@ -90,6 +91,7 @@ describe("StageActions", () => {
   it("disables and relabels verify while settlement is in flight", () => {
     sdk.settlement = sdk.makeSettlement({
       status: "reveal-submitting",
+      busy: true,
       canVerify: true,
       canClaim: false,
     });

--- a/src/components/crash-stage/overlay/stage-settle-dock.tsx
+++ b/src/components/crash-stage/overlay/stage-settle-dock.tsx
@@ -35,6 +35,10 @@ export function StageSettleDock({ settlement }: StageSettleDockProps) {
   const retryLabel = settlement.retryAction
     ? settlementRetryLabels[settlement.retryAction]
     : "Retry";
+  const busy =
+    settlement.status === "attesting" ||
+    settlement.status.endsWith("-submitting") ||
+    settlement.status.endsWith("-pending");
 
   return (
     <div className="text-left" data-testid="stage-settle-dock">
@@ -75,33 +79,37 @@ export function StageSettleDock({ settlement }: StageSettleDockProps) {
         {settlement.canVerify ? (
           <GameButton
             className="bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+            disabled={busy}
             onClick={() => void settlement.verifyAndSettle()}
             size="hero"
           >
-            Verify and settle
+            {busy ? "Verifying…" : "Verify and settle"}
           </GameButton>
         ) : null}
         {settlement.canClaim ? (
           <GameButton
             className="bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+            disabled={busy}
             onClick={() => void settlement.claim()}
             size="hero"
           >
-            Claim payout
+            {busy ? "Claiming…" : "Claim payout"}
           </GameButton>
         ) : null}
         {settlement.canSettle ? (
           <GameButton
+            disabled={busy}
             onClick={() => void settlement.settleLoss()}
             size="hero"
             variant="danger"
           >
-            Settle loss
+            {busy ? "Settling…" : "Settle loss"}
           </GameButton>
         ) : null}
         {settlement.canRetry ? (
           <button
             className={TERMINAL_ACTION_BUTTON_CLASS}
+            disabled={busy}
             onClick={() => void settlement.retry()}
             type="button"
           >

--- a/src/components/crash-stage/overlay/stage-settle-dock.tsx
+++ b/src/components/crash-stage/overlay/stage-settle-dock.tsx
@@ -17,6 +17,14 @@ export type StageSettleDockProps = {
   settlement: Settlement;
 };
 
+type SettleAction = {
+  show: boolean;
+  label: string;
+  busyLabel: string;
+  variant: "primary" | "danger" | "terminal";
+  onClick: () => void;
+};
+
 /**
  * Compact Floor settlement dock. Buttons follow the settlement flags;
  * copy follows the same priority as the awaiting-settle CTA.
@@ -36,6 +44,36 @@ export function StageSettleDock({ settlement }: StageSettleDockProps) {
     ? settlementRetryLabels[settlement.retryAction]
     : "Retry";
   const busy = settlement.busy;
+  const actions: SettleAction[] = [
+    {
+      show: settlement.canVerify,
+      label: "Verify and settle",
+      busyLabel: "Verifying…",
+      variant: "primary",
+      onClick: () => void settlement.verifyAndSettle(),
+    },
+    {
+      show: settlement.canClaim,
+      label: "Claim payout",
+      busyLabel: "Claiming…",
+      variant: "primary",
+      onClick: () => void settlement.claim(),
+    },
+    {
+      show: settlement.canSettle,
+      label: "Settle loss",
+      busyLabel: "Settling…",
+      variant: "danger",
+      onClick: () => void settlement.settleLoss(),
+    },
+    {
+      show: settlement.canRetry,
+      label: retryLabel,
+      busyLabel: retryLabel,
+      variant: "terminal",
+      onClick: () => void settlement.retry(),
+    },
+  ];
 
   return (
     <div className="text-left" data-testid="stage-settle-dock">
@@ -73,46 +111,36 @@ export function StageSettleDock({ settlement }: StageSettleDockProps) {
       ) : null}
 
       <div className="mt-4 flex flex-col gap-3">
-        {settlement.canVerify ? (
-          <GameButton
-            className="bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
-            disabled={busy}
-            onClick={() => void settlement.verifyAndSettle()}
-            size="hero"
-          >
-            {busy ? "Verifying…" : "Verify and settle"}
-          </GameButton>
-        ) : null}
-        {settlement.canClaim ? (
-          <GameButton
-            className="bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
-            disabled={busy}
-            onClick={() => void settlement.claim()}
-            size="hero"
-          >
-            {busy ? "Claiming…" : "Claim payout"}
-          </GameButton>
-        ) : null}
-        {settlement.canSettle ? (
-          <GameButton
-            disabled={busy}
-            onClick={() => void settlement.settleLoss()}
-            size="hero"
-            variant="danger"
-          >
-            {busy ? "Settling…" : "Settle loss"}
-          </GameButton>
-        ) : null}
-        {settlement.canRetry ? (
-          <button
-            className={TERMINAL_ACTION_BUTTON_CLASS}
-            disabled={busy}
-            onClick={() => void settlement.retry()}
-            type="button"
-          >
-            {retryLabel}
-          </button>
-        ) : null}
+        {actions
+          .filter((action) => action.show)
+          .map((action) =>
+            action.variant === "terminal" ? (
+              <button
+                className={TERMINAL_ACTION_BUTTON_CLASS}
+                disabled={busy}
+                key={action.label}
+                onClick={action.onClick}
+                type="button"
+              >
+                {busy ? action.busyLabel : action.label}
+              </button>
+            ) : (
+              <GameButton
+                className={
+                  action.variant === "primary"
+                    ? "bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+                    : undefined
+                }
+                disabled={busy}
+                key={action.label}
+                onClick={action.onClick}
+                size="hero"
+                variant={action.variant === "danger" ? "danger" : "primary"}
+              >
+                {busy ? action.busyLabel : action.label}
+              </GameButton>
+            )
+          )}
       </div>
     </div>
   );

--- a/src/components/crash-stage/overlay/stage-settle-dock.tsx
+++ b/src/components/crash-stage/overlay/stage-settle-dock.tsx
@@ -35,10 +35,7 @@ export function StageSettleDock({ settlement }: StageSettleDockProps) {
   const retryLabel = settlement.retryAction
     ? settlementRetryLabels[settlement.retryAction]
     : "Retry";
-  const busy =
-    settlement.status === "attesting" ||
-    settlement.status.endsWith("-submitting") ||
-    settlement.status.endsWith("-pending");
+  const busy = settlement.busy;
 
   return (
     <div className="text-left" data-testid="stage-settle-dock">

--- a/src/components/current-round/crash-live-ticket.tsx
+++ b/src/components/current-round/crash-live-ticket.tsx
@@ -21,6 +21,8 @@ type CrashLiveTicketProps = {
   isAlert?: boolean;
   canRetry?: boolean;
   retryLabel?: string;
+  /** True while a sponsored settlement/refund stage is in flight. */
+  busy?: boolean;
   onVerify?: () => void;
   onClaim?: () => void;
   onSettle?: () => void;
@@ -90,6 +92,7 @@ export function CrashLiveTicket({
   isAlert = false,
   canRetry = false,
   retryLabel = "Retry",
+  busy = false,
   onVerify,
   onClaim,
   onSettle,
@@ -175,52 +178,58 @@ export function CrashLiveTicket({
       <div className="mt-4 flex flex-wrap gap-3">
         {canVerify ? (
           <button
-            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)]"
+            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy}
             onClick={onVerify}
             type="button"
           >
-            Verify and settle
+            {busy ? "Verifying…" : "Verify and settle"}
           </button>
         ) : null}
         {canClaim ? (
           <button
-            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)]"
+            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy}
             onClick={onClaim}
             type="button"
           >
-            Claim payout
+            {busy ? "Claiming…" : "Claim payout"}
           </button>
         ) : null}
         {canSettle ? (
           <button
-            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
+            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy}
             onClick={onSettle}
             type="button"
           >
-            Settle loss
+            {busy ? "Settling…" : "Settle loss"}
           </button>
         ) : null}
         {canExpire ? (
           <button
-            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
+            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy}
             onClick={onExpire}
             type="button"
           >
-            Mark round expired
+            {busy ? "Expiring…" : "Mark round expired"}
           </button>
         ) : null}
         {canRefund ? (
           <button
-            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)]"
+            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy}
             onClick={onRefund}
             type="button"
           >
-            Refund margin
+            {busy ? "Refunding…" : "Refund margin"}
           </button>
         ) : null}
         {canRetry ? (
           <button
-            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
+            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={busy}
             onClick={onRetry}
             type="button"
           >

--- a/src/components/current-round/crash-live-ticket.tsx
+++ b/src/components/current-round/crash-live-ticket.tsx
@@ -7,6 +7,14 @@ import {
   type TicketOutcome,
 } from "@/lib/margin-call-crash";
 
+type TicketAction = {
+  show: boolean;
+  label: string;
+  busyLabel: string;
+  accent: boolean;
+  onClick?: () => void;
+};
+
 type CrashLiveTicketProps = {
   ticket: CrashTicket;
   outcome?: TicketOutcome | null;
@@ -101,6 +109,50 @@ export function CrashLiveTicket({
   onRetry,
 }: CrashLiveTicketProps) {
   const stamp = outcome ? outcomeStamps[outcome] : undefined;
+  const actions: TicketAction[] = [
+    {
+      show: canVerify,
+      label: "Verify and settle",
+      busyLabel: "Verifying…",
+      accent: true,
+      onClick: onVerify,
+    },
+    {
+      show: canClaim,
+      label: "Claim payout",
+      busyLabel: "Claiming…",
+      accent: true,
+      onClick: onClaim,
+    },
+    {
+      show: canSettle,
+      label: "Settle loss",
+      busyLabel: "Settling…",
+      accent: false,
+      onClick: onSettle,
+    },
+    {
+      show: canExpire,
+      label: "Mark round expired",
+      busyLabel: "Expiring…",
+      accent: false,
+      onClick: onExpire,
+    },
+    {
+      show: canRefund,
+      label: "Refund margin",
+      busyLabel: "Refunding…",
+      accent: true,
+      onClick: onRefund,
+    },
+    {
+      show: canRetry,
+      label: retryLabel,
+      busyLabel: retryLabel,
+      accent: false,
+      onClick: onRetry,
+    },
+  ];
 
   return (
     <div
@@ -176,66 +228,23 @@ export function CrashLiveTicket({
       </dl>
 
       <div className="mt-4 flex flex-wrap gap-3">
-        {canVerify ? (
-          <button
-            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy}
-            onClick={onVerify}
-            type="button"
-          >
-            {busy ? "Verifying…" : "Verify and settle"}
-          </button>
-        ) : null}
-        {canClaim ? (
-          <button
-            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy}
-            onClick={onClaim}
-            type="button"
-          >
-            {busy ? "Claiming…" : "Claim payout"}
-          </button>
-        ) : null}
-        {canSettle ? (
-          <button
-            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy}
-            onClick={onSettle}
-            type="button"
-          >
-            {busy ? "Settling…" : "Settle loss"}
-          </button>
-        ) : null}
-        {canExpire ? (
-          <button
-            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy}
-            onClick={onExpire}
-            type="button"
-          >
-            {busy ? "Expiring…" : "Mark round expired"}
-          </button>
-        ) : null}
-        {canRefund ? (
-          <button
-            className="rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy}
-            onClick={onRefund}
-            type="button"
-          >
-            {busy ? "Refunding…" : "Refund margin"}
-          </button>
-        ) : null}
-        {canRetry ? (
-          <button
-            className="rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={busy}
-            onClick={onRetry}
-            type="button"
-          >
-            {retryLabel}
-          </button>
-        ) : null}
+        {actions
+          .filter((action) => action.show)
+          .map((action) => (
+            <button
+              className={
+                action.accent
+                  ? "rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                  : "rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
+              }
+              disabled={busy}
+              key={action.label}
+              onClick={action.onClick}
+              type="button"
+            >
+              {busy ? action.busyLabel : action.label}
+            </button>
+          ))}
       </div>
 
       {statusMessage ? (

--- a/src/components/current-round/crash-round-entry.test.tsx
+++ b/src/components/current-round/crash-round-entry.test.tsx
@@ -128,6 +128,29 @@ describe("CrashRoundEntry", () => {
     expect(screen.queryByRole("button", { name: /enter/i })).toBeNull();
   });
 
+  it("relabels the enter CTA while approval or entry is in flight", () => {
+    sdk.entry = sdk.makeEntry({
+      status: "approval-submitting",
+      canEnter: false,
+      needsApproval: true,
+    });
+    const { rerender } = render(<CrashRoundEntry {...sdk.props} />);
+    expect(
+      screen.getByRole("button", { name: "Approval pending…" })
+    ).toHaveProperty("disabled", true);
+
+    sdk.entry = sdk.makeEntry({
+      status: "entry-pending",
+      canEnter: false,
+      needsApproval: false,
+    });
+    rerender(<CrashRoundEntry {...sdk.props} />);
+    expect(screen.getByRole("button", { name: "Entering…" })).toHaveProperty(
+      "disabled",
+      true
+    );
+  });
+
   it("labels receipt-recovery retries honestly", () => {
     sdk.entry = sdk.makeEntry({
       status: "error",

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -22,6 +22,7 @@ import {
   formatDeskDollarsAmountLabel,
 } from "@/lib/desk-dollars";
 import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
+import { entrySubmitLabel } from "@/lib/entry-submit-label";
 import { DeskDollarsFaucet } from "@/components/desk-dollars/desk-dollars-faucet";
 import { GameButton } from "@/components/ui/game-button";
 import { EntryOptionGroup } from "./entry-option-group";
@@ -202,15 +203,7 @@ export function CrashRoundEntry({
           onClick={() => void entry.enter()}
           size="hero"
         >
-          {entry.status === "approval-submitting" ||
-          entry.status === "approval-pending"
-            ? "Approval pending…"
-            : entry.status === "entry-submitting" ||
-                entry.status === "entry-pending"
-              ? "Entering…"
-              : entry.needsApproval
-                ? "Approve & enter"
-                : "Enter round"}
+          {entrySubmitLabel(entry.status, entry.needsApproval)}
         </GameButton>
         {entry.canRetry ? (
           <button

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -202,7 +202,15 @@ export function CrashRoundEntry({
           onClick={() => void entry.enter()}
           size="hero"
         >
-          {entry.needsApproval ? "Approve & enter" : "Enter round"}
+          {entry.status === "approval-submitting" ||
+          entry.status === "approval-pending"
+            ? "Approval pending…"
+            : entry.status === "entry-submitting" ||
+                entry.status === "entry-pending"
+              ? "Entering…"
+              : entry.needsApproval
+                ? "Approve & enter"
+                : "Enter round"}
         </GameButton>
         {entry.canRetry ? (
           <button

--- a/src/components/current-round/crash-ticket-refund.test.tsx
+++ b/src/components/current-round/crash-ticket-refund.test.tsx
@@ -41,6 +41,7 @@ const sdk = vi.hoisted(() => {
       canRefund: true,
       canRetry: false,
       retryAction: null,
+      busy: false,
       expireRound: vi.fn(),
       refund: vi.fn(),
       retry: vi.fn(),
@@ -91,6 +92,7 @@ describe("CrashTicketRefund", () => {
   it("disables and relabels refund while a refund stage is in flight", () => {
     sdk.refund = sdk.makeRefund({
       status: "refund-pending",
+      busy: true,
       canRefund: true,
     });
     render(<CrashTicketRefund />);

--- a/src/components/current-round/crash-ticket-refund.test.tsx
+++ b/src/components/current-round/crash-ticket-refund.test.tsx
@@ -88,6 +88,18 @@ describe("CrashTicketRefund", () => {
     expect(sdk.refund.expireRound).toHaveBeenCalledOnce();
   });
 
+  it("disables and relabels refund while a refund stage is in flight", () => {
+    sdk.refund = sdk.makeRefund({
+      status: "refund-pending",
+      canRefund: true,
+    });
+    render(<CrashTicketRefund />);
+    const button = screen.getByRole("button", { name: "Refunding…" });
+    expect(button).toHaveProperty("disabled", true);
+    fireEvent.click(button);
+    expect(sdk.refund.refund).not.toHaveBeenCalled();
+  });
+
   it("hides for non-expiry tickets owned by settlement", () => {
     sdk.refund = sdk.makeRefund({
       outcome: "won",

--- a/src/components/current-round/crash-ticket-refund.tsx
+++ b/src/components/current-round/crash-ticket-refund.tsx
@@ -47,8 +47,7 @@ export function CrashTicketRefund() {
       ? refund.error
       : (statusCopy[refund.status] ?? null);
   const isAlert = refund.status === "error";
-  const busy =
-    refund.status.endsWith("-submitting") || refund.status.endsWith("-pending");
+  const busy = refund.busy;
 
   return (
     <section aria-labelledby="ticket-refund-heading" className="mt-8 text-left">

--- a/src/components/current-round/crash-ticket-refund.tsx
+++ b/src/components/current-round/crash-ticket-refund.tsx
@@ -47,6 +47,8 @@ export function CrashTicketRefund() {
       ? refund.error
       : (statusCopy[refund.status] ?? null);
   const isAlert = refund.status === "error";
+  const busy =
+    refund.status.endsWith("-submitting") || refund.status.endsWith("-pending");
 
   return (
     <section aria-labelledby="ticket-refund-heading" className="mt-8 text-left">
@@ -58,6 +60,7 @@ export function CrashTicketRefund() {
       </h2>
       <div className="mt-4">
         <CrashLiveTicket
+          busy={busy}
           canExpire={refund.canExpire}
           canRefund={refund.canRefund}
           canRetry={refund.canRetry}

--- a/src/components/current-round/crash-ticket-settlement.test.tsx
+++ b/src/components/current-round/crash-ticket-settlement.test.tsx
@@ -153,6 +153,18 @@ describe("CrashTicketSettlement", () => {
     expect(voice.trigger).not.toHaveBeenCalled();
   });
 
+  it("disables and relabels claim while a claim stage is in flight", () => {
+    sdk.settlement = sdk.makeSettlement({
+      status: "claim-submitting",
+      canClaim: true,
+    });
+    render(<CrashTicketSettlement />);
+    const button = screen.getByRole("button", { name: "Claiming…" });
+    expect(button).toHaveProperty("disabled", true);
+    fireEvent.click(button);
+    expect(sdk.settlement.claim).not.toHaveBeenCalled();
+  });
+
   it("hides when the wallet has no recoverable ticket", () => {
     sdk.settlement = sdk.makeSettlement({
       ticket: null,

--- a/src/components/current-round/crash-ticket-settlement.test.tsx
+++ b/src/components/current-round/crash-ticket-settlement.test.tsx
@@ -43,6 +43,7 @@ const sdk = vi.hoisted(() => {
       canSettle: false,
       canRetry: false,
       retryAction: null,
+      busy: false,
       verifyAndSettle: vi.fn(),
       claim: vi.fn(),
       settleLoss: vi.fn(),
@@ -156,6 +157,7 @@ describe("CrashTicketSettlement", () => {
   it("disables and relabels claim while a claim stage is in flight", () => {
     sdk.settlement = sdk.makeSettlement({
       status: "claim-submitting",
+      busy: true,
       canClaim: true,
     });
     render(<CrashTicketSettlement />);

--- a/src/components/current-round/crash-ticket-settlement.tsx
+++ b/src/components/current-round/crash-ticket-settlement.tsx
@@ -55,10 +55,7 @@ export function CrashTicketSettlement() {
       ? settlement.error
       : (settlementStatusCopy[settlement.status] ?? null);
   const isAlert = settlement.status === "error";
-  const busy =
-    settlement.status === "attesting" ||
-    settlement.status.endsWith("-submitting") ||
-    settlement.status.endsWith("-pending");
+  const busy = settlement.busy;
   // Desk-phone voice owns this surface only — not theater replay.
   const isLiquidatedLoss =
     settlement.outcome === "lost" || settlement.outcome === "settled-loss";

--- a/src/components/current-round/crash-ticket-settlement.tsx
+++ b/src/components/current-round/crash-ticket-settlement.tsx
@@ -55,6 +55,10 @@ export function CrashTicketSettlement() {
       ? settlement.error
       : (settlementStatusCopy[settlement.status] ?? null);
   const isAlert = settlement.status === "error";
+  const busy =
+    settlement.status === "attesting" ||
+    settlement.status.endsWith("-submitting") ||
+    settlement.status.endsWith("-pending");
   // Desk-phone voice owns this surface only — not theater replay.
   const isLiquidatedLoss =
     settlement.outcome === "lost" || settlement.outcome === "settled-loss";
@@ -79,6 +83,7 @@ export function CrashTicketSettlement() {
           />
         ) : null}
         <CrashLiveTicket
+          busy={busy}
           canClaim={settlement.canClaim}
           canRetry={settlement.canRetry}
           canSettle={settlement.canSettle}

--- a/src/components/history/personal-history.test.tsx
+++ b/src/components/history/personal-history.test.tsx
@@ -208,5 +208,7 @@ describe("PersonalHistory", () => {
       screen.getByText(/Claim pending until its Base Sepolia receipt succeeds/)
     ).toBeTruthy();
     expect(screen.getByText("Won — claim your payout")).toBeTruthy();
+    const claim = screen.getByRole("button", { name: "Claiming…" });
+    expect(claim).toHaveProperty("disabled", true);
   });
 });

--- a/src/components/history/personal-history.tsx
+++ b/src/components/history/personal-history.tsx
@@ -124,30 +124,35 @@ function PersonalHistoryRow({
     {
       show: item.canVerify,
       label: "Verify and settle",
+      busyLabel: "Verifying…",
       accent: true,
       run: () => actions.verifyAndSettle(item.ticket, item.round),
     },
     {
       show: item.canClaim,
       label: "Claim payout",
+      busyLabel: "Claiming…",
       accent: true,
       run: () => actions.claim(item.ticket),
     },
     {
       show: item.canSettle,
       label: "Settle loss",
+      busyLabel: "Settling…",
       accent: false,
       run: () => actions.settleLoss(item.ticket),
     },
     {
       show: item.canExpire,
       label: "Mark round expired",
+      busyLabel: "Expiring…",
       accent: false,
       run: () => actions.expireRound(item.ticket, item.round),
     },
     {
       show: item.canRefund,
       label: "Refund margin",
+      busyLabel: "Refunding…",
       accent: true,
       run: () => actions.refund(item.ticket),
     },
@@ -230,15 +235,15 @@ function PersonalHistoryRow({
             <button
               className={
                 action.accent
-                  ? "rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)]"
-                  : "rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold"
+                  ? "rounded-sm bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                  : "rounded-sm border border-[var(--t-muted)] px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
               }
               disabled={actions.busy}
               key={action.label}
               onClick={() => void action.run()}
               type="button"
             >
-              {action.label}
+              {isActive && actions.busy ? action.busyLabel : action.label}
             </button>
           ))}
         {isActive && actions.status === "error" ? (

--- a/src/components/lp-desk/lp-desk.test.tsx
+++ b/src/components/lp-desk/lp-desk.test.tsx
@@ -256,10 +256,27 @@ describe("LpDesk", () => {
     expect(screen.getByText(/cannot exceed/)).not.toBeNull();
     fireEvent.change(input, { target: { value: "12.345678" } });
     fireEvent.submit(input.closest("form")!);
+    expect(sdk.vault.deposit).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm deposit USDC" })
+    );
     expect(sdk.vault.deposit).toHaveBeenCalledWith(12345678n);
     expect(
       screen.getByText(/never requests unlimited approval/)
     ).not.toBeNull();
+  });
+
+  it("cancels a deposit confirm and preserves the entered amount", () => {
+    render(<LpDesk />);
+    const input = screen.getByLabelText("LP deposit amount (USDC)");
+    fireEvent.change(input, { target: { value: "10" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(sdk.vault.deposit).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      (screen.getByLabelText("LP deposit amount (USDC)") as HTMLInputElement)
+        .value
+    ).toBe("10");
   });
 
   it("never claims the balance is still loading in permanent unavailable or error states", () => {
@@ -306,6 +323,10 @@ describe("LpDesk", () => {
     const input = screen.getByLabelText("LP withdrawal amount (USDC)");
     fireEvent.change(input, { target: { value: "12.345678" } });
     fireEvent.submit(input.closest("form")!);
+    expect(sdk.vault.withdraw).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm withdraw USDC" })
+    );
     expect(sdk.vault.withdraw).toHaveBeenCalledWith(12345678n);
   });
 
@@ -407,6 +428,10 @@ describe("LpDesk", () => {
     ).not.toBeNull();
     fireEvent.change(input, { target: { value: "10" } });
     fireEvent.submit(input.closest("form")!);
+    expect(sdk.vault.withdraw).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Confirm withdraw USDC" })
+    );
     expect(sdk.vault.withdraw).toHaveBeenCalledWith(10000000n);
     sdk.vault = {
       ...sdk.vault,

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -14,6 +14,7 @@ import {
   type LpFreezeActionStatus,
   type LpFreezeRetryAction,
 } from "@/hooks/use-lp-freeze-actions";
+import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import {
   getBankrollVaultConfig,
   type BlockingRoundDetail,
@@ -270,6 +271,11 @@ function TierCapacityList({ tiers }: { tiers: TierCapacity[] | undefined }) {
   );
 }
 
+type LpPendingAction = {
+  kind: "deposit" | "withdrawal";
+  amount: bigint;
+};
+
 export function LpDesk() {
   const { user } = usePrivy();
   const walletAddress = getEvmWalletAddress(user);
@@ -280,10 +286,7 @@ export function LpDesk() {
   const vaultConfig = getBankrollVaultConfig();
   const [amount, setAmount] = useState("");
   const [withdrawalAmount, setWithdrawalAmount] = useState("");
-  const [pendingDeposit, setPendingDeposit] = useState<bigint | null>(null);
-  const [pendingWithdrawal, setPendingWithdrawal] = useState<bigint | null>(
-    null
-  );
+  const pendingAction = usePendingConfirm<LpPendingAction>();
   const parsedAmount = parseTUsdInput(amount);
   const validationError = validateAmount(
     amount,
@@ -310,14 +313,12 @@ export function LpDesk() {
   const submit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canSubmit || parsedAmount === null) return;
-    setPendingWithdrawal(null);
-    setPendingDeposit(parsedAmount);
+    pendingAction.arm({ kind: "deposit", amount: parsedAmount });
   };
   const submitWithdrawal = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canWithdraw || parsedWithdrawalAmount === null) return;
-    setPendingDeposit(null);
-    setPendingWithdrawal(parsedWithdrawalAmount);
+    pendingAction.arm({ kind: "withdrawal", amount: parsedWithdrawalAmount });
   };
 
   const depositBusy =
@@ -325,21 +326,21 @@ export function LpDesk() {
   const withdrawalBusy =
     vault.status === "withdrawal-submitting" ||
     vault.status === "withdrawal-pending";
+  const pendingDeposit =
+    pendingAction.pending?.kind === "deposit"
+      ? pendingAction.pending.amount
+      : null;
+  const pendingWithdrawal =
+    pendingAction.pending?.kind === "withdrawal"
+      ? pendingAction.pending.amount
+      : null;
 
-  const confirmDeposit = () => {
-    if (pendingDeposit === null) return;
-    const assets = pendingDeposit;
-    void Promise.resolve(vault.deposit(assets)).finally(() => {
-      setPendingDeposit(null);
-    });
-  };
-
-  const confirmWithdrawal = () => {
-    if (pendingWithdrawal === null) return;
-    const assets = pendingWithdrawal;
-    void Promise.resolve(vault.withdraw(assets)).finally(() => {
-      setPendingWithdrawal(null);
-    });
+  const confirmPending = () => {
+    pendingAction.confirm((armed) =>
+      armed.kind === "deposit"
+        ? vault.deposit(armed.amount)
+        : vault.withdraw(armed.amount)
+    );
   };
 
   const withdrawalRecovery =
@@ -474,8 +475,8 @@ export function LpDesk() {
             busy={depositBusy}
             confirmLabel={`Confirm deposit ${DISPLAY_ASSET_SYMBOL}`}
             note={`An exact ${DISPLAY_ASSET_SYMBOL} approval for this deposit may be submitted first. The LP Desk never requests unlimited approval.`}
-            onCancel={() => setPendingDeposit(null)}
-            onConfirm={confirmDeposit}
+            onCancel={pendingAction.cancel}
+            onConfirm={confirmPending}
             rows={[
               {
                 label: "Amount",
@@ -538,8 +539,8 @@ export function LpDesk() {
             busy={withdrawalBusy}
             confirmLabel={`Confirm withdraw ${DISPLAY_ASSET_SYMBOL}`}
             note={`Withdraw ${DISPLAY_ASSET_SYMBOL}, not shares, up to your authoritative immediately withdrawable limit.`}
-            onCancel={() => setPendingWithdrawal(null)}
-            onConfirm={confirmWithdrawal}
+            onCancel={pendingAction.cancel}
+            onConfirm={confirmPending}
             rows={[
               {
                 label: "Amount",

--- a/src/components/lp-desk/lp-desk.tsx
+++ b/src/components/lp-desk/lp-desk.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
+import { TransactionConfirm } from "@/components/ui/transaction-confirm";
 import {
   useBankrollVaultDeposit,
   type BankrollVaultDepositStatus,
@@ -13,10 +14,15 @@ import {
   type LpFreezeActionStatus,
   type LpFreezeRetryAction,
 } from "@/hooks/use-lp-freeze-actions";
-import type { BlockingRoundDetail, TierCapacity } from "@/lib/bankroll-vault";
+import {
+  getBankrollVaultConfig,
+  type BlockingRoundDetail,
+  type TierCapacity,
+} from "@/lib/bankroll-vault";
 import {
   DISPLAY_ASSET_SYMBOL,
   formatDeskDollars,
+  formatDeskDollarsAmount,
   formatDeskDollarsAmountLabel,
   formatDeskDollarsSignedAmount,
   parseTUsdInput,
@@ -271,8 +277,13 @@ export function LpDesk() {
   // Freeze resolutions notify wallet-balance subscribers, which re-read the
   // vault state above — no explicit refresh wiring is needed.
   const freeze = useLpFreezeActions();
+  const vaultConfig = getBankrollVaultConfig();
   const [amount, setAmount] = useState("");
   const [withdrawalAmount, setWithdrawalAmount] = useState("");
+  const [pendingDeposit, setPendingDeposit] = useState<bigint | null>(null);
+  const [pendingWithdrawal, setPendingWithdrawal] = useState<bigint | null>(
+    null
+  );
   const parsedAmount = parseTUsdInput(amount);
   const validationError = validateAmount(
     amount,
@@ -299,12 +310,36 @@ export function LpDesk() {
   const submit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canSubmit || parsedAmount === null) return;
-    void vault.deposit(parsedAmount);
+    setPendingWithdrawal(null);
+    setPendingDeposit(parsedAmount);
   };
   const submitWithdrawal = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canWithdraw || parsedWithdrawalAmount === null) return;
-    void vault.withdraw(parsedWithdrawalAmount);
+    setPendingDeposit(null);
+    setPendingWithdrawal(parsedWithdrawalAmount);
+  };
+
+  const depositBusy =
+    vault.status.startsWith("approval-") || vault.status.startsWith("deposit-");
+  const withdrawalBusy =
+    vault.status === "withdrawal-submitting" ||
+    vault.status === "withdrawal-pending";
+
+  const confirmDeposit = () => {
+    if (pendingDeposit === null) return;
+    const assets = pendingDeposit;
+    void Promise.resolve(vault.deposit(assets)).finally(() => {
+      setPendingDeposit(null);
+    });
+  };
+
+  const confirmWithdrawal = () => {
+    if (pendingWithdrawal === null) return;
+    const assets = pendingWithdrawal;
+    void Promise.resolve(vault.withdraw(assets)).finally(() => {
+      setPendingWithdrawal(null);
+    });
   };
 
   const withdrawalRecovery =
@@ -433,99 +468,136 @@ export function LpDesk() {
         proportional, authoritative maxWithdraw amount and may be lower.
       </p>
 
-      <form
-        className="mt-6 border-t border-[var(--t-muted)] pt-5"
-        onSubmit={submit}
-      >
-        <label className="block text-sm font-bold" htmlFor="lp-deposit-amount">
-          LP deposit amount ({DISPLAY_ASSET_SYMBOL})
-        </label>
-        <input
-          aria-describedby="lp-deposit-help lp-deposit-validation"
-          className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
-          disabled={isFrozen}
-          id="lp-deposit-amount"
-          inputMode="decimal"
-          onChange={(event) => setAmount(event.target.value)}
-          placeholder="0.000000"
-          value={amount}
-        />
-        <p id="lp-deposit-help" className="mt-2 text-xs text-[var(--t-muted)]">
-          {isFrozen
-            ? "Deposits are blocked while share operations are frozen."
-            : `An exact ${DISPLAY_ASSET_SYMBOL} approval for this deposit may occur first. The LP Desk never requests unlimited approval.`}
-        </p>
-        {validationError ? (
-          <p id="lp-deposit-validation" role="alert" className="mt-2 text-sm">
-            {validationError}
-          </p>
-        ) : null}
-        <button
-          className="mt-4 bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
-          disabled={!canSubmit}
-          type="submit"
+      {pendingDeposit !== null ? (
+        <div className="mt-6 border-t border-[var(--t-muted)] pt-5">
+          <TransactionConfirm
+            busy={depositBusy}
+            confirmLabel={`Confirm deposit ${DISPLAY_ASSET_SYMBOL}`}
+            note={`An exact ${DISPLAY_ASSET_SYMBOL} approval for this deposit may be submitted first. The LP Desk never requests unlimited approval.`}
+            onCancel={() => setPendingDeposit(null)}
+            onConfirm={confirmDeposit}
+            rows={[
+              {
+                label: "Amount",
+                value: formatDeskDollarsAmount(pendingDeposit),
+              },
+              ...(vaultConfig
+                ? [{ label: "Vault", value: vaultConfig.vaultAddress }]
+                : []),
+            ]}
+            title="Confirm LP deposit"
+          />
+        </div>
+      ) : (
+        <form
+          className="mt-6 border-t border-[var(--t-muted)] pt-5"
+          onSubmit={submit}
         >
-          {vault.status.startsWith("approval-")
-            ? "Approval pending…"
-            : vault.status.startsWith("deposit-")
-              ? "LP deposit pending…"
-              : isFrozen
-                ? "Deposits frozen"
-                : `Deposit ${DISPLAY_ASSET_SYMBOL}`}
-        </button>
-      </form>
-
-      <form
-        className="mt-6 border-t border-[var(--t-muted)] pt-5"
-        onSubmit={submitWithdrawal}
-      >
-        <label
-          className="block text-sm font-bold"
-          htmlFor="lp-withdrawal-amount"
-        >
-          LP withdrawal amount ({DISPLAY_ASSET_SYMBOL})
-        </label>
-        <input
-          aria-describedby="lp-withdrawal-help lp-withdrawal-validation"
-          className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
-          disabled={isFrozen}
-          id="lp-withdrawal-amount"
-          inputMode="decimal"
-          onChange={(event) => setWithdrawalAmount(event.target.value)}
-          placeholder="0.000000"
-          value={withdrawalAmount}
-        />
-        <p
-          id="lp-withdrawal-help"
-          className="mt-2 text-xs text-[var(--t-muted)]"
-        >
-          {isFrozen
-            ? "Withdrawals are blocked while share operations are frozen."
-            : `Withdraw ${DISPLAY_ASSET_SYMBOL}, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity.`}
-        </p>
-        {withdrawalValidationError ? (
-          <p
-            id="lp-withdrawal-validation"
-            role="alert"
-            className="mt-2 text-sm"
+          <label
+            className="block text-sm font-bold"
+            htmlFor="lp-deposit-amount"
           >
-            {withdrawalValidationError}
+            LP deposit amount ({DISPLAY_ASSET_SYMBOL})
+          </label>
+          <input
+            aria-describedby="lp-deposit-help lp-deposit-validation"
+            className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+            disabled={isFrozen}
+            id="lp-deposit-amount"
+            inputMode="decimal"
+            onChange={(event) => setAmount(event.target.value)}
+            placeholder="0.000000"
+            value={amount}
+          />
+          <p
+            id="lp-deposit-help"
+            className="mt-2 text-xs text-[var(--t-muted)]"
+          >
+            {isFrozen
+              ? "Deposits are blocked while share operations are frozen."
+              : `An exact ${DISPLAY_ASSET_SYMBOL} approval for this deposit may occur first. The LP Desk never requests unlimited approval.`}
           </p>
-        ) : null}
-        <button
-          className="mt-4 bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
-          disabled={!canWithdraw}
-          type="submit"
+          {validationError ? (
+            <p id="lp-deposit-validation" role="alert" className="mt-2 text-sm">
+              {validationError}
+            </p>
+          ) : null}
+          <button
+            className="mt-4 bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
+            disabled={!canSubmit}
+            type="submit"
+          >
+            {isFrozen ? "Deposits frozen" : `Deposit ${DISPLAY_ASSET_SYMBOL}`}
+          </button>
+        </form>
+      )}
+
+      {pendingWithdrawal !== null ? (
+        <div className="mt-6 border-t border-[var(--t-muted)] pt-5">
+          <TransactionConfirm
+            busy={withdrawalBusy}
+            confirmLabel={`Confirm withdraw ${DISPLAY_ASSET_SYMBOL}`}
+            note={`Withdraw ${DISPLAY_ASSET_SYMBOL}, not shares, up to your authoritative immediately withdrawable limit.`}
+            onCancel={() => setPendingWithdrawal(null)}
+            onConfirm={confirmWithdrawal}
+            rows={[
+              {
+                label: "Amount",
+                value: formatDeskDollarsAmount(pendingWithdrawal),
+              },
+            ]}
+            title="Confirm LP withdrawal"
+          />
+        </div>
+      ) : (
+        <form
+          className="mt-6 border-t border-[var(--t-muted)] pt-5"
+          onSubmit={submitWithdrawal}
         >
-          {vault.status === "withdrawal-submitting"
-            ? "Withdrawal submitting…"
-            : vault.status === "withdrawal-pending"
-              ? "Withdrawal pending…"
-              : isFrozen
-                ? "Withdrawals frozen"
-                : `Withdraw ${DISPLAY_ASSET_SYMBOL}`}
-        </button>
-      </form>
+          <label
+            className="block text-sm font-bold"
+            htmlFor="lp-withdrawal-amount"
+          >
+            LP withdrawal amount ({DISPLAY_ASSET_SYMBOL})
+          </label>
+          <input
+            aria-describedby="lp-withdrawal-help lp-withdrawal-validation"
+            className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+            disabled={isFrozen}
+            id="lp-withdrawal-amount"
+            inputMode="decimal"
+            onChange={(event) => setWithdrawalAmount(event.target.value)}
+            placeholder="0.000000"
+            value={withdrawalAmount}
+          />
+          <p
+            id="lp-withdrawal-help"
+            className="mt-2 text-xs text-[var(--t-muted)]"
+          >
+            {isFrozen
+              ? "Withdrawals are blocked while share operations are frozen."
+              : `Withdraw ${DISPLAY_ASSET_SYMBOL}, not shares, up to your authoritative immediately withdrawable limit. This limit is separate from global free liquidity.`}
+          </p>
+          {withdrawalValidationError ? (
+            <p
+              id="lp-withdrawal-validation"
+              role="alert"
+              className="mt-2 text-sm"
+            >
+              {withdrawalValidationError}
+            </p>
+          ) : null}
+          <button
+            className="mt-4 bg-[var(--t-accent)] px-4 py-2 text-sm font-bold text-[var(--t-bg)] disabled:opacity-50"
+            disabled={!canWithdraw}
+            type="submit"
+          >
+            {isFrozen
+              ? "Withdrawals frozen"
+              : `Withdraw ${DISPLAY_ASSET_SYMBOL}`}
+          </button>
+        </form>
+      )}
 
       {statusMessage ? (
         <p

--- a/src/components/ui/transaction-confirm.test.tsx
+++ b/src/components/ui/transaction-confirm.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TransactionConfirm } from "./transaction-confirm";
+
+describe("TransactionConfirm", () => {
+  afterEach(cleanup);
+
+  it("renders summary rows, gas note, and wires confirm/cancel", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <TransactionConfirm
+        confirmLabel="Send USDC"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        rows={[
+          { label: "Recipient", value: "0xabc" },
+          { label: "Amount", value: "10 USDC" },
+        ]}
+        title="Confirm transfer"
+      />
+    );
+
+    expect(screen.getByText("Confirm transfer")).not.toBeNull();
+    expect(screen.getByText("Recipient")).not.toBeNull();
+    expect(screen.getByText("0xabc")).not.toBeNull();
+    expect(screen.getByText("10 USDC")).not.toBeNull();
+    expect(screen.getByText("Gas sponsored — no ETH required.")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send USDC" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables actions and shows submitting label while busy", () => {
+    render(
+      <TransactionConfirm
+        busy
+        confirmLabel="Deposit USDC"
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        rows={[{ label: "Amount", value: "5 USDC" }]}
+        title="Confirm deposit"
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submitting…" })).toHaveProperty(
+      "disabled",
+      true
+    );
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveProperty(
+      "disabled",
+      true
+    );
+  });
+});

--- a/src/components/ui/transaction-confirm.tsx
+++ b/src/components/ui/transaction-confirm.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { GameButton } from "@/components/ui/game-button";
+import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
+
+export type TransactionConfirmRow = {
+  label: string;
+  value: string;
+};
+
+export type TransactionConfirmProps = {
+  title: string;
+  rows: TransactionConfirmRow[];
+  note?: string;
+  confirmLabel: string;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+/**
+ * Inline confirm panel for high-stakes sponsored transactions.
+ * Renders in place of a form — not as a nested dialog.
+ */
+export function TransactionConfirm({
+  title,
+  rows,
+  note,
+  confirmLabel,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: TransactionConfirmProps) {
+  return (
+    <div className="mt-4" data-testid="transaction-confirm">
+      <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+        {title}
+      </p>
+      <dl className="mt-3 space-y-2 text-sm">
+        {rows.map((row) => (
+          <div key={row.label}>
+            <dt className="text-[var(--t-muted)]">{row.label}</dt>
+            <dd className="break-all tabular-nums text-[var(--t-text)]">
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      {note ? (
+        <p className="mt-3 text-xs leading-5 text-[var(--t-muted)]">{note}</p>
+      ) : null}
+      <p className="mt-3 text-xs leading-5 text-[var(--t-green)]">
+        Gas sponsored — no ETH required.
+      </p>
+      <div className="mt-4 flex flex-col gap-3">
+        <GameButton
+          className="w-full"
+          disabled={busy}
+          onClick={onConfirm}
+          size="sm"
+          type="button"
+        >
+          {busy ? "Submitting…" : confirmLabel}
+        </GameButton>
+        <button
+          className={TERMINAL_ACTION_BUTTON_CLASS}
+          disabled={busy}
+          onClick={onCancel}
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/wallet/wallet-dialog.test.tsx
+++ b/src/components/wallet/wallet-dialog.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sdk = vi.hoisted(() => ({
   transfer: vi.fn(),
+  transferValidated: vi.fn(),
   retry: vi.fn(),
   status: "idle" as string,
   error: null as string | null,
@@ -32,6 +33,7 @@ vi.mock("@/hooks/use-desk-dollars-transfer", async () => {
       canTransfer: sdk.canTransfer,
       canRetry: sdk.canRetry,
       transfer: sdk.transfer,
+      transferValidated: sdk.transferValidated,
       retry: sdk.retry,
     }),
   };
@@ -49,6 +51,7 @@ const TO = "0x0000000000000000000000000000000000000004" as const;
 describe("WalletDialog", () => {
   beforeEach(() => {
     sdk.transfer.mockReset().mockResolvedValue(true);
+    sdk.transferValidated.mockReset().mockResolvedValue(true);
     sdk.retry.mockReset().mockResolvedValue(true);
     sdk.status = "idle";
     sdk.error = null;
@@ -81,7 +84,7 @@ describe("WalletDialog", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Send USDC" }));
 
-    expect(sdk.transfer).not.toHaveBeenCalled();
+    expect(sdk.transferValidated).not.toHaveBeenCalled();
     expect(screen.getByTestId("transaction-confirm")).not.toBeNull();
     expect(screen.getByText(TO)).not.toBeNull();
     expect(screen.getByText("10 USDC")).not.toBeNull();
@@ -98,12 +101,12 @@ describe("WalletDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm send USDC" }));
 
     await waitFor(() =>
-      expect(sdk.transfer).toHaveBeenCalledWith({
-        recipient: TO,
-        amount: "10",
-        balance: 100_000_000n,
+      expect(sdk.transferValidated).toHaveBeenCalledWith({
+        to: TO,
+        amount: 10_000_000n,
       })
     );
+    expect(sdk.transfer).not.toHaveBeenCalled();
   });
 
   it("fills the amount field from Max", () => {
@@ -142,6 +145,6 @@ describe("WalletDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await waitFor(() => expect(sdk.retry).toHaveBeenCalledTimes(1));
-    expect(sdk.transfer).not.toHaveBeenCalled();
+    expect(sdk.transferValidated).not.toHaveBeenCalled();
   });
 });

--- a/src/components/wallet/wallet-dialog.test.tsx
+++ b/src/components/wallet/wallet-dialog.test.tsx
@@ -19,17 +19,23 @@ const sdk = vi.hoisted(() => ({
   canRetry: false,
 }));
 
-vi.mock("@/hooks/use-desk-dollars-transfer", () => ({
-  useDeskDollarsTransfer: () => ({
-    status: sdk.status,
-    error: sdk.error,
-    lastHash: sdk.lastHash,
-    canTransfer: sdk.canTransfer,
-    canRetry: sdk.canRetry,
-    transfer: sdk.transfer,
-    retry: sdk.retry,
-  }),
-}));
+vi.mock("@/hooks/use-desk-dollars-transfer", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/use-desk-dollars-transfer")
+  >("@/hooks/use-desk-dollars-transfer");
+  return {
+    ...actual,
+    useDeskDollarsTransfer: () => ({
+      status: sdk.status,
+      error: sdk.error,
+      lastHash: sdk.lastHash,
+      canTransfer: sdk.canTransfer,
+      canRetry: sdk.canRetry,
+      transfer: sdk.transfer,
+      retry: sdk.retry,
+    }),
+  };
+});
 
 vi.mock("@/components/desk-dollars/desk-dollars-faucet", () => ({
   DeskDollarsFaucet: () => null,
@@ -53,7 +59,7 @@ describe("WalletDialog", () => {
 
   afterEach(cleanup);
 
-  it("renders address, balance, and submits a transfer", async () => {
+  it("requires confirm before submitting a transfer and preserves input on cancel", async () => {
     render(
       <WalletDialog
         balance={100_000_000n}
@@ -74,6 +80,22 @@ describe("WalletDialog", () => {
       target: { value: "10" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Send USDC" }));
+
+    expect(sdk.transfer).not.toHaveBeenCalled();
+    expect(screen.getByTestId("transaction-confirm")).not.toBeNull();
+    expect(screen.getByText(TO)).not.toBeNull();
+    expect(screen.getByText("10 USDC")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect((screen.getByLabelText("Recipient") as HTMLInputElement).value).toBe(
+      TO
+    );
+    expect(
+      (screen.getByLabelText("Amount (USDC)") as HTMLInputElement).value
+    ).toBe("10");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send USDC" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm send USDC" }));
 
     await waitFor(() =>
       expect(sdk.transfer).toHaveBeenCalledWith({

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -12,6 +12,7 @@ import {
   validateDeskDollarsTransfer,
 } from "@/hooks/use-desk-dollars-transfer";
 import type { DeskDollarsTransferStatus } from "@/hooks/use-desk-dollars-transfer";
+import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import {
   DISPLAY_ASSET_SYMBOL,
   formatDeskDollars,
@@ -119,8 +120,7 @@ export function WalletDialog({
   const [recipient, setRecipient] = useState("");
   const [amount, setAmount] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
-  const [pendingTransfer, setPendingTransfer] =
-    useState<PendingTransfer | null>(null);
+  const pendingTransfer = usePendingConfirm<PendingTransfer>();
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
     "idle"
   );
@@ -173,11 +173,11 @@ export function WalletDialog({
       });
       if (!validation.ok) {
         setValidationError(validation.error);
-        setPendingTransfer(null);
+        pendingTransfer.cancel();
         return;
       }
       setValidationError(null);
-      setPendingTransfer({
+      pendingTransfer.arm({
         recipient,
         amount,
         balance,
@@ -185,25 +185,26 @@ export function WalletDialog({
         amountWei: validation.amount,
       });
     },
-    [amount, balance, isRetry, recipient, transfer, walletAddress]
+    [
+      amount,
+      balance,
+      isRetry,
+      pendingTransfer,
+      recipient,
+      transfer,
+      walletAddress,
+    ]
   );
 
   const handleConfirmTransfer = useCallback(() => {
-    if (!pendingTransfer) return;
-    void Promise.resolve(
+    pendingTransfer.confirm((armed) =>
       transfer.transfer({
-        recipient: pendingTransfer.recipient,
-        amount: pendingTransfer.amount,
-        balance: pendingTransfer.balance,
+        recipient: armed.recipient,
+        amount: armed.amount,
+        balance: armed.balance,
       })
-    ).finally(() => {
-      setPendingTransfer(null);
-    });
+    );
   }, [pendingTransfer, transfer]);
-
-  const handleCancelConfirm = useCallback(() => {
-    setPendingTransfer(null);
-  }, []);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -276,19 +277,21 @@ export function WalletDialog({
 
           <DeskDollarsFaucet />
 
-          {pendingTransfer ? (
+          {pendingTransfer.pending ? (
             <div className="mt-6 border-t border-[var(--t-border)] pt-5">
               <TransactionConfirm
                 busy={isBusy}
                 confirmLabel={`Confirm send ${DISPLAY_ASSET_SYMBOL}`}
                 note="Desk Dollars have no real value. Double-check the recipient before sending."
-                onCancel={handleCancelConfirm}
+                onCancel={pendingTransfer.cancel}
                 onConfirm={handleConfirmTransfer}
                 rows={[
-                  { label: "Recipient", value: pendingTransfer.to },
+                  { label: "Recipient", value: pendingTransfer.pending.to },
                   {
                     label: "Amount",
-                    value: formatDeskDollarsAmount(pendingTransfer.amountWei),
+                    value: formatDeskDollarsAmount(
+                      pendingTransfer.pending.amountWei
+                    ),
                   },
                 ]}
                 title="Confirm transfer"

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -6,11 +6,16 @@ import type { Address } from "viem";
 import { DeskDollarsFaucet } from "@/components/desk-dollars/desk-dollars-faucet";
 import { FlashValue } from "@/components/ui/flash-value";
 import { GameButton } from "@/components/ui/game-button";
-import { useDeskDollarsTransfer } from "@/hooks/use-desk-dollars-transfer";
+import { TransactionConfirm } from "@/components/ui/transaction-confirm";
+import {
+  useDeskDollarsTransfer,
+  validateDeskDollarsTransfer,
+} from "@/hooks/use-desk-dollars-transfer";
 import type { DeskDollarsTransferStatus } from "@/hooks/use-desk-dollars-transfer";
 import {
   DISPLAY_ASSET_SYMBOL,
   formatDeskDollars,
+  formatDeskDollarsAmount,
   formatDeskDollarsAmountLabel,
   formatDeskDollarsBalanceLabel,
   TUSD_DECIMALS,
@@ -37,6 +42,14 @@ type TransferStatusMessage = {
   status: DeskDollarsTransferStatus;
   error: string | null;
   lastHash: `0x${string}` | null;
+};
+
+type PendingTransfer = {
+  recipient: string;
+  amount: string;
+  balance: bigint | null;
+  to: Address;
+  amountWei: bigint;
 };
 
 function TransferStatusCopy({
@@ -105,6 +118,9 @@ export function WalletDialog({
   const transfer = useDeskDollarsTransfer(walletAddress);
   const [recipient, setRecipient] = useState("");
   const [amount, setAmount] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [pendingTransfer, setPendingTransfer] =
+    useState<PendingTransfer | null>(null);
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">(
     "idle"
   );
@@ -149,10 +165,45 @@ export function WalletDialog({
         void transfer.retry();
         return;
       }
-      void transfer.transfer({ recipient, amount, balance });
+      const validation = validateDeskDollarsTransfer({
+        recipient,
+        amount,
+        balance,
+        from: walletAddress,
+      });
+      if (!validation.ok) {
+        setValidationError(validation.error);
+        setPendingTransfer(null);
+        return;
+      }
+      setValidationError(null);
+      setPendingTransfer({
+        recipient,
+        amount,
+        balance,
+        to: validation.to,
+        amountWei: validation.amount,
+      });
     },
-    [amount, balance, isRetry, recipient, transfer]
+    [amount, balance, isRetry, recipient, transfer, walletAddress]
   );
+
+  const handleConfirmTransfer = useCallback(() => {
+    if (!pendingTransfer) return;
+    void Promise.resolve(
+      transfer.transfer({
+        recipient: pendingTransfer.recipient,
+        amount: pendingTransfer.amount,
+        balance: pendingTransfer.balance,
+      })
+    ).finally(() => {
+      setPendingTransfer(null);
+    });
+  }, [pendingTransfer, transfer]);
+
+  const handleCancelConfirm = useCallback(() => {
+    setPendingTransfer(null);
+  }, []);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -225,72 +276,109 @@ export function WalletDialog({
 
           <DeskDollarsFaucet />
 
-          <form
-            className="mt-6 border-t border-[var(--t-border)] pt-5"
-            onSubmit={handleSubmit}
-          >
-            <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]">
-              Transfer Desk Dollars
-            </p>
-
-            <label
-              className="mt-4 block text-sm font-bold"
-              htmlFor="wallet-transfer-recipient"
-            >
-              Recipient
-            </label>
-            <input
-              autoComplete="off"
-              className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
-              disabled={isBusy}
-              id="wallet-transfer-recipient"
-              onChange={(event) => setRecipient(event.target.value)}
-              placeholder="0x…"
-              spellCheck={false}
-              value={recipient}
-            />
-
-            <div className="mt-4 flex items-end justify-between gap-3">
-              <label
-                className="block text-sm font-bold"
-                htmlFor="wallet-transfer-amount"
-              >
-                Amount ({DISPLAY_ASSET_SYMBOL})
-              </label>
-              <button
-                className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] disabled:opacity-50"
-                disabled={isBusy || balance === null || balance <= 0n}
-                onClick={handleMax}
-                type="button"
-              >
-                Max
-              </button>
+          {pendingTransfer ? (
+            <div className="mt-6 border-t border-[var(--t-border)] pt-5">
+              <TransactionConfirm
+                busy={isBusy}
+                confirmLabel={`Confirm send ${DISPLAY_ASSET_SYMBOL}`}
+                note="Desk Dollars have no real value. Double-check the recipient before sending."
+                onCancel={handleCancelConfirm}
+                onConfirm={handleConfirmTransfer}
+                rows={[
+                  { label: "Recipient", value: pendingTransfer.to },
+                  {
+                    label: "Amount",
+                    value: formatDeskDollarsAmount(pendingTransfer.amountWei),
+                  },
+                ]}
+                title="Confirm transfer"
+              />
+              <TransferStatusCopy
+                error={transfer.error}
+                lastHash={transfer.lastHash}
+                status={transfer.status}
+              />
             </div>
-            <input
-              className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
-              disabled={isBusy}
-              id="wallet-transfer-amount"
-              inputMode="decimal"
-              onChange={(event) => setAmount(event.target.value)}
-              placeholder="0.000000"
-              value={amount}
-            />
-
-            <TransferStatusCopy
-              error={transfer.error}
-              lastHash={transfer.lastHash}
-              status={transfer.status}
-            />
-
-            <GameButton
-              className="mt-4 w-full"
-              disabled={!canSubmit}
-              size="sm"
-              type="submit"
+          ) : (
+            <form
+              className="mt-6 border-t border-[var(--t-border)] pt-5"
+              onSubmit={handleSubmit}
             >
-              {submitLabel}
-            </GameButton>
-          </form>
+              <p className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-muted)]">
+                Transfer Desk Dollars
+              </p>
+
+              <label
+                className="mt-4 block text-sm font-bold"
+                htmlFor="wallet-transfer-recipient"
+              >
+                Recipient
+              </label>
+              <input
+                autoComplete="off"
+                className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+                disabled={isBusy}
+                id="wallet-transfer-recipient"
+                onChange={(event) => {
+                  setRecipient(event.target.value);
+                  setValidationError(null);
+                }}
+                placeholder="0x…"
+                spellCheck={false}
+                value={recipient}
+              />
+
+              <div className="mt-4 flex items-end justify-between gap-3">
+                <label
+                  className="block text-sm font-bold"
+                  htmlFor="wallet-transfer-amount"
+                >
+                  Amount ({DISPLAY_ASSET_SYMBOL})
+                </label>
+                <button
+                  className="text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] disabled:opacity-50"
+                  disabled={isBusy || balance === null || balance <= 0n}
+                  onClick={handleMax}
+                  type="button"
+                >
+                  Max
+                </button>
+              </div>
+              <input
+                className="mt-2 w-full border border-[var(--t-muted)] bg-transparent px-3 py-2 text-[var(--t-text)]"
+                disabled={isBusy}
+                id="wallet-transfer-amount"
+                inputMode="decimal"
+                onChange={(event) => {
+                  setAmount(event.target.value);
+                  setValidationError(null);
+                }}
+                placeholder="0.000000"
+                value={amount}
+              />
+
+              {validationError ? (
+                <p role="alert" className="mt-3 text-sm">
+                  {validationError}
+                </p>
+              ) : null}
+
+              <TransferStatusCopy
+                error={transfer.error}
+                lastHash={transfer.lastHash}
+                status={transfer.status}
+              />
+
+              <GameButton
+                className="mt-4 w-full"
+                disabled={!canSubmit}
+                size="sm"
+                type="submit"
+              >
+                {submitLabel}
+              </GameButton>
+            </form>
+          )}
         </Dialog.Popup>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -46,9 +46,6 @@ type TransferStatusMessage = {
 };
 
 type PendingTransfer = {
-  recipient: string;
-  amount: string;
-  balance: bigint | null;
   to: Address;
   amountWei: bigint;
 };
@@ -178,9 +175,6 @@ export function WalletDialog({
       }
       setValidationError(null);
       pendingTransfer.arm({
-        recipient,
-        amount,
-        balance,
         to: validation.to,
         amountWei: validation.amount,
       });
@@ -198,10 +192,9 @@ export function WalletDialog({
 
   const handleConfirmTransfer = useCallback(() => {
     pendingTransfer.confirm((armed) =>
-      transfer.transfer({
-        recipient: armed.recipient,
-        amount: armed.amount,
-        balance: armed.balance,
+      transfer.transferValidated({
+        to: armed.to,
+        amount: armed.amountWei,
       })
     );
   }, [pendingTransfer, transfer]);

--- a/src/hooks/use-crash-ticket-refund.ts
+++ b/src/hooks/use-crash-ticket-refund.ts
@@ -3,6 +3,7 @@
 import { useCallback } from "react";
 import { expireRequest, refundRequest } from "@/lib/margin-call-crash";
 import { type StageErrorCopy } from "@/lib/sponsored-call";
+import { isSponsoredActionBusy } from "@/lib/sponsored-action-busy";
 import {
   useCrashTicketStages,
   type CrashTicketStageStatus,
@@ -123,6 +124,7 @@ export function useCrashTicketRefund() {
       phase === "expired-eligible" && !!ticket && !ticket.settled && canAct,
     canRefund: outcome === "refundable" && canAct,
     canRetry,
+    busy: isSponsoredActionBusy(state.status),
     retryAction,
     expireRound: () => submitStage("expire"),
     refund: () => submitStage("refund"),

--- a/src/hooks/use-crash-ticket-settlement.ts
+++ b/src/hooks/use-crash-ticket-settlement.ts
@@ -12,6 +12,7 @@ import {
   settleLossRequest,
 } from "@/lib/margin-call-crash";
 import { type StageErrorCopy } from "@/lib/sponsored-call";
+import { isSponsoredActionBusy } from "@/lib/sponsored-action-busy";
 import {
   useCrashTicketStages,
   type CrashTicketStageStatus,
@@ -258,6 +259,7 @@ export function useCrashTicketSettlement(options?: {
     canClaim: outcome === "won" && canAct,
     canSettle: outcome === "lost" && canAct,
     canRetry,
+    busy: isSponsoredActionBusy(state.status),
     retryAction,
     transactions,
     verifyAndSettle,

--- a/src/hooks/use-desk-dollars-transfer.ts
+++ b/src/hooks/use-desk-dollars-transfer.ts
@@ -195,6 +195,19 @@ export function useDeskDollarsTransfer(walletAddress: Address | null) {
     [submitTransfer, tokenAddress, walletAddress]
   );
 
+  const transferValidated = useCallback(
+    async (input: { to: Address; amount: bigint }): Promise<boolean> => {
+      if (!walletAddress) return false;
+      if (!tokenAddress) {
+        setStatus("unavailable");
+        setError(tokenUnavailable);
+        return false;
+      }
+      return submitTransfer(input.to, input.amount);
+    },
+    [submitTransfer, tokenAddress, walletAddress]
+  );
+
   const retry = useCallback(async (): Promise<boolean> => {
     if (pendingStage.current) {
       if (inFlight.current) return false;
@@ -238,6 +251,7 @@ export function useDeskDollarsTransfer(walletAddress: Address | null) {
       pendingStage.current === null,
     canRetry: status === "error" && retryKind.current !== null,
     transfer,
+    transferValidated,
     retry,
   };
 }

--- a/src/hooks/use-history-ticket-actions.ts
+++ b/src/hooks/use-history-ticket-actions.ts
@@ -17,6 +17,7 @@ import {
   runSponsoredStage,
   type StageErrorCopy,
 } from "@/lib/sponsored-call";
+import { isSponsoredActionBusy } from "@/lib/sponsored-action-busy";
 import { notifyWalletBalancesChanged } from "@/lib/wallet-balance-sync";
 import { usePrivySponsoredTransaction } from "./use-privy-sponsored-transaction";
 
@@ -220,10 +221,7 @@ export function useHistoryTicketActions(onSettled?: () => void) {
     status,
     error,
     activeTicketId,
-    busy:
-      status.endsWith("-submitting") ||
-      status.endsWith("-pending") ||
-      status === "attesting",
+    busy: isSponsoredActionBusy(status),
     claim,
     settleLoss,
     expireRound,

--- a/src/hooks/use-pending-confirm.test.tsx
+++ b/src/hooks/use-pending-confirm.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePendingConfirm } from "./use-pending-confirm";
+
+describe("usePendingConfirm", () => {
+  it("arms, cancels, and confirms with the armed payload", async () => {
+    const { result } = renderHook(() => usePendingConfirm<number>());
+
+    act(() => result.current.arm(42));
+    expect(result.current.pending).toBe(42);
+
+    act(() => result.current.cancel());
+    expect(result.current.pending).toBeNull();
+
+    act(() => result.current.arm(7));
+    const run = vi.fn().mockResolvedValue(true);
+    await act(async () => {
+      result.current.confirm(run);
+      await Promise.resolve();
+    });
+    expect(run).toHaveBeenCalledWith(7);
+    expect(result.current.pending).toBeNull();
+  });
+});

--- a/src/hooks/use-pending-confirm.ts
+++ b/src/hooks/use-pending-confirm.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Shared arm → confirm → clear lifecycle for high-stakes sponsored actions.
+ * Callers keep form field state; this only holds the armed payload.
+ */
+export function usePendingConfirm<T>() {
+  const [pending, setPending] = useState<T | null>(null);
+
+  const arm = useCallback((value: T) => {
+    setPending(value);
+  }, []);
+
+  const cancel = useCallback(() => {
+    setPending(null);
+  }, []);
+
+  const confirm = useCallback(
+    (run: (value: T) => Promise<unknown> | unknown) => {
+      if (pending === null) return;
+      const value = pending;
+      void (async () => {
+        try {
+          await run(value);
+        } finally {
+          setPending(null);
+        }
+      })();
+    },
+    [pending]
+  );
+
+  return { pending, arm, cancel, confirm };
+}

--- a/src/lib/entry-submit-label.test.ts
+++ b/src/lib/entry-submit-label.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { entrySubmitLabel } from "./entry-submit-label";
+
+describe("entrySubmitLabel", () => {
+  it("maps in-flight and idle entry statuses", () => {
+    expect(entrySubmitLabel("approval-submitting", true)).toBe(
+      "Approval pending…"
+    );
+    expect(entrySubmitLabel("entry-pending", false)).toBe("Entering…");
+    expect(entrySubmitLabel("ready", true)).toBe("Approve & enter");
+    expect(entrySubmitLabel("ready", false)).toBe("Enter round");
+  });
+});

--- a/src/lib/entry-submit-label.ts
+++ b/src/lib/entry-submit-label.ts
@@ -1,0 +1,15 @@
+import type { CrashEntryStatus } from "@/hooks/use-crash-round-entry";
+
+/** Primary enter CTA label from entry status and approval need. */
+export function entrySubmitLabel(
+  status: CrashEntryStatus,
+  needsApproval: boolean
+): string {
+  if (status === "approval-submitting" || status === "approval-pending") {
+    return "Approval pending…";
+  }
+  if (status === "entry-submitting" || status === "entry-pending") {
+    return "Entering…";
+  }
+  return needsApproval ? "Approve & enter" : "Enter round";
+}

--- a/src/lib/privy/__tests__/config.test.ts
+++ b/src/lib/privy/__tests__/config.test.ts
@@ -12,6 +12,7 @@ describe("Privy provider configuration", () => {
         ethereum: {
           createOnLogin: "all-users",
         },
+        showWalletUIs: false,
       },
     });
   });

--- a/src/lib/privy/config.ts
+++ b/src/lib/privy/config.ts
@@ -9,5 +9,7 @@ export const privyProviderConfig = {
     ethereum: {
       createOnLogin: "all-users",
     },
+    // App-owned buttons are the confirmation UI; keep Privy's modal off.
+    showWalletUIs: false,
   },
 } satisfies PrivyClientConfig;

--- a/src/lib/sponsored-action-busy.test.ts
+++ b/src/lib/sponsored-action-busy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isSponsoredActionBusy } from "./sponsored-action-busy";
+
+describe("isSponsoredActionBusy", () => {
+  it("matches mid-flight settlement and history statuses", () => {
+    expect(isSponsoredActionBusy("claim-submitting")).toBe(true);
+    expect(isSponsoredActionBusy("reveal-pending")).toBe(true);
+    expect(isSponsoredActionBusy("attesting")).toBe(true);
+    expect(isSponsoredActionBusy("ready")).toBe(false);
+    expect(isSponsoredActionBusy("confirmed")).toBe(false);
+    expect(isSponsoredActionBusy("error")).toBe(false);
+  });
+});

--- a/src/lib/sponsored-action-busy.ts
+++ b/src/lib/sponsored-action-busy.ts
@@ -1,0 +1,11 @@
+/**
+ * True while a sponsored ticket/history action is mid-flight.
+ * Matches the status vocabulary used by settlement, refund, and history hooks.
+ */
+export function isSponsoredActionBusy(status: string): boolean {
+  return (
+    status.endsWith("-submitting") ||
+    status.endsWith("-pending") ||
+    status === "attesting"
+  );
+}


### PR DESCRIPTION
## Summary
- Disable Privy wallet confirmation modals via `embeddedWallets.showWalletUIs: false` while keeping `sponsor: true` gas sponsorship.
- Add a shared inline `TransactionConfirm` panel for high-stakes flows (USDC transfer, LP deposit, LP withdraw).
- Harden one-click in-game actions (enter, claim, settle, refund, verify, history) with disabled busy states and pending labels.

## Test plan
- [ ] Enter a round with margin/leverage — no Privy modal; button shows Approval pending… / Entering… while in flight
- [ ] Claim faucet — still one-click with Claim pending… label
- [ ] Wallet transfer — Send shows confirm summary; Cancel preserves fields; Confirm send submits sponsored tx
- [ ] LP deposit/withdraw — form submit opens confirm; Confirm calls vault hooks; Cancel keeps amount
- [ ] Settlement/refund/history actions disable and relabel while submitting/pending
- [ ] `pnpm test` and `pnpm check:ci` pass


Made with [Cursor](https://cursor.com)