### PR TITLE
Keep the enter-round card visible on Floor load

### DIFF
--- a/src/components/crash-stage/overlay/stage-actions.test.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.test.tsx
@@ -108,6 +108,7 @@ describe("StageActions", () => {
 
     const dock = screen.getByTestId("stage-actions");
     expect(dock.className).not.toMatch(/overflow-y-auto/);
+    expect(dock.className).toMatch(/max-h-full/);
     expect(screen.queryByTestId("entry-form")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Verify and settle" })
@@ -136,6 +137,9 @@ describe("StageActions", () => {
     expect(screen.getByTestId("stage-actions")).toBeTruthy();
     expect(screen.getByTestId("entry-form")).toBeTruthy();
     expect(screen.getByText("Enter form")).toBeTruthy();
+    const card = screen.getByTestId("stage-actions").firstElementChild;
+    expect(card?.className).toMatch(/max-h-full/);
+    expect(card?.className).not.toMatch(/svh/);
   });
 
   it("keeps an armed dock mounted between rounds", () => {

--- a/src/components/crash-stage/overlay/stage-actions.tsx
+++ b/src/components/crash-stage/overlay/stage-actions.tsx
@@ -24,8 +24,10 @@ export type StageActionsProps = {
 };
 
 /**
- * Floor action dock — centered entry / settle card. Sized to fit the
- * entry form without scrolling on typical viewports; overflow remains a
+ * Floor action dock — centered entry / settle card. Height is content-sized
+ * and capped to the Floor slot (`max-h-full`), not the viewport: an `svh`
+ * cap is taller than the remaining column once the header and banner are
+ * in, and `flex-1 min-h-0` then collapses the card to zero. Overflow is a
  * fallback for short screens or expanded approval details. The primary
  * Enter / Verify CTA stays pinned at the card footer.
  */
@@ -60,11 +62,11 @@ export function StageActions({
 
   return (
     <div
-      className="pointer-events-auto mx-auto flex min-h-0 w-full max-w-xl flex-col"
+      className="pointer-events-auto mx-auto flex max-h-full min-h-0 w-full max-w-xl flex-col"
       data-testid="stage-actions"
     >
       {showEntry || showSettle ? (
-        <div className="flex max-h-[min(88svh,44rem)] min-h-0 w-full flex-col overflow-hidden rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 backdrop-blur-md">
+        <div className="flex max-h-full min-h-0 w-full flex-col overflow-hidden rounded-sm border border-[var(--t-border)]/70 bg-[var(--t-bg)]/90 backdrop-blur-md">
           {showEntry ? (
             <CrashRoundEntry
               armed={kind === "arm"}

--- a/src/components/crash-stage/overlay/stage-settle-dock.tsx
+++ b/src/components/crash-stage/overlay/stage-settle-dock.tsx
@@ -65,11 +65,11 @@ export function StageSettleDock({ settlement }: StageSettleDockProps) {
 
   return (
     <div
-      className="flex min-h-0 flex-1 flex-col text-left"
+      className="flex max-h-full min-h-0 flex-col overflow-hidden text-left"
       data-testid="stage-settle-dock"
     >
       <div
-        className="min-h-0 flex-1 overflow-y-auto p-2.5 sm:p-4"
+        className="min-h-0 overflow-y-auto p-2.5 sm:p-4"
         data-testid="stage-actions-body"
       >
         <h2 className="font-[family-name:var(--font-plex-sans)] text-base font-bold uppercase tracking-tight text-[var(--t-accent)] sm:text-lg">

--- a/src/components/current-round/crash-round-entry.tsx
+++ b/src/components/current-round/crash-round-entry.tsx
@@ -388,7 +388,9 @@ function ApprovalDetails({ entry }: { entry: EntryView }) {
 }
 
 /**
- * Scrollable pickers + pinned footer CTA so Enter stays on screen.
+ * Content-sized pickers + pinned footer CTA. No flex-1: a grow child with
+ * min-h-0 inside an auto-height card collapses to zero. The card's max-h-full
+ * bounds this shell when the Floor slot is shorter than the form.
  */
 function EntryShell({
   children,
@@ -402,10 +404,10 @@ function EntryShell({
   return (
     <div
       aria-labelledby="crash-entry-heading"
-      className="flex min-h-0 flex-1 flex-col text-left"
+      className="flex max-h-full min-h-0 flex-col overflow-hidden text-left"
     >
       <div
-        className="min-h-0 flex-1 overflow-y-auto p-2.5 sm:p-4"
+        className="min-h-0 overflow-y-auto p-2.5 sm:p-4"
         data-testid="stage-actions-body"
       >
         <h3


### PR DESCRIPTION
## Summary
- Cap the enter/settle card to the Floor slot (`max-h-full`) instead of `88svh`, which is taller than the remaining column after the header and banner.
- Drop `flex-1 min-h-0` on the entry and settle shells so an auto-height card cannot collapse to zero after #399.

## Test plan
- [ ] Hard-refresh `/` on production-like viewport and confirm Margin, Leverage, and Enter Round appear once the round read finishes (no empty pit with only the chip stack).
- [ ] Confirm a second refresh still shows the card; navigating away and back should also keep it.
- [ ] Confirm the card still fits without an internal scrollbar on a typical laptop, and still scrolls if Approval details are expanded on a short screen.
- [ ] Confirm the Enter / Verify CTA stays pinned at the bottom of the card.


Made with [Cursor](https://cursor.com)