### PR TITLE
Fit enter-round card without scrolling

### DIFF
--- a/src/components/crash-stage/overlay/stage-actions.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.tsx
@@ -24,8 +24,10 @@ export type StageActionsProps = {
 };
 
 /**
- * Floor action dock — centered entry / settle card. Pickers scroll in the
- * body; the primary Enter / Verify CTA stays pinned at the card footer.
+ * Floor action dock — centered entry / settle card. Sized to fit the
+ * entry form without scrolling on typical viewports; overflow remains a
+ * fallback for short screens or expanded approval details. The primary
+ * Enter / Verify CTA stays pinned at the card footer.
  */
 export function StageActions({
   mode,
@@ -62,7 +64,7 @@ export function StageActions({
       data-testid="stage-actions"
     >
       {showEntry || showSettle ? (
-        <div className="flex max-h-[min(70svh,32rem)] min-h-0 w-full flex-col overflow-hidden rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 backdrop-blur-md">
+        <div className="flex max-h-[min(88svh,44rem)] min-h-0 w-full flex-col overflow-hidden rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 backdrop-blur-md">
           {showEntry ? (
             <CrashRoundEntry
               armed={kind === "arm"}

--- a/src/components/current-round/crash-round-entry.test.tsx
+++ b/src/components/current-round/crash-round-entry.test.tsx
@@ -88,7 +88,7 @@ describe("CrashRoundEntry", () => {
   it("offers margin, leverage, and enter without requiring the helper paragraph", () => {
     render(<CrashRoundEntry {...sdk.props} />);
     expect(screen.getByRole("group", { name: "Margin" })).toBeTruthy();
-    expect(screen.getByRole("group", { name: "Arcade Leverage" })).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Leverage" })).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Approve & enter" })
     ).toBeTruthy();
@@ -191,7 +191,7 @@ describe("CrashRoundEntry", () => {
     render(<CrashRoundEntry {...sdk.props} armed />);
     expect(screen.getByRole("heading", { name: "Next round" })).toBeTruthy();
     expect(screen.getByRole("group", { name: "Margin" })).toBeTruthy();
-    expect(screen.getByRole("group", { name: "Arcade Leverage" })).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Leverage" })).toBeTruthy();
     const cta = screen.getByRole("button", { name: /Entry opens in/ });
     expect(cta).toHaveProperty("disabled", true);
     expect(

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -174,7 +174,7 @@ export function CrashRoundEntry({
     return (
       <EntryShell heading="Enter this round">
         <p className="hidden text-sm text-[var(--t-text)] sm:block">
-          Choose margin and Arcade Leverage. Expected payout is the maximum
+          Choose margin and leverage. Expected payout is the maximum
           reservation, not a guaranteed return.
         </p>
         <EntryPickers entry={entry} signedOut />
@@ -240,8 +240,8 @@ export function CrashRoundEntry({
       heading="Enter this round"
     >
       <p className="hidden text-sm text-[var(--t-text)] sm:block">
-        Choose margin and Arcade Leverage. Expected payout is the maximum
-        reservation, not a guaranteed return.
+        Choose margin and leverage. Expected payout is the maximum reservation,
+        not a guaranteed return.
       </p>
 
       <EntryPickers entry={entry} />
@@ -284,7 +284,7 @@ function EntryPickers({
       />
 
       <EntryOptionGroup
-        legend="Arcade Leverage"
+        legend="Leverage"
         options={ENTRY_LEVERAGE_TIERS_BPS}
         selected={entry.selectedLeverageBps}
         format={formatLeverageBps}


### PR DESCRIPTION
## Summary
- Raise the Floor action dock max height so Margin, Leverage, and Enter Round fit without scrolling on typical viewports.
- Relabel the entry picker from Arcade Leverage to Leverage.

## Test plan
- [ ] Open an enterable round on the Floor and confirm the enter-round card shows Margin, Leverage, wallet/payout, and Enter Round without a scrollbar.
- [ ] Confirm the section heading reads Leverage, not Arcade Leverage.
- [ ] Expand Approval details on a short viewport and confirm overflow still works.
- [ ] Confirm the Enter Round CTA stays pinned at the bottom.


Made with [Cursor](https://cursor.com)