### PR TITLE
Make Floor onboarding clear between rounds and on first visit

### DIFF
--- a/src/components/auth/sign-in-cta.tsx
+++ b/src/components/auth/sign-in-cta.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useLogin } from "@privy-io/react-auth";
+import { useCallback, useState } from "react";
+import { GameButton } from "@/components/ui/game-button";
+
+/**
+ * Floor / entry dock sign-in CTA. Same Privy login as AuthControls, sized for
+ * the action dock so a first-time visitor has something to click.
+ */
+export function SignInCta({
+  className,
+  size = "hero",
+}: {
+  className?: string;
+  size?: "default" | "sm" | "lg" | "hero";
+}) {
+  const [loginError, setLoginError] = useState(false);
+  const { login } = useLogin({
+    onError: () => setLoginError(true),
+  });
+
+  const handleLogin = useCallback(() => {
+    setLoginError(false);
+    login();
+  }, [login]);
+
+  return (
+    <div className={className}>
+      <GameButton
+        className="w-full bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+        data-testid="sign-in-cta"
+        onClick={handleLogin}
+        size={size}
+      >
+        Continue with phone
+      </GameButton>
+      <p className="mt-2 text-xs leading-5 text-[var(--t-muted)]">
+        No wallet app, seed phrase, or test ETH — claim free Desk Dollars after
+        you sign in.
+      </p>
+      {loginError ? (
+        <p className="mt-2 text-sm text-[var(--t-red)]" role="alert">
+          Sign-in did not complete. Try again.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/crash-stage/crash-stage.tsx
+++ b/src/components/crash-stage/crash-stage.tsx
@@ -543,7 +543,7 @@ function theaterLivePhase(live: TheaterLive): CrashRoundPhase | null {
   if (!isTheaterLiveReady(live)) return null;
   switch (live.kind) {
     case "open":
-      return "open";
+      return live.phaseLabel;
     case "delayed":
       return live.phaseLabel;
     case "finalized":

--- a/src/components/crash-stage/overlay/floor-how-to-play.tsx
+++ b/src/components/crash-stage/overlay/floor-how-to-play.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { memo, useEffect, useRef } from "react";
+
+const SEEN_KEY = "mc-floor-howto-seen";
+
+const steps = [
+  {
+    title: "Sign in",
+    body: "Continue with a phone number. An embedded smart wallet is created automatically — no wallet app, seed phrase, or test ETH.",
+  },
+  {
+    title: "Claim Desk Dollars",
+    body: "Tap the in-app faucet for free testnet Desk Dollars. Gas is sponsored for every action on the Floor.",
+  },
+  {
+    title: "Enter",
+    body: "Pick Margin (1, 5, or 10) and one of six Arcade Leverage tiers during the 45-second entry window. One Ticket per wallet per round.",
+  },
+  {
+    title: "Settle",
+    body: "After lock, verify and settle. Tiers at or below the Crash Point pay their reserved payout. The Replay dramatizes an already-final result — a new round opens every 60 seconds.",
+  },
+] as const;
+
+/**
+ * Non-blocking Floor how-to-play. Default-open once per browser, collapsed
+ * afterwards; native <details> so the theater's re-renders never clobber the
+ * player's toggle. Expanded body overlays the pit without pushing layout.
+ */
+export const FloorHowToPlay = memo(function FloorHowToPlay() {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    const seen = window.localStorage.getItem(SEEN_KEY) === "1";
+    if (!seen && detailsRef.current) detailsRef.current.open = true;
+    window.localStorage.setItem(SEEN_KEY, "1");
+  }, []);
+
+  return (
+    <div className="relative" data-testid="floor-how-to-play">
+      <details className="group" ref={detailsRef}>
+        <summary className="cursor-pointer list-none rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/70 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-accent)] backdrop-blur-sm marker:content-none [&::-webkit-details-marker]:hidden">
+          How to play
+        </summary>
+        <div className="pointer-events-auto absolute right-0 top-full z-30 mt-1.5 w-[min(calc(100vw-1.5rem),22rem)] border border-[var(--t-border)] bg-[var(--t-panel)] p-3 shadow-lg sm:w-[28rem] sm:p-4">
+          <ol className="grid gap-3 sm:grid-cols-2">
+            {steps.map((step, index) => (
+              <li className="text-xs leading-5" key={step.title}>
+                <p className="font-bold uppercase tracking-[0.14em] text-[var(--t-text)]">
+                  <span aria-hidden="true" className="text-[var(--t-accent)]">
+                    {index + 1}.{" "}
+                  </span>
+                  {step.title}
+                </p>
+                <p className="mt-1 text-[var(--t-muted)]">{step.body}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </details>
+    </div>
+  );
+});

--- a/src/components/crash-stage/overlay/stage-actions.test.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.test.tsx
@@ -49,7 +49,9 @@ vi.mock("@/components/auth/auth-gate", () => ({
 }));
 
 vi.mock("@/components/current-round/crash-round-entry", () => ({
-  CrashRoundEntry: () => <div data-testid="entry-form">Enter form</div>,
+  CrashRoundEntry: ({ armed }: { armed?: boolean }) => (
+    <div data-testid="entry-form">{armed ? "Armed form" : "Enter form"}</div>
+  ),
 }));
 
 vi.mock("@/components/current-round/crash-ticket-refund", () => ({
@@ -133,6 +135,30 @@ describe("StageActions", () => {
     );
     expect(screen.getByTestId("stage-actions")).toBeTruthy();
     expect(screen.getByTestId("entry-form")).toBeTruthy();
+    expect(screen.getByText("Enter form")).toBeTruthy();
+  });
+
+  it("keeps an armed dock mounted between rounds", () => {
+    sdk.settlement = sdk.makeSettlement({
+      ticket: null,
+      canVerify: false,
+      canClaim: false,
+      canSettle: false,
+      canRetry: false,
+    });
+    render(
+      <StageActions
+        countdownSeconds={8}
+        hasTicket={false}
+        mode="countdown"
+        phase="locked"
+        refund={emptyRefund}
+        roundId={12n}
+        settlement={sdk.settlement}
+      />
+    );
+    expect(screen.getByTestId("stage-actions")).toBeTruthy();
+    expect(screen.getByText("Armed form")).toBeTruthy();
   });
 
   it("disables and relabels verify while settlement is in flight", () => {

--- a/src/components/crash-stage/overlay/stage-actions.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.tsx
@@ -7,12 +7,9 @@ import {
   type CrashTicketRefundState,
 } from "@/components/current-round/crash-ticket-refund";
 import type { useCrashTicketSettlement } from "@/hooks/use-crash-ticket-settlement";
-import {
-  canOfferEntry,
-  isExpiryRefundTicket,
-  type CrashRoundPhase,
-} from "@/lib/margin-call-crash";
+import type { CrashRoundPhase } from "@/lib/margin-call-crash";
 import type { CrashStageMode } from "../use-crash-stage-mode";
+import { deriveStageDockKind } from "./stage-dock-state";
 import { StageSettleDock } from "./stage-settle-dock";
 
 export type StageActionsProps = {
@@ -41,36 +38,40 @@ export function StageActions({
   settlement,
   refund,
 }: StageActionsProps) {
-  const showSettle =
-    settlement.ticket !== null &&
-    (settlement.canVerify ||
-      settlement.canClaim ||
-      settlement.canSettle ||
-      settlement.canRetry);
-  const showEnter =
-    canOfferEntry(phase, countdownSeconds) && !hasTicket && !showSettle;
-  // Expiry leftovers can block the next Open round — show refund even when the
-  // live theater is no longer on the expired round.
-  const showRefund =
-    !showSettle &&
-    (mode === "expired" ||
-      isExpiryRefundTicket(settlement.phase, settlement.outcome));
+  const kind = deriveStageDockKind({
+    mode,
+    phase,
+    countdownSeconds,
+    hasTicket,
+    hasSettlementTicket: settlement.ticket !== null,
+    canVerify: settlement.canVerify,
+    canClaim: settlement.canClaim,
+    canSettle: settlement.canSettle,
+    canRetry: settlement.canRetry,
+    settlementPhase: settlement.phase,
+    settlementOutcome: settlement.outcome,
+  });
 
-  if (!showEnter && !showSettle && !showRefund) return null;
+  if (kind === "none") return null;
+
+  const showEntry = kind === "enter" || kind === "arm";
+  const showSettle = kind === "settle";
+  const showRefund = kind === "refund";
 
   return (
     <div
       className="pointer-events-auto flex min-h-0 max-h-[min(70%,32rem)] shrink flex-col px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-1.5 sm:max-h-[min(75%,36rem)] sm:px-6 sm:pb-[max(1rem,env(safe-area-inset-bottom))] sm:pt-2"
       data-testid="stage-actions"
     >
-      {showEnter || showSettle ? (
+      {showEntry || showSettle ? (
         <div className="mx-auto flex min-h-0 w-full max-w-xl flex-col overflow-hidden rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 backdrop-blur-md">
           <div
             className="min-h-0 overflow-y-auto p-3 sm:p-5"
             data-testid="stage-actions-body"
           >
-            {showEnter ? (
+            {showEntry ? (
               <CrashRoundEntry
+                armed={kind === "arm"}
                 countdownSeconds={countdownSeconds}
                 phase={phase}
                 roundId={roundId}

--- a/src/components/crash-stage/overlay/stage-dock-state.test.ts
+++ b/src/components/crash-stage/overlay/stage-dock-state.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveStageDockKind,
+  type StageDockStateInput,
+} from "./stage-dock-state";
+
+function base(
+  overrides: Partial<StageDockStateInput> = {}
+): StageDockStateInput {
+  return {
+    mode: "countdown",
+    phase: "open",
+    countdownSeconds: 22,
+    hasTicket: false,
+    hasSettlementTicket: false,
+    canVerify: false,
+    canClaim: false,
+    canSettle: false,
+    canRetry: false,
+    settlementPhase: null,
+    settlementOutcome: null,
+    ...overrides,
+  };
+}
+
+describe("deriveStageDockKind", () => {
+  it("offers enter while the round is open with time left", () => {
+    expect(deriveStageDockKind(base())).toBe("enter");
+  });
+
+  it("arms during the five-second cutoff", () => {
+    expect(deriveStageDockKind(base({ countdownSeconds: 4 }))).toBe("arm");
+  });
+
+  it("arms between rounds while locked or reveal-requested", () => {
+    expect(
+      deriveStageDockKind(base({ phase: "locked", countdownSeconds: 8 }))
+    ).toBe("arm");
+    expect(
+      deriveStageDockKind(
+        base({ phase: "reveal-requested", countdownSeconds: 5 })
+      )
+    ).toBe("arm");
+    expect(
+      deriveStageDockKind(base({ phase: "finalized", countdownSeconds: 3 }))
+    ).toBe("arm");
+  });
+
+  it("arms for prelaunch and uninitialized epochs", () => {
+    expect(deriveStageDockKind(base({ phase: "prelaunch" }))).toBe("arm");
+    expect(deriveStageDockKind(base({ phase: "uninitialized" }))).toBe("arm");
+  });
+
+  it("prefers settle when the settlement ticket can act", () => {
+    expect(
+      deriveStageDockKind(
+        base({
+          hasTicket: true,
+          hasSettlementTicket: true,
+          canVerify: true,
+          phase: "locked",
+          mode: "awaiting-settle",
+        })
+      )
+    ).toBe("settle");
+  });
+
+  it("prefers refund for expiry leftovers over arm or enter", () => {
+    expect(
+      deriveStageDockKind(
+        base({
+          hasTicket: true,
+          settlementPhase: "expired",
+          settlementOutcome: "refundable",
+        })
+      )
+    ).toBe("refund");
+  });
+
+  it("keeps enter available during a previous-round outcome when the next round is open", () => {
+    expect(
+      deriveStageDockKind(
+        base({
+          mode: "outcome",
+          phase: "open",
+          countdownSeconds: 22,
+        })
+      )
+    ).toBe("enter");
+  });
+
+  it("hides the dock during replay or outcome when entry is closed", () => {
+    expect(
+      deriveStageDockKind(
+        base({
+          mode: "replay",
+          phase: "finalized",
+          countdownSeconds: 8,
+        })
+      )
+    ).toBe("none");
+    expect(
+      deriveStageDockKind(
+        base({
+          mode: "outcome",
+          phase: "finalized",
+          hasTicket: true,
+          hasSettlementTicket: true,
+          countdownSeconds: 12,
+        })
+      )
+    ).toBe("none");
+  });
+
+  it("does not arm when the player already holds a ticket", () => {
+    expect(
+      deriveStageDockKind(
+        base({
+          hasTicket: true,
+          phase: "locked",
+          countdownSeconds: 10,
+        })
+      )
+    ).toBe("none");
+  });
+});

--- a/src/components/crash-stage/overlay/stage-dock-state.ts
+++ b/src/components/crash-stage/overlay/stage-dock-state.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure dock kind for the Floor action surface. Settle/refund take precedence;
+ * otherwise enter when the round can accept tickets, arm when the player can
+ * pre-pick for the next window, and none during climb/outcome theater.
+ */
+
+import {
+  canOfferEntry,
+  isExpiryRefundTicket,
+  type CrashRoundPhase,
+  type TicketOutcome,
+} from "@/lib/margin-call-crash";
+import type { CrashStageMode } from "../use-crash-stage-mode";
+
+export type StageDockKind = "enter" | "arm" | "settle" | "refund" | "none";
+
+/** Phases where the player may arm picks for the next entry window. */
+const ARMABLE_PHASES: ReadonlySet<CrashRoundPhase> = new Set([
+  "prelaunch",
+  "uninitialized",
+  "open",
+  "locked",
+  "reveal-requested",
+  "finalized",
+]);
+
+export type StageDockStateInput = {
+  mode: CrashStageMode;
+  phase: CrashRoundPhase;
+  countdownSeconds: number;
+  /** Live-round or stale ticket that blocks a fresh entry. */
+  hasTicket: boolean;
+  /** Settlement hook recovered a ticket (may differ from hasTicket). */
+  hasSettlementTicket: boolean;
+  canVerify: boolean;
+  canClaim: boolean;
+  canSettle: boolean;
+  canRetry: boolean;
+  settlementPhase: CrashRoundPhase | null;
+  settlementOutcome: TicketOutcome | null;
+};
+
+export function deriveStageDockKind(input: StageDockStateInput): StageDockKind {
+  const showSettle =
+    input.hasSettlementTicket &&
+    (input.canVerify || input.canClaim || input.canSettle || input.canRetry);
+
+  if (showSettle) return "settle";
+
+  // Expiry leftovers can block the next Open round — show refund even when the
+  // live theater is no longer on the expired round.
+  if (
+    input.mode === "expired" ||
+    isExpiryRefundTicket(input.settlementPhase, input.settlementOutcome)
+  ) {
+    return "refund";
+  }
+
+  if (canOfferEntry(input.phase, input.countdownSeconds) && !input.hasTicket) {
+    return "enter";
+  }
+
+  // Keep the climb uncluttered — no arm dock over replay/outcome unless enter
+  // already won above (next-round entry during a previous-round outcome).
+  if (input.mode === "replay" || input.mode === "outcome") {
+    return "none";
+  }
+
+  if (!input.hasTicket && ARMABLE_PHASES.has(input.phase)) {
+    return "arm";
+  }
+
+  return "none";
+}

--- a/src/components/crash-stage/overlay/stage-hud.test.tsx
+++ b/src/components/crash-stage/overlay/stage-hud.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/components/round-theater/theater-sound-toggle", () => ({
   TheaterSoundToggle: () => <div data-testid="sound-toggle" />,
 }));
 
+vi.mock("@/components/crash-stage/overlay/floor-how-to-play", () => ({
+  FloorHowToPlay: () => <div data-testid="floor-how-to-play" />,
+}));
+
 const ticket: CrashTicket = {
   id: 7n,
   player: "0x0000000000000000000000000000000000000003",

--- a/src/components/crash-stage/overlay/stage-hud.tsx
+++ b/src/components/crash-stage/overlay/stage-hud.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FloorHowToPlay } from "@/components/crash-stage/overlay/floor-how-to-play";
 import { TheaterSoundToggle } from "@/components/round-theater/theater-sound-toggle";
 import {
   formatDeskDollarsAmount,
@@ -27,7 +28,7 @@ export type StageHudProps = {
 };
 
 /**
- * Compact floor HUD: live region, YOU ticket chip, sound.
+ * Compact floor HUD: live region, YOU ticket chip, how-to-play, sound.
  * Faucet lives on CrashRoundEntry in the action overlay.
  */
 export function StageHud({
@@ -90,7 +91,8 @@ export function StageHud({
             )
           ) : null}
         </div>
-        <div className="pointer-events-auto shrink-0">
+        <div className="pointer-events-auto flex shrink-0 items-start gap-2">
+          <FloorHowToPlay />
           <TheaterSoundToggle suggest={suggestSound} />
         </div>
       </div>

--- a/src/components/crash-stage/use-crash-stage-mode.test.ts
+++ b/src/components/crash-stage/use-crash-stage-mode.test.ts
@@ -17,6 +17,7 @@ function openLive(): Extract<TheaterLive, { kind: "open" }> {
   return {
     kind: "open",
     roundId: 12n,
+    phaseLabel: "open",
     tape: null,
     timeline,
   };

--- a/src/components/current-round/crash-round-entry.test.tsx
+++ b/src/components/current-round/crash-round-entry.test.tsx
@@ -51,6 +51,14 @@ vi.mock("@/components/desk-dollars/desk-dollars-faucet", () => ({
   DeskDollarsFaucet: () => null,
 }));
 
+vi.mock("@/components/auth/sign-in-cta", () => ({
+  SignInCta: () => (
+    <button data-testid="sign-in-cta" type="button">
+      Continue with phone
+    </button>
+  ),
+}));
+
 import { CrashRoundEntry } from "./crash-round-entry";
 
 describe("CrashRoundEntry", () => {
@@ -175,5 +183,32 @@ describe("CrashRoundEntry", () => {
       screen.getByRole("button", { name: "Retry entry receipt check" })
     );
     expect(sdk.entry.retry).toHaveBeenCalledOnce();
+  });
+
+  it("arms pickers with a disabled countdown CTA between rounds", () => {
+    sdk.props.phase = "locked";
+    sdk.props.countdownSeconds = 8;
+    render(<CrashRoundEntry {...sdk.props} armed />);
+    expect(screen.getByRole("heading", { name: "Next round" })).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Margin" })).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Arcade Leverage" })).toBeTruthy();
+    const cta = screen.getByRole("button", { name: /Entry opens in/ });
+    expect(cta).toHaveProperty("disabled", true);
+    expect(
+      screen.queryByRole("button", { name: /Approve & enter/ })
+    ).toBeNull();
+  });
+
+  it("keeps pickers and a sign-in CTA when signed out", () => {
+    sdk.entry = sdk.makeEntry({
+      walletAddress: null,
+      canEnter: false,
+    });
+    render(<CrashRoundEntry {...sdk.props} />);
+    expect(screen.getByRole("group", { name: "Margin" })).toBeTruthy();
+    expect(screen.getByTestId("sign-in-cta")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Approve & enter/ })
+    ).toBeNull();
   });
 });

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -21,7 +21,9 @@ import {
   formatDeskDollarsAmount,
   formatDeskDollarsAmountLabel,
 } from "@/lib/desk-dollars";
+import { armedEntryCopy, formatArmedEntryCta } from "@/lib/round-phase-copy";
 import { STAGE_DOCK_STICKY_CTA_CLASS } from "@/components/crash-stage/overlay/stage-dock-chrome";
+import { SignInCta } from "@/components/auth/sign-in-cta";
 import { TERMINAL_ACTION_BUTTON_CLASS } from "@/lib/utils";
 import { entrySubmitLabel } from "@/lib/entry-submit-label";
 import { DeskDollarsFaucet } from "@/components/desk-dollars/desk-dollars-faucet";
@@ -52,17 +54,24 @@ type CrashRoundEntryProps = {
   roundId: bigint;
   phase: CrashRoundPhase;
   countdownSeconds: number;
+  /**
+   * Pre-entry wait: pickers stay interactive, CTA disabled until the next
+   * window opens. Mounted by StageActions when dock kind is `arm`.
+   */
+  armed?: boolean;
 };
 
 /**
  * Player entry surface for the current Crash round.
  * Offers 1/5/10 USDC margins and six leverage tiers only into initialized
- * open rounds with more than five seconds remaining before lock.
+ * open rounds with more than five seconds remaining before lock. When `armed`,
+ * the same pickers stay visible with a disabled countdown CTA.
  */
 export function CrashRoundEntry({
   roundId,
   phase,
   countdownSeconds,
+  armed = false,
 }: CrashRoundEntryProps) {
   const entry = useCrashRoundEntry({ roundId });
   const reducedMotion = useReducedMotion();
@@ -80,25 +89,51 @@ export function CrashRoundEntry({
     previousStatus.current = entry.status;
   }, [entry.status, reducedMotion]);
 
+  if (entry.ticket) {
+    const justEntered = entry.status === "confirmed";
+    return (
+      <EntryShell heading="Enter this round">
+        <div className={justEntered ? "mc-onboard-flash" : undefined}>
+          <CrashLiveTicket ticket={entry.ticket} />
+        </div>
+      </EntryShell>
+    );
+  }
+
+  if (armed) {
+    return (
+      <EntryShell heading="Next round">
+        <p className="text-sm text-[var(--t-muted)]">{armedEntryCopy(phase)}</p>
+        <EntryPickers entry={entry} signedOut={!entry.walletAddress} />
+        {!entry.walletAddress ? (
+          <SignInCta className="mt-3 sm:mt-4" />
+        ) : (
+          <>
+            <DeskDollarsFaucet className="mt-3 sm:mt-4" />
+            <div className={STAGE_DOCK_STICKY_CTA_CLASS}>
+              <GameButton
+                className="w-full bg-[var(--t-accent)] text-[var(--t-bg)] hover:bg-[var(--t-accent)] hover:text-[var(--t-bg)]"
+                disabled
+                size="hero"
+              >
+                {formatArmedEntryCta(countdownSeconds)}
+              </GameButton>
+            </div>
+            <ApprovalDetails entry={entry} />
+          </>
+        )}
+      </EntryShell>
+    );
+  }
+
   if (phase === "uninitialized" || phase === "prelaunch") {
     return (
-      <EntryShell>
+      <EntryShell heading="Enter this round">
         <p className="text-sm text-[var(--t-muted)]">
           Waiting for an ETH-holding opener to initialize this epoch. Embedded
           wallets never create rounds, so entry stays closed until a handle is
           pre-committed onchain.
         </p>
-      </EntryShell>
-    );
-  }
-
-  if (entry.ticket) {
-    const justEntered = entry.status === "confirmed";
-    return (
-      <EntryShell>
-        <div className={justEntered ? "mc-onboard-flash" : undefined}>
-          <CrashLiveTicket ticket={entry.ticket} />
-        </div>
       </EntryShell>
     );
   }
@@ -109,7 +144,7 @@ export function CrashRoundEntry({
 
   if (!canOfferEntry(phase, countdownSeconds)) {
     return (
-      <EntryShell>
+      <EntryShell heading="Enter this round">
         <p className="text-sm text-[var(--t-amber-hot)]" role="status">
           Entry cutoff — less than five seconds remain before onchain lock. New
           entries are no longer offered.
@@ -120,17 +155,20 @@ export function CrashRoundEntry({
 
   if (!entry.walletAddress) {
     return (
-      <EntryShell>
-        <p className="text-sm text-[var(--t-muted)]">
-          Sign in with phone to enter this round with a sponsored transaction.
+      <EntryShell heading="Enter this round">
+        <p className="hidden text-sm text-[var(--t-text)] sm:block">
+          Choose margin and Arcade Leverage. Expected payout is the maximum
+          reservation, not a guaranteed return.
         </p>
+        <EntryPickers entry={entry} signedOut />
+        <SignInCta className="mt-3 sm:mt-4" />
       </EntryShell>
     );
   }
 
   if (entry.status === "unavailable") {
     return (
-      <EntryShell>
+      <EntryShell heading="Enter this round">
         <p className="text-sm text-[var(--t-red)]" role="alert">
           {entry.error}
         </p>
@@ -147,48 +185,13 @@ export function CrashRoundEntry({
     : "Retry";
 
   return (
-    <EntryShell>
+    <EntryShell heading="Enter this round">
       <p className="hidden text-sm text-[var(--t-text)] sm:block">
         Choose margin and Arcade Leverage. Expected payout is the maximum
         reservation, not a guaranteed return.
       </p>
 
-      <EntryOptionGroup
-        legend="Margin"
-        options={ENTRY_MARGINS_TUSD}
-        selected={entry.selectedMargin}
-        format={(margin) => formatDeskDollarsAmount(margin)}
-        onSelect={entry.selectMargin}
-      />
-
-      <EntryOptionGroup
-        legend="Arcade Leverage"
-        options={ENTRY_LEVERAGE_TIERS_BPS}
-        selected={entry.selectedLeverageBps}
-        format={formatLeverageBps}
-        onSelect={entry.selectLeverage}
-      />
-
-      <dl className="mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[11px] tabular-nums sm:mt-4 sm:grid sm:grid-cols-2 sm:gap-3 sm:text-sm">
-        <div className="flex items-baseline gap-1.5 sm:block">
-          <dt className="text-[var(--t-muted)]">
-            <span className="sm:hidden">Wallet</span>
-            <span className="hidden sm:inline">Wallet Desk Dollars</span>
-          </dt>
-          <dd className="tabular-nums text-[var(--t-text)]">
-            {formatDeskDollarsAmountLabel(entry.tUsdBalance)}
-          </dd>
-        </div>
-        <div className="flex items-baseline gap-1.5 sm:block">
-          <dt className="text-[var(--t-muted)]">
-            <span className="sm:hidden">Max</span>
-            <span className="hidden sm:inline">Expected maximum payout</span>
-          </dt>
-          <dd className="tabular-nums text-[var(--t-green-hot)]">
-            {formatDeskDollarsAmount(entry.expectedPayout)}
-          </dd>
-        </div>
-      </dl>
+      <EntryPickers entry={entry} />
 
       <DeskDollarsFaucet className="mt-3 sm:mt-4" />
 
@@ -223,70 +226,144 @@ export function CrashRoundEntry({
         ) : null}
       </div>
 
-      <details className="mt-3 text-xs leading-5 text-[var(--t-muted)] sm:mt-4">
-        <summary className="cursor-pointer font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
-          Approval details
-        </summary>
-        <div className="mt-2 border border-[var(--t-border)] p-3">
-          <p>
-            Spender: Bankroll Vault
-            {entry.vaultAddress ? (
-              <>
-                {" "}
-                <code className="break-all text-[var(--t-accent)]">
-                  {entry.vaultAddress}
-                </code>
-              </>
-            ) : null}
-          </p>
-          <p className="mt-2">
-            One-time bounded approval:{" "}
-            {formatDeskDollarsAmount(BOUNDED_ENTRY_ALLOWANCE_TUSD)}. Later
-            entries reuse this allowance with sponsored enter-only transactions.
-            This interface never requests an unlimited allowance.
-          </p>
-          <p className="mt-2">
-            Game contract
-            {entry.gameAddress ? (
-              <>
-                :{" "}
-                <code className="break-all text-[var(--t-accent)]">
-                  {entry.gameAddress}
-                </code>
-              </>
-            ) : null}
-            . Margin moves directly from your wallet to the vault.
-          </p>
-          <p className="mt-2">
-            Current vault allowance:{" "}
-            {formatDeskDollarsAmountLabel(entry.allowance)}. Selected margin:{" "}
-            {formatDeskDollarsAmount(entry.selectedMargin)}.
-          </p>
-          {entry.needsApproval ? (
-            <p className="mt-2 text-[var(--t-amber-hot)]">
-              Your first entry will submit the bounded approval, wait for its
-              receipt, then submit enter.
-            </p>
-          ) : (
-            <p className="mt-2 text-[var(--t-green)]">
-              Allowance already covers this margin. Only a sponsored enter will
-              be submitted.
-            </p>
-          )}
-        </div>
-      </details>
+      <ApprovalDetails entry={entry} />
     </EntryShell>
   );
 }
 
-function EntryShell({ children }: { children: React.ReactNode }) {
+type EntryView = ReturnType<typeof useCrashRoundEntry>;
+
+function EntryPickers({
+  entry,
+  signedOut = false,
+}: {
+  entry: EntryView;
+  signedOut?: boolean;
+}) {
+  return (
+    <>
+      <EntryOptionGroup
+        legend="Margin"
+        options={ENTRY_MARGINS_TUSD}
+        selected={entry.selectedMargin}
+        format={(margin) => formatDeskDollarsAmount(margin)}
+        onSelect={entry.selectMargin}
+      />
+
+      <EntryOptionGroup
+        legend="Arcade Leverage"
+        options={ENTRY_LEVERAGE_TIERS_BPS}
+        selected={entry.selectedLeverageBps}
+        format={formatLeverageBps}
+        onSelect={entry.selectLeverage}
+      />
+
+      {!signedOut ? (
+        <dl className="mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[11px] tabular-nums sm:mt-4 sm:grid sm:grid-cols-2 sm:gap-3 sm:text-sm">
+          <div className="flex items-baseline gap-1.5 sm:block">
+            <dt className="text-[var(--t-muted)]">
+              <span className="sm:hidden">Wallet</span>
+              <span className="hidden sm:inline">Wallet Desk Dollars</span>
+            </dt>
+            <dd className="tabular-nums text-[var(--t-text)]">
+              {formatDeskDollarsAmountLabel(entry.tUsdBalance)}
+            </dd>
+          </div>
+          <div className="flex items-baseline gap-1.5 sm:block">
+            <dt className="text-[var(--t-muted)]">
+              <span className="sm:hidden">Max</span>
+              <span className="hidden sm:inline">Expected maximum payout</span>
+            </dt>
+            <dd className="tabular-nums text-[var(--t-green-hot)]">
+              {formatDeskDollarsAmount(entry.expectedPayout)}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <dl className="mt-3 text-[11px] tabular-nums sm:mt-4 sm:text-sm">
+          <div className="flex items-baseline gap-1.5 sm:block">
+            <dt className="text-[var(--t-muted)]">Expected maximum payout</dt>
+            <dd className="tabular-nums text-[var(--t-green-hot)]">
+              {formatDeskDollarsAmount(entry.expectedPayout)}
+            </dd>
+          </div>
+        </dl>
+      )}
+    </>
+  );
+}
+
+function ApprovalDetails({ entry }: { entry: EntryView }) {
+  return (
+    <details className="mt-3 text-xs leading-5 text-[var(--t-muted)] sm:mt-4">
+      <summary className="cursor-pointer font-bold uppercase tracking-[0.14em] text-[var(--t-accent)]">
+        Approval details
+      </summary>
+      <div className="mt-2 border border-[var(--t-border)] p-3">
+        <p>
+          Spender: Bankroll Vault
+          {entry.vaultAddress ? (
+            <>
+              {" "}
+              <code className="break-all text-[var(--t-accent)]">
+                {entry.vaultAddress}
+              </code>
+            </>
+          ) : null}
+        </p>
+        <p className="mt-2">
+          One-time bounded approval:{" "}
+          {formatDeskDollarsAmount(BOUNDED_ENTRY_ALLOWANCE_TUSD)}. Later entries
+          reuse this allowance with sponsored enter-only transactions. This
+          interface never requests an unlimited allowance.
+        </p>
+        <p className="mt-2">
+          Game contract
+          {entry.gameAddress ? (
+            <>
+              :{" "}
+              <code className="break-all text-[var(--t-accent)]">
+                {entry.gameAddress}
+              </code>
+            </>
+          ) : null}
+          . Margin moves directly from your wallet to the vault.
+        </p>
+        <p className="mt-2">
+          Current vault allowance:{" "}
+          {formatDeskDollarsAmountLabel(entry.allowance)}. Selected margin:{" "}
+          {formatDeskDollarsAmount(entry.selectedMargin)}.
+        </p>
+        {entry.needsApproval ? (
+          <p className="mt-2 text-[var(--t-amber-hot)]">
+            Your first entry will submit the bounded approval, wait for its
+            receipt, then submit enter.
+          </p>
+        ) : (
+          <p className="mt-2 text-[var(--t-green)]">
+            Allowance already covers this margin. Only a sponsored enter will be
+            submitted.
+          </p>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function EntryShell({
+  children,
+  heading,
+}: {
+  children: React.ReactNode;
+  heading: string;
+}) {
   return (
     <div aria-labelledby="crash-entry-heading" className="text-left">
       <h3
         id="crash-entry-heading"
         className="font-[family-name:var(--font-plex-sans)] text-base font-bold uppercase tracking-tight text-[var(--t-accent)] sm:text-lg"
       >
-        Enter this round
+        {heading}
       </h3>
       <div className="mt-2 sm:mt-3">{children}</div>
     </div>

--- a/src/components/round-theater/round-theater.test.tsx
+++ b/src/components/round-theater/round-theater.test.tsx
@@ -41,6 +41,7 @@ const sdk = vi.hoisted(() => {
     live: {
       kind: "open",
       roundId: 12n,
+      phaseLabel: "open",
       timeline: makeTimeline(),
       tape: {
         roundId: 12n,
@@ -363,6 +364,7 @@ describe("RoundTheater", () => {
       live: {
         kind: "open",
         roundId: 13n,
+        phaseLabel: "open",
         tape: null,
         timeline: sdk.makeTimeline(
           "open",

--- a/src/hooks/use-crash-round-entry.ts
+++ b/src/hooks/use-crash-round-entry.ts
@@ -7,10 +7,13 @@ import { getBankrollVaultConfig } from "@/lib/bankroll-vault";
 import { baseSepoliaPublicClient } from "@/lib/base-sepolia";
 import { DISPLAY_ASSET_SYMBOL, deskDollarsAbi } from "@/lib/desk-dollars";
 import {
+  setEntryLeverage,
+  setEntryMargin,
+  useEntryPreferences,
+} from "@/lib/entry-preferences";
+import {
   BOUNDED_ENTRY_ALLOWANCE_TUSD,
   computeMaximumPayout,
-  ENTRY_LEVERAGE_TIERS_BPS,
-  ENTRY_MARGINS_TUSD,
   getMarginCallCrashConfig,
   marginCallCrashAbi,
   readPlayerTicket,
@@ -57,15 +60,11 @@ type EntryValues = {
 type State = Partial<EntryValues> & {
   status: CrashEntryStatus;
   error: string | null;
-  selectedMargin: bigint;
-  selectedLeverageBps: bigint;
 };
 
 const initialState: State = {
   status: "loading",
   error: null,
-  selectedMargin: ENTRY_MARGINS_TUSD[0],
-  selectedLeverageBps: ENTRY_LEVERAGE_TIERS_BPS[0],
 };
 
 const unavailable =
@@ -123,12 +122,17 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
   const transaction = usePrivySponsoredTransaction();
   const gameConfig = useMemo(() => getMarginCallCrashConfig(), []);
   const vaultConfig = useMemo(() => getBankrollVaultConfig(), []);
+  const prefs = useEntryPreferences();
   const [state, setState] = useState<State>(initialState);
   const inFlight = useRef(false);
   const retryKind = useRef<Stage | "refresh" | null>(null);
   // A stage whose transaction was submitted but whose receipt is unresolved.
   // Retry must re-check this hash — resubmitting could double-enter.
   const pendingStage = useRef<{ stage: Stage; hash: Hex } | null>(null);
+  // Keep submitEntry reading the latest picks without rebuilding the callback
+  // on every preference change mid-flight.
+  const prefsRef = useRef(prefs);
+  prefsRef.current = prefs;
 
   const refresh = useCallback(async () => {
     if (!gameConfig || !vaultConfig || !walletAddress) return false;
@@ -204,11 +208,11 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
   );
 
   const selectMargin = useCallback((margin: bigint) => {
-    setState((current) => ({ ...current, selectedMargin: margin }));
+    setEntryMargin(margin);
   }, []);
 
   const selectLeverage = useCallback((leverageBps: bigint) => {
-    setState((current) => ({ ...current, selectedLeverageBps: leverageBps }));
+    setEntryLeverage(leverageBps);
   }, []);
 
   const submitEntry = useCallback(
@@ -222,8 +226,7 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
       if (pending && mode !== "resume") return false;
       if (mode === "resume" && !pending) return false;
 
-      const margin = state.selectedMargin;
-      const leverageBps = state.selectedLeverageBps;
+      const { margin, leverageBps } = prefsRef.current;
       inFlight.current = true;
 
       try {
@@ -288,8 +291,6 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
       roundId,
       runStage,
       state.allowance,
-      state.selectedLeverageBps,
-      state.selectedMargin,
       vaultConfig,
       walletAddress,
     ]
@@ -305,11 +306,13 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
     );
   }, [refresh, submitEntry]);
 
+  const selectedMargin = prefs.margin;
+  const selectedLeverageBps = prefs.leverageBps;
   const expectedPayout = computeMaximumPayout(
-    state.selectedMargin,
-    state.selectedLeverageBps
+    selectedMargin,
+    selectedLeverageBps
   );
-  const needsApproval = (state.allowance ?? 0n) < state.selectedMargin;
+  const needsApproval = (state.allowance ?? 0n) < selectedMargin;
   const canSubmitAfterError =
     state.status === "error" &&
     (retryKind.current === "approval" || retryKind.current === "entry") &&
@@ -327,6 +330,8 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
 
   return {
     ...state,
+    selectedMargin,
+    selectedLeverageBps,
     walletAddress,
     expectedPayout,
     needsApproval,
@@ -338,7 +343,7 @@ export function useCrashRoundEntry({ roundId }: { roundId: bigint }) {
       !!walletAddress &&
       !state.ticket &&
       (state.status === "ready" || canSubmitAfterError) &&
-      (state.tUsdBalance ?? 0n) >= state.selectedMargin &&
+      (state.tUsdBalance ?? 0n) >= selectedMargin &&
       !inFlight.current,
     canRetry:
       state.status === "error" &&

--- a/src/hooks/use-round-theater.ts
+++ b/src/hooks/use-round-theater.ts
@@ -27,6 +27,8 @@ export type TheaterLive =
   | {
       kind: "open";
       roundId: bigint;
+      /** Real pre-lock phase — open only when the round can accept entries. */
+      phaseLabel: "prelaunch" | "uninitialized" | "open";
       tape: RoundTicketTape | null;
       timeline: RoundTimeline;
     }
@@ -242,6 +244,7 @@ function toTheaterView(options: {
     const live: Extract<TheaterLive, { kind: "open" }> = {
       kind: "open",
       roundId: round.roundId,
+      phaseLabel: phase,
       tape,
       timeline: round.timeline,
     };

--- a/src/lib/entry-preferences.test.ts
+++ b/src/lib/entry-preferences.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ENTRY_LEVERAGE_TIERS_BPS,
+  ENTRY_MARGINS_TUSD,
+} from "@/lib/margin-call-crash";
+import {
+  ENTRY_PREFS_STORAGE_KEY,
+  getEntryPreferences,
+  normalizeEntryPreferences,
+  resetEntryPreferencesForTests,
+  setEntryLeverage,
+  setEntryMargin,
+} from "./entry-preferences";
+
+describe("normalizeEntryPreferences", () => {
+  it("falls back to defaults for missing or invalid values", () => {
+    expect(normalizeEntryPreferences({})).toEqual({
+      margin: ENTRY_MARGINS_TUSD[0],
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[0],
+    });
+    expect(
+      normalizeEntryPreferences({ margin: "999", leverageBps: "nope" })
+    ).toEqual({
+      margin: ENTRY_MARGINS_TUSD[0],
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[0],
+    });
+  });
+
+  it("accepts allowed margins and leverage tiers", () => {
+    expect(
+      normalizeEntryPreferences({
+        margin: ENTRY_MARGINS_TUSD[2],
+        leverageBps: ENTRY_LEVERAGE_TIERS_BPS[3],
+      })
+    ).toEqual({
+      margin: ENTRY_MARGINS_TUSD[2],
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[3],
+    });
+    expect(
+      normalizeEntryPreferences({
+        margin: ENTRY_MARGINS_TUSD[1].toString(),
+        leverageBps: ENTRY_LEVERAGE_TIERS_BPS[5].toString(),
+      })
+    ).toEqual({
+      margin: ENTRY_MARGINS_TUSD[1],
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[5],
+    });
+  });
+});
+
+describe("entry preferences store", () => {
+  beforeEach(() => {
+    resetEntryPreferencesForTests();
+  });
+
+  afterEach(() => {
+    resetEntryPreferencesForTests();
+  });
+
+  it("persists valid picks to localStorage", () => {
+    setEntryMargin(ENTRY_MARGINS_TUSD[1]);
+    setEntryLeverage(ENTRY_LEVERAGE_TIERS_BPS[2]);
+    expect(getEntryPreferences()).toEqual({
+      margin: ENTRY_MARGINS_TUSD[1],
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[2],
+    });
+    const raw = window.localStorage.getItem(ENTRY_PREFS_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toEqual({
+      margin: ENTRY_MARGINS_TUSD[1].toString(),
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[2].toString(),
+    });
+  });
+
+  it("ignores disallowed picks", () => {
+    setEntryMargin(7n * 1_000_000n);
+    setEntryLeverage(99_000n);
+    expect(getEntryPreferences()).toEqual({
+      margin: ENTRY_MARGINS_TUSD[0],
+      leverageBps: ENTRY_LEVERAGE_TIERS_BPS[0],
+    });
+  });
+});

--- a/src/lib/entry-preferences.ts
+++ b/src/lib/entry-preferences.ts
@@ -1,0 +1,182 @@
+/**
+ * Module store for Floor entry picks (Margin + Arcade Leverage). Survives dock
+ * unmounts, round flips, and reloads via localStorage.
+ */
+
+import { useSyncExternalStore } from "react";
+import {
+  ENTRY_LEVERAGE_TIERS_BPS,
+  ENTRY_MARGINS_TUSD,
+} from "@/lib/margin-call-crash";
+
+export const ENTRY_PREFS_STORAGE_KEY = "mc-entry-prefs";
+
+export type EntryPreferences = {
+  margin: bigint;
+  leverageBps: bigint;
+};
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+const DEFAULT_PREFS: EntryPreferences = {
+  margin: ENTRY_MARGINS_TUSD[0],
+  leverageBps: ENTRY_LEVERAGE_TIERS_BPS[0],
+};
+
+let cached: EntryPreferences = { ...DEFAULT_PREFS };
+let hydrated = false;
+
+function notify() {
+  for (const listener of [...listeners]) listener();
+}
+
+function isAllowedMargin(value: bigint): boolean {
+  return (ENTRY_MARGINS_TUSD as readonly bigint[]).includes(value);
+}
+
+function isAllowedLeverage(value: bigint): boolean {
+  return (ENTRY_LEVERAGE_TIERS_BPS as readonly bigint[]).includes(value);
+}
+
+/** Validate raw prefs; unknown values fall back to defaults. */
+export function normalizeEntryPreferences(input: {
+  margin?: bigint | string | null;
+  leverageBps?: bigint | string | null;
+}): EntryPreferences {
+  let margin = DEFAULT_PREFS.margin;
+  let leverageBps = DEFAULT_PREFS.leverageBps;
+
+  if (input.margin !== undefined && input.margin !== null) {
+    try {
+      const parsed =
+        typeof input.margin === "bigint" ? input.margin : BigInt(input.margin);
+      if (isAllowedMargin(parsed)) margin = parsed;
+    } catch {
+      // keep default
+    }
+  }
+
+  if (input.leverageBps !== undefined && input.leverageBps !== null) {
+    try {
+      const parsed =
+        typeof input.leverageBps === "bigint"
+          ? input.leverageBps
+          : BigInt(input.leverageBps);
+      if (isAllowedLeverage(parsed)) leverageBps = parsed;
+    } catch {
+      // keep default
+    }
+  }
+
+  return { margin, leverageBps };
+}
+
+function readFromStorage(): EntryPreferences {
+  if (typeof window === "undefined") return { ...DEFAULT_PREFS };
+  try {
+    const raw = window.localStorage.getItem(ENTRY_PREFS_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_PREFS };
+    const parsed = JSON.parse(raw) as {
+      margin?: string;
+      leverageBps?: string;
+    };
+    return normalizeEntryPreferences(parsed);
+  } catch {
+    return { ...DEFAULT_PREFS };
+  }
+}
+
+function writeToStorage(prefs: EntryPreferences) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      ENTRY_PREFS_STORAGE_KEY,
+      JSON.stringify({
+        margin: prefs.margin.toString(),
+        leverageBps: prefs.leverageBps.toString(),
+      })
+    );
+  } catch {
+    // Quota / private mode — keep in-memory prefs.
+  }
+}
+
+function ensureHydrated() {
+  if (hydrated) return;
+  hydrated = true;
+  cached = readFromStorage();
+}
+
+function getSnapshot(): EntryPreferences {
+  ensureHydrated();
+  return cached;
+}
+
+function getServerSnapshot(): EntryPreferences {
+  return DEFAULT_PREFS;
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getEntryPreferences(): EntryPreferences {
+  return getSnapshot();
+}
+
+export function setEntryMargin(margin: bigint) {
+  ensureHydrated();
+  const next = normalizeEntryPreferences({
+    margin,
+    leverageBps: cached.leverageBps,
+  });
+  if (
+    next.margin === cached.margin &&
+    next.leverageBps === cached.leverageBps
+  ) {
+    return;
+  }
+  cached = next;
+  writeToStorage(cached);
+  notify();
+}
+
+export function setEntryLeverage(leverageBps: bigint) {
+  ensureHydrated();
+  const next = normalizeEntryPreferences({
+    margin: cached.margin,
+    leverageBps,
+  });
+  if (
+    next.margin === cached.margin &&
+    next.leverageBps === cached.leverageBps
+  ) {
+    return;
+  }
+  cached = next;
+  writeToStorage(cached);
+  notify();
+}
+
+/** Test helper — resets in-memory cache and optional storage. */
+export function resetEntryPreferencesForTests() {
+  cached = { ...DEFAULT_PREFS };
+  hydrated = false;
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.removeItem(ENTRY_PREFS_STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }
+  notify();
+}
+
+export function useEntryPreferences(): EntryPreferences {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/lib/round-phase-copy.ts
+++ b/src/lib/round-phase-copy.ts
@@ -63,9 +63,45 @@ export const countdownCopy = {
   entryClosesIn: "Entry closes in",
   nextRoundOpensIn: "Next round opens in",
   nextRoundOpening: "Next round opening…",
+  entryOpensIn: "Entry opens in",
+  entryOpening: "Entry opening…",
   nextRoundEntryOpen: (clock: string) => `Entry is open — closes in ${clock}`,
   entriesReopen: (clock: string) => `Entries reopen in ${clock}`,
 } as const;
+
+/** Disabled CTA label while the player arms picks for the next entry window. */
+export function formatArmedEntryCta(seconds: number): string {
+  return seconds > 0
+    ? `${countdownCopy.entryOpensIn} ${formatCountdown(seconds)}`
+    : countdownCopy.entryOpening;
+}
+
+/**
+ * Plain-language dock copy while entry is closed. Uses CONTEXT.md vocabulary.
+ */
+export function armedEntryCopy(phase: CrashRoundPhase): string {
+  switch (phase) {
+    case "prelaunch":
+      return "This epoch has not started yet. Pick your Margin and Arcade Leverage now — entry opens for 45 seconds every 60-second Epoch.";
+    case "uninitialized":
+      return "This epoch is on the grid but no round has been opened onchain yet. Pick your Margin and Arcade Leverage; entry unlocks once an opener pre-commits the encrypted Crash Point.";
+    case "open":
+      return "Entry cutoff — less than five seconds remain before onchain lock. Keep your Margin and Arcade Leverage ready for the next round.";
+    case "locked":
+      return "Entry for this round is closed. Pick your Margin and Arcade Leverage now and you are ready the moment the next window opens.";
+    case "reveal-requested":
+      return "Entry for this round is closed — the Crash Point is being attested onchain. Pick your Margin and Arcade Leverage now and you are ready the moment the next window opens.";
+    case "finalized":
+      return "This round is finalized. The Replay dramatizes the attested Crash Point. Pick your Margin and Arcade Leverage for the next entry window.";
+    case "expired-eligible":
+    case "expired":
+      return "This round cannot finalize. Pick your Margin and Arcade Leverage for the next entry window once it opens.";
+    default: {
+      const _exhaustive: never = phase;
+      return _exhaustive;
+    }
+  }
+}
 
 /** Full strip sentence for the active timeline countdown. */
 export function formatTimelineCountdown(timeline: RoundTimeline): string {

--- a/src/lib/theater-live.test.ts
+++ b/src/lib/theater-live.test.ts
@@ -20,6 +20,7 @@ const timeline = {
 const openLive: Extract<TheaterLive, { kind: "open" }> = {
   kind: "open",
   roundId: 12n,
+  phaseLabel: "open",
   tape: {
     roundId: 12n,
     entries: [


### PR DESCRIPTION
## Summary
- Keep the Floor action dock mounted between rounds in an armed state so players can pre-pick Margin and Arcade Leverage before entry opens
- Add a non-blocking How to play panel in the HUD and a real Continue with phone CTA for signed-out visitors
- Thread honest pre-lock phases (`prelaunch` / `uninitialized`) so the Floor never offers an unfulfillable Enter button

## Test plan
- [ ] Land on `/` between rounds and confirm the dock stays visible with pickers + disabled “Entry opens in …” CTA
- [ ] First visit: How to play expands once; after refresh it stays collapsed but reopenable
- [ ] Signed out: pickers remain visible with Continue with phone; picks survive sign-in
- [ ] During open entry (>5s left): Enter CTA is live; near cutoff it switches to armed
- [ ] Replay/outcome without an open next-round entry: dock stays out of the way
- [ ] `pnpm test`, `pnpm lint`, `pnpm typecheck`


Made with [Cursor](https://cursor.com)