### PR TITLE
Tighten signed-in header chrome and align How to Play

### DIFF
--- a/src/components/auth/auth-boundary.test.ts
+++ b/src/components/auth/auth-boundary.test.ts
@@ -87,8 +87,8 @@ describe("authentication boundary", () => {
       })
     ).toEqual({
       status: "signed-in",
-      message: "",
-      action: "logout",
+      message: null,
+      action: null,
     });
   });
 
@@ -128,13 +128,31 @@ describe("authentication boundary", () => {
     });
   });
 
-  it("keeps the signed-in state and restores logout retry after a logout failure", () => {
+  it("keeps the signed-in wallet chip and leaves logout retry to the dialog after a logout failure", () => {
     expect(
       getAuthBoundaryState({
         privyReady: true,
         authenticated: true,
         walletsReady: true,
         walletAddress: "0x1234",
+        loginError: false,
+        logoutPending: false,
+        logoutError: true,
+      })
+    ).toEqual({
+      status: "logout-error",
+      message: "We couldn't sign you out. Please try again.",
+      action: null,
+    });
+  });
+
+  it("keeps header logout reachable after a logout failure with no wallet chip", () => {
+    expect(
+      getAuthBoundaryState({
+        privyReady: true,
+        authenticated: true,
+        walletsReady: false,
+        walletAddress: null,
         loginError: false,
         logoutPending: false,
         logoutError: true,

--- a/src/components/auth/auth-boundary.test.ts
+++ b/src/components/auth/auth-boundary.test.ts
@@ -87,7 +87,7 @@ describe("authentication boundary", () => {
       })
     ).toEqual({
       status: "signed-in",
-      message: "Signed in.",
+      message: "",
       action: "logout",
     });
   });

--- a/src/components/auth/auth-boundary.ts
+++ b/src/components/auth/auth-boundary.ts
@@ -63,7 +63,7 @@ export function getAuthBoundaryState(
   if (input.authenticated) {
     return {
       status: "signed-in",
-      message: "Signed in.",
+      message: "",
       action: "logout",
     };
   }

--- a/src/components/auth/auth-boundary.ts
+++ b/src/components/auth/auth-boundary.ts
@@ -19,7 +19,9 @@ export type AuthBoundaryState = {
     | "signed-in"
     | "logout-pending"
     | "logout-error";
-  message: string;
+  /** Header live-region copy; null when chrome should stay quiet. */
+  message: string | null;
+  /** Header CTA only — dialog owns logout when a wallet chip is available. */
   action: "login" | "logout" | null;
 };
 
@@ -46,7 +48,8 @@ export function getAuthBoundaryState(
     return {
       status: "logout-error",
       message: "We couldn't sign you out. Please try again.",
-      action: "logout",
+      // Wallet chip + dialog own retry when an address is available.
+      action: input.walletAddress ? null : "logout",
     };
   }
 
@@ -63,8 +66,8 @@ export function getAuthBoundaryState(
   if (input.authenticated) {
     return {
       status: "signed-in",
-      message: "",
-      action: "logout",
+      message: null,
+      action: null,
     };
   }
 

--- a/src/components/auth/auth-controls.test.tsx
+++ b/src/components/auth/auth-controls.test.tsx
@@ -160,8 +160,10 @@ describe("AuthControls", () => {
     renderSignedInControls();
     expect(screen.getByText("0x1234")).not.toBeNull();
     expect(screen.getByText("100 USDC")).not.toBeNull();
+    expect(screen.queryByText("Signed in.")).toBeNull();
     expect(screen.queryByText("+15555550123")).toBeNull();
     expect(screen.queryByRole("button", { name: /Desk phone/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
   });
 
   it("exposes Desk phone only in the wallet dialog", () => {
@@ -195,6 +197,7 @@ describe("AuthControls", () => {
     );
     renderSignedInControls();
 
+    fireEvent.click(screen.getByTestId("wallet-chip"));
     const logoutButton = screen.getByRole("button", { name: "Log out" });
     act(() => {
       fireEvent.click(logoutButton);
@@ -214,12 +217,14 @@ describe("AuthControls", () => {
       .mockResolvedValueOnce();
     renderSignedInControls();
 
+    fireEvent.click(screen.getByTestId("wallet-chip"));
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
     await screen.findByText("We couldn't sign you out. Please try again.");
     expect(screen.getByText("0x1234")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Log out" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
 
+    fireEvent.click(screen.getByTestId("wallet-chip"));
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
     await waitFor(() => expect(sdk.logout).toHaveBeenCalledTimes(2));
   });

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -10,6 +10,27 @@ import { formatShortAddress } from "@/lib/utils";
 import { useDeskDollarsBalance } from "@/hooks/use-desk-dollars-balance";
 import { getAuthBoundaryState } from "./auth-boundary";
 
+function WalletIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      height="14"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.75"
+      viewBox="0 0 24 24"
+      width="14"
+    >
+      <path d="M19 7V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+      <path d="M3 9h18a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H3" />
+      <path d="M17 13h.01" />
+    </svg>
+  );
+}
+
 /**
  * Compact shell auth: login/logout, wallet chip, and live USDC balance.
  * Desk phone consent lives in the wallet dialog (single mount).
@@ -75,22 +96,26 @@ export function AuthControls() {
       className="flex shrink-0 flex-nowrap items-center justify-end gap-2 sm:gap-3"
       data-testid="auth-controls"
     >
-      <p
-        aria-live="polite"
-        className="max-w-[10rem] truncate text-xs text-[var(--t-muted)] sm:max-w-[14rem]"
-      >
-        {state.message}
-      </p>
+      {state.message ? (
+        <p
+          aria-live="polite"
+          className="max-w-[10rem] truncate text-xs text-[var(--t-muted)] sm:max-w-[14rem]"
+        >
+          {state.message}
+        </p>
+      ) : null}
       {signedInWallet ? (
         <>
           <button
             aria-expanded={walletOpen}
             aria-haspopup="dialog"
-            className="flex flex-nowrap items-center gap-1.5 rounded-sm border border-transparent px-1.5 py-1 text-xs tabular-nums text-[var(--t-text)] transition-colors hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--t-accent)] sm:gap-2 sm:px-2"
+            aria-label="Wallet"
+            className="flex flex-nowrap items-center gap-1.5 rounded-sm border border-[var(--t-border)] px-2.5 py-1.5 text-xs tabular-nums text-[var(--t-text)] transition-colors hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] focus-visible:border-[var(--t-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--t-accent)] sm:gap-2"
             data-testid="wallet-chip"
             onClick={() => setWalletOpen(true)}
             type="button"
           >
+            <WalletIcon className="shrink-0" />
             <span>{formatShortAddress(signedInWallet)}</span>
             {balanceLabel && balance !== null ? (
               <FlashValue className="text-[var(--t-green-hot)]" value={balance}>
@@ -101,6 +126,7 @@ export function AuthControls() {
           <WalletDialog
             balance={balance}
             decimals={decimals}
+            onLogout={handleLogout}
             onOpenChange={setWalletOpen}
             open={walletOpen}
             walletAddress={signedInWallet}
@@ -116,7 +142,7 @@ export function AuthControls() {
           Continue with phone
         </button>
       ) : null}
-      {state.action === "logout" ? (
+      {state.action === "logout" && !signedInWallet ? (
         <button
           className="shrink-0 rounded-sm border border-[var(--t-muted)] px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wide text-[var(--t-text)] sm:px-3 sm:text-xs"
           onClick={handleLogout}

--- a/src/components/auth/auth-controls.tsx
+++ b/src/components/auth/auth-controls.tsx
@@ -142,7 +142,7 @@ export function AuthControls() {
           Continue with phone
         </button>
       ) : null}
-      {state.action === "logout" && !signedInWallet ? (
+      {state.action === "logout" ? (
         <button
           className="shrink-0 rounded-sm border border-[var(--t-muted)] px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wide text-[var(--t-text)] sm:px-3 sm:text-xs"
           onClick={handleLogout}

--- a/src/components/crash-stage/overlay/floor-how-to-play.tsx
+++ b/src/components/crash-stage/overlay/floor-how-to-play.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useEffect, useRef } from "react";
 import { HOW_TO_PLAY_URL } from "@/lib/product-docs";
+import { STAGE_HUD_CHIP_CLASS } from "@/lib/utils";
 
 const SEEN_KEY = "mc-floor-howto-seen";
 
@@ -41,7 +42,9 @@ export const FloorHowToPlay = memo(function FloorHowToPlay() {
   return (
     <div className="relative" data-testid="floor-how-to-play">
       <details className="group" ref={detailsRef}>
-        <summary className="inline-flex cursor-pointer list-none items-center border border-[var(--t-border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] marker:content-none [&::-webkit-details-marker]:hidden">
+        <summary
+          className={`inline-flex cursor-pointer list-none items-center ${STAGE_HUD_CHIP_CLASS} marker:content-none [&::-webkit-details-marker]:hidden`}
+        >
           How to play
         </summary>
         <div className="pointer-events-auto absolute right-0 top-full z-30 mt-1.5 w-[min(calc(100vw-1.5rem),22rem)] border border-[var(--t-border)] bg-[var(--t-panel)] p-3 shadow-lg sm:w-[28rem] sm:p-4">

--- a/src/components/crash-stage/overlay/floor-how-to-play.tsx
+++ b/src/components/crash-stage/overlay/floor-how-to-play.tsx
@@ -41,7 +41,7 @@ export const FloorHowToPlay = memo(function FloorHowToPlay() {
   return (
     <div className="relative" data-testid="floor-how-to-play">
       <details className="group" ref={detailsRef}>
-        <summary className="cursor-pointer list-none rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/70 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-accent)] backdrop-blur-sm marker:content-none [&::-webkit-details-marker]:hidden">
+        <summary className="inline-flex cursor-pointer list-none items-center border border-[var(--t-border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] marker:content-none [&::-webkit-details-marker]:hidden">
           How to play
         </summary>
         <div className="pointer-events-auto absolute right-0 top-full z-30 mt-1.5 w-[min(calc(100vw-1.5rem),22rem)] border border-[var(--t-border)] bg-[var(--t-panel)] p-3 shadow-lg sm:w-[28rem] sm:p-4">

--- a/src/components/crash-stage/overlay/stage-hud.tsx
+++ b/src/components/crash-stage/overlay/stage-hud.tsx
@@ -91,7 +91,7 @@ export function StageHud({
             )
           ) : null}
         </div>
-        <div className="pointer-events-auto flex shrink-0 items-start gap-2">
+        <div className="pointer-events-auto flex shrink-0 items-center gap-2">
           <FloorHowToPlay />
           <TheaterSoundToggle suggest={suggestSound} />
         </div>

--- a/src/components/round-theater/theater-sound-toggle.tsx
+++ b/src/components/round-theater/theater-sound-toggle.tsx
@@ -6,6 +6,7 @@ import {
   readTheaterSoundEnabled,
   subscribeTheaterSound,
 } from "@/lib/theater-audio";
+import { STAGE_HUD_CHIP_CLASS } from "@/lib/utils";
 import { theaterCopy } from "./theater-copy";
 
 const HINT_SEEN_KEY = "margin-call-sound-hint";
@@ -54,7 +55,7 @@ export function TheaterSoundToggle({ suggest = false }: { suggest?: boolean }) {
       ) : null}
       <button
         aria-pressed={enabled}
-        className={`border border-[var(--t-border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] ${
+        className={`${STAGE_HUD_CHIP_CLASS} ${
           showHint ? "mc-onboard-flash" : ""
         }`}
         onClick={toggle}

--- a/src/components/wallet/wallet-dialog.test.tsx
+++ b/src/components/wallet/wallet-dialog.test.tsx
@@ -72,6 +72,7 @@ describe("WalletDialog", () => {
       <WalletDialog
         balance={100_000_000n}
         decimals={6}
+        onLogout={vi.fn()}
         onOpenChange={vi.fn()}
         open
         walletAddress={FROM}
@@ -120,6 +121,7 @@ describe("WalletDialog", () => {
       <WalletDialog
         balance={12_500_000n}
         decimals={6}
+        onLogout={vi.fn()}
         onOpenChange={vi.fn()}
         open
         walletAddress={FROM}
@@ -143,6 +145,7 @@ describe("WalletDialog", () => {
       <WalletDialog
         balance={100_000_000n}
         decimals={6}
+        onLogout={vi.fn()}
         onOpenChange={vi.fn()}
         open
         walletAddress={FROM}
@@ -152,5 +155,22 @@ describe("WalletDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await waitFor(() => expect(sdk.retry).toHaveBeenCalledTimes(1));
     expect(sdk.transferValidated).not.toHaveBeenCalled();
+  });
+
+  it("exposes Log out and calls onLogout", () => {
+    const onLogout = vi.fn();
+    render(
+      <WalletDialog
+        balance={100_000_000n}
+        decimals={6}
+        onLogout={onLogout}
+        onOpenChange={vi.fn()}
+        open
+        walletAddress={FROM}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("wallet-dialog-logout"));
+    expect(onLogout).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/wallet/wallet-dialog.tsx
+++ b/src/components/wallet/wallet-dialog.tsx
@@ -38,6 +38,7 @@ type WalletDialogProps = {
   walletAddress: Address;
   balance: bigint | null;
   decimals: number | null;
+  onLogout: () => void | Promise<void>;
 };
 
 type TransferStatusMessage = {
@@ -113,6 +114,7 @@ export function WalletDialog({
   walletAddress,
   balance,
   decimals,
+  onLogout,
 }: WalletDialogProps) {
   const transfer = useDeskDollarsTransfer(walletAddress);
   const [recipient, setRecipient] = useState("");
@@ -380,6 +382,17 @@ export function WalletDialog({
               </GameButton>
             </form>
           )}
+
+          <div className="mt-6 border-t border-[var(--t-border)] pt-5">
+            <button
+              className="w-full rounded-sm border border-[var(--t-muted)] px-2.5 py-1.5 text-[10px] font-bold uppercase tracking-wide text-[var(--t-text)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)] sm:text-xs"
+              data-testid="wallet-dialog-logout"
+              onClick={() => void onLogout()}
+              type="button"
+            >
+              Log out
+            </button>
+          </div>
         </Dialog.Popup>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,6 +24,10 @@ export function dialogPopupClass(size: keyof typeof DIALOG_POPUP_SIZE_CLASS) {
 export const TERMINAL_ACTION_BUTTON_CLASS =
   "border border-[var(--t-accent)] px-4 py-2 text-xs font-bold uppercase tracking-[0.14em] text-[var(--t-accent)] hover:bg-[var(--t-accent-soft)]";
 
+/** Compact Floor HUD chip — How to Play / Sound Off keep matching heights. */
+export const STAGE_HUD_CHIP_CLASS =
+  "border border-[var(--t-border)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--t-muted)] hover:border-[var(--t-accent)] hover:text-[var(--t-accent)]";
+
 /** mm:ss countdown; negative inputs clamp to 00:00. */
 export function formatCountdown(seconds: number): string {
   const safe = Math.max(0, seconds);


### PR DESCRIPTION
## Summary
- Match How to Play chip height/padding to Sound Off and center-align the HUD controls.
- Remove the redundant "Signed in." label; make the wallet/USDC chip a bordered button with an icon.
- Move Log out into the wallet dialog footer; keep header Log out only during wallet provisioning.

## Test plan
- [ ] Signed-in header shows wallet chip only (no "Signed in." / no header Log out)
- [ ] Wallet chip opens dialog; dialog footer Log out signs out
- [ ] During "Setting up your wallet…", header Log out still works
- [ ] How to Play and Sound Off chips are the same height
- [ ] `pnpm exec vitest run src/components/auth/auth-boundary.test.ts src/components/auth/auth-controls.test.tsx src/components/wallet/wallet-dialog.test.tsx`


Made with [Cursor](https://cursor.com)